### PR TITLE
🤖 fix: render native macOS shortcut labels (⌘P, not ⌘·P)

### DIFF
--- a/src/browser/components/DirectoryPickerModal/DirectoryPickerModal.tsx
+++ b/src/browser/components/DirectoryPickerModal/DirectoryPickerModal.tsx
@@ -13,7 +13,7 @@ import { Input } from "@/browser/components/Input/Input";
 import type { FileTreeNode } from "@/common/utils/git/numstatParser";
 import { DirectoryTree } from "../DirectoryTree/DirectoryTree";
 import { useAPI } from "@/browser/contexts/API";
-import { formatKeybind, isMac } from "@/browser/utils/ui/keybinds";
+import { formatKeybind } from "@/browser/utils/ui/keybinds";
 import { getErrorMessage } from "@/common/utils/errors";
 
 const OPEN_KEYBIND = { key: "o", ctrl: true };
@@ -215,7 +215,7 @@ export const DirectoryPickerModal: React.FC<DirectoryPickerModalProps> = ({
       .filter((child) => showHiddenFiles || !child.name.startsWith("."))
       .map((child) => ({ name: child.name, path: child.path })) ?? [];
 
-  const shortcutLabel = isMac() ? "⌘O" : formatKeybind(OPEN_KEYBIND);
+  const shortcutLabel = formatKeybind(OPEN_KEYBIND);
 
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>

--- a/src/browser/utils/ui/keybinds.test.ts
+++ b/src/browser/utils/ui/keybinds.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, test } from "bun:test";
-import { isMac, matchesKeybind, isKeybindDeprecated, KEYBINDS } from "./keybinds";
+import { describe, it, expect, test, afterAll } from "bun:test";
+import { isMac, matchesKeybind, formatKeybind, isKeybindDeprecated, KEYBINDS } from "./keybinds";
 import type { Keybind } from "@/common/types/keybind";
 
 // Helper to create a minimal keyboard event
@@ -123,6 +123,51 @@ describe("isKeybindDeprecated", () => {
     expect(isKeybindDeprecated(KEYBINDS.TOGGLE_THINKING)).toBe(true);
     expect(isKeybindDeprecated(KEYBINDS.INCREASE_THINKING)).toBe(false);
     expect(isKeybindDeprecated(KEYBINDS.DECREASE_THINKING)).toBe(false);
+  });
+});
+
+describe("formatKeybind", () => {
+  const originalWindow = globalThis.window;
+  afterAll(() => {
+    globalThis.window = originalWindow;
+  });
+
+  describe("on macOS", () => {
+    const mockMac = () => {
+      globalThis.window = { api: { platform: "darwin" } } as unknown as Window & typeof globalThis;
+    };
+
+    it("renders ctrl as Command with no separator", () => {
+      mockMac();
+      expect(formatKeybind(KEYBINDS.TOGGLE_SIDEBAR)).toBe("\u2318P");
+    });
+
+    it("orders modifiers Control, Option, Shift, Command", () => {
+      mockMac();
+      expect(formatKeybind(KEYBINDS.OPEN_COMMAND_PALETTE)).toBe("\u21E7\u2318P");
+      expect(formatKeybind({ key: "i", ctrl: true, alt: true, shift: true })).toBe(
+        "\u2325\u21E7\u2318I"
+      );
+      expect(formatKeybind({ key: "k", ctrl: true, meta: true })).toBe("\u2303\u2318K");
+    });
+
+    it("renders ctrl as Control when macCtrlBehavior is control", () => {
+      mockMac();
+      expect(formatKeybind(KEYBINDS.INTERRUPT_STREAM_VIM)).toBe("\u2303C");
+    });
+
+    it("keeps key formatting (Space)", () => {
+      mockMac();
+      expect(formatKeybind({ key: " ", ctrl: true })).toBe("\u2318Space");
+    });
+  });
+
+  describe("on Linux/Windows", () => {
+    it("joins text modifiers with +", () => {
+      globalThis.window = { api: { platform: "linux" } } as unknown as Window & typeof globalThis;
+      expect(formatKeybind(KEYBINDS.TOGGLE_SIDEBAR)).toBe("Ctrl+P");
+      expect(formatKeybind(KEYBINDS.OPEN_COMMAND_PALETTE)).toBe("Ctrl+Shift+P");
+    });
   });
 });
 

--- a/src/browser/utils/ui/keybinds.ts
+++ b/src/browser/utils/ui/keybinds.ts
@@ -234,27 +234,20 @@ export function isDialogOpen(): boolean {
 
 /**
  * Format a keybind for display to users.
- * Returns Mac-style symbols on macOS, or Windows-style text elsewhere.
+ * macOS: native symbol run with no separator, modifiers ordered ⌃⌥⇧⌘ ("⇧⌘P").
+ * Elsewhere: "+"-joined text ("Ctrl+Shift+P").
  */
 export function formatKeybind(keybind: Keybind): string {
   const parts: string[] = [];
 
   if (isMac()) {
-    // Mac-style formatting with symbols (using Unicode escapes for safety)
     // For ctrl on Mac, we actually mean Cmd in most cases since matcher treats them as equivalent
-    if (keybind.ctrl && !keybind.meta) {
-      const macCtrlBehavior = keybind.macCtrlBehavior ?? "either";
-      if (macCtrlBehavior === "control") {
-        parts.push("\u2303"); // ⌃ Control
-      } else {
-        parts.push("\u2318"); // ⌘ Command
-      }
-    } else if (keybind.ctrl) {
-      parts.push("\u2303"); // ⌃ Control
-    }
+    const macCtrlBehavior = keybind.macCtrlBehavior ?? "either";
+    const ctrlIsCommand = keybind.ctrl && !keybind.meta && macCtrlBehavior !== "control";
+    if (keybind.ctrl && !ctrlIsCommand) parts.push("\u2303"); // ⌃ Control
     if (keybind.alt) parts.push("\u2325"); // ⌥ Option
     if (keybind.shift) parts.push("\u21E7"); // ⇧ Shift
-    if (keybind.meta) parts.push("\u2318"); // ⌘ Command
+    if (keybind.meta || ctrlIsCommand) parts.push("\u2318"); // ⌘ Command
   } else {
     // Windows/Linux-style formatting with text
     if (keybind.ctrl) parts.push("Ctrl");
@@ -274,7 +267,7 @@ export function formatKeybind(keybind: Keybind): string {
   }
   parts.push(key);
 
-  return isMac() ? parts.join("\u00B7") : parts.join("+"); // · on Mac, + elsewhere
+  return isMac() ? parts.join("") : parts.join("+");
 }
 
 /**


### PR DESCRIPTION
## Summary

On macOS, every keyboard shortcut label rendered with a middle-dot separator and Command first ("⌘·P", "⌘·⇧·P"). `formatKeybind` now emits the native macOS form: one run of symbols with no separator, modifiers ordered ⌃⌥⇧⌘ ("⌘P", "⇧⌘P", "⌃C"). Windows/Linux output ("Ctrl+Shift+P") is unchanged.

## Background

The collapsed-sidebar hamburger tooltip showed "Open sidebar (⌘·P)". The same formatter feeds the command palette, Settings → Keybinds, sidebar collapse buttons, composer hints and every other shortcut hint, so the fix is in the one shared function. `DirectoryPickerModal` had hardcoded `isMac() ? "⌘O"` to dodge the dot; that workaround is removed now that the formatter produces the same string.

## Implementation

`ctrl` still means Command on macOS (matching `matchesKeybind`) unless `macCtrlBehavior: "control"` or the keybind also sets `meta`, in which case it renders as ⌃. Only the presentation changed; matching logic and the KEYBINDS registry are untouched.

## Validation

- Unit tests cover separator, ⌃⌥⇧⌘ ordering, ctrl-as-Command vs ctrl-as-Control, multi-character keys, and the unchanged Linux/Windows format.
- Remote dogfood UAT (browser build, macOS spoofed via `navigator.userAgentData`, then plain Linux): hamburger tooltip, 70 command-palette labels and 60 Settings → Keybinds labels contain no middle dot and keep ⌃⌥⇧⌘ order; Cmd+P / Cmd+Shift+P still work; Linux labels unchanged.

## Risks

Low. Display-only change in one function; no keybind matching or registry changes.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=0.00 -->

