### PR TITLE
🤖 fix: version-lock mux compat package to v0.28.3

### DIFF
--- a/packages/mux-compat/package.json
+++ b/packages/mux-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mux",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "description": "Compatibility package forwarding the legacy mux command to @coder/xum",
   "bin": {
     "mux": "bin/mux.js"
@@ -10,7 +10,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@coder/xum": "0.28.2"
+    "@coder/xum": "0.28.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Syncs `packages/mux-compat/package.json` to `0.28.3` (both its `version` and its `@coder/xum` dependency pin) so it is version-locked to the root `package.json` again. This un-breaks `Test / Unit` on `main`.

## Background

The v0.28.3 release PR (#4042) bumped only the root `package.json`, leaving the legacy `mux` forwarding package at `0.28.2`. `src/common/compat/productIdentity.test.ts` enforces lockstep between the two manifests, so `main@bf97dfd52` fails `Test / Unit` with:

```
(fail) xum package transition contract > keeps the published mux forwarding package version-locked to @coder/xum
  Expected: "0.28.3"   Received: "0.28.2"
```

The published artifacts are unaffected: `_npm-publish.yml` and `_desktop-release.yml` run `scripts/set-package-version.js` at publish time, and the registry already has `mux@0.28.3 -> @coder/xum@0.28.3`. This PR only repairs the checked-in source.

## Implementation

Generated with the existing lockstep script rather than a hand edit, so the diff is exactly what CI would produce:

```
node ./scripts/set-package-version.js 0.28.3
```

Root `package.json` was a byte-identical rewrite (no diff).

## Validation

- `bun test src/common/compat/productIdentity.test.ts` → 8 pass / 0 fail (the previously failing test now passes)
- `make static-check` → exit 0

## Risks

None beyond the manifest values themselves; no runtime code changes.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$3.21`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=3.21 -->
