### PR TITLE
🤖 refactor: Effect Phase 11 PR 2 — EffectRunner + AppFiberScope runtime seams; TestClock on heartbeat/idleCompaction/retryManager

### DIFF
--- a/src/constants/terminationTimeouts.ts
+++ b/src/constants/terminationTimeouts.ts
@@ -15,3 +15,10 @@ export const BACKUP_GIT_TIMEOUT_MS = 5 * 60 * 1000;
  * `desktop/main.ts` and `cli/server.ts` race the whole dispose against.
  */
 export const APP_RUNTIME_DISPOSE_TIMEOUT_MS = 2 * 1000;
+
+/**
+ * Bounds the early `AppFiberScope` close in `ServiceContainer.dispose()`
+ * (interrupt + await of supervised fibers). Together with the runtime dispose
+ * bound this fits inside the same 5 s quit budgets.
+ */
+export const APP_FIBER_SCOPE_CLOSE_TIMEOUT_MS = 2 * 1000;

--- a/src/node/services/di/appFiberScope.test.ts
+++ b/src/node/services/di/appFiberScope.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import { Effect, Exit, Fiber, Layer, Scope } from "effect";
+import { log } from "@/node/services/log";
+import { AppFiberScopeLive, AppFiberScopeTag } from "./appFiberScope";
+import { closeScopeBounded, disposeAppRuntime, makeAppRuntime } from "./appRuntime";
+import { EffectRunnerLive, EffectRunnerTag } from "./effectRunner";
+
+/** An interruptible I/O-style suspension that never resolves; records interruption. */
+function hungIo(onInterrupt: () => void): Effect.Effect<void> {
+  return Effect.callback<void>(() =>
+    Effect.sync(() => {
+      onInterrupt();
+    })
+  );
+}
+
+function buildSeams() {
+  const app = makeAppRuntime(AppFiberScopeLive.pipe(Layer.provideMerge(EffectRunnerLive)));
+  return {
+    app,
+    appFiberScope: app.get(AppFiberScopeTag),
+    runner: app.get(EffectRunnerTag),
+  };
+}
+
+describe("AppFiberScope", () => {
+  it("closeScopeBounded interrupts and awaits an I/O-suspended fiber forked into it", async () => {
+    const { app, appFiberScope } = buildSeams();
+    const steps: string[] = [];
+    const fiber = app.managed.runSync(
+      Effect.forkIn(
+        hungIo(() => steps.push("cancelled")).pipe(
+          Effect.ensuring(Effect.sync(() => steps.push("finalized")))
+        ),
+        appFiberScope
+      )
+    );
+
+    await closeScopeBounded(appFiberScope);
+
+    // Interrupted (the cancel path ran) and awaited (its finalizer ran before
+    // the close resolved), so shutdown can rely on the fiber being gone.
+    expect(steps).toEqual(["cancelled", "finalized"]);
+    expect(fiber.pollUnsafe()).toBeDefined();
+    expect(Exit.isFailure(fiber.pollUnsafe()!)).toBe(true);
+    await disposeAppRuntime(app.managed);
+  });
+
+  it("fibers forked through the EffectRunner are interrupted by neither close (unsupervised)", async () => {
+    const { app, appFiberScope, runner } = buildSeams();
+    let interrupted = false;
+    const fiber = runner.runFork(
+      hungIo(() => {
+        interrupted = true;
+      })
+    );
+
+    await closeScopeBounded(appFiberScope);
+    await disposeAppRuntime(app.managed);
+
+    // The runner is not a supervisor: its fibers belong to whoever forked them
+    // (a worker's own scope with an explicit stop()), so dispose leaves them be.
+    expect(interrupted).toBe(false);
+    expect(fiber.pollUnsafe()).toBeUndefined();
+    await Effect.runPromise(Fiber.interrupt(fiber));
+    expect(interrupted).toBe(true);
+  });
+
+  it("disposeAppRuntime re-closes an already-closed AppFiberScope idempotently", async () => {
+    const { app, appFiberScope } = buildSeams();
+    let finalized = 0;
+    app.managed.runSync(
+      Scope.addFinalizer(
+        appFiberScope,
+        Effect.sync(() => {
+          finalized += 1;
+        })
+      )
+    );
+
+    await closeScopeBounded(appFiberScope);
+    expect(finalized).toBe(1);
+
+    // The runtime's layer scope owns the child; closing the runtime afterwards
+    // must neither throw nor run the child's finalizers a second time.
+    await disposeAppRuntime(app.managed);
+    expect(finalized).toBe(1);
+    expect(app.managed.cachedContext).toBeUndefined();
+  });
+
+  it("runtime dispose alone closes the AppFiberScope (backstop for a missed explicit close)", async () => {
+    const { app, appFiberScope } = buildSeams();
+    let interrupted = false;
+    app.managed.runSync(
+      Effect.forkIn(
+        hungIo(() => {
+          interrupted = true;
+        }),
+        appFiberScope
+      )
+    );
+
+    await disposeAppRuntime(app.managed);
+
+    expect(interrupted).toBe(true);
+    expect(appFiberScope.state._tag).toBe("Closed");
+  });
+
+  it("closeScopeBounded returns at the timeout when a fiber cannot be interrupted, warning instead of rejecting", async () => {
+    const warnSpy = spyOn(log, "warn").mockImplementation(() => undefined);
+    try {
+      const { app, appFiberScope } = buildSeams();
+      // Uninterruptible and never-resolving: the scope close can never finish.
+      app.managed.runSync(Effect.forkIn(Effect.uninterruptible(Effect.never), appFiberScope));
+
+      const startedAt = Date.now();
+      await closeScopeBounded(appFiberScope, 50);
+
+      expect(Date.now() - startedAt).toBeLessThan(2_000);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(String(warnSpy.mock.calls[0]?.[0])).toContain("timed out");
+      // The runtime dispose then hits the same hung finalizer; keep it bounded too.
+      await disposeAppRuntime(app.managed, 50);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/src/node/services/di/appFiberScope.ts
+++ b/src/node/services/di/appFiberScope.ts
@@ -1,0 +1,36 @@
+/**
+ * `AppFiberScope` — the runtime-owned, *supervised* fiber scope (Effect
+ * migration Phase 11, PR 2).
+ *
+ * A child of the app runtime's layer scope. Fibers forked into it with
+ * `Effect.forkIn(effect, appFiberScope)` are interrupted **and awaited** when
+ * it closes, which `ServiceContainer.dispose()` does explicitly and early
+ * (right after `backgroundProcessManager.beginShutdown()`, before the
+ * hand-ordered teardown steps) via `closeScopeBounded`, so interrupted fibers
+ * can still use their dependencies while they finalize. `runtime.dispose()`
+ * later re-closes it idempotently as a backstop.
+ *
+ * This is the seam for I/O-suspended, long-lived work that shutdown must wait
+ * for (the streamManager engine core, in a later phase). It is the counterpart
+ * of `EffectRunner` (`./effectRunner.ts`), which is unsupervised: a fiber forked
+ * through the runner is interrupted by neither close. Anything forked here must
+ * tolerate interruption at any suspension point and must not depend on
+ * resources torn down before the close (see the dispose order in
+ * `ServiceContainer`). No production occupant yet; the contract is pinned by
+ * tests.
+ */
+import { Context, Effect, Layer, Scope } from "effect";
+
+export class AppFiberScopeTag extends Context.Service<AppFiberScopeTag, Scope.Closeable>()(
+  "xum/AppFiberScope"
+) {}
+
+/**
+ * Synchronous body (DI contract: layers build without suspending). Parallel
+ * finalizer strategy: forked fibers are independent, so they are interrupted
+ * concurrently rather than one after another.
+ */
+export const AppFiberScopeLive: Layer.Layer<AppFiberScopeTag> = Layer.effect(
+  AppFiberScopeTag,
+  Effect.flatMap(Effect.scope, (parent) => Scope.fork(parent, "parallel"))
+);

--- a/src/node/services/di/appRuntime.ts
+++ b/src/node/services/di/appRuntime.ts
@@ -29,11 +29,20 @@
  *   `disposeAppRuntime` (the last dispose step) reorders nothing. It is wired
  *   now so that later phases (the streamManager engine core) have a fixed,
  *   bounded slot for scope-owned resources.
+ * - **Two runtime seams, not one handle.** Workers hold an `EffectRunner`
+ *   (`./effectRunner.ts`: context-bound, unsupervised, `R = never`) so they can
+ *   run on the runtime's `Clock` without ever holding the runtime; work that
+ *   shutdown must await forks into `AppFiberScope` (`./appFiberScope.ts`),
+ *   the one supervised resource, closed explicitly early in `dispose()` via
+ *   `closeScopeBounded` and re-closed idempotently by `disposeAppRuntime`.
  */
 import assert from "@/common/utils/assert";
-import { Context, Duration, Effect, Fiber, ManagedRuntime } from "effect";
+import { Context, Duration, Effect, Exit, Fiber, ManagedRuntime, Scope } from "effect";
 import type { Layer } from "effect";
-import { APP_RUNTIME_DISPOSE_TIMEOUT_MS } from "@/constants/terminationTimeouts";
+import {
+  APP_FIBER_SCOPE_CLOSE_TIMEOUT_MS,
+  APP_RUNTIME_DISPOSE_TIMEOUT_MS,
+} from "@/constants/terminationTimeouts";
 import { log } from "@/node/services/log";
 
 export interface AppRuntime<R> {
@@ -79,37 +88,63 @@ export function disposeAppRuntime(
   runtime: ManagedRuntime.ManagedRuntime<never, never>,
   timeoutMs: number = APP_RUNTIME_DISPOSE_TIMEOUT_MS
 ): Promise<void> {
-  return Effect.runPromise(disposeAppRuntimeEffect(runtime, timeoutMs));
+  return Effect.runPromise(
+    boundedTeardown("AppRuntime", "disposed", runtime.disposeEffect, timeoutMs)
+  );
 }
 
-function disposeAppRuntimeEffect(
-  runtime: ManagedRuntime.ManagedRuntime<never, never>,
+/**
+ * Close a runtime-owned scope (`AppFiberScope`), interrupting and awaiting the
+ * fibers forked into it, bounded by `timeoutMs`. Same contract as
+ * `disposeAppRuntime`: never rejects, idempotent (`Scope.close` on a closed
+ * scope is a no-op), warns and returns at the bound if a fiber's finalization
+ * hangs.
+ */
+export function closeScopeBounded(
+  scope: Scope.Closeable,
+  timeoutMs: number = APP_FIBER_SCOPE_CLOSE_TIMEOUT_MS
+): Promise<void> {
+  return Effect.runPromise(
+    boundedTeardown("AppFiberScope", "closed", Scope.close(scope, Exit.void), timeoutMs)
+  );
+}
+
+/**
+ * Uninterruptible teardown shell around a bounded wait on `target`. The target
+ * runs in a detached fiber and the caller waits on its join, so a hung
+ * finalizer cannot pin shutdown past the bound — only the wait is
+ * interruptible (so the timeout can win the race; house shape from #4038),
+ * the target keeps running best-effort, and a warning is logged. Defects are
+ * folded into a warning so the returned effect never fails.
+ */
+function boundedTeardown(
+  subject: string,
+  doneVerb: string,
+  target: Effect.Effect<void>,
   timeoutMs: number
 ): Effect.Effect<void> {
   const startedAt = performance.now();
-  // Uninterruptible teardown shell; only the bounded wait inside is interruptible
-  // so the timeout can win the race (house shape from #4038).
   return Effect.uninterruptible(
     Effect.gen(function* () {
-      const closing = yield* Effect.forkDetach(runtime.disposeEffect);
+      const closing = yield* Effect.forkDetach(target);
       yield* Effect.interruptible(
         Fiber.join(closing).pipe(Effect.timeout(Duration.millis(timeoutMs)))
       ).pipe(
         Effect.catchTag("TimeoutError", () =>
           Effect.sync(() => {
-            log.warn("[shutdown] AppRuntime dispose timed out; finalizers continue best-effort", {
+            log.warn(`[shutdown] ${subject} teardown timed out; finalizers continue best-effort`, {
               timeoutMs,
             });
           })
         )
       );
-      log.debug("[shutdown] AppRuntime disposed", {
+      log.debug(`[shutdown] ${subject} ${doneVerb}`, {
         ms: Math.round(performance.now() - startedAt),
       });
     }).pipe(
       Effect.catchDefect((defect) =>
         Effect.sync(() => {
-          log.warn("[shutdown] AppRuntime dispose failed", { error: defect });
+          log.warn(`[shutdown] ${subject} teardown failed`, { error: defect });
         })
       )
     )

--- a/src/node/services/di/effectRunner.test.ts
+++ b/src/node/services/di/effectRunner.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "bun:test";
+import { Clock, Context, Duration, Effect, Exit, Fiber, Schedule, Scope } from "effect";
+import { makeAppRuntime } from "./appRuntime";
+import { defaultEffectRunner, EffectRunnerLive, EffectRunnerTag } from "./effectRunner";
+import { makeTestEffectRunner } from "./testEffectRunner";
+
+/**
+ * Pins the runtime facts the clock-driven workers rely on when they run
+ * through an `EffectRunner` (Phase 11 PR 2 acceptance), so a later effect
+ * upgrade that changes them fails here rather than in a worker suite.
+ */
+describe("EffectRunner", () => {
+  it("defaultEffectRunner forks synchronously up to the first sleep", () => {
+    const steps: string[] = [];
+
+    const fiber = defaultEffectRunner.runFork(
+      Effect.gen(function* () {
+        steps.push("before-sleep");
+        yield* Effect.sleep(Duration.hours(1));
+        steps.push("after-sleep");
+      })
+    );
+
+    expect(steps).toEqual(["before-sleep"]);
+    defaultEffectRunner.runFork(Fiber.interrupt(fiber));
+  });
+
+  it("EffectRunnerLive captures the upstream Clock (a TestClock when provided)", async () => {
+    const clock = makeTestEffectRunner();
+    try {
+      expect(clock.runner.runSync(Clock.currentTimeMillis)).toBe(0);
+      await clock.adjust(Duration.millis(1_500));
+      expect(clock.runner.runSync(Clock.currentTimeMillis)).toBe(1_500);
+    } finally {
+      await clock.dispose();
+    }
+  });
+
+  it("schedules forked fibers on the default scheduler, not the eager build's sync scheduler", async () => {
+    // makeAppRuntime builds with runSync, whose fiber carries a microtask
+    // scheduler. EffectRunnerLive strips it so runner.runFork behaves like
+    // Effect.runFork: a yield resumes on a macrotask.
+    const app = makeAppRuntime(EffectRunnerLive);
+    const runner = app.get(EffectRunnerTag);
+    let resumed = false;
+
+    runner.runFork(
+      Effect.yieldNow.pipe(
+        Effect.andThen(
+          Effect.sync(() => {
+            resumed = true;
+          })
+        )
+      )
+    );
+
+    expect(resumed).toBe(false);
+    await Promise.resolve();
+    expect(resumed).toBe(false);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(resumed).toBe(true);
+  });
+
+  it("rejects effects with service requirements at the type level", () => {
+    class Probe extends Context.Service<Probe, { readonly name: string }>()("test/Probe") {}
+    const needsService: Effect.Effect<void, never, Probe> = Effect.void;
+    // @ts-expect-error -- EffectRunner is not a service locator: R must be never.
+    defaultEffectRunner.runSync(needsService);
+  });
+});
+
+describe("makeTestEffectRunner", () => {
+  it("runFork reaches its first sleep synchronously and adjust resumes it with its continuation", async () => {
+    const clock = makeTestEffectRunner();
+    try {
+      const steps: string[] = [];
+      clock.runner.runFork(
+        Effect.gen(function* () {
+          steps.push("before-sleep");
+          yield* Effect.sleep(Duration.minutes(1));
+          steps.push("after-sleep");
+        })
+      );
+      expect(steps).toEqual(["before-sleep"]);
+
+      await clock.adjust(Duration.seconds(59));
+      expect(steps).toEqual(["before-sleep"]);
+
+      // The due sleep and its synchronous continuation run before adjust resolves.
+      await clock.adjust(Duration.seconds(1));
+      expect(steps).toEqual(["before-sleep", "after-sleep"]);
+    } finally {
+      await clock.dispose();
+    }
+  });
+
+  it("drives a Schedule.fixed cadence one tick per interval, including nested due sleeps", async () => {
+    const clock = makeTestEffectRunner();
+    try {
+      let ticks = 0;
+      const scope = Scope.makeUnsafe();
+      clock.runner.runSync(
+        Effect.forkIn(
+          Effect.gen(function* () {
+            yield* Effect.sleep(Duration.seconds(60));
+            yield* Effect.sync(() => {
+              ticks += 1;
+            }).pipe(Effect.repeat(Schedule.fixed(Duration.seconds(30))));
+          }),
+          scope
+        )
+      );
+
+      await clock.adjust(Duration.seconds(60));
+      expect(ticks).toBe(1);
+      await clock.adjust(Duration.seconds(30));
+      expect(ticks).toBe(2);
+      // One adjust spanning two intervals fires both slots (the second sleep is
+      // registered while the first resumes, still inside the adjust window).
+      await clock.adjust(Duration.seconds(60));
+      expect(ticks).toBe(4);
+
+      clock.runner.runSync(Scope.close(scope, Exit.void));
+      await clock.adjust(Duration.seconds(90));
+      expect(ticks).toBe(4);
+    } finally {
+      await clock.dispose();
+    }
+  });
+
+  it("closes a scope owning a TestClock-suspended fiber synchronously", async () => {
+    const clock = makeTestEffectRunner();
+    try {
+      const scope = Scope.makeUnsafe();
+      let interrupted = false;
+      const fiber = clock.runner.runSync(
+        Effect.forkIn(
+          Effect.sleep(Duration.hours(1)).pipe(
+            Effect.onInterrupt(() =>
+              Effect.sync(() => {
+                interrupted = true;
+              })
+            )
+          ),
+          scope
+        )
+      );
+
+      // The worker stop() contract: the close completes synchronously because
+      // the fiber only suspends on its clock, TestClock included.
+      clock.runner.runSync(Scope.close(scope, Exit.void));
+
+      expect(interrupted).toBe(true);
+      expect(fiber.pollUnsafe()).toBeDefined();
+    } finally {
+      await clock.dispose();
+    }
+  });
+});

--- a/src/node/services/di/effectRunner.ts
+++ b/src/node/services/di/effectRunner.ts
@@ -1,0 +1,82 @@
+/**
+ * `EffectRunner` — the context-bound, *unsupervised* runner seam (Effect
+ * migration Phase 11, PR 2).
+ *
+ * Clock-driven workers (heartbeat, idle compaction, retry backoff) run their
+ * lifecycle fibers through an `EffectRunner` instead of the global
+ * `Effect.runX`. The runner is a thin `Effect.run…With(context)` bundle, so:
+ *
+ * - **Same start semantics as `Effect.runX`.** `runSync` completes
+ *   synchronously (a fiber that suspends is a defect, exactly like
+ *   `Effect.runSync`), and `runFork` executes the fiber up to its first async
+ *   boundary before returning — the ordering the workers' `start()`/`stop()`
+ *   contracts rely on.
+ * - **Unsupervised.** Fibers forked through it belong to the worker's own
+ *   `Scope` (explicit `start()`/`stop()`), not to the app runtime:
+ *   `runtime.dispose()` neither interrupts nor awaits them, and a late worker
+ *   callback after dispose cannot hit "ManagedRuntime disposed". Work that
+ *   must be awaited on shutdown forks into `AppFiberScope` instead
+ *   (`./appFiberScope.ts`).
+ * - **Not a service locator.** Every method accepts only `Effect<A, E, never>`:
+ *   defaulted references such as `Clock` do not appear in `R`, so a
+ *   context-bound runner lets a worker run on a `TestClock`, while anything
+ *   that needs a service must take it as an explicit constructor dependency.
+ *
+ * `defaultEffectRunner` is the global runtime (today's exact behavior) and is
+ * the default for every constructor parameter that accepts a runner, so
+ * direct construction in tests and CLI roots is unchanged.
+ */
+import { Context, Effect, Layer, Scheduler, Scope } from "effect";
+import type { Exit, Fiber } from "effect";
+
+export interface EffectRunner {
+  runSync<A, E>(effect: Effect.Effect<A, E, never>): A;
+  runSyncExit<A, E>(effect: Effect.Effect<A, E, never>): Exit.Exit<A, E>;
+  runFork<A, E>(effect: Effect.Effect<A, E, never>): Fiber.Fiber<A, E>;
+  runPromise<A, E>(effect: Effect.Effect<A, E, never>): Promise<A>;
+  runPromiseExit<A, E>(effect: Effect.Effect<A, E, never>): Promise<Exit.Exit<A, E>>;
+}
+
+/** The global Effect runtime — what every worker used before the seam existed. */
+export const defaultEffectRunner: EffectRunner = {
+  runSync: Effect.runSync,
+  runSyncExit: Effect.runSyncExit,
+  runFork: Effect.runFork,
+  runPromise: Effect.runPromise,
+  runPromiseExit: Effect.runPromiseExit,
+};
+
+/** A runner whose fibers start with `context` (its `Clock` and other refs). */
+export function effectRunnerFromContext(context: Context.Context<never>): EffectRunner {
+  return {
+    runSync: Effect.runSyncWith(context),
+    runSyncExit: Effect.runSyncExitWith(context),
+    runFork: Effect.runForkWith(context),
+    runPromise: Effect.runPromiseWith(context),
+    runPromiseExit: Effect.runPromiseExitWith(context),
+  };
+}
+
+export class EffectRunnerTag extends Context.Service<EffectRunnerTag, EffectRunner>()(
+  "xum/EffectRunner"
+) {}
+
+/**
+ * Captures the building fiber's context, so the runner carries whatever the
+ * layers beneath it provide (stores, and in tests a `TestClock` as the `Clock`
+ * reference). Place it at the base of the graph.
+ *
+ * Build-fiber artifacts are stripped because they are not services: the layer
+ * `Scope` (unsupervised fibers must not hold the runtime's scope), the layer
+ * memo map, and the eager `runSync` build's microtask scheduler — without the
+ * omit, every fiber forked through the runner would be scheduled on that
+ * scheduler instead of the default one `Effect.runFork` uses.
+ */
+export const EffectRunnerLive: Layer.Layer<EffectRunnerTag> = Layer.effect(
+  EffectRunnerTag,
+  Effect.map(Effect.context<never>(), (context) =>
+    effectRunnerFromContext(
+      Context.omit(Scope.Scope, Layer.CurrentMemoMap, Scheduler.Scheduler)(context)
+    )
+  )
+);

--- a/src/node/services/di/layers/app.ts
+++ b/src/node/services/di/layers/app.ts
@@ -1,5 +1,7 @@
 import { Layer } from "effect";
 import type { ConfigStores } from "@/node/config";
+import { AppFiberScopeLive } from "@/node/services/di/appFiberScope";
+import { EffectRunnerLive } from "@/node/services/di/effectRunner";
 import type { AppTags } from "@/node/services/di/tags";
 import { MemoryMetaLive } from "./core";
 import { StoresLive } from "./stores";
@@ -12,7 +14,14 @@ import { StoresLive } from "./stores";
  * right-hand operand satisfies the left-hand operand's requirements and both
  * stay exposed in the final context. `Layer.mergeAll` is only for true
  * siblings; it does not satisfy one sibling's requirements from another.
+ *
+ * The runtime seams sit at the base, above the stores: `EffectRunnerLive`
+ * captures its building context, so placing it there keeps that context to the
+ * stores plus references (`Clock`, …).
  */
 export function AppLive(stores: ConfigStores): Layer.Layer<AppTags> {
-  return MemoryMetaLive.pipe(Layer.provideMerge(StoresLive(stores)));
+  const runtimeSeams = AppFiberScopeLive.pipe(
+    Layer.provideMerge(EffectRunnerLive.pipe(Layer.provideMerge(StoresLive(stores))))
+  );
+  return MemoryMetaLive.pipe(Layer.provideMerge(runtimeSeams));
 }

--- a/src/node/services/di/tags.ts
+++ b/src/node/services/di/tags.ts
@@ -20,6 +20,8 @@ import type {
   WorkspaceSessionLocator,
 } from "@/node/config";
 import type { MemoryMetaService } from "@/node/services/memoryMeta";
+import type { AppFiberScopeTag } from "./appFiberScope";
+import type { EffectRunnerTag } from "./effectRunner";
 
 export class ConfigTag extends Context.Service<ConfigTag, Config>()("xum/Config") {}
 export class SessionLocatorTag extends Context.Service<
@@ -50,5 +52,11 @@ export type StoreTags =
   | SecretsStoreTag
   | FileLeaseManagerTag;
 
+/**
+ * The runtime seams provided at the base of every graph (`./effectRunner.ts`,
+ * `./appFiberScope.ts`); their tags live next to their layers.
+ */
+export type RuntimeSeamTags = EffectRunnerTag | AppFiberScopeTag;
+
 /** Every service the desktop/server app graph (`AppLive`) provides. */
-export type AppTags = StoreTags | MemoryMeta;
+export type AppTags = StoreTags | RuntimeSeamTags | MemoryMeta;

--- a/src/node/services/di/testEffectRunner.ts
+++ b/src/node/services/di/testEffectRunner.ts
@@ -1,0 +1,37 @@
+/**
+ * Test helper: an `EffectRunner` bound to a `TestClock`, so a worker
+ * constructed with `runner` sleeps on virtual time that the test advances with
+ * `adjust`/`setTime` (no real timers, no polling).
+ *
+ * Built exactly like production (`EffectRunnerLive` at the base of a
+ * `makeAppRuntime` graph) with `TestClock.layer()` as the provider, so the
+ * worker under test and the test's `adjust` share one clock. `adjust` resolves
+ * after every due sleep has been resumed and its synchronous continuation has
+ * run (pinned in `testEffectRunner.test.ts`).
+ */
+import { Layer } from "effect";
+import type { Duration } from "effect";
+import { TestClock } from "effect/testing";
+import { disposeAppRuntime, makeAppRuntime } from "./appRuntime";
+import { EffectRunnerLive, EffectRunnerTag, type EffectRunner } from "./effectRunner";
+
+export interface TestEffectRunner {
+  readonly runner: EffectRunner;
+  /** Advance the test clock, running every sleep due on or before the new time. */
+  adjust(duration: Duration.Input): Promise<void>;
+  /** Set the test clock to an absolute time (ms since epoch); same firing rule. */
+  setTime(timestampMs: number): Promise<void>;
+  dispose(): Promise<void>;
+}
+
+export function makeTestEffectRunner(options?: TestClock.TestClock.Options): TestEffectRunner {
+  const app = makeAppRuntime(EffectRunnerLive.pipe(Layer.provideMerge(TestClock.layer(options))));
+  const runner = app.get(EffectRunnerTag);
+  return {
+    runner,
+    // Run through the runner so `TestClock.adjust` reads the captured clock.
+    adjust: (duration) => runner.runPromise(TestClock.adjust(duration)),
+    setTime: (timestampMs) => runner.runPromise(TestClock.setTime(timestampMs)),
+    dispose: () => disposeAppRuntime(app.managed),
+  };
+}

--- a/src/node/services/heartbeatService.testClock.test.ts
+++ b/src/node/services/heartbeatService.testClock.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { EventEmitter } from "events";
+import { Duration } from "effect";
+import type { ProjectsConfig } from "@/common/types/project";
+import type { Config } from "@/node/config";
+import { makeTestEffectRunner, type TestEffectRunner } from "./di/testEffectRunner";
+import type { ExtensionMetadataService } from "./ExtensionMetadataService";
+import { CHECK_INTERVAL_MS, HeartbeatService, STARTUP_DELAY_MS } from "./heartbeatService";
+import type { TaskService } from "./taskService";
+import type { WorkspaceService } from "./workspaceService";
+
+/**
+ * Cadence on virtual time. The real-timer suite (`heartbeatService.test.ts`)
+ * keeps exercising the default runner; this one drives the scheduler fiber
+ * through a TestClock-bound `EffectRunner`.
+ */
+describe("HeartbeatService on a TestClock", () => {
+  let clock: TestEffectRunner;
+  let service: HeartbeatService;
+  // Every tick starts with a synchronous getAllSnapshots() call, so its call
+  // count is the tick count.
+  let getAllSnapshotsMock: ReturnType<typeof mock<() => Promise<Map<string, never>>>>;
+
+  beforeEach(() => {
+    clock = makeTestEffectRunner();
+    getAllSnapshotsMock = mock(() => Promise.resolve(new Map<string, never>()));
+    const config = {
+      loadConfigOrDefault: mock((): ProjectsConfig => ({ projects: new Map() })),
+    } as unknown as Config;
+    const extensionMetadata = {
+      getAllSnapshots: getAllSnapshotsMock,
+      getSnapshot: mock(() => Promise.resolve(null)),
+    } as unknown as ExtensionMetadataService;
+    const workspaceService = Object.assign(new EventEmitter(), {
+      getChatHistory: mock(() => Promise.resolve([])),
+      executeHeartbeat: mock(() => Promise.resolve()),
+      isBusyForMessage: mock(() => false),
+    }) as unknown as WorkspaceService;
+    const taskService = {
+      hasActiveDescendantAgentTasksForWorkspace: mock(() => false),
+    } as unknown as TaskService;
+
+    service = new HeartbeatService(
+      config,
+      extensionMetadata,
+      workspaceService,
+      taskService,
+      undefined,
+      clock.runner
+    );
+  });
+
+  afterEach(async () => {
+    service.stop();
+    await clock.dispose();
+  });
+
+  test("first tick after the startup delay, then one per check interval, none after stop()", async () => {
+    service.start();
+    expect(getAllSnapshotsMock).toHaveBeenCalledTimes(0);
+
+    await clock.adjust(Duration.millis(STARTUP_DELAY_MS - 1));
+    expect(getAllSnapshotsMock).toHaveBeenCalledTimes(0);
+
+    await clock.adjust(Duration.millis(1));
+    expect(getAllSnapshotsMock).toHaveBeenCalledTimes(1);
+
+    await clock.adjust(Duration.millis(CHECK_INTERVAL_MS - 1));
+    expect(getAllSnapshotsMock).toHaveBeenCalledTimes(1);
+    await clock.adjust(Duration.millis(1));
+    expect(getAllSnapshotsMock).toHaveBeenCalledTimes(2);
+    await clock.adjust(Duration.millis(CHECK_INTERVAL_MS));
+    expect(getAllSnapshotsMock).toHaveBeenCalledTimes(3);
+
+    service.stop();
+    await clock.adjust(Duration.millis(CHECK_INTERVAL_MS * 3));
+    expect(getAllSnapshotsMock).toHaveBeenCalledTimes(3);
+  });
+
+  test("stop() during the startup delay cancels the first tick", async () => {
+    service.start();
+    await clock.adjust(Duration.millis(STARTUP_DELAY_MS / 2));
+
+    service.stop();
+
+    await clock.adjust(Duration.millis(STARTUP_DELAY_MS + CHECK_INTERVAL_MS));
+    expect(getAllSnapshotsMock).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/node/services/heartbeatService.ts
+++ b/src/node/services/heartbeatService.ts
@@ -13,6 +13,7 @@ import {
   type HeartbeatTrigger,
 } from "@/constants/heartbeat";
 import type { Config } from "@/node/config";
+import { defaultEffectRunner, type EffectRunner } from "./di/effectRunner";
 import type { ExtensionMetadataService } from "./ExtensionMetadataService";
 import { IdleDispatcher, type IdleDispatchPayload } from "./idleDispatcher";
 import { log } from "./log";
@@ -20,8 +21,8 @@ import type { TaskService } from "./taskService";
 import { NOOP_TIMELINE_RECORDER, type TimelineRecorder } from "./timelineRecorder";
 import type { WorkspaceService } from "./workspaceService";
 
-const STARTUP_DELAY_MS = 60 * 1000; // 60s - let startup settle
-const CHECK_INTERVAL_MS = 30 * 1000; // 30s tick
+export const STARTUP_DELAY_MS = 60 * 1000; // 60s - let startup settle
+export const CHECK_INTERVAL_MS = 30 * 1000; // 30s tick
 const MAX_CONCURRENT_HEARTBEATS = 1;
 const HEARTBEAT_IDLE_CONSUMER_NAME = "heartbeat";
 const HEARTBEAT_IDLE_CONSUMER_PRIORITY = 50;
@@ -59,6 +60,12 @@ export class HeartbeatService {
   private readonly workspaceService: WorkspaceService;
   private readonly taskService: TaskService;
   private readonly idleDispatcher: IdleDispatcher;
+  /**
+   * Runs the lifecycle effects below (scope acquisition, scheduler fork, scope
+   * close). Context-bound in the app (so the scheduler fiber reads the
+   * runtime's `Clock` — a `TestClock` in tests); the global runtime by default.
+   */
+  private readonly runner: EffectRunner;
 
   private timelineRecorder: TimelineRecorder = NOOP_TIMELINE_RECORDER;
 
@@ -104,13 +111,15 @@ export class HeartbeatService {
     extensionMetadata: ExtensionMetadataService,
     workspaceService: WorkspaceService,
     taskService: TaskService,
-    idleDispatcher?: IdleDispatcher
+    idleDispatcher?: IdleDispatcher,
+    runner: EffectRunner = defaultEffectRunner
   ) {
     this.config = config;
     this.extensionMetadata = extensionMetadata;
     this.workspaceService = workspaceService;
     this.taskService = taskService;
     this.idleDispatcher = idleDispatcher ?? new IdleDispatcher();
+    this.runner = runner;
 
     this.onActivity = (event) => this.handleActivityEvent(event);
     this.onMetadata = (event) => this.handleMetadataEvent(event);
@@ -200,7 +209,7 @@ export class HeartbeatService {
       // the scheduler up to its first sleep before returning, so the startup
       // timer is registered before start() returns (same observable ordering
       // as the previous setTimeout call).
-      Effect.runSync(Scope.provide(scope)(acquireResources));
+      this.runner.runSync(Scope.provide(scope)(acquireResources));
     } catch (error) {
       // Guaranteed cleanup on partial startup failure: close the scope so the
       // finalizers registered before the failing step run (the hand-rolled
@@ -210,7 +219,7 @@ export class HeartbeatService {
       this.startupTimeout = null;
       this.checkInterval = null;
       this.stopped = true;
-      Effect.runSync(Scope.close(scope, Exit.void));
+      this.runner.runSync(Scope.close(scope, Exit.void));
       throw error;
     }
 
@@ -239,7 +248,7 @@ export class HeartbeatService {
       // scheduler fiber interrupt (synchronously clearing its pending timer),
       // listeners off, consumer disposer — completing synchronously because
       // the fiber only ever suspends on its clock timer.
-      Effect.runSync(Scope.close(scope, Exit.void));
+      this.runner.runSync(Scope.close(scope, Exit.void));
     }
     this.startupTimeout = null;
     this.checkInterval = null;

--- a/src/node/services/idleCompactionService.testClock.test.ts
+++ b/src/node/services/idleCompactionService.testClock.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Duration } from "effect";
+import type { ProjectsConfig } from "@/common/types/project";
+import type { Config } from "@/node/config";
+import { makeTestEffectRunner, type TestEffectRunner } from "./di/testEffectRunner";
+import type { ExtensionMetadataService } from "./ExtensionMetadataService";
+import type { HistoryService } from "./historyService";
+import {
+  CHECK_INTERVAL_MS,
+  IdleCompactionService,
+  INITIAL_CHECK_DELAY_MS,
+} from "./idleCompactionService";
+
+/**
+ * Checker cadence on virtual time (the real-timer suite in
+ * `idleCompactionService.test.ts` keeps covering the default runner).
+ */
+describe("IdleCompactionService on a TestClock", () => {
+  let clock: TestEffectRunner;
+  let service: IdleCompactionService;
+  // checkAllWorkspaces() reads the config synchronously first, so with no
+  // projects configured its call count is the check count.
+  let loadConfigMock: ReturnType<typeof mock<() => ProjectsConfig>>;
+
+  beforeEach(() => {
+    clock = makeTestEffectRunner();
+    loadConfigMock = mock((): ProjectsConfig => ({ projects: new Map() }));
+    service = new IdleCompactionService(
+      { loadConfigOrDefault: loadConfigMock } as unknown as Config,
+      {} as HistoryService,
+      {} as ExtensionMetadataService,
+      () => Promise.resolve(),
+      clock.runner
+    );
+  });
+
+  afterEach(async () => {
+    service.stop();
+    await clock.dispose();
+  });
+
+  test("first check after the initial delay, then one per interval, none after stop()", async () => {
+    service.start();
+    expect(loadConfigMock).toHaveBeenCalledTimes(0);
+
+    await clock.adjust(Duration.millis(INITIAL_CHECK_DELAY_MS - 1));
+    expect(loadConfigMock).toHaveBeenCalledTimes(0);
+    await clock.adjust(Duration.millis(1));
+    expect(loadConfigMock).toHaveBeenCalledTimes(1);
+
+    await clock.adjust(Duration.millis(CHECK_INTERVAL_MS));
+    expect(loadConfigMock).toHaveBeenCalledTimes(2);
+    // Sweeps are fire-and-forget, so an adjust spanning two slots fires both.
+    await clock.adjust(Duration.millis(CHECK_INTERVAL_MS * 2));
+    expect(loadConfigMock).toHaveBeenCalledTimes(4);
+
+    service.stop();
+    await clock.adjust(Duration.millis(CHECK_INTERVAL_MS * 3));
+    expect(loadConfigMock).toHaveBeenCalledTimes(4);
+  });
+
+  test("stop() during the initial delay cancels the first check", async () => {
+    service.start();
+    await clock.adjust(Duration.millis(INITIAL_CHECK_DELAY_MS / 2));
+
+    service.stop();
+
+    await clock.adjust(Duration.millis(INITIAL_CHECK_DELAY_MS + CHECK_INTERVAL_MS));
+    expect(loadConfigMock).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/node/services/idleCompactionService.ts
+++ b/src/node/services/idleCompactionService.ts
@@ -1,13 +1,14 @@
 import { Duration, Effect, Exit, Schedule, Scope } from "effect";
 import assert from "@/common/utils/assert";
 import type { Config } from "@/node/config";
+import { defaultEffectRunner, type EffectRunner } from "./di/effectRunner";
 import type { HistoryService } from "./historyService";
 import type { ExtensionMetadataService } from "./ExtensionMetadataService";
 import { computeRecencyFromMessages } from "@/common/utils/recency";
 import { log } from "./log";
 
-const INITIAL_CHECK_DELAY_MS = 60 * 1000; // 1 minute - let startup initialization settle
-const CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+export const INITIAL_CHECK_DELAY_MS = 60 * 1000; // 1 minute - let startup initialization settle
+export const CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 const HOURS_TO_MS = 60 * 60 * 1000;
 
 /**
@@ -46,6 +47,12 @@ export class IdleCompactionService {
   private readonly extensionMetadata: ExtensionMetadataService;
   private readonly executeIdleCompaction: (workspaceId: string) => Promise<void>;
   /**
+   * Runs the checker fork and the scope close. Context-bound in the app (the
+   * checker reads the runtime's `Clock` — a `TestClock` in tests); the global
+   * runtime by default.
+   */
+  private readonly runner: EffectRunner;
+  /**
    * Owns the checker fiber forked by start(): sleep(INITIAL_CHECK_DELAY_MS),
    * then check immediately and every CHECK_INTERVAL_MS. Closing the scope in
    * stop() interrupts the fiber, synchronously clearing its pending timer.
@@ -66,12 +73,14 @@ export class IdleCompactionService {
     config: Config,
     historyService: HistoryService,
     extensionMetadata: ExtensionMetadataService,
-    executeIdleCompaction: (workspaceId: string) => Promise<void>
+    executeIdleCompaction: (workspaceId: string) => Promise<void>,
+    runner: EffectRunner = defaultEffectRunner
   ) {
     this.config = config;
     this.historyService = historyService;
     this.extensionMetadata = extensionMetadata;
     this.executeIdleCompaction = executeIdleCompaction;
+    this.runner = runner;
   }
 
   /**
@@ -100,7 +109,7 @@ export class IdleCompactionService {
     // Runs synchronously up to the checker's first sleep, so the initial-delay
     // timer is registered before start() returns (same as the previous
     // setTimeout call).
-    Effect.runSync(Effect.forkIn(checker, scope));
+    this.runner.runSync(Effect.forkIn(checker, scope));
 
     log.info("IdleCompactionService started", {
       initialDelayMs: INITIAL_CHECK_DELAY_MS,
@@ -119,7 +128,7 @@ export class IdleCompactionService {
       this.lifecycleScope = null;
       // Interrupts the checker fiber, synchronously clearing its pending
       // timer — the fiber only ever suspends on its clock timer.
-      Effect.runSync(Scope.close(scope, Exit.void));
+      this.runner.runSync(Scope.close(scope, Exit.void));
     }
 
     // Best-effort queue reset: do not start new compactions after stop().

--- a/src/node/services/retryManager.testClock.test.ts
+++ b/src/node/services/retryManager.testClock.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { Duration } from "effect";
+import { calculateBackoffDelay } from "@/common/utils/messages/retryState";
+import { makeTestEffectRunner, type TestEffectRunner } from "./di/testEffectRunner";
+import { RetryManager, type RetryStatusEvent } from "./retryManager";
+
+/**
+ * Backoff timing on virtual time (the real-timer suite in
+ * `retryManager.test.ts` keeps covering the default runner, which today's
+ * streamManager call site still uses).
+ */
+describe("RetryManager on a TestClock", () => {
+  let clock: TestEffectRunner;
+  let manager: RetryManager;
+  let onRetry: ReturnType<typeof mock<() => Promise<void>>>;
+  let events: RetryStatusEvent[];
+
+  beforeEach(() => {
+    clock = makeTestEffectRunner();
+    onRetry = mock(() => Promise.resolve());
+    events = [];
+    manager = new RetryManager(
+      "workspace-1",
+      onRetry,
+      (event) => {
+        events.push(event);
+      },
+      clock.runner
+    );
+  });
+
+  afterEach(async () => {
+    manager.dispose();
+    await clock.dispose();
+  });
+
+  it("fires exactly at the backoff delay", async () => {
+    manager.handleStreamFailure({ type: "unknown", message: "transient" });
+    const delayMs = calculateBackoffDelay(1);
+    expect(events.map((event) => event.type)).toEqual(["auto-retry-scheduled"]);
+    expect(manager.isRetryPending).toBe(true);
+
+    await clock.adjust(Duration.millis(delayMs - 1));
+    expect(onRetry).not.toHaveBeenCalled();
+    expect(manager.isRetryPending).toBe(true);
+
+    await clock.adjust(Duration.millis(1));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(manager.isRetryPending).toBe(false);
+    expect(events.map((event) => event.type)).toEqual([
+      "auto-retry-scheduled",
+      "auto-retry-starting",
+    ]);
+  });
+
+  it("cancel() before the delay elapses means the retry never fires", async () => {
+    manager.handleStreamFailure({ type: "unknown", message: "transient" });
+    manager.cancel();
+    expect(manager.isRetryPending).toBe(false);
+
+    await clock.adjust(Duration.millis(calculateBackoffDelay(1) * 10));
+
+    expect(onRetry).not.toHaveBeenCalled();
+    expect(events.map((event) => event.type)).toEqual(["auto-retry-scheduled"]);
+  });
+
+  it("a second failure before the delay reschedules with the next backoff", async () => {
+    manager.handleStreamFailure({ type: "unknown" });
+    await clock.adjust(Duration.millis(calculateBackoffDelay(1) - 1));
+    manager.handleStreamFailure({ type: "unknown" });
+    const secondDelayMs = calculateBackoffDelay(2);
+
+    // The superseded timer is gone: only the new one can fire.
+    await clock.adjust(Duration.millis(secondDelayMs - 1));
+    expect(onRetry).not.toHaveBeenCalled();
+    await clock.adjust(Duration.millis(1));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/node/services/retryManager.ts
+++ b/src/node/services/retryManager.ts
@@ -10,6 +10,7 @@ import {
   isNonRetryableSendError,
   isNonRetryableStreamError,
 } from "@/common/utils/messages/retryEligibility";
+import { defaultEffectRunner, type EffectRunner } from "./di/effectRunner";
 
 export interface RetryFailureError {
   type: string;
@@ -63,7 +64,14 @@ export class RetryManager {
   constructor(
     private readonly workspaceId: string,
     private readonly onRetry: () => Promise<void>,
-    private readonly onStatusChange: (event: RetryStatusEvent) => void
+    private readonly onStatusChange: (event: RetryStatusEvent) => void,
+    /**
+     * Runs the retry fiber fork and its interrupt. The global runtime by
+     * default (the streamManager call site keeps it until the runtime seam
+     * reaches StreamManager); a context-bound runner puts the backoff sleep on
+     * the runtime's `Clock` — a `TestClock` in tests.
+     */
+    private readonly runner: EffectRunner = defaultEffectRunner
   ) {
     assert(this.workspaceId.trim().length > 0, "RetryManager: workspaceId must be non-empty");
     assert(typeof this.onRetry === "function", "RetryManager: onRetry must be a function");
@@ -118,7 +126,7 @@ export class RetryManager {
   }
 
   /**
-   * Fork the retry fiber. `Effect.runFork` executes synchronously up to the
+   * Fork the retry fiber. `runner.runFork` executes synchronously up to the
    * sleep, so the backoff timer is registered before this method returns —
    * the same observable ordering as the previous `setTimeout` call.
    *
@@ -131,7 +139,7 @@ export class RetryManager {
     // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
     const self = this;
     this.retryPending = true;
-    this.retryFiber = Effect.runFork(
+    this.retryFiber = this.runner.runFork(
       Effect.gen(function* () {
         yield* Effect.sleep(Duration.millis(delayMs));
         self.retryPending = false;
@@ -195,7 +203,7 @@ export class RetryManager {
       this.retryPending = false;
       // Fire-and-forget: the interrupt signal lands synchronously; awaiting
       // full fiber exit is unnecessary (and impossible from sync callers).
-      Effect.runFork(Fiber.interrupt(fiber));
+      this.runner.runFork(Fiber.interrupt(fiber));
     }
   }
 

--- a/src/node/services/serviceContainer.test.ts
+++ b/src/node/services/serviceContainer.test.ts
@@ -2,9 +2,12 @@ import * as path from "path";
 import * as fs from "fs";
 import * as os from "os";
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
-import { Context, Layer } from "effect";
+import { Context, Duration, Effect, Layer } from "effect";
+import { TestClock } from "effect/testing";
 import { MULTI_PROJECT_CONFIG_KEY } from "@/common/constants/multiProject";
 import { createConfigStores, type Config, type ConfigStores } from "@/node/config";
+import { AppFiberScopeTag } from "@/node/services/di/appFiberScope";
+import { EffectRunnerTag } from "@/node/services/di/effectRunner";
 import * as appLayers from "@/node/services/di/layers/app";
 import { MemoryMeta } from "@/node/services/di/tags";
 import { ServiceContainer } from "./serviceContainer";
@@ -141,6 +144,88 @@ describe("ServiceContainer", () => {
     // ManagedRuntime clears its cached context when its scope closes.
     expect(services.runtime.managed.cachedContext).toBeUndefined();
     // The afterEach dispose()+shutdown() pair then exercises the latched path.
+  });
+
+  it("exposes the runtime seams through the field and the Effect context", () => {
+    services = new ServiceContainer(stores);
+
+    const effectContext = services.toORPCContext()["effect/context"];
+
+    expect(Context.get(effectContext, AppFiberScopeTag)).toBe(services.appFiberScope);
+    expect(services.appFiberScope.state._tag).not.toBe("Closed");
+    expect(Context.get(effectContext, EffectRunnerTag)).toBe(services.runtime.get(EffectRunnerTag));
+  });
+
+  it("closes the AppFiberScope (interrupt + await) before the explicit teardown steps", async () => {
+    services = new ServiceContainer(stores);
+    const steps: string[] = [];
+    // An I/O-suspended occupant: never resolves on its own, records its cancel
+    // path and finalizer. Supervised fibers must be gone before any explicit
+    // teardown step so they can still use their dependencies while finalizing.
+    services.runtime.managed.runSync(
+      Effect.forkIn(
+        Effect.callback<void>(() =>
+          Effect.sync(() => {
+            steps.push("occupant-cancelled");
+          })
+        ).pipe(Effect.ensuring(Effect.sync(() => steps.push("occupant-finalized")))),
+        services.appFiberScope
+      )
+    );
+    // desktopBridgeServer.stop() is the first explicit teardown step after the
+    // shutdown latch.
+    const bridgeStopSpy = spyOn(services.desktopBridgeServer, "stop").mockImplementation(() => {
+      steps.push("bridge-stop");
+      return Promise.resolve(undefined);
+    });
+
+    await services.dispose();
+
+    expect(bridgeStopSpy).toHaveBeenCalledTimes(1);
+    expect(steps).toEqual(["occupant-cancelled", "occupant-finalized", "bridge-stop"]);
+    expect(services.appFiberScope.state._tag).toBe("Closed");
+  });
+
+  it("runs the clock-driven workers on the runtime's clock", async () => {
+    // Inject a TestClock beneath the real graph: EffectRunnerLive captures it,
+    // so the workers' lifecycle fibers sleep on virtual time if (and only if)
+    // the container hands them the runtime's runner.
+    const realAppLive = appLayers.AppLive;
+    const appLiveSpy = spyOn(appLayers, "AppLive").mockImplementation((appStores) =>
+      realAppLive(appStores).pipe(Layer.provideMerge(TestClock.layer()))
+    );
+    try {
+      services = new ServiceContainer(stores);
+    } finally {
+      appLiveSpy.mockRestore();
+    }
+    const runtime = services.runtime.managed;
+    // IdleCompactionService.checkAllWorkspaces reads the config synchronously
+    // at the start of every check.
+    const loadConfigSpy = spyOn(services.config, "loadConfigOrDefault");
+    // HeartbeatService's observable lifecycle contract: the scheduler fiber is
+    // held in `startupTimeout` during the startup delay and moves to
+    // `checkInterval` once ticking (same shape heartbeatService.test.ts pins).
+    const heartbeatInternals = services.heartbeatService as unknown as {
+      startupTimeout: unknown;
+      checkInterval: unknown;
+    };
+
+    services.idleCompactionService.start();
+    services.heartbeatService.start();
+    expect(loadConfigSpy).not.toHaveBeenCalled();
+    expect(heartbeatInternals.startupTimeout).not.toBeNull();
+    expect(heartbeatInternals.checkInterval).toBeNull();
+
+    // Both workers wait one minute before their first tick.
+    await runtime.runPromise(TestClock.adjust(Duration.minutes(1)));
+
+    expect(loadConfigSpy).toHaveBeenCalledTimes(1);
+    expect(heartbeatInternals.startupTimeout).toBeNull();
+    expect(heartbeatInternals.checkInterval).not.toBeNull();
+
+    services.heartbeatService.stop();
+    services.idleCompactionService.stop();
   });
 
   it("surfaces a throwing layer as a synchronous constructor throw", () => {

--- a/src/node/services/serviceContainer.test.ts
+++ b/src/node/services/serviceContainer.test.ts
@@ -186,6 +186,36 @@ describe("ServiceContainer", () => {
     expect(services.appFiberScope.state._tag).toBe("Closed");
   });
 
+  it("shares one teardown across concurrent dispose() calls", async () => {
+    services = new ServiceContainer(stores);
+    const steps: string[] = [];
+    // An occupant whose finalization is asynchronous: the first dispose() is
+    // still awaiting it when the second dispose() arrives. Without a shared
+    // teardown the second call would find the scope already marked closed and
+    // proceed to the explicit steps while this finalizer is still running.
+    services.runtime.managed.runSync(
+      Effect.forkIn(
+        Effect.callback<void>(() => Effect.void).pipe(
+          Effect.ensuring(
+            Effect.promise(() => new Promise<void>((resolve) => setTimeout(resolve, 30))).pipe(
+              Effect.andThen(Effect.sync(() => steps.push("occupant-finalized")))
+            )
+          )
+        ),
+        services.appFiberScope
+      )
+    );
+    const bridgeStopSpy = spyOn(services.desktopBridgeServer, "stop").mockImplementation(() => {
+      steps.push("bridge-stop");
+      return Promise.resolve(undefined);
+    });
+
+    await Promise.all([services.dispose(), services.dispose()]);
+
+    expect(bridgeStopSpy).toHaveBeenCalledTimes(1);
+    expect(steps).toEqual(["occupant-finalized", "bridge-stop"]);
+  });
+
   it("runs the clock-driven workers on the runtime's clock", async () => {
     // Inject a TestClock beneath the real graph: EffectRunnerLive captures it,
     // so the workers' lifecycle fibers sleep on virtual time if (and only if)

--- a/src/node/services/serviceContainer.ts
+++ b/src/node/services/serviceContainer.ts
@@ -81,7 +81,15 @@ import { DesktopBridgeServer } from "@/node/services/desktop/DesktopBridgeServer
 import { DesktopSessionManager } from "@/node/services/desktop/DesktopSessionManager";
 import { DesktopTokenManager } from "@/node/services/desktop/DesktopTokenManager";
 import type { ORPCContext } from "@/node/orpc/context";
-import { disposeAppRuntime, makeAppRuntime, type AppRuntime } from "@/node/services/di/appRuntime";
+import type { Scope } from "effect";
+import { AppFiberScopeTag } from "@/node/services/di/appFiberScope";
+import {
+  closeScopeBounded,
+  disposeAppRuntime,
+  makeAppRuntime,
+  type AppRuntime,
+} from "@/node/services/di/appRuntime";
+import { EffectRunnerTag } from "@/node/services/di/effectRunner";
 import { AppLive } from "@/node/services/di/layers/app";
 import { MemoryMeta, type AppTags } from "@/node/services/di/tags";
 /**
@@ -97,6 +105,11 @@ import { MemoryMeta, type AppTags } from "@/node/services/di/tags";
  */
 export class ServiceContainer {
   public readonly runtime: AppRuntime<AppTags>;
+  /**
+   * Supervised fiber scope owned by the runtime (`di/appFiberScope.ts`).
+   * Closed early in `dispose()`; no production occupant yet.
+   */
+  public readonly appFiberScope: Scope.Closeable;
   public readonly workflowRuntimeFactory = new QuickJSRuntimeFactory();
   public readonly config: Config;
   public readonly sessionLocator: WorkspaceSessionLocator;
@@ -172,6 +185,10 @@ export class ServiceContainer {
     // constructor, like any service constructor) before the constructor-wired
     // services so layer-provided instances can be passed into them.
     this.runtime = makeAppRuntime(AppLive(stores));
+    this.appFiberScope = this.runtime.get(AppFiberScopeTag);
+    // Clock-driven workers run their lifecycle fibers through the runtime's
+    // context-bound runner (unsupervised; see di/effectRunner.ts).
+    const effectRunner = this.runtime.get(EffectRunnerTag);
     const config = stores.config;
     this.config = config;
     this.sessionLocator = stores.sessionLocator;
@@ -294,7 +311,8 @@ export class ServiceContainer {
       config,
       this.historyService,
       this.extensionMetadata,
-      (workspaceId) => this.workspaceService.executeIdleCompaction(workspaceId)
+      (workspaceId) => this.workspaceService.executeIdleCompaction(workspaceId),
+      effectRunner
     );
     // Forward terminal idle-compaction outcomes so the loop stops re-attempting a
     // persistently failing workspace (immediately on model_not_found, otherwise after
@@ -312,7 +330,8 @@ export class ServiceContainer {
       this.extensionMetadata,
       this.workspaceService,
       this.taskService,
-      this.idleDispatcher
+      this.idleDispatcher,
+      effectRunner
     );
     this.timelineService = new TimelineService(
       config,
@@ -762,6 +781,11 @@ export class ServiceContainer {
     // backgroundProcessManager.cleanup(), which would otherwise erase the persisted
     // armed-monitor registry records that drive post-restart "monitor lost" wakes.
     this.backgroundProcessManager.beginShutdown();
+    // Interrupt and await the runtime's supervised fibers while every dependency
+    // they might touch during finalization is still alive. Fixed here (before
+    // the explicit teardown) so later occupants do not re-derive the position;
+    // bounded and idempotent, and never rejects (di/appRuntime.ts).
+    await closeScopeBounded(this.appFiberScope);
     // Stop the bridge before closing sessions so desktop clients get a clean disconnect.
     await this.desktopBridgeServer.stop();
     this.desktopTokenManager.dispose();

--- a/src/node/services/serviceContainer.ts
+++ b/src/node/services/serviceContainer.ts
@@ -178,7 +178,15 @@ export class ServiceContainer {
   public readonly idleDispatcher: IdleDispatcher;
   public readonly heartbeatService: HeartbeatService;
   public readonly agentStatusService: AgentStatusService;
-  private runtimeDisposed = false;
+  /**
+   * The in-flight (or completed) `dispose()` teardown. Every caller shares it,
+   * so a concurrent or repeated dispose() (the desktop's two before-quit
+   * paths, tests' dispose-then-shutdown) awaits the one sequence instead of
+   * re-running steps — in particular it cannot observe the AppFiberScope as
+   * already closed and start tearing down dependencies while the first call
+   * is still awaiting the scope's fibers.
+   */
+  private disposePromise: Promise<void> | null = null;
 
   constructor(stores: ConfigStores) {
     // Built eagerly and synchronously (a layer body that throws fails the
@@ -774,9 +782,15 @@ export class ServiceContainer {
 
   /**
    * Dispose all services. Called on app quit to clean up resources.
-   * Terminates all background processes to prevent orphans.
+   * Terminates all background processes to prevent orphans. Idempotent:
+   * concurrent and repeated calls share one teardown (see `disposePromise`).
    */
-  async dispose(): Promise<void> {
+  dispose(): Promise<void> {
+    this.disposePromise ??= this.disposeOnce();
+    return this.disposePromise;
+  }
+
+  private async disposeOnce(): Promise<void> {
     // Must run before any session teardown: AgentSession.dispose() triggers
     // backgroundProcessManager.cleanup(), which would otherwise erase the persisted
     // armed-monitor registry records that drive post-restart "monitor lost" wakes.
@@ -816,12 +830,7 @@ export class ServiceContainer {
     await this.timelineService.flush();
     // Last: close the Effect runtime's scope. No layer owns finalizers yet, so
     // this only releases the runtime; the position (after every explicit
-    // teardown step) is fixed now for later scope-owned occupants. Latched so
-    // the concurrent before-quit paths and dispose-then-shutdown callers cannot
-    // race a second close into the bounded wait.
-    if (!this.runtimeDisposed) {
-      this.runtimeDisposed = true;
-      await disposeAppRuntime(this.runtime.managed);
-    }
+    // teardown step) is fixed now for later scope-owned occupants.
+    await disposeAppRuntime(this.runtime.managed);
   }
 }


### PR DESCRIPTION
## Summary

Phase 11 PR 2 of the Effect migration adds the two runtime seams the plan defines and puts the three clock-driven workers on the first one: **`EffectRunner`** (context-bound, *unsupervised*, `R = never` runner — lets `HeartbeatService`, `IdleCompactionService` and `RetryManager` run on the app runtime's `Clock`, i.e. a `TestClock` in tests) and **`AppFiberScope`** (a runtime-owned, *supervised* `Scope` that `ServiceContainer.dispose()` now closes explicitly and early, bounded, before the hand-ordered teardown). Service constructors gain one trailing optional `runner` parameter defaulting to the global runtime; no call site outside `ServiceContainer` changes, no persisted data or IPC shapes change.

Stacked on #4049 (PR 1). Plan: §2.1 `effectRunner.ts`/`appFiberScope.ts`, §2.3 I2/I5, §3 "PR 2", §4, §5 (full plan in the toggle below).

## Implementation

- `di/effectRunner.ts` — `EffectRunner` interface (`runSync/runSyncExit/runFork/runPromise/runPromiseExit`, accepting only `Effect<A, E, never>`), `defaultEffectRunner` (global `Effect.runX`), `effectRunnerFromContext(ctx)` (`Effect.run…With(ctx)`), `EffectRunnerTag`, `EffectRunnerLive` (captures `Effect.context<never>()` at the base of the graph).
- `di/appFiberScope.ts` — `AppFiberScopeTag: Scope.Closeable`, `AppFiberScopeLive` (synchronous body: child of the runtime's layer scope, parallel finalizers).
- `di/appRuntime.ts` — `closeScopeBounded(scope, timeoutMs)`; shares one `boundedTeardown` shape with `disposeAppRuntime` (uninterruptible shell, detached target fiber, interruptible bounded join, `TimeoutError`/defect → `log.warn`, never rejects, idempotent). `APP_FIBER_SCOPE_CLOSE_TIMEOUT_MS` (2 s) in `src/constants/terminationTimeouts.ts`.
- `layers/app.ts` — `AppLive = MemoryMetaLive ▹ AppFiberScopeLive ▹ EffectRunnerLive ▹ StoresLive`; `AppTags` gains `RuntimeSeamTags`.
- Workers — every lifecycle `Effect.runSync/runFork` in `start/stop/scheduleRetry/interruptRetryFiber` becomes `this.runner.runX`; deadline math (`Date.now()`) untouched. `ServiceContainer` passes `Context.get(ctx, EffectRunnerTag)` to heartbeat and idle compaction; `RetryManager` keeps the default at its `agentSession.ts` call site (StreamManager gets its runner in PR 5).
- `ServiceContainer` — `appFiberScope` field; `dispose()` = `beginShutdown()` → **`closeScopeBounded(appFiberScope)`** → existing explicit sequence → `disposeAppRuntime` (plan §5). `dispose()` is latched as a whole (`disposePromise ??= disposeOnce()`, plan §5.3): concurrent/repeated callers await the one in-flight teardown, so a second caller cannot observe the already-marked-closed scope and run the explicit steps while the first is still awaiting supervised fibers (Codex P2, round 1). This replaces PR 1's runtime-only `runtimeDisposed` latch.
- `di/testEffectRunner.ts` — `makeTestEffectRunner()` → `{ runner, adjust, setTime, dispose }` over `EffectRunnerLive ▹ TestClock.layer()`; the worker under test and `adjust` share one clock.

## PR 2 notes

**Deviations from the plan text**

1. `EffectRunnerLive` strips three *build-fiber artifacts* from the captured context: the layer `Scope`, `Layer.CurrentMemoMap`, and `Scheduler.Scheduler`. The plan assumed `Effect.context<never>()` yields "refs plus stores"; in rc.112 a `Layer.effect` body's fiber context also carries the layer scope, the memo map, and — because `makeAppRuntime` builds eagerly with `runSync` — the **sync (microtask) `MixedScheduler`** of that build. Without the omit every fiber forked through the runner would be scheduled on microtasks instead of the default `setImmediate` scheduler `Effect.runFork` uses. Pinned by `effectRunner.test.ts` ("schedules forked fibers on the default scheduler…", red without the omit).
2. `STARTUP_DELAY_MS`/`CHECK_INTERVAL_MS` (heartbeat) and `INITIAL_CHECK_DELAY_MS`/`CHECK_INTERVAL_MS` (idle compaction) are now exported so the cadence tests do not hard-code the values.
3. `EffectRunner` methods take no `RunOptions` (no worker passes any); add when a caller needs them.
4. Whole-`dispose()` latch (above) instead of the runtime-only latch from PR 1 — `Scope.close` marks a scope closed before its finalizers finish, so per-step idempotence is not enough to keep the §5 order under concurrent disposal.
5. `boundedTeardown` log lines: `[shutdown] AppRuntime disposed {ms}` (unchanged wording) and `[shutdown] AppFiberScope closed {ms}`; timeout → `[shutdown] <subject> teardown timed out; finalizers continue best-effort`.

**Pinned runtime facts (rc.112, all asserted in `di/*.test.ts`)**

- `runFork` through a runner (default or TestClock-bound) executes the fiber up to its first `Effect.sleep` before returning; `runSync(Effect.forkIn(...))` flushes the forked child to its first sleep too.
- `runner.runSync(Scope.close(scope, Exit.void))` completes synchronously for a fiber suspended on a `TestClock` sleep (interrupt → latch cancel path → exit, all synchronous) — the workers' sync `stop()` contract holds on both clocks.
- `TestClock.adjust` resumes every due sleep **and runs its synchronous continuation** before resolving (latch `openUnsafe` → `fiber.evaluate` inline, then `yieldNow`); a sleep registered during that continuation whose deadline is still inside the adjust window fires in the same `adjust` (`Schedule.fixed` cadence: one tick per interval, `adjust(2×interval)` → 2 ticks). No extra `yieldNow`/`Fiber.await` needed in the helper.
- `Effect.context<never>()` inside `EffectRunnerLive` sees an upstream `TestClock` provided via `provideMerge` (`Clock.currentTimeMillis` through the runner reads 0, then the adjusted time) — the explicit `Clock.Clock` fallback was not needed.
- `Scope.fork(parent)` in a `Layer.effect` body yields a child that the runtime's layer scope closes on `disposeAppRuntime` (backstop test), and re-closing an already-closed child is a no-op (no second finalizer run, no error).
- `Effect.forkIn(_, scope)` registers a finalizer that interrupts **and awaits** the fiber; an `Effect.uninterruptible(Effect.never)` occupant makes the close hang → `closeScopeBounded` warns and returns at the bound.
- Asymmetry documented by test: a fiber forked through the `EffectRunner` is interrupted by neither `closeScopeBounded(appFiberScope)` nor `disposeAppRuntime`.

**Pre-review audits (plan §3 preamble)**

1. Interruption posture — heartbeat scheduler / idle-compaction checker: forked via `runner.runSync(Effect.forkIn(_, lifecycleScope))`, unsupervised, interrupted synchronously by `stop()` (unchanged). Retry fiber: `runner.runFork`, unsupervised, interrupted by `interruptRetryFiber` (unchanged). `closeScopeBounded`/`disposeAppRuntime`: one detached fiber each for the close target (kept running best-effort past the bound). No production occupant of `AppFiberScope`.
2. Uninterruptible teardown — `boundedTeardown` is `Effect.uninterruptible` end-to-end; only the bounded join is `Effect.interruptible`.
3. No defect escapes — `boundedTeardown` folds `TimeoutError` and defects to `log.warn`; both Promise facades never reject (timeout tests for both).
4. Spy-seam check — `rg 'spyOn\('` finds no spies on the three workers' methods in `src`/`tests`; constructor arity unchanged (trailing optional params only); typecheck of tests green.
5. Sync-start — pinned (see above).
6. Constructor side-effect audit — no constructor moved into a layer; `AppFiberScopeLive`/`EffectRunnerLive` have no side effects beyond forking a scope / capturing a context.
7. N/A (`memoryConsolidationService` untouched).

## Validation

- `bun test` gate: `heartbeatService*.test.ts`, `idleCompactionService*.test.ts`, `retryManager*.test.ts`, `serviceContainer.test.ts`, `di/*`, `src/node/orpc` — 235 pass, 0 fail, 3 skipped (7 new TestClock cases across the three workers, 7 runner-fact cases, 5 `AppFiberScope` contract cases, 3 new container cases incl. the dispose-order assertion against `desktopBridgeServer.stop` a TestClock injected beneath the real `AppLive` via `spyOn(appLayers, "AppLive")`, and the concurrent-`dispose()` case).
- `make static-check` green. `TEST_INTEGRATION=1 bun x jest tests/ipc/...` locally: 20/25 suites pass; the 5 failing suites (`fork`, `nameGeneration`, `modelNotFound`, `mcpConfig`, `init` "even when init fails") all need real provider calls (HTTP 403 from the Coder AI bridge) or SSH and fail identically for environment reasons — CI `Test / Integration` is the lane for those.
- **Dogfooding** (headless Coder host; `node dist/cli/index.js server` under `script -q -e` with a temp `XUM_ROOT`, `XUM_LOG_LEVEL=debug`):
  - Startup order unchanged: `[startup] AppRuntime built {ms: 3}` → `ServiceContainer.initialize starting` → step logs → `IdleCompactionService started` / `HeartbeatService started` → `initialize completed {totalMs: 305}`.
  - Graceful quit (SIGTERM 36 s after start): `[shutdown] AppFiberScope closed {ms: 1}` → `AgentStatusService stopped` → `terminateAll` → `[shutdown] AppRuntime disposed {ms: 3}`, exit **0** in 190 ms, no force-exit message.
  - Timeout branch (scratch `PR2_HANG_PROBE` env-gated occupant `Effect.uninterruptible(Effect.never)` forked into `appFiberScope`, **not committed**): `[shutdown] AppFiberScope teardown timed out; finalizers continue best-effort {timeoutMs: 2000}` → `AppFiberScope closed {ms: 2036}` → explicit steps → `AppRuntime disposed`, exit 0.
  - Note (pre-existing, not this PR): a SIGTERM sent ~6 s after startup exits ~12 s later on **both** this branch and an `origin/main` build (`AppRuntime disposed` lands within ~40 ms of `Shutting down server...` in both; the tail is after `dispose()`, in `serverService.stopServer()`), while at 36 s after startup both exit in <200 ms.
  - Dev-server sandbox (`--clean-projects`): added a scratch repo project, created a workspace, sent a message and got the reply; enabled the Workspace Heartbeats experiment and configured a 5-minute heartbeat on the workspace — the heartbeat ticker (running on the real clock through the context-bound runner) picked the workspace up once the interval elapsed: `HeartbeatService: tracking workspace` (3:01) → `HeartbeatService: queued heartbeat` → `HeartbeatService: executing heartbeat` (3:06) and the `[Heartbeat]` turn appeared in the chat. Screenshots attached in the chat transcript.

## Risks

Low. Production forks are byte-for-byte the same effects; only the runner object differs (`Effect.run…With(ctx)` vs `Effect.runX`), and the `Scheduler`/`Scope` omit keeps the fiber scheduling identical to before. `dispose()` gains one bounded, idempotent, never-rejecting await with no occupants yet. Rollback: revert restores the defaults; no call site depends on the new parameters.

## Lessons for PR 3

- `Effect.context<never>()` inside a layer body is the *build fiber's* context: expect `Scope`, `Layer.CurrentMemoMap` and the eager build's sync `Scheduler` in it — never capture it without the omit, and keep `EffectRunnerLive` at the base so stores are the only services it carries.
- `TestClock.layer()` provided beneath the real `AppLive` (`realAppLive(stores).pipe(Layer.provideMerge(TestClock.layer()))` via `spyOn(appLayers, "AppLive")`) puts the whole container's runner on virtual time — reusable for `createCoreServices` identity/cadence tests without production seams.
- The `boundedTeardown` helper is the shape for the CLI roots' `closeScopeBounded(appFiberScope)` (before `session.dispose()`) and `disposeAppRuntime(runtime)` (after `terminateAll`) in `cli/run.ts`/`cli/workflow.ts`.
- PR 3 must record the PR 4 decision-gate numbers: `make typecheck` wall time (branch vs `origin/main`), `[startup] AppRuntime built` ms (this PR: 3 ms) and `initialize` totals (this PR: 227–305 ms in the sandbox/CLI probes) vs baseline.

---

<details>
<summary>📋 Implementation Plan</summary>

# Effect migration — Wave 3 / Phase 11: ManagedRuntime + Layer dependency injection

## 0. Summary

Replace the two hand-written composition roots (`createCoreServices` + the `ServiceContainer` constructor) with an **Effect `Layer` graph** built once per process by a **`ManagedRuntime`** ("AppRuntime"), while keeping every service class, constructor signature, Promise facade, private method, and test seam compatible. The runtime becomes (a) the owner of the app-lifetime `Scope`, (b) the provider of `"effect/context"` for oRPC Effect-native handlers, and (c) the source of two runtime seams: an **`EffectRunner`** (context-bound, *unsupervised* runner that lets clock-driven workers run on a `TestClock`) and an **`AppFiberScope`** (a runtime-owned, *supervised* scope whose close is awaited by `dispose()` — the slot the streamManager engine core will occupy later).

Six stacked, independently mergeable PRs. Product PRs keep existing tests unchanged; only the final test-modernization PR edits tests. Net product LoC ≈ **+420** (per-PR estimates below). Service classes are *not* rewritten — Layers are thin adapters around existing constructors; cycle-breaking setter wiring moves into explicit "wiring layers" that replay today's order.

Unlocks (not done here): streamManager ENGINE CORE conversion, `TestClock` for timing suites, app-lifetime scopes.

## 1. Verified current state (evidence)

- **Roots.** `src/node/services/coreServices.ts:103-389` (`createCoreServices`: 25 constructions, 12 `turnRequestBuilderBindings` writes, ~14 setters) and `src/node/services/serviceContainer.ts:161-575` (45 more constructions; `aiService.on(...)`/`workspaceService.on(...)` analytics wiring at 474-574; global registrations `setGlobalCoderService/setSshPromptService` at 469-471). `new ServiceContainer(stores)` is called by `headlessEnvironment.ts:111`, `tests/ipc/setup.ts`, `src/cli/server.ts:132`, `src/node/acp/serverConnection.ts:155`, `src/desktop/main.ts:653`; `src/cli/run.ts:661` and `src/cli/workflow.ts:376` call `createCoreServices` directly. ⇒ two graph roots (App vs Core), five process entry points, all constructing **synchronously**.
- **Startup.** `ServiceContainer.initialize()` (577-642) awaits six `initialize()`s (no try/catch; failure propagates to `main.ts:1255-1265` "Startup Failed" dialog + quit; `server.ts`/ACP log and exit), then sync `start()`s idleCompaction/heartbeat/agentStatus, then two fire-and-forget sweeps. All constructors are synchronous; two have side effects on **declared constructor dependencies** only (`AIService` → `streamManager.setEventSink`, `WorkspaceService` → `backgroundProcessManager.on/aiService.on`).
- **Teardown.** `dispose()` (746-779) is explicit and hand-ordered (`backgroundProcessManager.beginShutdown()` MUST be first — it is a latch protecting persisted monitor records; bridges stop before sessions close; `terminateAll` late; `timelineService.flush()` last). `shutdown()` (718-732) is a *second* sequence fired concurrently by a second `before-quit` listener (`main.ts:1321`). `main.ts:1296-1304` races `dispose()` against 5 s then `app.quit()`; `cli/server.ts:227-268` has a 5 s `process.exit(1)` force timer; `tests/ipc` cleanup calls `dispose()` then `shutdown()`; `headlessEnvironment.dispose` never calls `services.dispose()`.
- **Existing Effect surface.** 25 files import `effect`. Only `Context.Service` tag: `MemoryMeta` (`src/node/orpc/effectContext.ts:21`). `handlerGen` (`@orpc/experimental-effect`) runs `Effect.runPromiseExit` per request and `Effect.provide`s `opts.context["effect/context"]`. `streamBridge.ts` runs streams on the global runtime. Scope-owning workers: `heartbeatService.ts:134-243`, `idleCompactionService.ts:86-122` (`Scope.makeUnsafe` + `Effect.runSync(Scope.close(..))`, valid only because their fibers suspend solely on the clock), `oauthFlowManager.ts:164`, `streamManager.ts:4767/4054` (already `Effect.runFork(Scope.close(..))` — the async-close precedent). `memoryConsolidationService.ts:667-703, 837-860`: check-and-reserve funnels with zero suspensions before `inFlight.set`/`harvestInFlight.set`.
- **effect@4.0.0-rc.112 API (verified in `node_modules/effect/dist`).** `Context.Service<Self, Shape>()("id")` (module `Context`, not `ServiceMap`); `Layer.{succeed,sync,effect,effectContext,effectDiscard,provide,provideMerge,mergeAll,build,buildWithScope}` (no `Layer.scoped`; `Layer.effect` strips `Scope` from R); `ManagedRuntime.make(layer)` → `{ runSync, runSyncExit, runFork, runPromise, runPromiseExit, contextEffect, cachedContext, scope, dispose(), disposeEffect }`; `Effect.{runSyncWith,runForkWith,runPromiseWith,runPromiseExitWith}(context)`; `Effect.context<R>()`; `Effect.serviceOption`; `Scope.{fork,forkUnsafe,close,provide}`; `TestClock` from `effect/testing` (`layer, adjust, setTime, withLive`); `Clock.Clock` is a `Context.Reference` (defaulted; `TestClock.layer()` overrides it).
- **ManagedRuntime internals the design relies on** (`ManagedRuntime.js`): `make` creates `scope = Scope.makeUnsafe("parallel")` and `layerScope = Scope.forkUnsafe(scope, "sequential")`; the first `runX` forks a build fiber over `Layer.buildWithMemoMap` — a **fully synchronous layer graph builds synchronously**, so `runtime.runSync(Effect.context())` succeeds and sets `cachedContext`; afterwards every `runX` is `Effect.run…With(cachedContext)` (no extra async boundary). Fibers started through `runtime.runX` are registered in `scope` (`onFiberStart: Fiber.runIn(scope)`). `dispose()` = `Scope.close(scope)` (interrupt registered fibers in parallel → layer finalizers sequentially in reverse), after which any `runtime.runX` dies with `"ManagedRuntime disposed"`.
- **Layer composition semantics.** `Layer.mergeAll(A, B)` is *not* a dependency resolver: B's requirements are not satisfied by A's outputs; requirements bubble up. Dependencies are satisfied only via `Layer.provide`/`provideMerge` chains. Siblings in `mergeAll` may build concurrently.
- **Test seams that pin signatures** (Explore report): private-method spies (`Config.saveConfig`, `WorkspaceService.retireKernelWorkflowRunReferences/startStartupRecovery/createSession/updateAgentStatus`, `MCPServerManager.startServers`, `AgentPluginInstallService.reconcileJournals`, …); module-level export spies (`agentStatusService.generateWorkspaceStatus`, `sshConnectionPool.verifyHostKeyAgainstPolicyEffect`, …); direct construction in tests (`Config` 44 files, `HistoryService` 22, `MemoryMetaService` 11, `WorkspaceService` 7, `IdleDispatcher` 6, `StreamManager` 4, `ServiceContainer` 3); partial-mock casts (`InitStateManager` 193, `AIService` 158, `TaskService` 149, `ORPCContext` 62). `effectBridge.test.ts:24-30` builds a partial `ORPCContext` via `buildOrpcEffectContext` + `as unknown as ORPCContext`.
- **Timing probes** (TestClock candidates): `heartbeatService.test.ts` 6 real sleeps, `idleCompactionService.test.ts` 2, `retryManager.test.ts` 3 `setSystemTime`, `streamManager.test.ts` 7 (partial-write debounce), `streamBridge.test.ts` 11 (heartbeat ticker), OAuth device-flow suites 14 (non-goal).

## 2. Target architecture

### 2.1 Building blocks (all under `src/node/services/di/`; the *only* directory allowed to import `Layer`/`Context`/`ManagedRuntime`/`TestClock`)

| Module | Contents |
|---|---|
| `tags.ts` | One `Context.Service` tag per service class provided by the graph. Type-only imports of service classes ⇒ no runtime import cycles. Ids `"xum/<Name>"`. Naming: class name minus trailing `Service` (`MemoryMeta`, `Workspace`, `History`); classes without that suffix or colliding with an exported name get a `Tag` suffix (`ConfigTag`, `StreamManagerTag`, `IdleDispatcherTag`). Exports the unions `CoreTags` and `AppTags`. |
| `effectRunner.ts` | `interface EffectRunner { runSync<A,E>(e: Effect<A,E,never>): A; runSyncExit; runFork; runPromise; runPromiseExit }` — a **context-bound, unsupervised** runner whose methods accept only effects with **no service requirements** (`R = never`; defaulted references like `Clock` do not appear in `R`). That makes "not a service locator" type-enforced: a fiber that needs services must take them as explicit constructor dependencies and, if it must be awaited on shutdown, fork into `AppFiberScope`. `defaultEffectRunner` = the global `Effect.runX` (today's exact behavior). `effectRunnerFromContext(ctx)` = `Effect.run…With(ctx)`. `EffectRunnerTag` + `EffectRunnerLive = Layer.effect(EffectRunnerTag, Effect.map(Effect.context<never>(), effectRunnerFromContext))`, placed at the **base** of the graph so the captured context contains only refs (`Clock`, later `Logger`/`Random`) plus stores. Fibers forked through it are owned by the worker's own `Scope` (explicit `start/stop`), **not** by the ManagedRuntime; `runtime.dispose()` does not interrupt them. Services import only this file from `di/`. |
| `appFiberScope.ts` | `AppFiberScopeTag: Scope.Closeable`. `AppFiberScopeLive = Layer.effect(AppFiberScopeTag, Effect.gen(function*(){ const parent = yield* Effect.scope; return yield* Scope.fork(parent, "parallel"); }))` — a child of the runtime's layer scope. Fibers forked into it via `Effect.forkIn(_, appFiberScope)` are interrupted **and awaited** when the scope closes. This is the **supervised** seam for I/O-suspended fibers (engine core, later). `ServiceContainer.dispose()` closes it explicitly and early (§5) so interrupted fibers can still use their dependencies during finalization; `runtime.dispose()` later re-closes it idempotently as a backstop. No production occupant in Phase 11; the seam exists with tests. |
| `appRuntime.ts` | `makeAppRuntime(layer)`: `ManagedRuntime.make(layer)` + **eager synchronous build** (`runtime.runSync(Effect.context<R>())`; `assert(runtime.cachedContext !== undefined)`); a layer body that suspends is a programming error and throws here — exactly where a throwing constructor throws today, so every entry point's existing catch/dialog/log path is preserved. `disposeAppRuntime(runtime, timeoutMs)` and `closeScopeBounded(scope, timeoutMs)` share one shape: `Effect.uninterruptible` teardown shell around `Effect.interruptible(target.pipe(Effect.timeout(timeoutMs)))` where `target` is `runtime.disposeEffect` resp. `Scope.close(scope, Exit.void)` (never a non-cancellable JS Promise wrapper); `Effect.catchTag("TimeoutError", …)` + `Effect.catchDefect` → `log.warn`; run via `Effect.runPromise`; **never rejects**; idempotent (`Scope.close` is idempotent; `disposeEffect` is guarded by a latch). Verify the exact rc `Effect.timeout` error type at implementation time (rc.112: fails with `Cause.TimeoutError`, `_tag: "TimeoutError"`). Module doc comment = the DI contract (§2.3, §5). |
| `layers/stores.ts` | `StoresLive(stores: ConfigStores)` = `Layer.mergeAll` of `Layer.succeed` for `ConfigTag`, `SessionLocatorTag`, `ProvidersConfigStoreTag`, `SecretsStoreTag`, `FileLeaseManagerTag` (true siblings — no inter-dependencies). `StoresFromCoreOptionsLive` reproduces the `opts.x ?? new X(config.rootDir)` defaults of `coreServices.ts:106-112` for the CLI root. |
| `layers/core.ts` | `CoreOptionsTag` (today's `CoreServicesOptions` minus stores — carries the *optional* cross-cutting services exactly as today). **PR 3:** `CoreProjectionLive = Layer.effectContext(...)` wrapping the existing `createCoreServices` body and returning a `Context<CoreTags>` (coarse projection, zero behavior change). **PR 4:** peel into per-service `Layer.effect(Tag, Effect.gen(...))` layers composed in **explicit dependency stages** (`Layer.provideMerge` between stages; `Layer.mergeAll` only for true siblings within a stage — every sibling claim below was checked against the constructor argument lists in `coreServices.ts` and must be re-checked in the PR): S1 History · InitState · Provider · BackgroundProcess · ExtensionMetadata · MemoryMeta · TerminalAttention · IdleDispatcher · WorkspaceMcpOverrides(default) · `TurnRequestBuilderBindingsTag` (`Layer.succeed(_, {})`) → S2a SessionUsage · Goal · Memory → S2b StreamManager (needs SessionUsage) → S3 AIService → S4 Consolidation · MCPConfig → S5 MCPServerManager → S6 Workspace → S7 Task → S8 TurnManager → `CoreWiringLive` (`Layer.effectDiscard`, **`Effect.sync` only — no `acquireRelease`**, replays `coreServices.ts:137-166, 209-210, 258-270, 288-325, 349-352, 360-367` in order). |
| `layers/desktop.ts` | `CrossCuttingLive` (policy, telemetry, experiments, backup, sessionTiming, analytics, devTools, workspaceMcpOverrides, browserBridgeTokenManager), `CoreOptionsFromDesktopLive` (derives `CoreOptionsTag` from those tags + `extensionMetadataPath`), then **group layers** (`Layer.effectContext` returning a `Context` of several tags, constructed in today's order): `BrowserLive`, `DesktopBridgeLive`, `OauthLive`, `WorkersLive` (idleCompaction, heartbeat, agentStatus, timeline, refine), `TerminalEditorLive`, `MiscDesktopLive`; staged with `provideMerge` where one group needs another. `DesktopWiringLive` (`Effect.sync` only) = setters + `aiService.on/workspaceService.on/memoryConsolidationService.on` wiring + global registrations. |
| `layers/app.ts` | `AppLive(stores) = DesktopLive ▹ CoreLive ▹ CoreOptionsFromDesktopLive ▹ CrossCuttingLive ▹ AppFiberScopeLive ▹ EffectRunnerLive ▹ StoresLive(stores)` — read `X ▹ Y` as "X is *provided with* Y, and both stay exposed", i.e. **`X.pipe(Layer.provideMerge(Y))`** (rc.112 signature: `provideMerge(that: provider)(self: consumer)`; the *right-hand* operand is the dependency). Every `▹` keeps all tags visible in the final `Context<AppTags>`. |
| `testEffectRunner.ts` (test helper, sibling of `testHistoryService.ts`) | `makeTestEffectRunner()` → `{ runner, adjust(duration), setTime(ms), dispose }` over one memoised `ManagedRuntime.make(EffectRunnerLive.pipe(Layer.provideMerge(TestClock.layer())))` (the TestClock is the *provider*; the runner captures it), so the worker under test and `TestClock.adjust` share one `TestClock`. |

### 2.2 Composition roots after Phase 11

```mermaid
flowchart TB
  Stores["StoresLive(stores)<br/>Config · SessionLocator · ProvidersConfigStore · SecretsStore · FileLeaseManager"]
  Runner["EffectRunnerLive (unsupervised, ref-bound)<br/>+ AppFiberScopeLive (supervised, closed on dispose)"]
  Cross["CrossCuttingLive (desktop only)<br/>Policy · Telemetry · Experiments · Analytics · SessionTiming · DevTools · WorkspaceMcpOverrides · Backup"]
  Opts["CoreOptionsTag<br/>desktop: derived from CrossCutting · CLI: Layer.succeed(opts)"]
  Core["CoreLive<br/>PR 3: coarse CoreProjectionLive → PR 4: stages S1…S8 + CoreWiringLive"]
  Desk["DesktopLive — group Layers<br/>Browser · DesktopBridge · OAuth · Workers · TerminalEditor · Misc → DesktopWiringLive"]
  RT["AppRuntime = ManagedRuntime.make(AppLive)<br/>eager sync build · Context<AppTags> = oRPC effect/context · dispose() last"]
  Stores --> Runner --> Cross --> Opts --> Core --> Desk --> RT
  CLI["CLI root (xum run / xum workflow)<br/>createCoreServices(opts) = makeAppRuntime(CoreLive ▹ StoresFromCoreOptionsLive ▹ AppFiberScopeLive ▹ EffectRunnerLive ▹ succeed(CoreOptionsTag, opts))"]
  Core -.same Layer definitions.-> CLI
```

`ServiceContainer` keeps its public fields and the synchronous `new ServiceContainer(stores)`: the constructor calls `makeAppRuntime(AppLive(stores))`, stores `this.serviceContext = runtime.runSync(Effect.context<AppTags>())`, and assigns fields via `Context.get(this.serviceContext, Tag)`. `toORPCContext()` returns the same plain fields plus `"effect/context": this.serviceContext`. `initialize()` is untouched. `dispose()` follows §5.

`createCoreServices(opts)` keeps its signature and return shape plus `runtime` and `appFiberScope` fields; `cli/run.ts:1574-1580` and `cli/workflow.ts:275-320` cleanup lists gain `closeScopeBounded(appFiberScope)` before `session.dispose()` and `disposeAppRuntime(runtime)` as the final step (PR 3).

**Staged composition skeleton (PR 4 shape; direction matters):**

```ts
// Each stage depends only on stages defined above it. `provideMerge` keeps both sides exposed.
const S1 = Layer.mergeAll(HistoryLive, InitStateLive, ProviderLive, /* … true siblings only */);
const S2a = Layer.mergeAll(SessionUsageLive, GoalLive, MemoryLive).pipe(Layer.provideMerge(S1));
const S2b = StreamManagerLive.pipe(Layer.provideMerge(S2a));          // StreamManager needs SessionUsage
const S3 = AIServiceLive.pipe(Layer.provideMerge(S2b));
// … S4 … S8 likewise …
export const CoreLive = CoreWiringLive.pipe(Layer.provideMerge(S8));  // wiring runs after every service exists
```

**oRPC typing.** `OrpcEffectServices` (in `effectContext.ts`) becomes `AppTags`, so `ORPCContext["effect/context"]: Context<AppTags>` is satisfied by the runtime context in production. `buildOrpcEffectContext` stays as the narrow test helper it already is (its only caller, `effectBridge.test.ts:24-30`, deliberately builds a partial context and casts it via `unknown`); no production caller remains after PR 1.

### 2.3 Invariants (the "DI contract"; enforced by tests and the `appRuntime.ts` doc comment)

| # | Invariant | Constraint served |
|---|---|---|
| I1 | **Phase 11 compatibility contract, not permanent law:** layer bodies are synchronous (`Layer.succeed`/`Layer.sync`/`Layer.effect` over sync effects; `acquireRelease` with a sync acquire is fine). `makeAppRuntime` asserts the eager build completed. Future async resource acquisition belongs in `initialize()`/startup effects or an explicit async factory root (`ServiceContainer.create()`), never silently inside a layer. | #2 sync-start, #5 startup parity |
| I2 | Services never hold the `ManagedRuntime`. Workers hold an `EffectRunner` (default `defaultEffectRunner`); `EffectRunner.runX` ≡ `Effect.run…With(ctx)` — same sync-start semantics as `Effect.runX`, and still valid after `runtime.dispose()`, so late callbacks cannot hit "ManagedRuntime disposed". Supervision, when needed, is explicit via `AppFiberScope`. | #2, #3 |
| I3 | Per-call pipelines (`Effect.runPromise(this.effects…)` facades) and the `memoryConsolidationService` funnels are untouched. **Audit item:** no DI lookup, runner call, or `await` may be inserted before `inFlight.set` / `harvestInFlight.set`. Only lifecycle forks in workers move to `this.runner.runX`. | #1, #2 |
| I4 | Constructors, facades, private methods, module exports unchanged; new constructor parameters are optional, trailing, defaulting to `defaultEffectRunner`. | #1, #6 |
| I5 | Teardown order stays explicit in `dispose()`/`shutdown()`. Layer bodies and wiring layers register **no finalizers** in Phase 11 (`Effect.sync` only), so `runtime.dispose()` reorders nothing. The one supervised resource (`AppFiberScope`) is closed explicitly at a fixed position in `dispose()` (§5). | #3 |
| I6 | Wiring layers replay today's setter/listener order; a constructor may touch only its *declared* dependencies (built earlier by staging). Per-PR audit: grep each moved constructor for calls on setter-provided collaborators → forbidden. Dependency order is expressed only with `provide`/`provideMerge` stages; never rely on `mergeAll` sibling order. | #6 |
| I7 | No persisted-data changes; DI is in-process only. | #4 |
| I8 | Every process root builds from the same Layer definitions (`CoreLive` shared by App and CLI). Unit harnesses (`createTestHistoryService`, `createTestToolConfig`, `createAgentSessionHarness`, …) intentionally bypass Layers. | #7 |

### 2.4 Decisions and alternatives (product-LoC deltas)

<details>
<summary>D1 — Granularity: coarse core first (PR 3), per-service core stages behind a decision gate (PR 4), group layers for the desktop tail (PR 5)</summary>

Honest framing: the three unlocks (engine-core async scope, TestClock, app-lifetime scope) are delivered by `AppRuntime` + `EffectRunner` + `AppFiberScope` and **do not require per-service layers**. Per-service core layers are *migration leverage*: typed requirement sets for the engine-core work, per-service swap in integration tests, explicit dependency stages instead of implicit ordering.

- **(A) Per-service everywhere** (~70 layers): +~900/−~700. Desktop tail has hand-tuned teardown that must not become finalizers, so per-service there buys uniformity only. Rejected.
- **(B) Recommended:** PR 3 coarse `CoreProjectionLive` (+~120/−~10) delivers the shared root and runtime ownership; PR 4 peels the core into staged per-service layers (+~330/−~290) **only if** PR 3's typecheck/startup budgets hold (gate in §3); desktop tail as ~6 group layers (+~170/−~150). Tags for all services either way (~3 LoC each).
- **(C) Coarse only:** stop after PR 3 + desktop projection (~+200 total). Cheapest; the engine-core phase would then redo dependency declarations. Remains the fallback if PR 4's gate fails.
</details>

<details>
<summary>D2 — Async init stays an explicit `initialize()`; Layers construct only</summary>

Folding `initialize()` into layer construction would make the build asynchronous (breaks I1), change failure semantics (today: fail-fast → dialog/log), and move the six-step order into memoised builds. Deferred; a later phase can turn `initialize()` into `runtime.runPromise(startupEffect)` with per-step `Effect.timeout`.
</details>

<details>
<summary>D3 — Optional cross-cutting services stay optional via `CoreOptionsTag`, not `Effect.serviceOption`</summary>

Core layer bodies read `opts.policyService` etc. exactly as today, so CLI (absent) vs desktop (present) behavior is unchanged and no service gains a new `undefined` branch.
</details>

<details>
<summary>D4 — Two seams instead of one: `EffectRunner` (unsupervised, clock-bound) + `AppFiberScope` (supervised)</summary>

A single "runtime handle" conflates two needs. Workers need *which clock* (TestClock) and must keep sync `stop()`; the engine core needs *who awaits me on shutdown*. Explicit `Clock` injection per worker was rejected (a `provideService(Clock.Clock, …)` at every fork site, and it does not extend to other refs).
</details>

<details>
<summary>D5 — oRPC: `effect/context` = the runtime's `Context`; `handlerGen` unchanged</summary>

`handlerGen` already `Effect.provide`s the context per request; providing ~70 entries instead of one is one Map merge per request. The existing `echoAsync`/`echoEffect` probes record the delta as a **diagnostic** in the PR body (no stable benchmark harness exists to make it a hard gate). `effect/wrap` not needed.
</details>

## 3. Phasing — six stacked PRs

Every PR: `make static-check`; gate suites below; existing tests unchanged (PR 6 is the only PR that edits tests, and only to replace real-timer probes). Before `@codex review`, run the **house pre-review audits**:

1. **Interruption posture** — list every new/moved fiber fork; state what interrupts it and when (unsupervised via `EffectRunner` + worker scope, or supervised via `AppFiberScope`).
2. **Uninterruptible teardown** — teardown effects are `Effect.uninterruptible` end-to-end; bounded waits inside use `Effect.interruptible(Effect.timeout(...))` (house shape from #4038).
3. **No defect escapes** — `disposeAppRuntime`/`closeScopeBounded` and every Promise facade fold defects; `makeAppRuntime` is the one place allowed to throw (constructor semantics).
4. **Spy-seam check** — `rg 'spyOn\(' src/node/services/<touched>.test.ts tests/` per touched class; constructor arity and private-method Promise signatures unchanged (typecheck of tests proves it).
5. **Sync-start check** — a fork through `EffectRunner` runs to its first `sleep` before `runFork` returns (mirrors `heartbeatService.ts:199-202`).
6. **Constructor side-effect audit (I6)** for every constructor moved into a Layer in that PR.
7. **Zero-suspension audit (I3)** whenever `memoryConsolidationService` is in the diff.

### PR 1 — Skeleton: AppRuntime + Stores/MemoryMeta layers + runtime-backed `effect/context` + dispose hook (+~150 LoC)

**Scope**
- `di/tags.ts` (`ConfigTag`, `SessionLocatorTag`, `ProvidersConfigStoreTag`, `SecretsStoreTag`, `FileLeaseManagerTag`, `MemoryMeta` moved from `orpc/effectContext.ts`, which re-exports it; `AppTags` union).
- `di/layers/stores.ts` (`StoresLive`), `di/layers/core.ts` with `MemoryMetaLive = Layer.effect(MemoryMeta, Effect.map(ConfigTag, c => new MemoryMetaService(c.rootDir)))`, `di/layers/app.ts` (`AppLive(stores) = MemoryMetaLive ▹ StoresLive`).
- `di/appRuntime.ts` (`makeAppRuntime`, `disposeAppRuntime`); `APP_RUNTIME_DISPOSE_TIMEOUT_MS` in `src/constants/`.
- `coreServices.ts`: `CoreServicesOptions.memoryMetaService?` (precedent: `workspaceMcpOverridesService?`).
- `serviceContainer.ts`: build runtime first, pass `Context.get(ctx, MemoryMeta)` to `createCoreServices`, `public readonly runtime`, `toORPCContext()["effect/context"] = this.serviceContext`, `dispose()` appends `disposeAppRuntime` behind a `disposed` latch; new `log.debug("[startup] AppRuntime built", { ms })`.
- `orpc/effectContext.ts`: `OrpcEffectServices = AppTags`; `buildOrpcEffectContext` retyped/test-helper doc.
- `headlessEnvironment.dispose` calls `await services.dispose()` before removing the temp dir (the bench harness currently leaks the container; runtime ownership starts here).

**Acceptance**
- `di/appRuntime.test.ts`: (a) sync build sets `cachedContext`; (b) a layer with an async body makes `makeAppRuntime` **throw synchronously** (I1 enforced); (c) probe layers' finalizers run in reverse order on dispose; (d) dispose is idempotent and bounded (hung finalizer → `warn`, resolves at the timeout); (e) `runtime.runFork` after the eager build starts synchronously.
- `serviceContainer.test.ts`: `Context.get(toORPCContext()["effect/context"], MemoryMeta) === services.memoryMetaService`; `dispose()` closes the runtime; `dispose(); shutdown()` (tests/ipc order) is clean; a throwing layer surfaces as a synchronous throw from `new ServiceContainer(stores)` (same shape as today's constructor throw → existing entry-point catch paths).
- `effectBridge.test.ts`, `memoryMeta*.test.ts` unchanged and green; echo-probe overhead recorded in the PR body.
- Gate: `bun test src/node/services/di src/node/services/serviceContainer.test.ts src/node/orpc src/node/services/memoryMeta*` · `make test-integration` · `make static-check`.

**Rollback:** `git revert`; classes untouched.

### PR 2 — Runtime seams: `EffectRunner` + `AppFiberScope`; TestClock on idleCompaction/heartbeat/retryManager (+~140 LoC)

**Scope**
- `di/effectRunner.ts`, `di/appFiberScope.ts`; `AppLive` gains `AppFiberScopeLive ▹ EffectRunnerLive` at the base; `ServiceContainer` exposes `appFiberScope` (used only by `dispose()` in Phase 11) and closes it per §5.
- `IdleCompactionService`, `HeartbeatService`, `RetryManager`: trailing optional `runner: EffectRunner = defaultEffectRunner`; every lifecycle `Effect.runSync/runFork` in `start/stop/schedule/cancel` becomes `this.runner.runX`. Deadline math (`Date.now()`/injected `now`) unchanged. `ServiceContainer` passes `Context.get(ctx, EffectRunnerTag)` to the two workers; `RetryManager` keeps the default until PR 5 (so `streamManager.ts` is untouched here).
- `di/testEffectRunner.ts` helper.

**Acceptance**
- New TestClock tests (existing real-timer tests untouched — they exercise the `defaultEffectRunner` path, which is production behavior wherever no runner is injected): heartbeat `STARTUP_DELAY_MS` → first tick after `adjust`, one tick per `CHECK_INTERVAL_MS`, no ticks after `stop()`; idleCompaction initial delay + cadence; retryManager fires exactly at `delayMs`, `cancel()` before `adjust` never fires.
- Pin runtime facts: `runner.runSync(Scope.close(scope, Exit.void))` completes synchronously for a fiber suspended on a TestClock sleep; `runFork` through the runner reaches its first sleep synchronously; `Effect.context<never>()` inside `EffectRunnerLive` sees the upstream `TestClock` (else the helper provides `Clock.Clock` explicitly — same seam, one line).
- `AppFiberScope` contract tests: (i) an **I/O-suspended** fiber (interruptible `Effect.async` that never resolves, with a cancel path) forked with `Effect.forkIn(_, appFiberScope)` is interrupted **and awaited** by `closeScopeBounded(appFiberScope)` — and this happens *before* the explicit teardown steps in `dispose()` (assert ordering against a spy on `desktopBridgeServer.stop`); (ii) a fiber forked via `EffectRunner` is *not* interrupted by either close (documents the asymmetry); (iii) `disposeAppRuntime` afterwards idempotently re-closes the already-closed child scope (no error, no second finalizer run).
- If `TestClock.adjust` leaves continuations pending, the helper adds `Effect.yieldNow`/`Fiber.await` — decided by tests.
- Gate: `heartbeatService.test.ts`, `idleCompactionService.test.ts`, `retryManager.test.ts`, `serviceContainer.test.ts`, `di/*`, tests/ipc.

**Rollback:** revert restores defaults; no call site depends on the new params.

### PR 3 — Shared core root: coarse `CoreProjectionLive` + `createCoreServices` facade + CLI runtime disposal (+~120 / −~10)

**Scope**
- Tags for the remaining 19 core services; `CoreOptionsTag`; `StoresFromCoreOptionsLive`.
- `CoreProjectionLive = Layer.effectContext(Effect.gen(function*(){ const opts = yield* CoreOptionsTag; const stores = yield* …; const core = buildCoreGraph({ ...opts, ...stores }); return Context.make(History, core.historyService).pipe(Context.add(...)) }))` where `buildCoreGraph` is today's `createCoreServices` body, unchanged, renamed.
- `createCoreServices(opts)` = `makeAppRuntime(CoreProjectionLive ▹ StoresFromCoreOptionsLive ▹ AppFiberScopeLive ▹ EffectRunnerLive ▹ Layer.succeed(CoreOptionsTag, opts))`, returns today's `CoreServices` object read from the context plus `runtime` and `appFiberScope`. `cli/run.ts` and `cli/workflow.ts` cleanup lists append `closeScopeBounded(appFiberScope)` **before** `session.dispose()` and `disposeAppRuntime(runtime)` **after** `backgroundProcessManager.terminateAll()`.
- `ServiceContainer` stops calling `createCoreServices`; `AppLive = CoreProjectionLive ▹ CoreOptionsFromDesktopLive ▹ CrossCuttingLive ▹ …` (cross-cutting services move into `CrossCuttingLive` now because core options derive from them). Desktop constructions otherwise stay in the constructor.

**Acceptance**
- Identity test: every `CoreServices` field `===` `Context.get(ctx, Tag)`; `serviceContainer.test.ts` unchanged and green.
- **Decision gate for PR 4** recorded in the PR body: `make typecheck` wall time, `[startup] AppRuntime built` ms and `initialize` totals vs `origin/main` baseline from the sandbox (§7). Proceed to PR 4 only if typecheck regresses < 10 % and startup within noise; otherwise stop at (C).
- Gate: `bun test src/node/services`, `src/cli/*.test.ts` (run/workflow/server/cli), tests/ipc, `make static-check`.

**Rollback:** revert restores the imperative call; PR 1/2 unaffected.

### PR 4 — Peel the core into staged per-service Layers + `CoreWiringLive` (+~330 / −~290 ⇒ net ≈ +40; split 4a/4b if > ~600 diff lines)

**Scope**
- Stages S1, S2a, S2b, S3…S8 (§2.1 + skeleton in §2.2) as `Layer.effect` adapters with today's argument lists; `CoreWiringLive` (`Effect.sync` only) replays the wiring lines in order; `CoreLive = CoreWiringLive.pipe(Layer.provideMerge(S8))` replaces `CoreProjectionLive`; `buildCoreGraph` deleted.
- Before writing any stage: re-derive the DAG from the constructor argument lists (the plan's stage table was checked once; `StreamManager → SessionUsage` is the kind of edge that turns "siblings" into a stage split) and record it in the PR body.
- 4a (S1–S3: leaves through `AIService`) / 4b (S4–S8 + wiring) if needed — 4a alone is mergeable because the remaining services are built by a shrunken projection layer that reads S1–S3 from the context.

**Acceptance**
- Wiring assertions that are behavioral (a missing wiring line fails them): `turnRequestBuilderBindings` fully populated; goal continuation consumer registered on `idleDispatcher`; `streamManager` MCP manager set; registration probe installed on `extensionMetadata`.
- I6 audit table for all 19 constructors in the PR body; missing-provider = compile error (R must be `never` at `makeAppRuntime`) demonstrated by a type-level test (`// @ts-expect-error`).
- Gate: as PR 3 plus `streamManager*.test.ts`, `aiService.test.ts`, `workspaceService*.test.ts`.

**Rollback:** revert to PR 3's projection.

### PR 5 — `DesktopLive` group layers + `DesktopWiringLive`; thin `ServiceContainer`; `StreamManager` runner param (+~170 / −~150 ⇒ net ≈ +20)

**Scope**
- Tags for the 45 desktop services; six group layers (`Layer.effectContext`, today's construction order inside each; `provideMerge` between groups that depend on each other); `DesktopWiringLive` (`Effect.sync` only) = `serviceContainer.ts:209, 263-265, 271, 288-290, 334-340, 348, 365, 375, 381-382, 434, 438-471, 474-574` in order.
- `ServiceContainer` constructor = `makeAppRuntime(AppLive(stores))` + field assignment from the context. `toORPCContext()` unchanged in shape.
- `StreamManager`: optional trailing `runner: EffectRunner`; `schedulePartialWrite` fork (`streamManager.ts:1141`) and `RetryManager` construction use it; `Scope.close` stays `Effect.runFork` (existing async-close precedent). `WorkersLive` receives `EffectRunnerTag`.

**Acceptance**
- All four existing `serviceContainer.test.ts` assertions unchanged; new identity test over `toORPCContext()` fields vs tags; `dispose()`/`shutdown()` call order asserted via spies on the *public* methods already spied today.
- I6 audit for the 45 constructors.
- Gate: tests/ipc + tests/ui (`make test-integration`), `src/cli/server.test.ts`, `src/cli/cli.test.ts`, `streamManager*.test.ts`, `aiService.test.ts`.

### PR 6 — TestClock adoption sweep + shutdown hardening + contract docs (+~20 LoC product; tests edited)

**Scope**
- Replace real-sleep cadence probes with `makeTestEffectRunner()` in `heartbeatService.test.ts`, `idleCompactionService.test.ts`, `retryManager.test.ts`, and the partial-write debounce cases of `streamManager.test.ts`; keep **one real-timer smoke test per worker** (guards the `defaultEffectRunner` path).
- `cli/server.ts`: `[shutdown]` log lines per step incl. `AppRuntime disposed {ms}`; confirm the whole `dispose()` fits the existing 5 s force-exit budget.
- Finalize the contract doc comment in `di/appRuntime.ts` (I1–I8, §5).

**Acceptance:** converted suites have zero `setTimeout`-based cadence waits (grep in PR body), same assertions; `make test-integration` green; sandbox startup/shutdown evidence (§7).

## 4. TestClock story

- **Mechanism.** `Effect.sleep`, `Schedule.fixed`, `Effect.timeout`, `Clock.currentTimeMillis` read the `Clock` reference from the running fiber's context. Workers that fork through an `EffectRunner` built under `TestClock.layer()` run on the test clock; `await testRunner.adjust("2 minutes")` advances it. `Date.now()`, `setTimeout`, `setInterval` are unaffected — heartbeat deadline math via injected `now`, `AgentStatusService`'s ref'd `setInterval`, and `backgroundProcessManager` stay on real timers/injected timestamps.
- **Benefit now:** `heartbeatService.test.ts` (6), `idleCompactionService.test.ts` (2), `retryManager.test.ts` (3 `setSystemTime` → `adjust`; `Date.now`-based `retryAt` may move to `Clock.currentTimeMillis` only if a test needs both clocks aligned), `streamManager.test.ts` debounce cases (7).
- **Deferred:** `streamBridge.test.ts` ticker (11) — needs a context/runner parameter on `subscriptionIterable`; OAuth device-flow polling and `oauthFlowManager.test.ts` (25) — non-goal.
- **Stays real:** child-process/PTY/WASM/fs-lock waits (`backgroundProcessManager` 72, `quickjsRuntime` 26, lock sleeps in `workspaceService`/`taskService`), end-to-end suites (tests/ipc, e2e).
- **Pinned in PR 2, not assumed:** `adjust` runs due sleeps and their synchronous continuations before resolving (or the helper yields until they do); `Schedule.fixed` anchoring under `TestClock` matches the wall-clock expectations in `heartbeatService.ts:149-155`; sync `Scope.close` of a TestClock-suspended fiber completes synchronously.

## 5. Shutdown protocol

1. **Trigger points unchanged:** `main.ts` `before-quit` (preventDefault → `dispose()` raced with 5 s → `app.quit()`; update-install path fire-and-forget), the second `before-quit` listener's `shutdown()` (unchanged, concurrent), `cli/server.ts` SIGINT/SIGTERM (5 s force exit), ACP `close()`, tests/ipc (`dispose()` then `shutdown()`), headless bench (`dispose()` from PR 1).
2. **`ServiceContainer.dispose()` order:**
   1. `backgroundProcessManager.beginShutdown()` — unchanged, first (latch protecting persisted monitor records).
   2. **`closeScopeBounded(appFiberScope, APP_FIBER_SCOPE_CLOSE_TIMEOUT_MS)`** — interrupts and awaits supervised fibers *while every dependency they might touch during finalization is still alive*. No occupants in Phase 11; the position is fixed now so the engine-core phase does not have to re-derive it.
   3. The existing explicit sequence verbatim (`desktopBridgeServer.stop()` … `terminateAll()` … `timelineService.flush()`).
   4. **`disposeAppRuntime(runtime, APP_RUNTIME_DISPOSE_TIMEOUT_MS)`** — closes the runtime scope (interrupts any fiber started via `runtime.runX` — none long-lived in Phase 11; runs layer finalizers — none in Phase 11 by I5). Hung → `warn` at the timeout; never rejects.
   Budget: 2 s + 2 s inner bounds inside the callers' 5 s outer budgets; the outer race in `main.ts` remains the last line of defense.
   **Rule for future occupants:** anything forked into `AppFiberScope` must tolerate interruption at any suspension point and must not depend on resources torn down in step 1; anything that needs a Layer finalizer must first prove reverse-construction order is compatible with steps 2–3 (I5).
3. **Latches:** `disposed` makes `dispose()` idempotent (two `before-quit` listeners, tests/ipc dispose+shutdown). `shutdown()` never touches the runtime or `AppFiberScope`.
4. **Late callers:** `EffectRunner` handles keep working after runtime dispose (I2), so a stray `tick()`/`scheduleRetry()` after quit cannot defect. The `ManagedRuntime` is referenced only by `ServiceContainer` and the `createCoreServices` return value.
5. **Worker `stop()` stays synchronous** (`runner.runSync(Scope.close)`) because their fibers suspend only on the clock. The engine core will fork into `AppFiberScope` (step 2.2 awaits it) — the reason both seams exist now.
6. **Crash paths:** unchanged — `uncaughtException`/SIGKILL run no finalizers. Finalizers are best-effort; durable state must remain crash-safe without them (AGENTS.md self-healing rule). Nothing in Phase 11 makes a finalizer the sole guardian of durable state.

## 6. Risk register

| # | Risk | L/I | Mitigation |
|---|---|---|---|
| R1 | A layer body suspends → `runSync` throws at startup | M/H | I1 assert + PR 1 test (b); doc comment; review checklist; entry-point catch paths verified in PR 1 |
| R2 | Construction-order side effects differ under staged builds | L/H | I6 audit per moved constructor; explicit `provideMerge` stages; wiring layers replay today's order; tests/ipc as behavioral gate |
| R3 | Double teardown (`shutdown()` ∥ `dispose()`; dispose+shutdown in tests) | M/M | `disposed` latch; runtime/AppFiberScope closed only in `dispose()`; PR 1 test |
| R4 | Late `runtime.runX` after dispose → defect | M/M | I2: services hold `EffectRunner`, never the ManagedRuntime |
| R5 | TestClock semantics differ from assumptions | M/L | PR 2 pins them before any suite converts; per-suite fallback to real timers |
| R6 | effect v4 RC churn (`Context`→`ServiceMap`, Layer renames) | M/M | All `Layer/Context/ManagedRuntime/TestClock` imports confined to `di/`; exact pin |
| R7 | Startup latency regression (splash) | L/M | `AppRuntime built` ms + `initialize` totals vs baseline in sandbox; PR 3 gate |
| R8 | Typecheck slowdown from large requirement unions | L/L | PR 3 gate records `make typecheck` wall time; fallback (C) |
| R9 | Per-request `Effect.provide` of a ~70-entry Context | L/L | echo-probe diagnostic in PR 1/5 bodies |
| R10 | Spy seams / direct-construction tests break | L/H | I4; optional trailing params; audit 4; typecheck of tests |
| R11 | CLI roots forget to dispose runtime/scope | M/L | PR 3 wires both cleanups; `src/cli/*.test.ts` assert the cleanup steps exist |
| R12 | Someone forks long-lived I/O work via `EffectRunner` expecting dispose to await it | M/M | Doc on `EffectRunner` ("unsupervised"); PR 2 asymmetry test; review audit 1 |

**Rollback:** PRs are stacked; revert in reverse order (6→1). Service classes are never modified except for optional trailing params, so any revert restores the previous composition root wholesale with no data or API implications.

## 7. Dogfooding (per PR; evidence attached to the PR body)

**Environment (headless Coder host, no `DISPLAY`):**
```bash
XUM_LOG_LEVEL=debug DEV_SERVER_SANDBOX_ARGS="--clean-projects" make dev-server-sandbox   # background bash task; prints URL + XUM_ROOT
```
- **Startup correctness:** `<XUM_ROOT>/logs/*.log` shows, in order: `Loading services...`, `[startup] AppRuntime built {ms}`, `[startup] ServiceContainer.initialize starting`, six step durations, `[startup] ServiceContainer.initialize completed {totalMs, stepDurationsMs}`. Paste baseline (`origin/main`) vs branch numbers.
- **Startup-never-crash parity (once, locally, not committed):** inject a throwing scratch layer → `xum server` exits non-zero with the existing logged error and **no** unhandled-rejection trace; for desktop, confirm by code path (`loadServices()` rejects → `main.ts:1255` dialog) and via `src/cli/server.test.ts`/ACP tests.
- **UI smoke (agent-browser):** `open <url>` → `snapshot -i` → add a scratch git repo as a project → create a workspace → send one message → `screenshot` the loaded app and the response; `attach_file` both. **Video:** start `agent-browser record` before the flow and stop it with a hard timeout (`timeout 30 agent-browser record stop`); if stopping hangs (known), attach the truncated WebM plus the screenshots and say so.
- **oRPC Effect path:** pin/unpin a memory entry (rides `handlerGen` + runtime `effect/context`); screenshot before/after; grep logs for `ManagedRuntime disposed`/defect lines (expect none).
- **Graceful quit:** record the terminal with `script -q /tmp/<workspace>-shutdown.log` (or `agent-tty` if present), `kill -TERM <pid>` → expect `[shutdown]` lines, `AppRuntime disposed {ms}`, exit 0, no force-exit message; attach the typescript. Exercise the timeout branch once with a scratch hung finalizer → `warn` + timely exit.
- **Electron (best effort):** with `Xvfb`, `make dev` + agent-browser via CDP (electron skill): screenshot splash → main window, quit via menu, confirm exit < 5 s; otherwise state that the Electron path is covered by `tests/e2e` in CI and the shared `dispose()` path exercised by `server.ts`.

**Gate suites per PR** (plus `make static-check` always):

| PR | Must pass |
|---|---|
| 1 | `src/node/services/di/*`, `serviceContainer.test.ts`, `src/node/orpc/*`, `memoryMeta*`, `make test-integration` |
| 2 | + `heartbeatService.test.ts`, `idleCompactionService.test.ts`, `retryManager.test.ts` |
| 3 | + `bun test src/node/services`, `src/cli/*.test.ts`; record PR 4 gate numbers |
| 4 | + `streamManager*.test.ts`, `aiService.test.ts`, `workspaceService*.test.ts` |
| 5 | + tests/ui via `make test-integration`, `src/cli/server.test.ts`, `src/cli/cli.test.ts` |
| 6 | converted suites + full `make test-integration` + sandbox startup/shutdown evidence |

## 8. Non-goals (explicit)

- streamManager ENGINE CORE conversion (first `AppFiberScope` occupant; separate phase).
- `Schema` at persistence boundaries; OAuth refresh/device-flow workers; `AgentStatusService` `setInterval` → Effect.
- `initialize()` as a Layer/startup effect (D2); per-service optional tags (D3); `streamBridge` on the runtime; layer finalizers for existing `dispose()` steps.
- Any change to persisted data, IPC wire shapes, or oRPC handler bodies beyond the `effect/context` source.

## 9. Assumptions stated

- `Effect.context<never>()` inside `EffectRunnerLive` returns the enclosing build context including an upstream `TestClock` entry (PR 2 test; fallback: provide `Clock.Clock` explicitly in the helper).
- `Scope.fork(parent)` inside a `Layer.effect` body yields a child closed by the runtime's layer scope on `dispose()` (PR 2 `AppFiberScope` test).
- Layer bodies never need to observe sibling construction order; all ordering that matters is expressed as `provide`/`provideMerge` stages or wiring-layer statement order.
- `EffectRunner`'s `R = never` constraint is sufficient for every lifecycle fork in the three Phase 11 workers and `StreamManager.schedulePartialWrite` (they only use `Effect.sleep`/`Schedule`/`Effect.sync`/`Effect.tryPromise` — no service tags). Verified by typecheck in PR 2/5.
- The desktop tail's teardown remains explicit unless a later RFC proves reverse-construction order compatible; this plan does not attempt it.

</details>

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$14.97`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=14.97 -->
