### PR TITLE
🤖 refactor: Effect Phase 11 PR 3 — coarse CoreProjectionLive shared core root + createCoreServices facade + CLI runtime disposal

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -23,7 +23,8 @@ import { CodexOauthService } from "../node/services/codexOauthService";
 import { CoderOauthService } from "../node/services/coderOauthService";
 import { PolicyService } from "../node/services/policyService";
 import { ProviderService } from "../node/services/providerService";
-import { createCoreServices } from "../node/services/coreServices";
+import { createCoreServices } from "../node/services/coreServicesRoot";
+import { closeScopeBounded, disposeAppRuntime } from "../node/services/di/appRuntime";
 import {
   isCaughtUpMessage,
   isReasoningDelta,
@@ -658,6 +659,8 @@ async function main(): Promise<number> {
     idleDispatcher,
     streamManager,
     turnRequestBuilderBindings,
+    runtime: coreRuntime,
+    appFiberScope,
   } = createCoreServices({
     ...runStores,
     policyService,
@@ -1571,6 +1574,9 @@ async function main(): Promise<number> {
           name: "backgroundProcessManager.beginShutdown",
           run: () => backgroundProcessManager.beginShutdown(),
         },
+        // Interrupt + await the runtime's supervised fibers while their
+        // dependencies are still alive (same slot as ServiceContainer.dispose).
+        { name: "appFiberScope.close", run: () => closeScopeBounded(appFiberScope) },
         { name: "session.dispose", run: () => session.dispose() },
         { name: "mcpServerManager.dispose", run: () => mcpServerManager.dispose() },
         { name: "codexOauthService.dispose", run: () => codexOauthService.dispose() },
@@ -1585,6 +1591,8 @@ async function main(): Promise<number> {
                 run: () => backgroundProcessManager.terminateAll(),
               },
             ]),
+        // Last: release the Effect runtime that owns the core graph.
+        { name: "appRuntime.dispose", run: () => disposeAppRuntime(coreRuntime.managed) },
       ],
       (stepName, error) => {
         const message = getErrorMessage(error);

--- a/src/cli/workflow.test.ts
+++ b/src/cli/workflow.test.ts
@@ -78,6 +78,40 @@ describe("xum workflow CLI helpers", () => {
     expect(result.exitCode).toBe(0);
   });
 
+  // The CLI root owns an Effect runtime (createCoreServices). Its cleanup must
+  // close the supervised fiber scope before the session-level disposers and
+  // release the runtime after the background processes are terminated, mirroring
+  // ServiceContainer.dispose(); the debug shutdown lines pin that order.
+  test("CLI run closes the AppFiberScope first and disposes the AppRuntime last", async () => {
+    using tmp = new DisposableTempDir("workflow-cli-runtime");
+    const repo = path.join(tmp.path, "repo");
+    const muxRoot = path.join(tmp.path, "mux-root");
+    await fs.mkdir(path.join(repo, "workflows"), { recursive: true });
+    await fs.mkdir(muxRoot, { recursive: true });
+    await fs.writeFile(
+      path.join(repo, "workflows", "echo.js"),
+      `export default function workflow() { return { reportMarkdown: "ok" }; }
+`,
+      "utf-8"
+    );
+    await trustProject(muxRoot, repo);
+
+    const result =
+      await Bun.$`${BUN_EXECUTABLE} ${INDEX_ENTRY} wf run ./workflows/echo.js --dir ${repo}`
+        .env({ ...process.env, MUX_ROOT: muxRoot, XUM_LOG_LEVEL: "debug", NO_COLOR: "1" })
+        .nothrow()
+        .quiet();
+
+    expect(result.exitCode).toBe(0);
+    const output = result.stdout.toString() + result.stderr.toString();
+    const scopeClosedAt = output.indexOf("[shutdown] AppFiberScope closed");
+    const terminateAllAt = output.indexOf("BackgroundProcessManager.terminateAll() called");
+    const runtimeDisposedAt = output.indexOf("[shutdown] AppRuntime disposed");
+    expect(scopeClosedAt).toBeGreaterThan(output.indexOf("[startup] AppRuntime built"));
+    expect(terminateAllAt).toBeGreaterThan(scopeClosedAt);
+    expect(runtimeDisposedAt).toBeGreaterThan(terminateAllAt);
+  });
+
   // Regression: headless `xum workflow` must initialize PolicyService and thread
   // it through the core service graph like the desktop wiring. Without it, a
   // stored credential for a provider that MUX_POLICY_FILE / Xum Governor now

--- a/src/cli/workflow.ts
+++ b/src/cli/workflow.ts
@@ -30,7 +30,8 @@ import { CodexOauthService } from "@/node/services/codexOauthService";
 import { CoderOauthService } from "@/node/services/coderOauthService";
 import { PolicyService } from "@/node/services/policyService";
 import { ProviderService } from "@/node/services/providerService";
-import { createCoreServices } from "@/node/services/coreServices";
+import { createCoreServices } from "@/node/services/coreServicesRoot";
+import { closeScopeBounded, disposeAppRuntime } from "@/node/services/di/appRuntime";
 import { log, type LogLevel } from "@/node/services/log";
 import { DisposableTempDir } from "@/node/services/tempDir";
 import { QuickJSRuntimeFactory } from "@/node/services/ptc/quickjsRuntime";
@@ -269,6 +270,11 @@ async function disposeWorkflowResources(input: {
   // Suppress monitor:stopped before session.dispose() triggers cleanup() so persisted
   // armed-monitor registry records survive shutdown (post-restart "monitor lost" wakes).
   input.services?.backgroundProcessManager.beginShutdown();
+  // Interrupt + await the runtime's supervised fibers while their dependencies
+  // are still alive (same slot as ServiceContainer.dispose); never rejects.
+  if (input.services) {
+    await closeScopeBounded(input.services.appFiberScope);
+  }
   try {
     input.session?.dispose();
   } catch (error) {
@@ -315,6 +321,10 @@ async function disposeWorkflowResources(input: {
     log.warn("xum workflow: failed to terminate background processes", {
       error: getErrorMessage(error),
     });
+  }
+  // Last: release the Effect runtime that owns the core graph; never rejects.
+  if (input.services) {
+    await disposeAppRuntime(input.services.runtime.managed);
   }
   input.tempDir[Symbol.dispose]();
 }

--- a/src/node/services/coreServices.ts
+++ b/src/node/services/coreServices.ts
@@ -1,5 +1,13 @@
 /**
- * Core service graph shared by `xum run` (CLI) and `ServiceContainer` (desktop).
+ * Core service graph shared by `xum run`/`xum workflow` (CLI) and
+ * `ServiceContainer` (desktop).
+ *
+ * `buildCoreGraph` is the imperative construction body. Both roots reach it
+ * through the Effect Layer graph — `CoreProjectionLive` in `di/layers/core.ts`
+ * wraps it as a single coarse layer (Effect migration Phase 11) — so the roots
+ * are `createCoreServices` (`./coreServicesRoot.ts`, CLI) and `AppLive`
+ * (`di/layers/app.ts`, desktop). Construction order and wiring here are the
+ * behavioral contract the per-service layers of the next phase must replay.
  */
 
 import * as os from "os";
@@ -105,7 +113,7 @@ export interface CoreServices {
   turnRequestBuilderBindings: TurnRequestBuilderBindings;
 }
 
-export function createCoreServices(opts: CoreServicesOptions): CoreServices {
+export function buildCoreGraph(opts: CoreServicesOptions): CoreServices {
   const { config, extensionMetadataPath } = opts;
 
   const sessionLocator = opts.sessionLocator ?? new WorkspaceSessionLocator(config.rootDir);
@@ -357,7 +365,7 @@ export function createCoreServices(opts: CoreServicesOptions): CoreServices {
   workspaceService.setAgentTaskIntegration(taskService);
 
   // Goal continuation bridge lives at the core scope so every codepath that
-  // uses createCoreServices (xum run, xum server via ServiceContainer, tests)
+  // uses the core graph (xum run, xum server via ServiceContainer, tests)
   // gets a working dispatcher. Without this, requestContinuationAfterStreamEnd
   // is a no-op and the auto-continuation loop never fires. The dispatcher is
   // also exposed so ServiceContainer can share it with HeartbeatService.

--- a/src/node/services/coreServicesRoot.test.ts
+++ b/src/node/services/coreServicesRoot.test.ts
@@ -1,0 +1,170 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import type { Context } from "effect";
+import { createConfigStores, type ConfigStores } from "@/node/config";
+import * as coreServices from "@/node/services/coreServices";
+import type { CoreServices } from "@/node/services/coreServices";
+import { AppFiberScopeTag } from "@/node/services/di/appFiberScope";
+import { closeScopeBounded, disposeAppRuntime } from "@/node/services/di/appRuntime";
+import { EffectRunnerTag } from "@/node/services/di/effectRunner";
+import { CoreOptionsTag } from "@/node/services/di/layers/core";
+import {
+  AI,
+  BackgroundProcessManagerTag,
+  ConfigTag,
+  ExtensionMetadata,
+  FileLeaseManagerTag,
+  History,
+  IdleDispatcherTag,
+  InitStateManagerTag,
+  MCPConfig,
+  MCPServerManagerTag,
+  Memory,
+  MemoryConsolidation,
+  MemoryMeta,
+  Provider,
+  ProvidersConfigStoreTag,
+  SecretsStoreTag,
+  SessionLocatorTag,
+  SessionUsage,
+  StreamManagerTag,
+  Task,
+  TurnRequestBuilderBindingsTag,
+  Workspace,
+  WorkspaceGoal,
+  WorkspaceTurnManagerTag,
+  type CoreRootTags,
+  type CoreTags,
+} from "@/node/services/di/tags";
+import { createCoreServices, type CoreServicesRoot } from "./coreServicesRoot";
+
+/**
+ * Independent field → tag listing (the production mapping lives in
+ * di/layers/core.ts); `Record<keyof CoreServices, …>` keeps it exhaustive.
+ */
+const CORE_FIELD_TAGS: Record<keyof CoreServices, Context.Key<CoreTags, unknown>> = {
+  historyService: History,
+  initStateManager: InitStateManagerTag,
+  providerService: Provider,
+  backgroundProcessManager: BackgroundProcessManagerTag,
+  sessionUsageService: SessionUsage,
+  workspaceGoalService: WorkspaceGoal,
+  idleDispatcher: IdleDispatcherTag,
+  aiService: AI,
+  streamManager: StreamManagerTag,
+  mcpConfigService: MCPConfig,
+  mcpServerManager: MCPServerManagerTag,
+  extensionMetadata: ExtensionMetadata,
+  workspaceService: Workspace,
+  taskService: Task,
+  workspaceTurnManager: WorkspaceTurnManagerTag,
+  memoryService: Memory,
+  memoryMetaService: MemoryMeta,
+  memoryConsolidationService: MemoryConsolidation,
+  turnRequestBuilderBindings: TurnRequestBuilderBindingsTag,
+};
+
+describe("createCoreServices", () => {
+  let tempDir: string;
+  let stores: ConfigStores;
+  let root: CoreServicesRoot | undefined;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "mux-core-root-test-"));
+    stores = createConfigStores(tempDir);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      // The CLI cleanup order: supervised scope first, runtime last.
+      await closeScopeBounded(root.appFiberScope);
+      await disposeAppRuntime(root.runtime.managed);
+      root = undefined;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("serves every CoreServices field through its tag (one instance each)", () => {
+    root = createCoreServices({
+      ...stores,
+      extensionMetadataPath: path.join(tempDir, "extensionMetadata.json"),
+    });
+
+    for (const [field, tag] of Object.entries(CORE_FIELD_TAGS) as Array<
+      [keyof CoreServices, Context.Key<CoreRootTags, unknown>]
+    >) {
+      expect(root.runtime.get(tag)).toBe(root[field]);
+    }
+    expect(root.appFiberScope).toBe(root.runtime.get(AppFiberScopeTag));
+    expect(root.appFiberScope.state._tag).not.toBe("Closed");
+    expect(root.runtime.get(EffectRunnerTag)).toBeDefined();
+  });
+
+  it("uses the caller's stores and carries the remaining options under CoreOptionsTag", () => {
+    const extensionMetadataPath = path.join(tempDir, "extensionMetadata.json");
+    root = createCoreServices({ ...stores, extensionMetadataPath, mcpConfig: stores.config });
+
+    expect(root.runtime.get(ConfigTag)).toBe(stores.config);
+    expect(root.runtime.get(SessionLocatorTag)).toBe(stores.sessionLocator);
+    expect(root.runtime.get(ProvidersConfigStoreTag)).toBe(stores.providersConfigStore);
+    expect(root.runtime.get(SecretsStoreTag)).toBe(stores.secretsStore);
+    expect(root.runtime.get(FileLeaseManagerTag)).toBe(stores.fileLeaseManager);
+    // Options minus stores, exactly as passed (no cross-cutting services in a CLI root).
+    expect(root.runtime.get(CoreOptionsTag)).toEqual({
+      extensionMetadataPath,
+      mcpConfig: stores.config,
+    });
+  });
+
+  it("defaults omitted stores to the config root, like the graph body did", () => {
+    root = createCoreServices({
+      config: stores.config,
+      extensionMetadataPath: path.join(tempDir, "extensionMetadata.json"),
+    });
+
+    expect(root.runtime.get(ConfigTag)).toBe(stores.config);
+    expect(root.runtime.get(SessionLocatorTag).rootDir).toBe(stores.config.rootDir);
+    expect(root.runtime.get(ProvidersConfigStoreTag).rootDir).toBe(stores.config.rootDir);
+    expect(root.runtime.get(SecretsStoreTag).rootDir).toBe(stores.config.rootDir);
+    expect(root.runtime.get(FileLeaseManagerTag).rootDir).toBe(stores.config.rootDir);
+    expect(root.runtime.get(SessionLocatorTag)).not.toBe(stores.sessionLocator);
+  });
+
+  it("releases the runtime through the CLI cleanup steps, idempotently", async () => {
+    root = createCoreServices({
+      ...stores,
+      extensionMetadataPath: path.join(tempDir, "extensionMetadata.json"),
+    });
+    const { appFiberScope, runtime } = root;
+
+    await closeScopeBounded(appFiberScope);
+    expect(appFiberScope.state._tag).toBe("Closed");
+    // Dependencies are still alive between the two steps (the explicit CLI
+    // disposers run here).
+    expect(runtime.managed.cachedContext).toBeDefined();
+
+    await disposeAppRuntime(runtime.managed);
+    expect(runtime.managed.cachedContext).toBeUndefined();
+    // The afterEach pair then exercises the idempotent second close/dispose.
+  });
+
+  it("surfaces a throwing graph body as a synchronous throw", () => {
+    const buildSpy = spyOn(coreServices, "buildCoreGraph").mockImplementation(() => {
+      throw new Error("core boom");
+    });
+    try {
+      // Same shape as a throwing service constructor, so the CLI roots' existing
+      // startup error paths apply unchanged.
+      expect(() =>
+        createCoreServices({
+          ...stores,
+          extensionMetadataPath: path.join(tempDir, "extensionMetadata.json"),
+        })
+      ).toThrow("core boom");
+    } finally {
+      buildSpy.mockRestore();
+    }
+  });
+});

--- a/src/node/services/coreServicesRoot.ts
+++ b/src/node/services/coreServicesRoot.ts
@@ -1,0 +1,37 @@
+/**
+ * Composition root for the headless CLI processes (`xum run`, `xum workflow`).
+ *
+ * Builds the core service graph through the same Layer definitions the desktop
+ * `ServiceContainer` uses (`di/layers/core.ts`) and hands back the plain
+ * `CoreServices` object the CLI code consumes, plus the runtime handles the
+ * CLI's cleanup list must release: `closeScopeBounded(appFiberScope)` before
+ * the session is disposed and `disposeAppRuntime(runtime.managed)` as the very
+ * last step (see the dispose order in `ServiceContainer` and the DI contract in
+ * `di/appRuntime.ts`).
+ */
+import type { Scope } from "effect";
+import type { CoreServices, CoreServicesOptions } from "@/node/services/coreServices";
+import { AppFiberScopeTag } from "@/node/services/di/appFiberScope";
+import { makeAppRuntime, type AppRuntime } from "@/node/services/di/appRuntime";
+import { CoreRootLive, coreServicesFromContext } from "@/node/services/di/layers/core";
+import type { CoreRootTags } from "@/node/services/di/tags";
+
+export interface CoreServicesRoot extends CoreServices {
+  /** The runtime that owns the graph; composition roots only (DI contract). */
+  readonly runtime: AppRuntime<CoreRootTags>;
+  /** Supervised fiber scope (`di/appFiberScope.ts`); closed first during cleanup. */
+  readonly appFiberScope: Scope.Closeable;
+}
+
+/**
+ * Synchronous, like every service constructor: a layer body that throws (or
+ * suspends) fails here, inside the caller's existing startup error path.
+ */
+export function createCoreServices(opts: CoreServicesOptions): CoreServicesRoot {
+  const runtime = makeAppRuntime(CoreRootLive(opts));
+  return {
+    ...coreServicesFromContext(runtime.context),
+    runtime,
+    appFiberScope: runtime.get(AppFiberScopeTag),
+  };
+}

--- a/src/node/services/di/layers/app.ts
+++ b/src/node/services/di/layers/app.ts
@@ -3,7 +3,8 @@ import type { ConfigStores } from "@/node/config";
 import { AppFiberScopeLive } from "@/node/services/di/appFiberScope";
 import { EffectRunnerLive } from "@/node/services/di/effectRunner";
 import type { AppTags } from "@/node/services/di/tags";
-import { MemoryMetaLive } from "./core";
+import { CoreProjectionLive, MemoryMetaLive } from "./core";
+import { CoreOptionsFromDesktopLive, CrossCuttingLive } from "./desktop";
 import { StoresLive } from "./stores";
 
 /**
@@ -17,11 +18,18 @@ import { StoresLive } from "./stores";
  *
  * The runtime seams sit at the base, above the stores: `EffectRunnerLive`
  * captures its building context, so placing it there keeps that context to the
- * stores plus references (`Clock`, …).
+ * stores plus references (`Clock`, …). Above them the graph replays the
+ * constructor's former order: memory metadata, the cross-cutting services, the
+ * core options derived from them, then the core graph.
  */
 export function AppLive(stores: ConfigStores): Layer.Layer<AppTags> {
   const runtimeSeams = AppFiberScopeLive.pipe(
     Layer.provideMerge(EffectRunnerLive.pipe(Layer.provideMerge(StoresLive(stores))))
   );
-  return MemoryMetaLive.pipe(Layer.provideMerge(runtimeSeams));
+  return CoreProjectionLive.pipe(
+    Layer.provideMerge(CoreOptionsFromDesktopLive),
+    Layer.provideMerge(CrossCuttingLive),
+    Layer.provideMerge(MemoryMetaLive),
+    Layer.provideMerge(runtimeSeams)
+  );
 }

--- a/src/node/services/di/layers/core.ts
+++ b/src/node/services/di/layers/core.ts
@@ -1,6 +1,43 @@
-import { Effect, Layer } from "effect";
-import { ConfigTag, MemoryMeta } from "@/node/services/di/tags";
+import { Context, Effect, Layer } from "effect";
+import type { ConfigStores } from "@/node/config";
+import {
+  buildCoreGraph,
+  type CoreServices,
+  type CoreServicesOptions,
+} from "@/node/services/coreServices";
+import { AppFiberScopeLive } from "@/node/services/di/appFiberScope";
+import { EffectRunnerLive } from "@/node/services/di/effectRunner";
+import {
+  AI,
+  BackgroundProcessManagerTag,
+  ConfigTag,
+  ExtensionMetadata,
+  FileLeaseManagerTag,
+  History,
+  IdleDispatcherTag,
+  InitStateManagerTag,
+  MCPConfig,
+  MCPServerManagerTag,
+  Memory,
+  MemoryConsolidation,
+  MemoryMeta,
+  Provider,
+  ProvidersConfigStoreTag,
+  SecretsStoreTag,
+  SessionLocatorTag,
+  SessionUsage,
+  StreamManagerTag,
+  Task,
+  TurnRequestBuilderBindingsTag,
+  Workspace,
+  WorkspaceGoal,
+  WorkspaceTurnManagerTag,
+  type CoreRootTags,
+  type CoreTags,
+  type StoreTags,
+} from "@/node/services/di/tags";
 import { MemoryMetaService } from "@/node/services/memoryMeta";
+import { StoresFromCoreOptionsLive } from "./stores";
 
 /**
  * Layers for the core service graph shared by the desktop/server app and the
@@ -13,3 +50,113 @@ export const MemoryMetaLive: Layer.Layer<MemoryMeta, never, ConfigTag> = Layer.e
   MemoryMeta,
   Effect.map(ConfigTag, (config) => new MemoryMetaService(config.rootDir))
 );
+
+/**
+ * The core graph's inputs other than the stores: today's `CoreServicesOptions`
+ * minus `ConfigStores`. The optional cross-cutting services stay optional here
+ * (present in the desktop graph, absent in CLI roots), so core constructors
+ * see exactly the arguments they saw before.
+ */
+export type CoreOptions = Omit<CoreServicesOptions, keyof ConfigStores>;
+
+export class CoreOptionsTag extends Context.Service<CoreOptionsTag, CoreOptions>()(
+  "xum/CoreOptions"
+) {}
+
+/**
+ * Coarse projection of the whole core graph: runs today's imperative
+ * construction body (`buildCoreGraph`, unchanged) once and exposes every
+ * `CoreServices` field under its tag. Zero behavior change by construction —
+ * the peel into staged per-service layers is the next phase's work, gated on
+ * this layer's typecheck/startup budgets.
+ */
+export const CoreProjectionLive: Layer.Layer<CoreTags, never, CoreOptionsTag | StoreTags> =
+  Layer.effectContext(
+    Effect.gen(function* () {
+      const opts = yield* CoreOptionsTag;
+      const core = buildCoreGraph({
+        ...opts,
+        config: yield* ConfigTag,
+        sessionLocator: yield* SessionLocatorTag,
+        providersConfigStore: yield* ProvidersConfigStoreTag,
+        secretsStore: yield* SecretsStoreTag,
+        fileLeaseManager: yield* FileLeaseManagerTag,
+      });
+      return coreContextFromServices(core);
+    })
+  );
+
+/** `CoreServices` → tagged context; inverse of `coreServicesFromContext`. */
+export function coreContextFromServices(core: CoreServices): Context.Context<CoreTags> {
+  return Context.empty().pipe(
+    Context.add(History, core.historyService),
+    Context.add(InitStateManagerTag, core.initStateManager),
+    Context.add(Provider, core.providerService),
+    Context.add(BackgroundProcessManagerTag, core.backgroundProcessManager),
+    Context.add(SessionUsage, core.sessionUsageService),
+    Context.add(WorkspaceGoal, core.workspaceGoalService),
+    Context.add(IdleDispatcherTag, core.idleDispatcher),
+    Context.add(AI, core.aiService),
+    Context.add(StreamManagerTag, core.streamManager),
+    Context.add(MCPConfig, core.mcpConfigService),
+    Context.add(MCPServerManagerTag, core.mcpServerManager),
+    Context.add(ExtensionMetadata, core.extensionMetadata),
+    Context.add(Workspace, core.workspaceService),
+    Context.add(Task, core.taskService),
+    Context.add(WorkspaceTurnManagerTag, core.workspaceTurnManager),
+    Context.add(Memory, core.memoryService),
+    Context.add(MemoryMeta, core.memoryMetaService),
+    Context.add(MemoryConsolidation, core.memoryConsolidationService),
+    Context.add(TurnRequestBuilderBindingsTag, core.turnRequestBuilderBindings)
+  );
+}
+
+/** Tagged context → the plain `CoreServices` object the roots hand out. */
+export function coreServicesFromContext(context: Context.Context<CoreTags>): CoreServices {
+  return {
+    historyService: Context.get(context, History),
+    initStateManager: Context.get(context, InitStateManagerTag),
+    providerService: Context.get(context, Provider),
+    backgroundProcessManager: Context.get(context, BackgroundProcessManagerTag),
+    sessionUsageService: Context.get(context, SessionUsage),
+    workspaceGoalService: Context.get(context, WorkspaceGoal),
+    idleDispatcher: Context.get(context, IdleDispatcherTag),
+    aiService: Context.get(context, AI),
+    streamManager: Context.get(context, StreamManagerTag),
+    mcpConfigService: Context.get(context, MCPConfig),
+    mcpServerManager: Context.get(context, MCPServerManagerTag),
+    extensionMetadata: Context.get(context, ExtensionMetadata),
+    workspaceService: Context.get(context, Workspace),
+    taskService: Context.get(context, Task),
+    workspaceTurnManager: Context.get(context, WorkspaceTurnManagerTag),
+    memoryService: Context.get(context, Memory),
+    memoryMetaService: Context.get(context, MemoryMeta),
+    memoryConsolidationService: Context.get(context, MemoryConsolidation),
+    turnRequestBuilderBindings: Context.get(context, TurnRequestBuilderBindingsTag),
+  };
+}
+
+/**
+ * Full Layer graph for a headless CLI root (`xum run`, `xum workflow`): the
+ * core projection over the caller's options, with the runtime seams at the
+ * base exactly as in `AppLive` (`./app.ts`). Composition direction is
+ * `consumer.pipe(Layer.provideMerge(provider))`; every tag stays exposed.
+ */
+export function CoreRootLive(opts: CoreServicesOptions): Layer.Layer<CoreRootTags> {
+  // The stores travel under their own tags (StoresFromCoreOptionsLive).
+  const {
+    config,
+    sessionLocator,
+    providersConfigStore,
+    secretsStore,
+    fileLeaseManager,
+    ...coreOptions
+  } = opts;
+  const runtimeSeams = AppFiberScopeLive.pipe(
+    Layer.provideMerge(EffectRunnerLive.pipe(Layer.provideMerge(StoresFromCoreOptionsLive(opts))))
+  );
+  return CoreProjectionLive.pipe(
+    Layer.provideMerge(Layer.succeed(CoreOptionsTag)(coreOptions)),
+    Layer.provideMerge(runtimeSeams)
+  );
+}

--- a/src/node/services/di/layers/desktop.ts
+++ b/src/node/services/di/layers/desktop.ts
@@ -1,0 +1,84 @@
+import * as path from "path";
+import { Context, Effect, Layer } from "effect";
+import { AnalyticsService } from "@/node/services/analytics/analyticsService";
+import { DevToolsService } from "@/node/services/devToolsService";
+import {
+  Analytics,
+  ConfigTag,
+  DevTools,
+  Experiments,
+  MemoryMeta,
+  Policy,
+  SessionTiming,
+  Telemetry,
+  WorkspaceMcpOverrides,
+  type CrossCuttingTags,
+} from "@/node/services/di/tags";
+import { ExperimentsService } from "@/node/services/experimentsService";
+import { PolicyService } from "@/node/services/policyService";
+import { SessionTimingService } from "@/node/services/sessionTimingService";
+import { TelemetryService } from "@/node/services/telemetryService";
+import { WorkspaceMcpOverridesService } from "@/node/services/workspaceMcpOverridesService";
+import { CoreOptionsTag } from "./core";
+
+/**
+ * Desktop/server-only layers (`ServiceContainer` roots). Only the services the
+ * core graph's options derive from live here so far; the remaining desktop
+ * constructions stay in the `ServiceContainer` constructor until they get
+ * their own group layers.
+ */
+
+/**
+ * Cross-cutting services, built in the order the `ServiceContainer`
+ * constructor used before they moved here. Their constructors only capture
+ * arguments; `initialize()` stays with `ServiceContainer.initialize()`.
+ */
+export const CrossCuttingLive: Layer.Layer<CrossCuttingTags, never, ConfigTag> =
+  Layer.effectContext(
+    Effect.map(ConfigTag, (config) => {
+      const policyService = new PolicyService(config);
+      const telemetryService = new TelemetryService(config.rootDir);
+      const experimentsService = new ExperimentsService({
+        telemetryService,
+        xumHome: config.rootDir,
+      });
+      const sessionTimingService = new SessionTimingService(config, telemetryService);
+      const analyticsService = new AnalyticsService(config);
+      const devToolsService = new DevToolsService(config);
+      // Desktop passes WorkspaceMcpOverridesService explicitly so AIService uses
+      // the persistent config rather than creating a default with an ephemeral one.
+      const workspaceMcpOverridesService = new WorkspaceMcpOverridesService(config);
+      return Context.empty().pipe(
+        Context.add(Policy, policyService),
+        Context.add(Telemetry, telemetryService),
+        Context.add(Experiments, experimentsService),
+        Context.add(SessionTiming, sessionTimingService),
+        Context.add(Analytics, analyticsService),
+        Context.add(DevTools, devToolsService),
+        Context.add(WorkspaceMcpOverrides, workspaceMcpOverridesService)
+      );
+    })
+  );
+
+/** The desktop's core graph options: every optional cross-cutting service present. */
+export const CoreOptionsFromDesktopLive: Layer.Layer<
+  CoreOptionsTag,
+  never,
+  ConfigTag | MemoryMeta | CrossCuttingTags
+> = Layer.effect(
+  CoreOptionsTag,
+  Effect.gen(function* () {
+    const config = yield* ConfigTag;
+    return {
+      extensionMetadataPath: path.join(config.rootDir, "extensionMetadata.json"),
+      workspaceMcpOverridesService: yield* WorkspaceMcpOverrides,
+      memoryMetaService: yield* MemoryMeta,
+      policyService: yield* Policy,
+      telemetryService: yield* Telemetry,
+      analyticsService: yield* Analytics,
+      experimentsService: yield* Experiments,
+      sessionTimingService: yield* SessionTiming,
+      devToolsService: yield* DevTools,
+    };
+  })
+);

--- a/src/node/services/di/layers/stores.ts
+++ b/src/node/services/di/layers/stores.ts
@@ -1,5 +1,12 @@
 import { Layer } from "effect";
-import type { ConfigStores } from "@/node/config";
+import {
+  FileLeaseManager,
+  ProvidersConfigStore,
+  SecretsStore,
+  WorkspaceSessionLocator,
+  type ConfigStores,
+} from "@/node/config";
+import type { CoreServicesOptions } from "@/node/services/coreServices";
 import {
   ConfigTag,
   FileLeaseManagerTag,
@@ -23,4 +30,22 @@ export function StoresLive(stores: ConfigStores): Layer.Layer<StoreTags> {
     Layer.succeed(SecretsStoreTag)(stores.secretsStore),
     Layer.succeed(FileLeaseManagerTag)(stores.fileLeaseManager)
   );
+}
+
+/**
+ * Stores for a headless CLI root (`createCoreServices`): the caller's stores
+ * when given, otherwise the same per-store defaults rooted at
+ * `config.rootDir` that the core graph body applied before the stores became
+ * layer inputs. Store constructors only compute paths, so building them ahead
+ * of the graph changes nothing observable.
+ */
+export function StoresFromCoreOptionsLive(opts: CoreServicesOptions): Layer.Layer<StoreTags> {
+  const { config } = opts;
+  return StoresLive({
+    config,
+    sessionLocator: opts.sessionLocator ?? new WorkspaceSessionLocator(config.rootDir),
+    providersConfigStore: opts.providersConfigStore ?? new ProvidersConfigStore(config.rootDir),
+    secretsStore: opts.secretsStore ?? new SecretsStore(config.rootDir),
+    fileLeaseManager: opts.fileLeaseManager ?? new FileLeaseManager(config.rootDir),
+  });
 }

--- a/src/node/services/di/tags.ts
+++ b/src/node/services/di/tags.ts
@@ -19,9 +19,35 @@ import type {
   SecretsStore,
   WorkspaceSessionLocator,
 } from "@/node/config";
+import type { AIService } from "@/node/services/aiService";
+import type { AnalyticsService } from "@/node/services/analytics/analyticsService";
+import type { BackgroundProcessManager } from "@/node/services/backgroundProcessManager";
+import type { DevToolsService } from "@/node/services/devToolsService";
+import type { ExperimentsService } from "@/node/services/experimentsService";
+import type { ExtensionMetadataService } from "@/node/services/ExtensionMetadataService";
+import type { HistoryService } from "@/node/services/historyService";
+import type { IdleDispatcher } from "@/node/services/idleDispatcher";
+import type { InitStateManager } from "@/node/services/initStateManager";
+import type { MCPConfigService } from "@/node/services/mcpConfigService";
+import type { MCPServerManager } from "@/node/services/mcpServerManager";
+import type { MemoryConsolidationService } from "@/node/services/memoryConsolidationService";
 import type { MemoryMetaService } from "@/node/services/memoryMeta";
+import type { MemoryService } from "@/node/services/memoryService";
+import type { PolicyService } from "@/node/services/policyService";
+import type { ProviderService } from "@/node/services/providerService";
+import type { SessionTimingService } from "@/node/services/sessionTimingService";
+import type { SessionUsageService } from "@/node/services/sessionUsageService";
+import type { StreamManager } from "@/node/services/streamManager";
+import type { TaskService } from "@/node/services/taskService";
+import type { TelemetryService } from "@/node/services/telemetryService";
+import type { TurnRequestBuilderBindings } from "@/node/services/turnRequestBuilder";
+import type { WorkspaceGoalService } from "@/node/services/workspaceGoalService";
+import type { WorkspaceMcpOverridesService } from "@/node/services/workspaceMcpOverridesService";
+import type { WorkspaceService } from "@/node/services/workspaceService";
+import type { WorkspaceTurnManager } from "@/node/services/workspaceTurnManager";
 import type { AppFiberScopeTag } from "./appFiberScope";
 import type { EffectRunnerTag } from "./effectRunner";
+import type { CoreOptionsTag } from "./layers/core";
 
 export class ConfigTag extends Context.Service<ConfigTag, Config>()("xum/Config") {}
 export class SessionLocatorTag extends Context.Service<
@@ -44,6 +70,72 @@ export class MemoryMeta extends Context.Service<MemoryMeta, MemoryMetaService>()
   "xum/MemoryMeta"
 ) {}
 
+// Core service graph (`CoreServices` in coreServices.ts), shared by the desktop
+// app and the headless CLI roots. One tag per `CoreServices` field.
+export class History extends Context.Service<History, HistoryService>()("xum/History") {}
+export class InitStateManagerTag extends Context.Service<InitStateManagerTag, InitStateManager>()(
+  "xum/InitStateManager"
+) {}
+export class Provider extends Context.Service<Provider, ProviderService>()("xum/Provider") {}
+export class BackgroundProcessManagerTag extends Context.Service<
+  BackgroundProcessManagerTag,
+  BackgroundProcessManager
+>()("xum/BackgroundProcessManager") {}
+export class SessionUsage extends Context.Service<SessionUsage, SessionUsageService>()(
+  "xum/SessionUsage"
+) {}
+export class WorkspaceGoal extends Context.Service<WorkspaceGoal, WorkspaceGoalService>()(
+  "xum/WorkspaceGoal"
+) {}
+export class IdleDispatcherTag extends Context.Service<IdleDispatcherTag, IdleDispatcher>()(
+  "xum/IdleDispatcher"
+) {}
+export class AI extends Context.Service<AI, AIService>()("xum/AI") {}
+export class StreamManagerTag extends Context.Service<StreamManagerTag, StreamManager>()(
+  "xum/StreamManager"
+) {}
+export class MCPConfig extends Context.Service<MCPConfig, MCPConfigService>()("xum/MCPConfig") {}
+export class MCPServerManagerTag extends Context.Service<MCPServerManagerTag, MCPServerManager>()(
+  "xum/MCPServerManager"
+) {}
+export class ExtensionMetadata extends Context.Service<
+  ExtensionMetadata,
+  ExtensionMetadataService
+>()("xum/ExtensionMetadata") {}
+export class Workspace extends Context.Service<Workspace, WorkspaceService>()("xum/Workspace") {}
+export class Task extends Context.Service<Task, TaskService>()("xum/Task") {}
+export class WorkspaceTurnManagerTag extends Context.Service<
+  WorkspaceTurnManagerTag,
+  WorkspaceTurnManager
+>()("xum/WorkspaceTurnManager") {}
+export class Memory extends Context.Service<Memory, MemoryService>()("xum/Memory") {}
+export class MemoryConsolidation extends Context.Service<
+  MemoryConsolidation,
+  MemoryConsolidationService
+>()("xum/MemoryConsolidation") {}
+/** Late-bound collaborators of the turn request builder (a mutable record, filled by wiring). */
+export class TurnRequestBuilderBindingsTag extends Context.Service<
+  TurnRequestBuilderBindingsTag,
+  TurnRequestBuilderBindings
+>()("xum/TurnRequestBuilderBindings") {}
+
+// Desktop cross-cutting services that the core graph's options derive from
+// (`CrossCuttingLive` in ./layers/desktop.ts).
+export class Policy extends Context.Service<Policy, PolicyService>()("xum/Policy") {}
+export class Telemetry extends Context.Service<Telemetry, TelemetryService>()("xum/Telemetry") {}
+export class Experiments extends Context.Service<Experiments, ExperimentsService>()(
+  "xum/Experiments"
+) {}
+export class SessionTiming extends Context.Service<SessionTiming, SessionTimingService>()(
+  "xum/SessionTiming"
+) {}
+export class Analytics extends Context.Service<Analytics, AnalyticsService>()("xum/Analytics") {}
+export class DevTools extends Context.Service<DevTools, DevToolsService>()("xum/DevTools") {}
+export class WorkspaceMcpOverrides extends Context.Service<
+  WorkspaceMcpOverrides,
+  WorkspaceMcpOverridesService
+>()("xum/WorkspaceMcpOverrides") {}
+
 /** The process's config stores (`ConfigStores`), one tag per store. */
 export type StoreTags =
   | ConfigTag
@@ -58,5 +150,40 @@ export type StoreTags =
  */
 export type RuntimeSeamTags = EffectRunnerTag | AppFiberScopeTag;
 
+/** Every `CoreServices` field, as provided by `CoreProjectionLive` (./layers/core.ts). */
+export type CoreTags =
+  | History
+  | InitStateManagerTag
+  | Provider
+  | BackgroundProcessManagerTag
+  | SessionUsage
+  | WorkspaceGoal
+  | IdleDispatcherTag
+  | AI
+  | StreamManagerTag
+  | MCPConfig
+  | MCPServerManagerTag
+  | ExtensionMetadata
+  | Workspace
+  | Task
+  | WorkspaceTurnManagerTag
+  | Memory
+  | MemoryMeta
+  | MemoryConsolidation
+  | TurnRequestBuilderBindingsTag;
+
+/** Everything a headless CLI root (`createCoreServices`) provides. */
+export type CoreRootTags = StoreTags | RuntimeSeamTags | CoreOptionsTag | CoreTags;
+
+/** The desktop cross-cutting services provided by `CrossCuttingLive`. */
+export type CrossCuttingTags =
+  | Policy
+  | Telemetry
+  | Experiments
+  | SessionTiming
+  | Analytics
+  | DevTools
+  | WorkspaceMcpOverrides;
+
 /** Every service the desktop/server app graph (`AppLive`) provides. */
-export type AppTags = StoreTags | RuntimeSeamTags | MemoryMeta;
+export type AppTags = CoreRootTags | CrossCuttingTags;

--- a/src/node/services/serviceContainer.test.ts
+++ b/src/node/services/serviceContainer.test.ts
@@ -9,7 +9,32 @@ import { createConfigStores, type Config, type ConfigStores } from "@/node/confi
 import { AppFiberScopeTag } from "@/node/services/di/appFiberScope";
 import { EffectRunnerTag } from "@/node/services/di/effectRunner";
 import * as appLayers from "@/node/services/di/layers/app";
-import { MemoryMeta } from "@/node/services/di/tags";
+import { CoreOptionsTag } from "@/node/services/di/layers/core";
+import {
+  AI,
+  Analytics,
+  DevTools,
+  Experiments,
+  IdleDispatcherTag,
+  InitStateManagerTag,
+  MCPConfig,
+  MCPServerManagerTag,
+  Memory,
+  MemoryConsolidation,
+  MemoryMeta,
+  Policy,
+  Provider,
+  SessionTiming,
+  SessionUsage,
+  StreamManagerTag,
+  Task,
+  Telemetry,
+  Workspace,
+  WorkspaceGoal,
+  WorkspaceMcpOverrides,
+  WorkspaceTurnManagerTag,
+  type AppTags,
+} from "@/node/services/di/tags";
 import { ServiceContainer } from "./serviceContainer";
 
 describe("ServiceContainer", () => {
@@ -256,6 +281,46 @@ describe("ServiceContainer", () => {
 
     services.heartbeatService.stop();
     services.idleCompactionService.stop();
+  });
+
+  it("serves the layer-built core and cross-cutting services through the fields and the Effect context", () => {
+    services = new ServiceContainer(stores);
+    const effectContext = services.toORPCContext()["effect/context"];
+
+    const fieldTags: Array<[keyof ServiceContainer, Context.Key<AppTags, unknown>]> = [
+      ["aiService", AI],
+      ["streamManager", StreamManagerTag],
+      ["initStateManager", InitStateManagerTag],
+      ["workspaceService", Workspace],
+      ["taskService", Task],
+      ["workspaceTurnManager", WorkspaceTurnManagerTag],
+      ["providerService", Provider],
+      ["mcpConfigService", MCPConfig],
+      ["mcpServerManager", MCPServerManagerTag],
+      ["sessionUsageService", SessionUsage],
+      ["workspaceGoalService", WorkspaceGoal],
+      ["memoryService", Memory],
+      ["memoryMetaService", MemoryMeta],
+      ["memoryConsolidationService", MemoryConsolidation],
+      ["idleDispatcher", IdleDispatcherTag],
+      ["policyService", Policy],
+      ["telemetryService", Telemetry],
+      ["experimentsService", Experiments],
+      ["sessionTimingService", SessionTiming],
+      ["analyticsService", Analytics],
+      ["devToolsService", DevTools],
+      ["workspaceMcpOverridesService", WorkspaceMcpOverrides],
+    ];
+    for (const [field, tag] of fieldTags) {
+      expect(Context.get(effectContext, tag)).toBe(services[field]);
+    }
+    // The core graph's options are derived from the layer-built cross-cutting
+    // instances, so core constructors received the same objects the fields expose.
+    const coreOptions = services.runtime.get(CoreOptionsTag);
+    expect(coreOptions.policyService).toBe(services.policyService);
+    expect(coreOptions.experimentsService).toBe(services.experimentsService);
+    expect(coreOptions.workspaceMcpOverridesService).toBe(services.workspaceMcpOverridesService);
+    expect(coreOptions.memoryMetaService).toBe(services.memoryMetaService);
   });
 
   it("surfaces a throwing layer as a synchronous constructor throw", () => {

--- a/src/node/services/serviceContainer.ts
+++ b/src/node/services/serviceContainer.ts
@@ -4,7 +4,7 @@ import { DEFAULT_WORKTREE_ARCHIVE_BEHAVIOR } from "@/common/config/worktreeArchi
 import { log } from "@/node/services/log";
 import type { Config, ConfigStores, WorkspaceSessionLocator } from "@/node/config";
 import type { FileLeaseManager, ProvidersConfigStore, SecretsStore } from "@/node/config";
-import { createCoreServices, type CoreServices } from "@/node/services/coreServices";
+import type { CoreServices } from "@/node/services/coreServices";
 import { PTYService } from "@/node/services/ptyService";
 import type { TerminalWindowManager } from "@/desktop/terminalWindowManager";
 import { ProjectService } from "@/node/services/projectService";
@@ -24,7 +24,7 @@ import { InstructionsService } from "@/node/services/instructionsService";
 import { ServerService } from "@/node/services/serverService";
 import { MenuEventService } from "@/node/services/menuEventService";
 import { VoiceService } from "@/node/services/voiceService";
-import { TelemetryService } from "@/node/services/telemetryService";
+import type { TelemetryService } from "@/node/services/telemetryService";
 import type {
   ErrorEvent,
   ReasoningDeltaEvent,
@@ -41,15 +41,15 @@ import { AgentBrowserSessionDiscoveryService } from "@/node/services/browser/Age
 import { BrowserBridgeTokenManager } from "@/node/services/browser/BrowserBridgeTokenManager";
 import { BrowserControlService } from "@/node/services/browser/BrowserControlService";
 import { BrowserSessionStateHub } from "@/node/services/browser/BrowserSessionStateHub";
-import { DevToolsService } from "@/node/services/devToolsService";
-import { SessionTimingService } from "@/node/services/sessionTimingService";
+import type { DevToolsService } from "@/node/services/devToolsService";
+import type { SessionTimingService } from "@/node/services/sessionTimingService";
 import { TimelineService } from "@/node/services/timelineService";
-import {
+import type {
   AnalyticsService,
-  type IngestWorkspaceMeta,
+  IngestWorkspaceMeta,
 } from "@/node/services/analytics/analyticsService";
-import { ExperimentsService } from "@/node/services/experimentsService";
-import { WorkspaceMcpOverridesService } from "@/node/services/workspaceMcpOverridesService";
+import type { ExperimentsService } from "@/node/services/experimentsService";
+import type { WorkspaceMcpOverridesService } from "@/node/services/workspaceMcpOverridesService";
 import { AgentPluginInstallService } from "@/node/services/agentPlugins/installService";
 import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import { McpOauthService } from "@/node/services/mcpOauthService";
@@ -75,7 +75,7 @@ import {
   createRuntimeForWorkspace,
   resolveWorkspaceExecutionPath,
 } from "@/node/runtime/runtimeHelpers";
-import { PolicyService } from "@/node/services/policyService";
+import type { PolicyService } from "@/node/services/policyService";
 import { ServerAuthService } from "@/node/services/serverAuthService";
 import { DesktopBridgeServer } from "@/node/services/desktop/DesktopBridgeServer";
 import { DesktopSessionManager } from "@/node/services/desktop/DesktopSessionManager";
@@ -91,17 +91,28 @@ import {
 } from "@/node/services/di/appRuntime";
 import { EffectRunnerTag } from "@/node/services/di/effectRunner";
 import { AppLive } from "@/node/services/di/layers/app";
-import { MemoryMeta, type AppTags } from "@/node/services/di/tags";
+import { coreServicesFromContext } from "@/node/services/di/layers/core";
+import {
+  Analytics,
+  DevTools,
+  Experiments,
+  Policy,
+  SessionTiming,
+  Telemetry,
+  WorkspaceMcpOverrides,
+  type AppTags,
+} from "@/node/services/di/tags";
 /**
  * ServiceContainer - Central dependency container for all backend services.
  *
  * This class instantiates and wires together all services needed by the ORPC router.
  * Services are accessed via the ORPC context object.
  *
- * Services provided by the Effect Layer graph (`di/layers/app.ts`) are built
- * first by `runtime` and handed to the constructor-wired remainder; the
- * migration moves services into the graph incrementally (see the DI contract in
- * `di/appRuntime.ts`).
+ * Services provided by the Effect Layer graph (`di/layers/app.ts`: the stores,
+ * the runtime seams, the cross-cutting services and the whole core graph) are
+ * built first by `runtime` and handed to the constructor-wired desktop
+ * remainder; the migration moves services into the graph incrementally (see
+ * the DI contract in `di/appRuntime.ts`).
  */
 export class ServiceContainer {
   public readonly runtime: AppRuntime<AppTags>;
@@ -116,7 +127,8 @@ export class ServiceContainer {
   public readonly providersConfigStore: ProvidersConfigStore;
   public readonly secretsStore: SecretsStore;
   public readonly fileLeaseManager: FileLeaseManager;
-  // Core services — instantiated by createCoreServices (shared with `xum run` CLI)
+  // Core services — built by the shared core graph layer (`di/layers/core.ts`;
+  // the same definitions back the `xum run`/`xum workflow` roots)
   private readonly historyService: CoreServices["historyService"];
   public readonly aiService: CoreServices["aiService"];
   public readonly streamManager: CoreServices["streamManager"];
@@ -204,41 +216,26 @@ export class ServiceContainer {
     this.secretsStore = stores.secretsStore;
     this.fileLeaseManager = stores.fileLeaseManager;
 
-    // Cross-cutting services: created first so they can be passed to core
-    // services via constructor params (no setter injection needed).
-    this.policyService = new PolicyService(config);
-    this.telemetryService = new TelemetryService(config.rootDir);
-    this.experimentsService = new ExperimentsService({
-      telemetryService: this.telemetryService,
-      xumHome: config.rootDir,
-    });
+    // Cross-cutting services: layer-built (`CrossCuttingLive`) ahead of the
+    // core graph, whose options derive from them (`CoreOptionsFromDesktopLive`).
+    this.policyService = this.runtime.get(Policy);
+    this.telemetryService = this.runtime.get(Telemetry);
+    this.experimentsService = this.runtime.get(Experiments);
     this.backupService = new BackupService(config, {
       gitRepo: createBackupGitRepo({
         cacheRoot: path.join(config.rootDir, "backup-cache"),
       }),
       payload: createBackupPayloadStore({ config }),
     });
-    this.sessionTimingService = new SessionTimingService(config, this.telemetryService);
-    this.analyticsService = new AnalyticsService(config);
-    this.devToolsService = new DevToolsService(config);
+    this.sessionTimingService = this.runtime.get(SessionTiming);
+    this.analyticsService = this.runtime.get(Analytics);
+    this.devToolsService = this.runtime.get(DevTools);
     this.browserBridgeTokenManager = new BrowserBridgeTokenManager();
+    this.workspaceMcpOverridesService = this.runtime.get(WorkspaceMcpOverrides);
 
-    // Desktop passes WorkspaceMcpOverridesService explicitly so AIService uses
-    // the persistent config rather than creating a default with an ephemeral one.
-    this.workspaceMcpOverridesService = new WorkspaceMcpOverridesService(config);
-
-    const core = createCoreServices({
-      ...stores,
-      extensionMetadataPath: path.join(config.rootDir, "extensionMetadata.json"),
-      workspaceMcpOverridesService: this.workspaceMcpOverridesService,
-      memoryMetaService: this.runtime.get(MemoryMeta),
-      policyService: this.policyService,
-      telemetryService: this.telemetryService,
-      analyticsService: this.analyticsService,
-      experimentsService: this.experimentsService,
-      sessionTimingService: this.sessionTimingService,
-      devToolsService: this.devToolsService,
-    });
+    // The core graph (shared with the `xum run`/`xum workflow` roots) is built by
+    // `CoreProjectionLive`; read it back as the plain object the wiring below uses.
+    const core = coreServicesFromContext(this.runtime.context);
 
     // Spread core services into class fields
     this.historyService = core.historyService;
@@ -328,7 +325,7 @@ export class ServiceContainer {
     this.workspaceService.setIdleCompactionOutcomeListener((workspaceId, outcome) =>
       this.idleCompactionService.recordOutcome(workspaceId, outcome)
     );
-    // IdleDispatcher + goal continuation bridge are owned by createCoreServices
+    // IdleDispatcher + goal continuation bridge are owned by the core graph
     // so the wiring works for `xum run` too. Share the same dispatcher with
     // HeartbeatService — its priority ordering ensures an active goal
     // suppresses background heartbeats.
@@ -421,7 +418,7 @@ export class ServiceContainer {
     // Wire terminal service to workspace service for cleanup on removal
     this.workspaceService.setTerminalService(this.terminalService);
     this.workspaceService.setDesktopSessionManager(this.desktopSessionManager);
-    // Plugin-override pruning is wired inside createCoreServices (shared with
+    // Plugin-override pruning is wired inside the core graph (shared with
     // headless CLI registration), using this.workspaceMcpOverridesService.
     // Editor service for opening workspaces in code editors
     this.editorService = new EditorService(config, this.workspaceService);


### PR DESCRIPTION
## Summary

Effect migration Phase 11, PR 3 of 6: the whole core service graph now builds inside the app's Effect `ManagedRuntime` as one coarse layer (`CoreProjectionLive`), shared by the desktop `ServiceContainer` and the headless CLI roots (`xum run`, `xum workflow`), which gain runtime ownership + disposal. Zero behavior change by construction: today's imperative construction body (`createCoreServices` → renamed `buildCoreGraph`) runs unchanged inside the layer. This PR also records the **PR 4 decision gate** numbers (typecheck wall time, startup timings) — see below.

Plan: `~/.xum/plans/mux/effect-phase11-managed-runtime-di.md` §3 "PR 3" (attached verbatim below). Stack: #4049 (PR 1, skeleton) → #4050 (PR 2, runtime seams) → **this**.

## Implementation

- `di/tags.ts`: tags for the 18 remaining `CoreServices` fields (`History`, `InitStateManagerTag`, `Provider`, `BackgroundProcessManagerTag`, `SessionUsage`, `WorkspaceGoal`, `IdleDispatcherTag`, `AI`, `StreamManagerTag`, `MCPConfig`, `MCPServerManagerTag`, `ExtensionMetadata`, `Workspace`, `Task`, `WorkspaceTurnManagerTag`, `Memory`, `MemoryConsolidation`, `TurnRequestBuilderBindingsTag`) + the 7 desktop cross-cutting services (`Policy`, `Telemetry`, `Experiments`, `SessionTiming`, `Analytics`, `DevTools`, `WorkspaceMcpOverrides`); unions `CoreTags`, `CoreRootTags`, `CrossCuttingTags`, `AppTags`.
- `di/layers/core.ts`: `CoreOptionsTag` (`CoreServicesOptions` minus `ConfigStores`), **`CoreProjectionLive = Layer.effectContext(…)`** wrapping `buildCoreGraph` and returning `Context<CoreTags>`; `coreContextFromServices` / `coreServicesFromContext` (the two directions of the projection); `CoreRootLive(opts)` = the CLI root graph (`CoreProjectionLive ▹ succeed(CoreOptionsTag) ▹ AppFiberScopeLive ▹ EffectRunnerLive ▹ StoresFromCoreOptionsLive`).
- `di/layers/stores.ts`: `StoresFromCoreOptionsLive(opts)` reproduces the `opts.x ?? new X(config.rootDir)` store defaults for CLI roots.
- `di/layers/desktop.ts` (new): `CrossCuttingLive` (group layer, `Layer.effectContext`, today's construction order) and `CoreOptionsFromDesktopLive` (derives the core options from the layer-built cross-cutting instances + `MemoryMeta` + `Config`).
- `di/layers/app.ts`: `AppLive = CoreProjectionLive ▹ CoreOptionsFromDesktopLive ▹ CrossCuttingLive ▹ MemoryMetaLive ▹ AppFiberScopeLive ▹ EffectRunnerLive ▹ StoresLive`.
- `coreServicesRoot.ts` (new): `createCoreServices(opts)` = `makeAppRuntime(CoreRootLive(opts))`, returns today's `CoreServices` object read back from the context **plus `runtime` and `appFiberScope`**. Kept as a separate module from `coreServices.ts` (see notes).
- `serviceContainer.ts`: stops calling `createCoreServices`; reads the cross-cutting services and the core graph from the runtime context. `BackupService`/`BrowserBridgeTokenManager` and all other desktop constructions stay in the constructor (PR 5).
- `cli/run.ts`, `cli/workflow.ts`: cleanup lists gain `closeScopeBounded(appFiberScope)` right after `backgroundProcessManager.beginShutdown()` (before `session.dispose()`) and `disposeAppRuntime(runtime.managed)` after `backgroundProcessManager.terminateAll()` (PR 2's `boundedTeardown` shape: uninterruptible, bounded, never rejects, idempotent).

### Tests
- `coreServicesRoot.test.ts` (new): identity of every `CoreServices` field vs `runtime.get(Tag)` (exhaustive `Record<keyof CoreServices, Tag>`), stores identity/defaults, `CoreOptionsTag` contents, the CLI cleanup pair (scope closed while runtime alive → runtime disposed, idempotent), throwing graph body → synchronous throw.
- `serviceContainer.test.ts`: existing tests unchanged; one added identity test over 22 public fields vs tags + `CoreOptionsTag` derivation.
- `cli/workflow.test.ts`: one added end-to-end test pinning the cleanup order through the debug shutdown lines (`AppFiberScope closed` → `terminateAll() called` → `AppRuntime disposed`).

## PR 3 notes

**Deviations from the plan**
1. `createCoreServices` lives in a new module `coreServicesRoot.ts` instead of `coreServices.ts`: `di/layers/core.ts` must import `buildCoreGraph` from `coreServices.ts`, so a facade in the same module would create a runtime import cycle (`coreServices → di/layers/core → coreServices`). Keeping the body in place gives reviewers a 3-line diff on `coreServices.ts` proving the body is unchanged; the two CLI import sites move to the new module. PR 4 deletes `buildCoreGraph`, after which the facade can fold back if desired.
2. `CrossCuttingLive` carries only the seven services the core options derive from. `BackupService` and `BrowserBridgeTokenManager` (pure constructors, no core dependency) stay in the constructor until PR 5's group layers.
3. `CoreOptionsTag` is provided **above** the runtime seams in `CoreRootLive` (not beneath `EffectRunnerLive` as the plan's formula reads), so the runner's captured context stays "stores + refs" exactly as PR 2 pinned.
4. The `xum run` cleanup order cannot be unit-tested without a provider (the provider-denial path exits through the `unhandledRejection` handler before the cleanup list — pre-existing); it is pinned through `xum workflow` (same helpers, same order) and shown live in the dogfooding transcript below.

**Pre-review audits (plan §3)**
1. Interruption posture — no new fiber forks; the only fibers are the synchronous layer build fiber and `boundedTeardown`'s detached teardown fibers (PR 2).
2. Uninterruptible teardown — CLI roots call PR 2's `closeScopeBounded`/`disposeAppRuntime` unchanged.
3. No defect escapes — both helpers never reject (pinned by `di/*.test.ts`); in `run.ts` they additionally sit inside `runBestEffortCleanup`. `createCoreServices` throws only from `makeAppRuntime` (constructor semantics), inside the callers' existing startup error paths (`main().catch` / `createWorkflowContext`'s catch → `disposeWorkflowResources`).
4. Spy seams — `rg 'createCoreServices'` → only `cli/run.ts`, `cli/workflow.ts` (+ new test); no test constructs or spies through it. Return shape is additive (`runtime`, `appFiberScope`); every field identity is asserted. No service class, constructor, facade or private method changed.
5. Sync-start — eager `runSync` build; `CoreProjectionLive`'s body only reads tags; asserted by `cachedContext !== undefined` after `createCoreServices` and by the unchanged TestClock test on `ServiceContainer`.
6. Constructor side-effect audit (I6) for the constructors that moved into layers: `PolicyService` (`setMaxListeners` on its own emitter), `TelemetryService`, `ExperimentsService`, `SessionTimingService`, `AnalyticsService`, `DevToolsService`, `WorkspaceMcpOverridesService` (assert on its own arg) — each touches only its declared arguments; relative order preserved (policy → telemetry → experiments → sessionTiming → analytics → devTools → workspaceMcpOverrides). Store defaults for CLI roots (`WorkspaceSessionLocator`, `ProvidersConfigStore`, `SecretsStore`, `FileLeaseManager`) now build before `HistoryService`/`InitStateManager`; their constructors only compute paths. Core body constructors: unmoved.
7. Zero-suspension audit — `memoryConsolidationService` is constructed inside `buildCoreGraph`; `git diff` on `coreServices.ts` is the module doc comment, the function rename, and one stale comment word — no code change.

## DECISION GATE for PR 4 — **GATE: PASS**

Criteria (plan §3 PR 3): proceed to PR 4 (staged per-service core layers) only if `make typecheck` regresses **< 10 %** AND startup is **within noise**; otherwise stop at (C) coarse projection.

**Methodology.** Same host, same `node_modules` (symlinked), both revisions checked out as sibling `git worktree`s under `/tmp` (`origin/main` = `655bc56f4` vs this branch = `c6494b1d2`) so Make/git prerequisite overhead is location-neutral — a first attempt that compared the Mux-managed worktree against a `/tmp` worktree carried a ~0.6 s prerequisite bias (`make typecheck TSGO=true`: 1.44 s vs 0.85 s) unrelated to code. Runs interleaved main/branch/main/… to cancel host drift; host was a shared 96-core Coder box at load ≈ 130–146 with CPU PSI `some avg60` ≈ 30–34 % throughout (recorded before/after each series). Medians reported.

**(a) `make typecheck` wall time** (both `tsgo` projects concurrently, 6 interleaved pairs):

| | origin/main | branch | Δ |
|---|---|---|---|
| median | **10.77 s** | **11.20 s** | **+4.0 %** |
| min / max | 10.46 / 11.73 s | 10.67 / 11.85 s | |

tsgo `--extendedDiagnostics` (4 runs each, interleaved) isolates the compiler itself:

| project | metric | origin/main | branch | Δ |
|---|---|---|---|---|
| renderer (`tsconfig.json`) | check time (median) | 7.43 s | 7.53 s | +1.3 % |
| renderer | types / instantiations | 1 942 113 / 7 799 643 | 1 928 628 / 7 775 777 | −0.7 % / −0.3 % |
| main (`tsconfig.main.json`) | check time (median) | 3.34 s | 3.28 s | −1.8 % |
| main | types / instantiations | 1 047 206 / 4 264 332 | 1 047 163 / 4 250 448 | ±0 / −0.3 % |

**(b) Startup** (`bun src/cli/index.ts server --no-auth` with a fresh `XUM_ROOT`, `XUM_LOG_LEVEL=debug`, recorded under `script -f`, 5 interleaved pairs; SIGTERM ≈1 s after `initialize completed`):

| metric | origin/main | branch | note |
|---|---|---|---|
| `[startup] AppRuntime built` ms (median, min–max) | 4 (4–4) | 11 (10–21) | expected: the whole core graph + cross-cutting services now build inside the runtime (relocated from the constructor, see next row) |
| `new ServiceContainer(stores)` cold, first construction in a fresh process (3 processes) | 15.7 / 15.8 / 17.1 ms | 17.3 / 18.0 / 27.8 ms | total construction ≈ +2 ms cold; warm (2nd–15th construction) median 0.9 → 1.1 ms |
| `[startup] ServiceContainer.initialize completed { totalMs }` (median, min–max) | 80 (78–97) | 82 (73–120) | within noise |
| SIGTERM → exit wall (median), exit code | 156 ms, 0/0/0/0/0 | 150 ms, 0/0/0/0/0 | `[shutdown] AppFiberScope closed` → explicit steps → `[shutdown] AppRuntime disposed` in every transcript |

PR 2 measured 3 ms / 227–305 ms on a different day/host state; today's baseline on `origin/main` is 4 ms / 80 ms, so the comparison above is like-for-like.

**Verdict: GATE: PASS** — typecheck +4.0 % wall (< 10 %; compiler-internal check time within ±2 %, type counts flat), startup within noise (initialize 80 → 82 ms; construction +≈2 ms cold). Proceed to PR 4.

## Lessons for PR 4
- Re-derive the DAG from the constructor argument lists in `buildCoreGraph` before writing stages; the plan's stage table was checked once. Known splitting edge: `StreamManager(historyService, sessionUsageService, …)` needs `SessionUsage` ⇒ S2a (SessionUsage · Goal · Memory) → S2b (StreamManager); `MemoryService(config, memoryMetaService)` needs `MemoryMeta` (S1); `MemoryConsolidationService` needs `AIService` (S3) ⇒ S4; `MCPConfigService` needs `aiService` as `workspaceMetadataProvider` ⇒ S4; `MCPServerManager` needs `mcpConfigService` + `workspaceMcpOverridesService` ⇒ S5; `WorkspaceService` needs `streamManager`, `aiService`, `extensionMetadata`, … ⇒ S6; `TaskService` needs `workspaceService` + `TerminalAttentionStore` ⇒ S7; `WorkspaceTurnManager` needs `taskService` ⇒ S8; `IdleDispatcher` is constructed last today but has no dependencies (S1) — the wiring layer must still register the goal-continuation consumer after `Task`/`Workspace` exist.
- `CoreWiringLive` must replay, in order: `extensionMetadata.setRegistrationProbe`, `turnRequestBuilderBindings.*` (memoryService, mcpServerManager, workspaceHeartbeatService, onWorkflowRunStatusChanged, workflowResultContinuationSender, taskService, workspaceTurnManager), `streamManager.setMCPServerManager`, `mcpServerManager.setSecretsResolver`, the `workspaceService.set*` calls, `workspaceGoalService.setOnActivityChange/setStreamInterrupter/registerGoalContinuationConsumer`, `taskService.setWorkspaceTurnManager`, `workspaceService.setAgentTaskIntegration`.
- `TerminalAttentionStore` and the default `WorkspaceMcpOverridesService` are constructed inside the body but not exported in `CoreServices`; they need tags in PR 4 (`TerminalAttentionStoreTag`; `WorkspaceMcpOverrides` exists — CLI roots need a `Layer.sync` default beneath `CoreOptionsTag`).
- `coreContextFromServices`/`coreServicesFromContext` and the exhaustive `Record<keyof CoreServices, Tag>` identity test are the acceptance harness for the peel: after PR 4 the same test must pass with `CoreProjectionLive` replaced by `CoreLive`.
- The `xum run` cleanup order can only be observed end-to-end with a provider (transcript below); keep the `xum workflow` debug-line test as the CI pin.

## Validation

- `make static-check` green; `bun test src/node/services` (6,762 pass; the only failures — `taskGitPatchEngine` ×2, `WorkspaceTurnManager` terminal recovery ×2, `agent_skill_delete` ×1, `BackupRepoCache` ×7, `workflow_run duplicate guard` wedge — reproduce identically on a pristine `origin/main` worktree on this host, i.e. pre-existing environment baselines; `workflow_run.test.ts` passes 25/25 in isolation); `bun test src/cli` 185/185; jest `tests/ipc/{doubleRegister,savedQueries,windowTitle,acp.disconnectCleanup}` 18/18 (the `ServiceContainer`-booting suites that need no provider; the provider/SSH-dependent rest is CI's lane).
- Dogfooding (headless Coder host, `script -f`-recorded transcripts, `XUM_LOG_LEVEL=debug`):
  - **`xum run`** (real turn, `anthropic:claude-haiku-4-5` via the Coder AI bridge): reply `pong`, `Cost: $0.02`, exit 0; tail of the transcript shows `[startup] AppRuntime built {ms: 8}` … `[shutdown] AppFiberScope closed {ms: 6}` → `BackgroundProcessManager.cleanup(run-…)` (session.dispose) → `terminateAll() called` → `Cleaned up temp dir` → `[shutdown] AppRuntime disposed {ms: 9}` → `COMMAND_EXIT_CODE="0"`. A first attempt with the plain API key hit the bridge's 403 — that errored stream also ran the full cleanup list in the same order (exit 1 from the stream error, not from cleanup).
  - **`xum workflow`** (`wf run ./workflows/echo.js`): `AppRuntime built` → `ok from pr3` → `AppFiberScope closed` → `terminateAll() called` → `AppRuntime disposed` → exit 0 (same order the new `workflow.test.ts` case pins in CI).
  - **`xum server` graceful quit**: 5/5 probe runs on the branch exit 0 within 127–164 ms of SIGTERM with `[shutdown] AppFiberScope closed` before the explicit steps and `[shutdown] AppRuntime disposed` last (identical shape on `origin/main`, where PR 2 already placed these two steps in `ServiceContainer.dispose()`).
  - **Dev-server sandbox** (`make dev-server-sandbox --clean-projects`): backend boots (`AppRuntime built {ms: 8}`, `initialize completed {totalMs: 235–281}` with the seeded config), the web UI loads (screenshot in the workspace chat shows the branch version string `v0.28.3-nightly.148-16-gc6494b1d2`), and SIGTERM exits in 241 ms with the two `[shutdown]` runtime lines in place.
  - Not exercised headless: the Electron `before-quit` path (covered by code path parity — `main.ts` calls the same `ServiceContainer.dispose()` — and `tests/e2e` in CI). The oRPC Effect path (`handlerGen` + `effect/context`) is covered by the unchanged `effectBridge.test.ts` and the identity tests (`Context.get(effectContext, MemoryMeta) === services.memoryMetaService`).

## Risks

- **Low.** Service classes, constructors, facades and the core construction body are unchanged; the only construction-order changes are the pure store defaults (CLI roots) and `BackupService`/`BrowserBridgeTokenManager` moving after the core graph on the desktop (both constructors capture arguments only). A layer body that throws still surfaces as the same synchronous throw from `new ServiceContainer(stores)` / `createCoreServices(opts)` (tests). New CLI cleanup steps never reject (PR 2 contract, tests) and are bounded (2 s each) inside the existing budgets.
- Startup: construction moves inside the runtime (+≈2 ms cold total, see gate); no `initialize()` changes.

---

<details>
<summary>📋 Implementation Plan</summary>

# Effect migration — Wave 3 / Phase 11: ManagedRuntime + Layer dependency injection

## 0. Summary

Replace the two hand-written composition roots (`createCoreServices` + the `ServiceContainer` constructor) with an **Effect `Layer` graph** built once per process by a **`ManagedRuntime`** ("AppRuntime"), while keeping every service class, constructor signature, Promise facade, private method, and test seam compatible. The runtime becomes (a) the owner of the app-lifetime `Scope`, (b) the provider of `"effect/context"` for oRPC Effect-native handlers, and (c) the source of two runtime seams: an **`EffectRunner`** (context-bound, *unsupervised* runner that lets clock-driven workers run on a `TestClock`) and an **`AppFiberScope`** (a runtime-owned, *supervised* scope whose close is awaited by `dispose()` — the slot the streamManager engine core will occupy later).

Six stacked, independently mergeable PRs. Product PRs keep existing tests unchanged; only the final test-modernization PR edits tests. Net product LoC ≈ **+420** (per-PR estimates below). Service classes are *not* rewritten — Layers are thin adapters around existing constructors; cycle-breaking setter wiring moves into explicit "wiring layers" that replay today's order.

Unlocks (not done here): streamManager ENGINE CORE conversion, `TestClock` for timing suites, app-lifetime scopes.

## 1. Verified current state (evidence)

- **Roots.** `src/node/services/coreServices.ts:103-389` (`createCoreServices`: 25 constructions, 12 `turnRequestBuilderBindings` writes, ~14 setters) and `src/node/services/serviceContainer.ts:161-575` (45 more constructions; `aiService.on(...)`/`workspaceService.on(...)` analytics wiring at 474-574; global registrations `setGlobalCoderService/setSshPromptService` at 469-471). `new ServiceContainer(stores)` is called by `headlessEnvironment.ts:111`, `tests/ipc/setup.ts`, `src/cli/server.ts:132`, `src/node/acp/serverConnection.ts:155`, `src/desktop/main.ts:653`; `src/cli/run.ts:661` and `src/cli/workflow.ts:376` call `createCoreServices` directly. ⇒ two graph roots (App vs Core), five process entry points, all constructing **synchronously**.
- **Startup.** `ServiceContainer.initialize()` (577-642) awaits six `initialize()`s (no try/catch; failure propagates to `main.ts:1255-1265` "Startup Failed" dialog + quit; `server.ts`/ACP log and exit), then sync `start()`s idleCompaction/heartbeat/agentStatus, then two fire-and-forget sweeps. All constructors are synchronous; two have side effects on **declared constructor dependencies** only (`AIService` → `streamManager.setEventSink`, `WorkspaceService` → `backgroundProcessManager.on/aiService.on`).
- **Teardown.** `dispose()` (746-779) is explicit and hand-ordered (`backgroundProcessManager.beginShutdown()` MUST be first — it is a latch protecting persisted monitor records; bridges stop before sessions close; `terminateAll` late; `timelineService.flush()` last). `shutdown()` (718-732) is a *second* sequence fired concurrently by a second `before-quit` listener (`main.ts:1321`). `main.ts:1296-1304` races `dispose()` against 5 s then `app.quit()`; `cli/server.ts:227-268` has a 5 s `process.exit(1)` force timer; `tests/ipc` cleanup calls `dispose()` then `shutdown()`; `headlessEnvironment.dispose` never calls `services.dispose()`.
- **Existing Effect surface.** 25 files import `effect`. Only `Context.Service` tag: `MemoryMeta` (`src/node/orpc/effectContext.ts:21`). `handlerGen` (`@orpc/experimental-effect`) runs `Effect.runPromiseExit` per request and `Effect.provide`s `opts.context["effect/context"]`. `streamBridge.ts` runs streams on the global runtime. Scope-owning workers: `heartbeatService.ts:134-243`, `idleCompactionService.ts:86-122` (`Scope.makeUnsafe` + `Effect.runSync(Scope.close(..))`, valid only because their fibers suspend solely on the clock), `oauthFlowManager.ts:164`, `streamManager.ts:4767/4054` (already `Effect.runFork(Scope.close(..))` — the async-close precedent). `memoryConsolidationService.ts:667-703, 837-860`: check-and-reserve funnels with zero suspensions before `inFlight.set`/`harvestInFlight.set`.
- **effect@4.0.0-rc.112 API (verified in `node_modules/effect/dist`).** `Context.Service<Self, Shape>()("id")` (module `Context`, not `ServiceMap`); `Layer.{succeed,sync,effect,effectContext,effectDiscard,provide,provideMerge,mergeAll,build,buildWithScope}` (no `Layer.scoped`; `Layer.effect` strips `Scope` from R); `ManagedRuntime.make(layer)` → `{ runSync, runSyncExit, runFork, runPromise, runPromiseExit, contextEffect, cachedContext, scope, dispose(), disposeEffect }`; `Effect.{runSyncWith,runForkWith,runPromiseWith,runPromiseExitWith}(context)`; `Effect.context<R>()`; `Effect.serviceOption`; `Scope.{fork,forkUnsafe,close,provide}`; `TestClock` from `effect/testing` (`layer, adjust, setTime, withLive`); `Clock.Clock` is a `Context.Reference` (defaulted; `TestClock.layer()` overrides it).
- **ManagedRuntime internals the design relies on** (`ManagedRuntime.js`): `make` creates `scope = Scope.makeUnsafe("parallel")` and `layerScope = Scope.forkUnsafe(scope, "sequential")`; the first `runX` forks a build fiber over `Layer.buildWithMemoMap` — a **fully synchronous layer graph builds synchronously**, so `runtime.runSync(Effect.context())` succeeds and sets `cachedContext`; afterwards every `runX` is `Effect.run…With(cachedContext)` (no extra async boundary). Fibers started through `runtime.runX` are registered in `scope` (`onFiberStart: Fiber.runIn(scope)`). `dispose()` = `Scope.close(scope)` (interrupt registered fibers in parallel → layer finalizers sequentially in reverse), after which any `runtime.runX` dies with `"ManagedRuntime disposed"`.
- **Layer composition semantics.** `Layer.mergeAll(A, B)` is *not* a dependency resolver: B's requirements are not satisfied by A's outputs; requirements bubble up. Dependencies are satisfied only via `Layer.provide`/`provideMerge` chains. Siblings in `mergeAll` may build concurrently.
- **Test seams that pin signatures** (Explore report): private-method spies (`Config.saveConfig`, `WorkspaceService.retireKernelWorkflowRunReferences/startStartupRecovery/createSession/updateAgentStatus`, `MCPServerManager.startServers`, `AgentPluginInstallService.reconcileJournals`, …); module-level export spies (`agentStatusService.generateWorkspaceStatus`, `sshConnectionPool.verifyHostKeyAgainstPolicyEffect`, …); direct construction in tests (`Config` 44 files, `HistoryService` 22, `MemoryMetaService` 11, `WorkspaceService` 7, `IdleDispatcher` 6, `StreamManager` 4, `ServiceContainer` 3); partial-mock casts (`InitStateManager` 193, `AIService` 158, `TaskService` 149, `ORPCContext` 62). `effectBridge.test.ts:24-30` builds a partial `ORPCContext` via `buildOrpcEffectContext` + `as unknown as ORPCContext`.
- **Timing probes** (TestClock candidates): `heartbeatService.test.ts` 6 real sleeps, `idleCompactionService.test.ts` 2, `retryManager.test.ts` 3 `setSystemTime`, `streamManager.test.ts` 7 (partial-write debounce), `streamBridge.test.ts` 11 (heartbeat ticker), OAuth device-flow suites 14 (non-goal).

## 2. Target architecture

### 2.1 Building blocks (all under `src/node/services/di/`; the *only* directory allowed to import `Layer`/`Context`/`ManagedRuntime`/`TestClock`)

| Module | Contents |
|---|---|
| `tags.ts` | One `Context.Service` tag per service class provided by the graph. Type-only imports of service classes ⇒ no runtime import cycles. Ids `"xum/<Name>"`. Naming: class name minus trailing `Service` (`MemoryMeta`, `Workspace`, `History`); classes without that suffix or colliding with an exported name get a `Tag` suffix (`ConfigTag`, `StreamManagerTag`, `IdleDispatcherTag`). Exports the unions `CoreTags` and `AppTags`. |
| `effectRunner.ts` | `interface EffectRunner { runSync<A,E>(e: Effect<A,E,never>): A; runSyncExit; runFork; runPromise; runPromiseExit }` — a **context-bound, unsupervised** runner whose methods accept only effects with **no service requirements** (`R = never`; defaulted references like `Clock` do not appear in `R`). That makes "not a service locator" type-enforced: a fiber that needs services must take them as explicit constructor dependencies and, if it must be awaited on shutdown, fork into `AppFiberScope`. `defaultEffectRunner` = the global `Effect.runX` (today's exact behavior). `effectRunnerFromContext(ctx)` = `Effect.run…With(ctx)`. `EffectRunnerTag` + `EffectRunnerLive = Layer.effect(EffectRunnerTag, Effect.map(Effect.context<never>(), effectRunnerFromContext))`, placed at the **base** of the graph so the captured context contains only refs (`Clock`, later `Logger`/`Random`) plus stores. Fibers forked through it are owned by the worker's own `Scope` (explicit `start/stop`), **not** by the ManagedRuntime; `runtime.dispose()` does not interrupt them. Services import only this file from `di/`. |
| `appFiberScope.ts` | `AppFiberScopeTag: Scope.Closeable`. `AppFiberScopeLive = Layer.effect(AppFiberScopeTag, Effect.gen(function*(){ const parent = yield* Effect.scope; return yield* Scope.fork(parent, "parallel"); }))` — a child of the runtime's layer scope. Fibers forked into it via `Effect.forkIn(_, appFiberScope)` are interrupted **and awaited** when the scope closes. This is the **supervised** seam for I/O-suspended fibers (engine core, later). `ServiceContainer.dispose()` closes it explicitly and early (§5) so interrupted fibers can still use their dependencies during finalization; `runtime.dispose()` later re-closes it idempotently as a backstop. No production occupant in Phase 11; the seam exists with tests. |
| `appRuntime.ts` | `makeAppRuntime(layer)`: `ManagedRuntime.make(layer)` + **eager synchronous build** (`runtime.runSync(Effect.context<R>())`; `assert(runtime.cachedContext !== undefined)`); a layer body that suspends is a programming error and throws here — exactly where a throwing constructor throws today, so every entry point's existing catch/dialog/log path is preserved. `disposeAppRuntime(runtime, timeoutMs)` and `closeScopeBounded(scope, timeoutMs)` share one shape: `Effect.uninterruptible` teardown shell around `Effect.interruptible(target.pipe(Effect.timeout(timeoutMs)))` where `target` is `runtime.disposeEffect` resp. `Scope.close(scope, Exit.void)` (never a non-cancellable JS Promise wrapper); `Effect.catchTag("TimeoutError", …)` + `Effect.catchDefect` → `log.warn`; run via `Effect.runPromise`; **never rejects**; idempotent (`Scope.close` is idempotent; `disposeEffect` is guarded by a latch). Verify the exact rc `Effect.timeout` error type at implementation time (rc.112: fails with `Cause.TimeoutError`, `_tag: "TimeoutError"`). Module doc comment = the DI contract (§2.3, §5). |
| `layers/stores.ts` | `StoresLive(stores: ConfigStores)` = `Layer.mergeAll` of `Layer.succeed` for `ConfigTag`, `SessionLocatorTag`, `ProvidersConfigStoreTag`, `SecretsStoreTag`, `FileLeaseManagerTag` (true siblings — no inter-dependencies). `StoresFromCoreOptionsLive` reproduces the `opts.x ?? new X(config.rootDir)` defaults of `coreServices.ts:106-112` for the CLI root. |
| `layers/core.ts` | `CoreOptionsTag` (today's `CoreServicesOptions` minus stores — carries the *optional* cross-cutting services exactly as today). **PR 3:** `CoreProjectionLive = Layer.effectContext(...)` wrapping the existing `createCoreServices` body and returning a `Context<CoreTags>` (coarse projection, zero behavior change). **PR 4:** peel into per-service `Layer.effect(Tag, Effect.gen(...))` layers composed in **explicit dependency stages** (`Layer.provideMerge` between stages; `Layer.mergeAll` only for true siblings within a stage — every sibling claim below was checked against the constructor argument lists in `coreServices.ts` and must be re-checked in the PR): S1 History · InitState · Provider · BackgroundProcess · ExtensionMetadata · MemoryMeta · TerminalAttention · IdleDispatcher · WorkspaceMcpOverrides(default) · `TurnRequestBuilderBindingsTag` (`Layer.succeed(_, {})`) → S2a SessionUsage · Goal · Memory → S2b StreamManager (needs SessionUsage) → S3 AIService → S4 Consolidation · MCPConfig → S5 MCPServerManager → S6 Workspace → S7 Task → S8 TurnManager → `CoreWiringLive` (`Layer.effectDiscard`, **`Effect.sync` only — no `acquireRelease`**, replays `coreServices.ts:137-166, 209-210, 258-270, 288-325, 349-352, 360-367` in order). |
| `layers/desktop.ts` | `CrossCuttingLive` (policy, telemetry, experiments, backup, sessionTiming, analytics, devTools, workspaceMcpOverrides, browserBridgeTokenManager), `CoreOptionsFromDesktopLive` (derives `CoreOptionsTag` from those tags + `extensionMetadataPath`), then **group layers** (`Layer.effectContext` returning a `Context` of several tags, constructed in today's order): `BrowserLive`, `DesktopBridgeLive`, `OauthLive`, `WorkersLive` (idleCompaction, heartbeat, agentStatus, timeline, refine), `TerminalEditorLive`, `MiscDesktopLive`; staged with `provideMerge` where one group needs another. `DesktopWiringLive` (`Effect.sync` only) = setters + `aiService.on/workspaceService.on/memoryConsolidationService.on` wiring + global registrations. |
| `layers/app.ts` | `AppLive(stores) = DesktopLive ▹ CoreLive ▹ CoreOptionsFromDesktopLive ▹ CrossCuttingLive ▹ AppFiberScopeLive ▹ EffectRunnerLive ▹ StoresLive(stores)` — read `X ▹ Y` as "X is *provided with* Y, and both stay exposed", i.e. **`X.pipe(Layer.provideMerge(Y))`** (rc.112 signature: `provideMerge(that: provider)(self: consumer)`; the *right-hand* operand is the dependency). Every `▹` keeps all tags visible in the final `Context<AppTags>`. |
| `testEffectRunner.ts` (test helper, sibling of `testHistoryService.ts`) | `makeTestEffectRunner()` → `{ runner, adjust(duration), setTime(ms), dispose }` over one memoised `ManagedRuntime.make(EffectRunnerLive.pipe(Layer.provideMerge(TestClock.layer())))` (the TestClock is the *provider*; the runner captures it), so the worker under test and `TestClock.adjust` share one `TestClock`. |

### 2.2 Composition roots after Phase 11

```mermaid
flowchart TB
  Stores["StoresLive(stores)<br/>Config · SessionLocator · ProvidersConfigStore · SecretsStore · FileLeaseManager"]
  Runner["EffectRunnerLive (unsupervised, ref-bound)<br/>+ AppFiberScopeLive (supervised, closed on dispose)"]
  Cross["CrossCuttingLive (desktop only)<br/>Policy · Telemetry · Experiments · Analytics · SessionTiming · DevTools · WorkspaceMcpOverrides · Backup"]
  Opts["CoreOptionsTag<br/>desktop: derived from CrossCutting · CLI: Layer.succeed(opts)"]
  Core["CoreLive<br/>PR 3: coarse CoreProjectionLive → PR 4: stages S1…S8 + CoreWiringLive"]
  Desk["DesktopLive — group Layers<br/>Browser · DesktopBridge · OAuth · Workers · TerminalEditor · Misc → DesktopWiringLive"]
  RT["AppRuntime = ManagedRuntime.make(AppLive)<br/>eager sync build · Context<AppTags> = oRPC effect/context · dispose() last"]
  Stores --> Runner --> Cross --> Opts --> Core --> Desk --> RT
  CLI["CLI root (xum run / xum workflow)<br/>createCoreServices(opts) = makeAppRuntime(CoreLive ▹ StoresFromCoreOptionsLive ▹ AppFiberScopeLive ▹ EffectRunnerLive ▹ succeed(CoreOptionsTag, opts))"]
  Core -.same Layer definitions.-> CLI
```

`ServiceContainer` keeps its public fields and the synchronous `new ServiceContainer(stores)`: the constructor calls `makeAppRuntime(AppLive(stores))`, stores `this.serviceContext = runtime.runSync(Effect.context<AppTags>())`, and assigns fields via `Context.get(this.serviceContext, Tag)`. `toORPCContext()` returns the same plain fields plus `"effect/context": this.serviceContext`. `initialize()` is untouched. `dispose()` follows §5.

`createCoreServices(opts)` keeps its signature and return shape plus `runtime` and `appFiberScope` fields; `cli/run.ts:1574-1580` and `cli/workflow.ts:275-320` cleanup lists gain `closeScopeBounded(appFiberScope)` before `session.dispose()` and `disposeAppRuntime(runtime)` as the final step (PR 3).

**Staged composition skeleton (PR 4 shape; direction matters):**

```ts
// Each stage depends only on stages defined above it. `provideMerge` keeps both sides exposed.
const S1 = Layer.mergeAll(HistoryLive, InitStateLive, ProviderLive, /* … true siblings only */);
const S2a = Layer.mergeAll(SessionUsageLive, GoalLive, MemoryLive).pipe(Layer.provideMerge(S1));
const S2b = StreamManagerLive.pipe(Layer.provideMerge(S2a));          // StreamManager needs SessionUsage
const S3 = AIServiceLive.pipe(Layer.provideMerge(S2b));
// … S4 … S8 likewise …
export const CoreLive = CoreWiringLive.pipe(Layer.provideMerge(S8));  // wiring runs after every service exists
```

**oRPC typing.** `OrpcEffectServices` (in `effectContext.ts`) becomes `AppTags`, so `ORPCContext["effect/context"]: Context<AppTags>` is satisfied by the runtime context in production. `buildOrpcEffectContext` stays as the narrow test helper it already is (its only caller, `effectBridge.test.ts:24-30`, deliberately builds a partial context and casts it via `unknown`); no production caller remains after PR 1.

### 2.3 Invariants (the "DI contract"; enforced by tests and the `appRuntime.ts` doc comment)

| # | Invariant | Constraint served |
|---|---|---|
| I1 | **Phase 11 compatibility contract, not permanent law:** layer bodies are synchronous (`Layer.succeed`/`Layer.sync`/`Layer.effect` over sync effects; `acquireRelease` with a sync acquire is fine). `makeAppRuntime` asserts the eager build completed. Future async resource acquisition belongs in `initialize()`/startup effects or an explicit async factory root (`ServiceContainer.create()`), never silently inside a layer. | #2 sync-start, #5 startup parity |
| I2 | Services never hold the `ManagedRuntime`. Workers hold an `EffectRunner` (default `defaultEffectRunner`); `EffectRunner.runX` ≡ `Effect.run…With(ctx)` — same sync-start semantics as `Effect.runX`, and still valid after `runtime.dispose()`, so late callbacks cannot hit "ManagedRuntime disposed". Supervision, when needed, is explicit via `AppFiberScope`. | #2, #3 |
| I3 | Per-call pipelines (`Effect.runPromise(this.effects…)` facades) and the `memoryConsolidationService` funnels are untouched. **Audit item:** no DI lookup, runner call, or `await` may be inserted before `inFlight.set` / `harvestInFlight.set`. Only lifecycle forks in workers move to `this.runner.runX`. | #1, #2 |
| I4 | Constructors, facades, private methods, module exports unchanged; new constructor parameters are optional, trailing, defaulting to `defaultEffectRunner`. | #1, #6 |
| I5 | Teardown order stays explicit in `dispose()`/`shutdown()`. Layer bodies and wiring layers register **no finalizers** in Phase 11 (`Effect.sync` only), so `runtime.dispose()` reorders nothing. The one supervised resource (`AppFiberScope`) is closed explicitly at a fixed position in `dispose()` (§5). | #3 |
| I6 | Wiring layers replay today's setter/listener order; a constructor may touch only its *declared* dependencies (built earlier by staging). Per-PR audit: grep each moved constructor for calls on setter-provided collaborators → forbidden. Dependency order is expressed only with `provide`/`provideMerge` stages; never rely on `mergeAll` sibling order. | #6 |
| I7 | No persisted-data changes; DI is in-process only. | #4 |
| I8 | Every process root builds from the same Layer definitions (`CoreLive` shared by App and CLI). Unit harnesses (`createTestHistoryService`, `createTestToolConfig`, `createAgentSessionHarness`, …) intentionally bypass Layers. | #7 |

### 2.4 Decisions and alternatives (product-LoC deltas)

<details>
<summary>D1 — Granularity: coarse core first (PR 3), per-service core stages behind a decision gate (PR 4), group layers for the desktop tail (PR 5)</summary>

Honest framing: the three unlocks (engine-core async scope, TestClock, app-lifetime scope) are delivered by `AppRuntime` + `EffectRunner` + `AppFiberScope` and **do not require per-service layers**. Per-service core layers are *migration leverage*: typed requirement sets for the engine-core work, per-service swap in integration tests, explicit dependency stages instead of implicit ordering.

- **(A) Per-service everywhere** (~70 layers): +~900/−~700. Desktop tail has hand-tuned teardown that must not become finalizers, so per-service there buys uniformity only. Rejected.
- **(B) Recommended:** PR 3 coarse `CoreProjectionLive` (+~120/−~10) delivers the shared root and runtime ownership; PR 4 peels the core into staged per-service layers (+~330/−~290) **only if** PR 3's typecheck/startup budgets hold (gate in §3); desktop tail as ~6 group layers (+~170/−~150). Tags for all services either way (~3 LoC each).
- **(C) Coarse only:** stop after PR 3 + desktop projection (~+200 total). Cheapest; the engine-core phase would then redo dependency declarations. Remains the fallback if PR 4's gate fails.
</details>

<details>
<summary>D2 — Async init stays an explicit `initialize()`; Layers construct only</summary>

Folding `initialize()` into layer construction would make the build asynchronous (breaks I1), change failure semantics (today: fail-fast → dialog/log), and move the six-step order into memoised builds. Deferred; a later phase can turn `initialize()` into `runtime.runPromise(startupEffect)` with per-step `Effect.timeout`.
</details>

<details>
<summary>D3 — Optional cross-cutting services stay optional via `CoreOptionsTag`, not `Effect.serviceOption`</summary>

Core layer bodies read `opts.policyService` etc. exactly as today, so CLI (absent) vs desktop (present) behavior is unchanged and no service gains a new `undefined` branch.
</details>

<details>
<summary>D4 — Two seams instead of one: `EffectRunner` (unsupervised, clock-bound) + `AppFiberScope` (supervised)</summary>

A single "runtime handle" conflates two needs. Workers need *which clock* (TestClock) and must keep sync `stop()`; the engine core needs *who awaits me on shutdown*. Explicit `Clock` injection per worker was rejected (a `provideService(Clock.Clock, …)` at every fork site, and it does not extend to other refs).
</details>

<details>
<summary>D5 — oRPC: `effect/context` = the runtime's `Context`; `handlerGen` unchanged</summary>

`handlerGen` already `Effect.provide`s the context per request; providing ~70 entries instead of one is one Map merge per request. The existing `echoAsync`/`echoEffect` probes record the delta as a **diagnostic** in the PR body (no stable benchmark harness exists to make it a hard gate). `effect/wrap` not needed.
</details>

## 3. Phasing — six stacked PRs

Every PR: `make static-check`; gate suites below; existing tests unchanged (PR 6 is the only PR that edits tests, and only to replace real-timer probes). Before `@codex review`, run the **house pre-review audits**:

1. **Interruption posture** — list every new/moved fiber fork; state what interrupts it and when (unsupervised via `EffectRunner` + worker scope, or supervised via `AppFiberScope`).
2. **Uninterruptible teardown** — teardown effects are `Effect.uninterruptible` end-to-end; bounded waits inside use `Effect.interruptible(Effect.timeout(...))` (house shape from #4038).
3. **No defect escapes** — `disposeAppRuntime`/`closeScopeBounded` and every Promise facade fold defects; `makeAppRuntime` is the one place allowed to throw (constructor semantics).
4. **Spy-seam check** — `rg 'spyOn\(' src/node/services/<touched>.test.ts tests/` per touched class; constructor arity and private-method Promise signatures unchanged (typecheck of tests proves it).
5. **Sync-start check** — a fork through `EffectRunner` runs to its first `sleep` before `runFork` returns (mirrors `heartbeatService.ts:199-202`).
6. **Constructor side-effect audit (I6)** for every constructor moved into a Layer in that PR.
7. **Zero-suspension audit (I3)** whenever `memoryConsolidationService` is in the diff.

### PR 1 — Skeleton: AppRuntime + Stores/MemoryMeta layers + runtime-backed `effect/context` + dispose hook (+~150 LoC)

**Scope**
- `di/tags.ts` (`ConfigTag`, `SessionLocatorTag`, `ProvidersConfigStoreTag`, `SecretsStoreTag`, `FileLeaseManagerTag`, `MemoryMeta` moved from `orpc/effectContext.ts`, which re-exports it; `AppTags` union).
- `di/layers/stores.ts` (`StoresLive`), `di/layers/core.ts` with `MemoryMetaLive = Layer.effect(MemoryMeta, Effect.map(ConfigTag, c => new MemoryMetaService(c.rootDir)))`, `di/layers/app.ts` (`AppLive(stores) = MemoryMetaLive ▹ StoresLive`).
- `di/appRuntime.ts` (`makeAppRuntime`, `disposeAppRuntime`); `APP_RUNTIME_DISPOSE_TIMEOUT_MS` in `src/constants/`.
- `coreServices.ts`: `CoreServicesOptions.memoryMetaService?` (precedent: `workspaceMcpOverridesService?`).
- `serviceContainer.ts`: build runtime first, pass `Context.get(ctx, MemoryMeta)` to `createCoreServices`, `public readonly runtime`, `toORPCContext()["effect/context"] = this.serviceContext`, `dispose()` appends `disposeAppRuntime` behind a `disposed` latch; new `log.debug("[startup] AppRuntime built", { ms })`.
- `orpc/effectContext.ts`: `OrpcEffectServices = AppTags`; `buildOrpcEffectContext` retyped/test-helper doc.
- `headlessEnvironment.dispose` calls `await services.dispose()` before removing the temp dir (the bench harness currently leaks the container; runtime ownership starts here).

**Acceptance**
- `di/appRuntime.test.ts`: (a) sync build sets `cachedContext`; (b) a layer with an async body makes `makeAppRuntime` **throw synchronously** (I1 enforced); (c) probe layers' finalizers run in reverse order on dispose; (d) dispose is idempotent and bounded (hung finalizer → `warn`, resolves at the timeout); (e) `runtime.runFork` after the eager build starts synchronously.
- `serviceContainer.test.ts`: `Context.get(toORPCContext()["effect/context"], MemoryMeta) === services.memoryMetaService`; `dispose()` closes the runtime; `dispose(); shutdown()` (tests/ipc order) is clean; a throwing layer surfaces as a synchronous throw from `new ServiceContainer(stores)` (same shape as today's constructor throw → existing entry-point catch paths).
- `effectBridge.test.ts`, `memoryMeta*.test.ts` unchanged and green; echo-probe overhead recorded in the PR body.
- Gate: `bun test src/node/services/di src/node/services/serviceContainer.test.ts src/node/orpc src/node/services/memoryMeta*` · `make test-integration` · `make static-check`.

**Rollback:** `git revert`; classes untouched.

### PR 2 — Runtime seams: `EffectRunner` + `AppFiberScope`; TestClock on idleCompaction/heartbeat/retryManager (+~140 LoC)

**Scope**
- `di/effectRunner.ts`, `di/appFiberScope.ts`; `AppLive` gains `AppFiberScopeLive ▹ EffectRunnerLive` at the base; `ServiceContainer` exposes `appFiberScope` (used only by `dispose()` in Phase 11) and closes it per §5.
- `IdleCompactionService`, `HeartbeatService`, `RetryManager`: trailing optional `runner: EffectRunner = defaultEffectRunner`; every lifecycle `Effect.runSync/runFork` in `start/stop/schedule/cancel` becomes `this.runner.runX`. Deadline math (`Date.now()`/injected `now`) unchanged. `ServiceContainer` passes `Context.get(ctx, EffectRunnerTag)` to the two workers; `RetryManager` keeps the default until PR 5 (so `streamManager.ts` is untouched here).
- `di/testEffectRunner.ts` helper.

**Acceptance**
- New TestClock tests (existing real-timer tests untouched — they exercise the `defaultEffectRunner` path, which is production behavior wherever no runner is injected): heartbeat `STARTUP_DELAY_MS` → first tick after `adjust`, one tick per `CHECK_INTERVAL_MS`, no ticks after `stop()`; idleCompaction initial delay + cadence; retryManager fires exactly at `delayMs`, `cancel()` before `adjust` never fires.
- Pin runtime facts: `runner.runSync(Scope.close(scope, Exit.void))` completes synchronously for a fiber suspended on a TestClock sleep; `runFork` through the runner reaches its first sleep synchronously; `Effect.context<never>()` inside `EffectRunnerLive` sees the upstream `TestClock` (else the helper provides `Clock.Clock` explicitly — same seam, one line).
- `AppFiberScope` contract tests: (i) an **I/O-suspended** fiber (interruptible `Effect.async` that never resolves, with a cancel path) forked with `Effect.forkIn(_, appFiberScope)` is interrupted **and awaited** by `closeScopeBounded(appFiberScope)` — and this happens *before* the explicit teardown steps in `dispose()` (assert ordering against a spy on `desktopBridgeServer.stop`); (ii) a fiber forked via `EffectRunner` is *not* interrupted by either close (documents the asymmetry); (iii) `disposeAppRuntime` afterwards idempotently re-closes the already-closed child scope (no error, no second finalizer run).
- If `TestClock.adjust` leaves continuations pending, the helper adds `Effect.yieldNow`/`Fiber.await` — decided by tests.
- Gate: `heartbeatService.test.ts`, `idleCompactionService.test.ts`, `retryManager.test.ts`, `serviceContainer.test.ts`, `di/*`, tests/ipc.

**Rollback:** revert restores defaults; no call site depends on the new params.

### PR 3 — Shared core root: coarse `CoreProjectionLive` + `createCoreServices` facade + CLI runtime disposal (+~120 / −~10)

**Scope**
- Tags for the remaining 19 core services; `CoreOptionsTag`; `StoresFromCoreOptionsLive`.
- `CoreProjectionLive = Layer.effectContext(Effect.gen(function*(){ const opts = yield* CoreOptionsTag; const stores = yield* …; const core = buildCoreGraph({ ...opts, ...stores }); return Context.make(History, core.historyService).pipe(Context.add(...)) }))` where `buildCoreGraph` is today's `createCoreServices` body, unchanged, renamed.
- `createCoreServices(opts)` = `makeAppRuntime(CoreProjectionLive ▹ StoresFromCoreOptionsLive ▹ AppFiberScopeLive ▹ EffectRunnerLive ▹ Layer.succeed(CoreOptionsTag, opts))`, returns today's `CoreServices` object read from the context plus `runtime` and `appFiberScope`. `cli/run.ts` and `cli/workflow.ts` cleanup lists append `closeScopeBounded(appFiberScope)` **before** `session.dispose()` and `disposeAppRuntime(runtime)` **after** `backgroundProcessManager.terminateAll()`.
- `ServiceContainer` stops calling `createCoreServices`; `AppLive = CoreProjectionLive ▹ CoreOptionsFromDesktopLive ▹ CrossCuttingLive ▹ …` (cross-cutting services move into `CrossCuttingLive` now because core options derive from them). Desktop constructions otherwise stay in the constructor.

**Acceptance**
- Identity test: every `CoreServices` field `===` `Context.get(ctx, Tag)`; `serviceContainer.test.ts` unchanged and green.
- **Decision gate for PR 4** recorded in the PR body: `make typecheck` wall time, `[startup] AppRuntime built` ms and `initialize` totals vs `origin/main` baseline from the sandbox (§7). Proceed to PR 4 only if typecheck regresses < 10 % and startup within noise; otherwise stop at (C).
- Gate: `bun test src/node/services`, `src/cli/*.test.ts` (run/workflow/server/cli), tests/ipc, `make static-check`.

**Rollback:** revert restores the imperative call; PR 1/2 unaffected.

### PR 4 — Peel the core into staged per-service Layers + `CoreWiringLive` (+~330 / −~290 ⇒ net ≈ +40; split 4a/4b if > ~600 diff lines)

**Scope**
- Stages S1, S2a, S2b, S3…S8 (§2.1 + skeleton in §2.2) as `Layer.effect` adapters with today's argument lists; `CoreWiringLive` (`Effect.sync` only) replays the wiring lines in order; `CoreLive = CoreWiringLive.pipe(Layer.provideMerge(S8))` replaces `CoreProjectionLive`; `buildCoreGraph` deleted.
- Before writing any stage: re-derive the DAG from the constructor argument lists (the plan's stage table was checked once; `StreamManager → SessionUsage` is the kind of edge that turns "siblings" into a stage split) and record it in the PR body.
- 4a (S1–S3: leaves through `AIService`) / 4b (S4–S8 + wiring) if needed — 4a alone is mergeable because the remaining services are built by a shrunken projection layer that reads S1–S3 from the context.

**Acceptance**
- Wiring assertions that are behavioral (a missing wiring line fails them): `turnRequestBuilderBindings` fully populated; goal continuation consumer registered on `idleDispatcher`; `streamManager` MCP manager set; registration probe installed on `extensionMetadata`.
- I6 audit table for all 19 constructors in the PR body; missing-provider = compile error (R must be `never` at `makeAppRuntime`) demonstrated by a type-level test (`// @ts-expect-error`).
- Gate: as PR 3 plus `streamManager*.test.ts`, `aiService.test.ts`, `workspaceService*.test.ts`.

**Rollback:** revert to PR 3's projection.

### PR 5 — `DesktopLive` group layers + `DesktopWiringLive`; thin `ServiceContainer`; `StreamManager` runner param (+~170 / −~150 ⇒ net ≈ +20)

**Scope**
- Tags for the 45 desktop services; six group layers (`Layer.effectContext`, today's construction order inside each; `provideMerge` between groups that depend on each other); `DesktopWiringLive` (`Effect.sync` only) = `serviceContainer.ts:209, 263-265, 271, 288-290, 334-340, 348, 365, 375, 381-382, 434, 438-471, 474-574` in order.
- `ServiceContainer` constructor = `makeAppRuntime(AppLive(stores))` + field assignment from the context. `toORPCContext()` unchanged in shape.
- `StreamManager`: optional trailing `runner: EffectRunner`; `schedulePartialWrite` fork (`streamManager.ts:1141`) and `RetryManager` construction use it; `Scope.close` stays `Effect.runFork` (existing async-close precedent). `WorkersLive` receives `EffectRunnerTag`.

**Acceptance**
- All four existing `serviceContainer.test.ts` assertions unchanged; new identity test over `toORPCContext()` fields vs tags; `dispose()`/`shutdown()` call order asserted via spies on the *public* methods already spied today.
- I6 audit for the 45 constructors.
- Gate: tests/ipc + tests/ui (`make test-integration`), `src/cli/server.test.ts`, `src/cli/cli.test.ts`, `streamManager*.test.ts`, `aiService.test.ts`.

### PR 6 — TestClock adoption sweep + shutdown hardening + contract docs (+~20 LoC product; tests edited)

**Scope**
- Replace real-sleep cadence probes with `makeTestEffectRunner()` in `heartbeatService.test.ts`, `idleCompactionService.test.ts`, `retryManager.test.ts`, and the partial-write debounce cases of `streamManager.test.ts`; keep **one real-timer smoke test per worker** (guards the `defaultEffectRunner` path).
- `cli/server.ts`: `[shutdown]` log lines per step incl. `AppRuntime disposed {ms}`; confirm the whole `dispose()` fits the existing 5 s force-exit budget.
- Finalize the contract doc comment in `di/appRuntime.ts` (I1–I8, §5).

**Acceptance:** converted suites have zero `setTimeout`-based cadence waits (grep in PR body), same assertions; `make test-integration` green; sandbox startup/shutdown evidence (§7).

## 4. TestClock story

- **Mechanism.** `Effect.sleep`, `Schedule.fixed`, `Effect.timeout`, `Clock.currentTimeMillis` read the `Clock` reference from the running fiber's context. Workers that fork through an `EffectRunner` built under `TestClock.layer()` run on the test clock; `await testRunner.adjust("2 minutes")` advances it. `Date.now()`, `setTimeout`, `setInterval` are unaffected — heartbeat deadline math via injected `now`, `AgentStatusService`'s ref'd `setInterval`, and `backgroundProcessManager` stay on real timers/injected timestamps.
- **Benefit now:** `heartbeatService.test.ts` (6), `idleCompactionService.test.ts` (2), `retryManager.test.ts` (3 `setSystemTime` → `adjust`; `Date.now`-based `retryAt` may move to `Clock.currentTimeMillis` only if a test needs both clocks aligned), `streamManager.test.ts` debounce cases (7).
- **Deferred:** `streamBridge.test.ts` ticker (11) — needs a context/runner parameter on `subscriptionIterable`; OAuth device-flow polling and `oauthFlowManager.test.ts` (25) — non-goal.
- **Stays real:** child-process/PTY/WASM/fs-lock waits (`backgroundProcessManager` 72, `quickjsRuntime` 26, lock sleeps in `workspaceService`/`taskService`), end-to-end suites (tests/ipc, e2e).
- **Pinned in PR 2, not assumed:** `adjust` runs due sleeps and their synchronous continuations before resolving (or the helper yields until they do); `Schedule.fixed` anchoring under `TestClock` matches the wall-clock expectations in `heartbeatService.ts:149-155`; sync `Scope.close` of a TestClock-suspended fiber completes synchronously.

## 5. Shutdown protocol

1. **Trigger points unchanged:** `main.ts` `before-quit` (preventDefault → `dispose()` raced with 5 s → `app.quit()`; update-install path fire-and-forget), the second `before-quit` listener's `shutdown()` (unchanged, concurrent), `cli/server.ts` SIGINT/SIGTERM (5 s force exit), ACP `close()`, tests/ipc (`dispose()` then `shutdown()`), headless bench (`dispose()` from PR 1).
2. **`ServiceContainer.dispose()` order:**
   1. `backgroundProcessManager.beginShutdown()` — unchanged, first (latch protecting persisted monitor records).
   2. **`closeScopeBounded(appFiberScope, APP_FIBER_SCOPE_CLOSE_TIMEOUT_MS)`** — interrupts and awaits supervised fibers *while every dependency they might touch during finalization is still alive*. No occupants in Phase 11; the position is fixed now so the engine-core phase does not have to re-derive it.
   3. The existing explicit sequence verbatim (`desktopBridgeServer.stop()` … `terminateAll()` … `timelineService.flush()`).
   4. **`disposeAppRuntime(runtime, APP_RUNTIME_DISPOSE_TIMEOUT_MS)`** — closes the runtime scope (interrupts any fiber started via `runtime.runX` — none long-lived in Phase 11; runs layer finalizers — none in Phase 11 by I5). Hung → `warn` at the timeout; never rejects.
   Budget: 2 s + 2 s inner bounds inside the callers' 5 s outer budgets; the outer race in `main.ts` remains the last line of defense.
   **Rule for future occupants:** anything forked into `AppFiberScope` must tolerate interruption at any suspension point and must not depend on resources torn down in step 1; anything that needs a Layer finalizer must first prove reverse-construction order is compatible with steps 2–3 (I5).
3. **Latches:** `disposed` makes `dispose()` idempotent (two `before-quit` listeners, tests/ipc dispose+shutdown). `shutdown()` never touches the runtime or `AppFiberScope`.
4. **Late callers:** `EffectRunner` handles keep working after runtime dispose (I2), so a stray `tick()`/`scheduleRetry()` after quit cannot defect. The `ManagedRuntime` is referenced only by `ServiceContainer` and the `createCoreServices` return value.
5. **Worker `stop()` stays synchronous** (`runner.runSync(Scope.close)`) because their fibers suspend only on the clock. The engine core will fork into `AppFiberScope` (step 2.2 awaits it) — the reason both seams exist now.
6. **Crash paths:** unchanged — `uncaughtException`/SIGKILL run no finalizers. Finalizers are best-effort; durable state must remain crash-safe without them (AGENTS.md self-healing rule). Nothing in Phase 11 makes a finalizer the sole guardian of durable state.

## 6. Risk register

| # | Risk | L/I | Mitigation |
|---|---|---|---|
| R1 | A layer body suspends → `runSync` throws at startup | M/H | I1 assert + PR 1 test (b); doc comment; review checklist; entry-point catch paths verified in PR 1 |
| R2 | Construction-order side effects differ under staged builds | L/H | I6 audit per moved constructor; explicit `provideMerge` stages; wiring layers replay today's order; tests/ipc as behavioral gate |
| R3 | Double teardown (`shutdown()` ∥ `dispose()`; dispose+shutdown in tests) | M/M | `disposed` latch; runtime/AppFiberScope closed only in `dispose()`; PR 1 test |
| R4 | Late `runtime.runX` after dispose → defect | M/M | I2: services hold `EffectRunner`, never the ManagedRuntime |
| R5 | TestClock semantics differ from assumptions | M/L | PR 2 pins them before any suite converts; per-suite fallback to real timers |
| R6 | effect v4 RC churn (`Context`→`ServiceMap`, Layer renames) | M/M | All `Layer/Context/ManagedRuntime/TestClock` imports confined to `di/`; exact pin |
| R7 | Startup latency regression (splash) | L/M | `AppRuntime built` ms + `initialize` totals vs baseline in sandbox; PR 3 gate |
| R8 | Typecheck slowdown from large requirement unions | L/L | PR 3 gate records `make typecheck` wall time; fallback (C) |
| R9 | Per-request `Effect.provide` of a ~70-entry Context | L/L | echo-probe diagnostic in PR 1/5 bodies |
| R10 | Spy seams / direct-construction tests break | L/H | I4; optional trailing params; audit 4; typecheck of tests |
| R11 | CLI roots forget to dispose runtime/scope | M/L | PR 3 wires both cleanups; `src/cli/*.test.ts` assert the cleanup steps exist |
| R12 | Someone forks long-lived I/O work via `EffectRunner` expecting dispose to await it | M/M | Doc on `EffectRunner` ("unsupervised"); PR 2 asymmetry test; review audit 1 |

**Rollback:** PRs are stacked; revert in reverse order (6→1). Service classes are never modified except for optional trailing params, so any revert restores the previous composition root wholesale with no data or API implications.

## 7. Dogfooding (per PR; evidence attached to the PR body)

**Environment (headless Coder host, no `DISPLAY`):**
```bash
XUM_LOG_LEVEL=debug DEV_SERVER_SANDBOX_ARGS="--clean-projects" make dev-server-sandbox   # background bash task; prints URL + XUM_ROOT
```
- **Startup correctness:** `<XUM_ROOT>/logs/*.log` shows, in order: `Loading services...`, `[startup] AppRuntime built {ms}`, `[startup] ServiceContainer.initialize starting`, six step durations, `[startup] ServiceContainer.initialize completed {totalMs, stepDurationsMs}`. Paste baseline (`origin/main`) vs branch numbers.
- **Startup-never-crash parity (once, locally, not committed):** inject a throwing scratch layer → `xum server` exits non-zero with the existing logged error and **no** unhandled-rejection trace; for desktop, confirm by code path (`loadServices()` rejects → `main.ts:1255` dialog) and via `src/cli/server.test.ts`/ACP tests.
- **UI smoke (agent-browser):** `open <url>` → `snapshot -i` → add a scratch git repo as a project → create a workspace → send one message → `screenshot` the loaded app and the response; `attach_file` both. **Video:** start `agent-browser record` before the flow and stop it with a hard timeout (`timeout 30 agent-browser record stop`); if stopping hangs (known), attach the truncated WebM plus the screenshots and say so.
- **oRPC Effect path:** pin/unpin a memory entry (rides `handlerGen` + runtime `effect/context`); screenshot before/after; grep logs for `ManagedRuntime disposed`/defect lines (expect none).
- **Graceful quit:** record the terminal with `script -q /tmp/<workspace>-shutdown.log` (or `agent-tty` if present), `kill -TERM <pid>` → expect `[shutdown]` lines, `AppRuntime disposed {ms}`, exit 0, no force-exit message; attach the typescript. Exercise the timeout branch once with a scratch hung finalizer → `warn` + timely exit.
- **Electron (best effort):** with `Xvfb`, `make dev` + agent-browser via CDP (electron skill): screenshot splash → main window, quit via menu, confirm exit < 5 s; otherwise state that the Electron path is covered by `tests/e2e` in CI and the shared `dispose()` path exercised by `server.ts`.

**Gate suites per PR** (plus `make static-check` always):

| PR | Must pass |
|---|---|
| 1 | `src/node/services/di/*`, `serviceContainer.test.ts`, `src/node/orpc/*`, `memoryMeta*`, `make test-integration` |
| 2 | + `heartbeatService.test.ts`, `idleCompactionService.test.ts`, `retryManager.test.ts` |
| 3 | + `bun test src/node/services`, `src/cli/*.test.ts`; record PR 4 gate numbers |
| 4 | + `streamManager*.test.ts`, `aiService.test.ts`, `workspaceService*.test.ts` |
| 5 | + tests/ui via `make test-integration`, `src/cli/server.test.ts`, `src/cli/cli.test.ts` |
| 6 | converted suites + full `make test-integration` + sandbox startup/shutdown evidence |

## 8. Non-goals (explicit)

- streamManager ENGINE CORE conversion (first `AppFiberScope` occupant; separate phase).
- `Schema` at persistence boundaries; OAuth refresh/device-flow workers; `AgentStatusService` `setInterval` → Effect.
- `initialize()` as a Layer/startup effect (D2); per-service optional tags (D3); `streamBridge` on the runtime; layer finalizers for existing `dispose()` steps.
- Any change to persisted data, IPC wire shapes, or oRPC handler bodies beyond the `effect/context` source.

## 9. Assumptions stated

- `Effect.context<never>()` inside `EffectRunnerLive` returns the enclosing build context including an upstream `TestClock` entry (PR 2 test; fallback: provide `Clock.Clock` explicitly in the helper).
- `Scope.fork(parent)` inside a `Layer.effect` body yields a child closed by the runtime's layer scope on `dispose()` (PR 2 `AppFiberScope` test).
- Layer bodies never need to observe sibling construction order; all ordering that matters is expressed as `provide`/`provideMerge` stages or wiring-layer statement order.
- `EffectRunner`'s `R = never` constraint is sufficient for every lifecycle fork in the three Phase 11 workers and `StreamManager.schedulePartialWrite` (they only use `Effect.sleep`/`Schedule`/`Effect.sync`/`Effect.tryPromise` — no service tags). Verified by typecheck in PR 2/5.
- The desktop tail's teardown remains explicit unless a later RFC proves reverse-construction order compatible; this plan does not attempt it.

</details>

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$22.48`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=22.48 -->
