### PR TITLE
🤖 fix: terminal wakes skip the compaction request's disable-all tool policy

### DIFF
--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -2582,6 +2582,102 @@ describe("TaskService", () => {
     expect(liftedOptions.toolPolicy).toBeUndefined();
   });
 
+  test("workflow wakes skip the compaction request's own disable-all tool policy", async () => {
+    const config = await createTestConfig(rootDir);
+    const { parentId } = await saveLocalParentWorkspace(config, rootDir);
+    const restrictedPolicy = [{ regex_match: "^bash$", action: "disable" as const }];
+    const compactionPolicy = [{ regex_match: ".*", action: "disable" as const }];
+    const runStore = new WorkflowRunStore({ sessionDir: path.join(config.sessionsDir, parentId) });
+    const createRun = async (runId: string) => {
+      await runStore.createRun({
+        id: runId,
+        workspaceId: parentId,
+        workflow: {
+          name: "research",
+          description: "Research workflow",
+          scope: "built-in",
+          executable: true,
+        },
+        source: "export default function workflow() { return { reportMarkdown: 'done' }; }\n",
+        args: {},
+        attentionPolicy: "notify_on_terminal",
+        now: "2026-06-19T00:00:00.000Z",
+      });
+      await runStore.appendStatus(runId, "running", "2026-06-19T00:00:01.000Z");
+      await runStore.appendStatus(runId, "completed", "2026-06-19T00:00:03.000Z");
+    };
+    await createRun("wfr_policy_through_compaction");
+    await createRun("wfr_policy_unrestricted_compaction");
+
+    const sendMessage = mock(
+      (..._args: unknown[]): Promise<Result<void>> => Promise.resolve(Ok(undefined))
+    );
+    const { workspaceService } = createWorkspaceServiceMocks({ sendMessage });
+    (workspaceService as unknown as Record<string, unknown>).getWorkflowInvocationCurrentness =
+      mock(() => Promise.resolve("current"));
+    const { taskService, historyService } = createTaskServiceHarness(config, { workspaceService });
+
+    const appendCompaction = async (id: string, timestamp: number) => {
+      await historyService.appendToHistory(
+        parentId,
+        createMuxMessage(id, "user", "Summarize this conversation", {
+          timestamp,
+          synthetic: true,
+          toolPolicy: compactionPolicy,
+          muxMetadata: { type: "compaction-request", rawCommand: "/compact", parsed: {} },
+        })
+      );
+      await historyService.appendToHistory(
+        parentId,
+        createMuxMessage(id + "-summary", "assistant", "Summary", { timestamp: timestamp + 1 })
+      );
+      await historyService.appendToHistory(
+        parentId,
+        createMuxMessage(id + "-continue", "user", "Continue", {
+          timestamp: timestamp + 2,
+          synthetic: true,
+        })
+      );
+    };
+
+    // The compaction row is the newest user row carrying a tool policy, but that policy only
+    // governed the summary turn. The wake must reach the manual row beneath it.
+    await historyService.appendToHistory(
+      parentId,
+      createMuxMessage("manual-restricted", "user", "run the audit", {
+        timestamp: 1_000,
+        toolPolicy: restrictedPolicy,
+      })
+    );
+    await appendCompaction("compaction-1", 1_100);
+    taskService.noteWorkflowRunTerminalAttention({
+      ownerWorkspaceId: parentId,
+      runId: "wfr_policy_through_compaction",
+      status: "completed",
+    });
+    await flushTerminalAttentionDrains(taskService);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0]?.[2] as Record<string, unknown>).toMatchObject({
+      toolPolicy: restrictedPolicy,
+    });
+
+    // An unrestricted manual row followed by a compaction must wake with tools available.
+    await historyService.appendToHistory(
+      parentId,
+      createMuxMessage("manual-unrestricted", "user", "carry on", { timestamp: 1_200 })
+    );
+    await appendCompaction("compaction-2", 1_300);
+    taskService.noteWorkflowRunTerminalAttention({
+      ownerWorkspaceId: parentId,
+      runId: "wfr_policy_unrestricted_compaction",
+      status: "completed",
+    });
+    await flushTerminalAttentionDrains(taskService);
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    const unrestrictedOptions = sendMessage.mock.calls[1]?.[2] as { toolPolicy?: unknown };
+    expect(unrestrictedOptions.toolPolicy).toBeUndefined();
+  });
+
   test("wake restoration walks a long agent-less tail: caller policy, agent identity, disable flag", async () => {
     const config = await createTestConfig(rootDir);
     const { parentId } = await saveLocalParentWorkspace(config, rootDir);

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -1030,6 +1030,10 @@ function isResetBoundaryMessage(message: MuxMessage): boolean {
   return message.metadata?.contextBoundaryKind === CONTEXT_BOUNDARY_KINDS.RESET;
 }
 
+function isCompactionRequestMessage(message: MuxMessage): boolean {
+  return message.metadata?.muxMetadata?.type === "compaction-request";
+}
+
 function isWorkflowSupersessionMessage(message: MuxMessage): boolean {
   return isManualUserSupersessionMessage(message) || isResetBoundaryMessage(message);
 }
@@ -6680,6 +6684,13 @@ export class TaskService implements AgentTaskIntegration {
             return false;
           }
           if (message.role !== "user") {
+            continue;
+          }
+          // A compaction request disables every tool for its own summary turn only. That
+          // per-turn policy is not a caller restriction: adopting it would strip all tools
+          // from every wake until the next manual send, so the walk keeps going to the row
+          // that actually defines the conversation's restrictions.
+          if (isCompactionRequestMessage(message)) {
             continue;
           }
           const metadata = message.metadata;


### PR DESCRIPTION
## Summary

Terminal-attention wakes (workflow results, workspace-turn wakes) no longer inherit the compaction request's disable-all tool policy. `resolveTerminalWakeCallerSendRestrictions` now skips `compaction-request` rows while walking history for the caller's restrictions, so the wake adopts the row that actually defines the conversation's tool policy.

## Background

After a compaction, the newest user row carrying a `toolPolicy` is the synthetic compaction-request row, whose `[{ regex_match: ".*", action: "disable" }]` policy exists only for its own summary turn. The wake walk treated it as the caller's restriction, so every terminal wake until the next manual send ran with zero tools (`tool configuration ... "toolNames":[]` in `mux.log`). The agent could only answer with text ("Let me inspect the checkout...") and stalled. Observed live on a dogfood workspace whose `improve-codebase-architecture` workflow finished after a compaction; a paused goal meant nothing re-prompted it.

## Implementation

Same doctrine as `resolveParentAutoResumeOptions`, which already excludes the `compact` identity: the compaction row is a per-turn policy, not a caller restriction, so the backward walk skips it and keeps going.

## Validation

- New test: "workflow wakes skip the compaction request's own disable-all tool policy". It seeds a restricted manual row (`^bash$`) followed by a compaction row and asserts the wake carries the manual restriction; a second run seeds an unrestricted manual row plus compaction and asserts the wake has no `toolPolicy`.
- Red-green: with the skip stubbed out, the test fails with the incident's exact signature (received the `.*` disable policy instead of `^bash$`).

## Risks

Low. The change only affects which user row the terminal-wake walk adopts, and only when a compaction row sits between the wake and the last manual send. Workspaces on older builds still hit the stall after their next compaction until upgraded; a manual message clears it.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$8.76`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=8.76 -->
