### PR TITLE
🤖 fix: queue a send behind an earlier send still in preflight

### DIFF
--- a/src/node/services/agentSession.drainQueuedMessagesIfIdle.test.ts
+++ b/src/node/services/agentSession.drainQueuedMessagesIfIdle.test.ts
@@ -10,6 +10,7 @@ import { createStreamLifecycleMocks } from "./agentSession.testHarness";
 import type { BackgroundProcessManager } from "./backgroundProcessManager";
 import type { InitStateManager } from "./initStateManager";
 import { createTestHistoryService } from "./testHistoryService";
+import { Err } from "@/common/types/result";
 
 /**
  * drainQueuedMessagesIfIdle is the release valve for messages queued behind a
@@ -22,6 +23,8 @@ const WORKSPACE_ID = "workspace-drain-if-idle-test";
 interface PrivateSessionAccess {
   midStreamCompactionPending: boolean;
   autoRetryStarting: boolean;
+  activeStreamContext?: { modelString: string; options?: unknown; providersConfig: null };
+  interruptForCompaction: () => Promise<void>;
 }
 
 describe("AgentSession.drainQueuedMessagesIfIdle", () => {
@@ -116,6 +119,29 @@ describe("AgentSession.drainQueuedMessagesIfIdle", () => {
     agentSession.drainQueuedMessagesIfIdle();
 
     expect(dispatch).toHaveBeenCalledTimes(expectedDispatches);
+  });
+
+  test("a mid-stream compaction that never becomes a turn releases the queue it held", async () => {
+    // Codex P2 (PRRT_kwDOPxxmWM6ebqSN): a drain deferred to the pending compaction has no
+    // other retry, so the compaction's exit must drain when its request failed to start.
+    const agentSession = await createSession();
+    const dispatch = spyOn(agentSession, "sendQueuedMessages").mockImplementation(() => undefined);
+    const sendOptions = { model: "openai:gpt-4o-mini", agentId: "exec" };
+    agentSession.queueMessage("queued during the interrupted stream", sendOptions);
+    const privateSession = agentSession as unknown as PrivateSessionAccess;
+    privateSession.activeStreamContext = {
+      modelString: sendOptions.model,
+      options: sendOptions,
+      providersConfig: null,
+    };
+    spyOn(agentSession, "sendMessage").mockResolvedValue(
+      Err({ type: "unknown", raw: "compaction request rejected before admission" })
+    );
+
+    await privateSession.interruptForCompaction();
+
+    expect(privateSession.midStreamCompactionPending).toBe(false);
+    expect(dispatch).toHaveBeenCalledTimes(1);
   });
 
   test("an empty queue never dispatches", async () => {

--- a/src/node/services/agentSession.drainQueuedMessagesIfIdle.test.ts
+++ b/src/node/services/agentSession.drainQueuedMessagesIfIdle.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { EventEmitter } from "events";
+import * as path from "node:path";
+
+import type { Config } from "@/node/config";
+
+import type { AIService } from "./aiService";
+import { AgentSession } from "./agentSession";
+import { createStreamLifecycleMocks } from "./agentSession.testHarness";
+import type { BackgroundProcessManager } from "./backgroundProcessManager";
+import type { InitStateManager } from "./initStateManager";
+import { createTestHistoryService } from "./testHistoryService";
+
+/**
+ * drainQueuedMessagesIfIdle is the release valve for messages queued behind a
+ * WorkspaceService preflight that never became a turn. It must defer to every
+ * owner of the next dispatch, not just an active turn phase.
+ */
+
+const WORKSPACE_ID = "workspace-drain-if-idle-test";
+
+interface PrivateSessionAccess {
+  midStreamCompactionPending: boolean;
+  autoRetryStarting: boolean;
+}
+
+describe("AgentSession.drainQueuedMessagesIfIdle", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+  let session: AgentSession | undefined;
+
+  afterEach(async () => {
+    session?.dispose();
+    session = undefined;
+    await cleanup?.();
+    cleanup = undefined;
+  });
+
+  async function createSession(): Promise<AgentSession> {
+    const created = await createTestHistoryService();
+    cleanup = created.cleanup;
+    const aiEmitter = new EventEmitter();
+    const aiService: AIService = {
+      ...createStreamLifecycleMocks(),
+      on(eventName: string | symbol, listener: (...args: unknown[]) => void) {
+        aiEmitter.on(String(eventName), listener);
+        return this;
+      },
+      off(eventName: string | symbol, listener: (...args: unknown[]) => void) {
+        aiEmitter.off(String(eventName), listener);
+        return this;
+      },
+      stopStream: mock(() => Promise.resolve({ success: true as const, data: undefined })),
+    } as unknown as AIService;
+    const initStateManager: InitStateManager = {
+      on() {
+        return this;
+      },
+      off() {
+        return this;
+      },
+    } as unknown as InitStateManager;
+    const backgroundProcessManager: BackgroundProcessManager = {
+      setMessageQueued: mock(() => undefined),
+      cleanup: mock(() => Promise.resolve()),
+    } as unknown as BackgroundProcessManager;
+    const config: Config = {
+      rootDir: created.config.rootDir,
+      sessionsDir: created.config.sessionsDir,
+      srcDir: path.join(created.config.rootDir, "src"),
+      loadConfigOrDefault: mock(() => ({})),
+    } as unknown as Config;
+    session = new AgentSession({
+      workspaceId: WORKSPACE_ID,
+      config,
+      historyService: created.historyService,
+      aiService,
+      initStateManager,
+      backgroundProcessManager,
+    });
+    return session;
+  }
+
+  const cases: Array<[string, (s: PrivateSessionAccess) => void, number]> = [
+    ["an idle session drains", () => undefined, 1],
+    // Codex P1 (PRRT_kwDOPxxmWM6eaers): between interruptForCompaction stopping the original
+    // stream and dispatching the compaction request, the turn phase is IDLE while the
+    // compaction still owns the next dispatch.
+    [
+      "a pending mid-stream compaction owns the next dispatch",
+      (s) => {
+        s.midStreamCompactionPending = true;
+      },
+      0,
+    ],
+    [
+      "a pending auto-retry owns the next dispatch",
+      (s) => {
+        s.autoRetryStarting = true;
+      },
+      0,
+    ],
+  ];
+
+  test.each(cases)("%s", async (_name, arrange, expectedDispatches) => {
+    const agentSession = await createSession();
+    const dispatch = spyOn(agentSession, "sendQueuedMessages").mockImplementation(() => undefined);
+    agentSession.queueMessage("queued behind a failed preflight", {
+      model: "openai:gpt-4o-mini",
+      agentId: "exec",
+    });
+    arrange(agentSession as unknown as PrivateSessionAccess);
+
+    agentSession.drainQueuedMessagesIfIdle();
+
+    expect(dispatch).toHaveBeenCalledTimes(expectedDispatches);
+  });
+
+  test("an empty queue never dispatches", async () => {
+    const agentSession = await createSession();
+    const dispatch = spyOn(agentSession, "sendQueuedMessages").mockImplementation(() => undefined);
+
+    agentSession.drainQueuedMessagesIfIdle();
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/node/services/agentSession.drainQueuedMessagesIfIdle.test.ts
+++ b/src/node/services/agentSession.drainQueuedMessagesIfIdle.test.ts
@@ -92,12 +92,15 @@ describe("AgentSession.drainQueuedMessagesIfIdle", () => {
       },
       0,
     ],
+    // Codex P2 (PRRT_kwDOPxxmWM6ebIHW): this is the only drain the queued input gets, and a
+    // retry that is later abandoned never drains, so a scheduled retry must not hold it.
+    // The retry defers to the busy session and is cancelled by stream success.
     [
-      "a pending auto-retry owns the next dispatch",
+      "a scheduled auto-retry does not hold the queue",
       (s) => {
         s.autoRetryStarting = true;
       },
-      0,
+      1,
     ],
   ];
 

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -6902,13 +6902,15 @@ export class AgentSession {
    * reservation kept a send invisible to isBusy() (WorkspaceService preflight)
    * and that settled without a turn, so no stream end will drain what queued
    * behind them. A turn in flight, a mid-stream compaction about to dispatch its
-   * request, a pending auto-retry, or the edit flow still owns the next
-   * dispatch, so the queue keeps waiting for them.
+   * request, or the edit flow still owns the next dispatch, so the queue keeps
+   * waiting for them. A scheduled auto-retry does not: this is the only drain
+   * the queued input gets, and the retry defers to the busy session
+   * (retry_deferred_busy) until stream success cancels it, matching the
+   * failed-startup drains elsewhere in this file.
    */
   drainQueuedMessagesIfIdle(): void {
     if (
       this.hasActiveOrPendingTurnWork() ||
-      this.hasPendingAutoRetry() ||
       this.deferQueuedFlushUntilAfterEdit ||
       this.messageQueue.isEmpty()
     ) {

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -6898,6 +6898,25 @@ export class AgentSession {
   }
 
   /**
+   * Drain the queue when no turn owns the next dispatch. For callers whose
+   * reservation kept a send invisible to isBusy() (WorkspaceService preflight)
+   * and that settled without a turn, so no stream end will drain what queued
+   * behind them. A pending auto-retry or the edit flow still owns the next
+   * dispatch, so the queue keeps waiting for them.
+   */
+  drainQueuedMessagesIfIdle(): void {
+    if (
+      this.isBusy() ||
+      this.hasPendingAutoRetry() ||
+      this.deferQueuedFlushUntilAfterEdit ||
+      this.messageQueue.isEmpty()
+    ) {
+      return;
+    }
+    this.sendQueuedMessages();
+  }
+
+  /**
    * Send queued messages if any exist.
    * Called when the current turn ends or the user chooses to send immediately.
    */

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -4830,6 +4830,9 @@ export class AgentSession {
       }
     } finally {
       this.midStreamCompactionPending = false;
+      // Preflight drains deferred to this pending compaction have no other retry: if the
+      // compaction request never became a turn, release the queue now (no-op when it did).
+      this.drainQueuedMessagesIfIdle();
     }
   }
 

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -6901,12 +6901,13 @@ export class AgentSession {
    * Drain the queue when no turn owns the next dispatch. For callers whose
    * reservation kept a send invisible to isBusy() (WorkspaceService preflight)
    * and that settled without a turn, so no stream end will drain what queued
-   * behind them. A pending auto-retry or the edit flow still owns the next
+   * behind them. A turn in flight, a mid-stream compaction about to dispatch its
+   * request, a pending auto-retry, or the edit flow still owns the next
    * dispatch, so the queue keeps waiting for them.
    */
   drainQueuedMessagesIfIdle(): void {
     if (
-      this.isBusy() ||
+      this.hasActiveOrPendingTurnWork() ||
       this.hasPendingAutoRetry() ||
       this.deferQueuedFlushUntilAfterEdit ||
       this.messageQueue.isEmpty()

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -6242,6 +6242,7 @@ describe("WorkspaceService truncateHistory goal acknowledgment", () => {
       const fakeSession = {
         isBusy: mock(() => false),
         emitMetadata: mock(() => undefined),
+        drainQueuedMessagesIfIdle: mock(() => undefined),
         sendMessage: mock(
           (_msg: string, _opts: unknown, internal?: { admissionStale?: () => boolean }) => {
             capturedProbe = internal?.admissionStale;
@@ -8354,6 +8355,7 @@ describe("WorkspaceService sendMessage status clearing", () => {
     queueMessage: ReturnType<typeof mock>;
     sendMessage: ReturnType<typeof mock>;
     resumeStream: ReturnType<typeof mock>;
+    drainQueuedMessagesIfIdle: ReturnType<typeof mock>;
   };
 
   beforeEach(async () => {
@@ -8428,6 +8430,7 @@ describe("WorkspaceService sendMessage status clearing", () => {
       queueMessage: mock(() => "tool-end" as const),
       sendMessage: mock(() => Promise.resolve(Ok(undefined))),
       resumeStream: mock(() => Promise.resolve(Ok({ started: true }))),
+      drainQueuedMessagesIfIdle: mock(() => undefined),
     };
 
     (
@@ -8471,6 +8474,62 @@ describe("WorkspaceService sendMessage status clearing", () => {
       expect.objectContaining({ model: "custom:unpriced-model", agentId: "exec" }),
       expect.objectContaining({ synthetic: undefined })
     );
+  });
+
+  test("a send arriving during an earlier send's preflight queues instead of starting a second turn", async () => {
+    // The session only reports busy once AgentSession.sendMessage claims PREPARING. A
+    // later send admitted against the idle snapshot would start a competing stream that
+    // StreamManager resolves by aborting the earlier turn. Both sends sit in preflight
+    // awaits here, so arrival order (not who checks first) must decide who yields.
+    fakeSession.isBusy.mockReturnValue(false);
+    const firstSend = createDeferred<Result<void, SendMessageError>>();
+    fakeSession.sendMessage.mockImplementationOnce(() => firstSend.promise);
+
+    const firstResult = workspaceService.sendMessage("test-workspace", "first", {
+      model: "openai:gpt-4o-mini",
+      agentId: "exec",
+    });
+    const secondResult = workspaceService.sendMessage("test-workspace", "second", {
+      model: "openai:gpt-4o-mini",
+      agentId: "exec",
+    });
+    expect((await secondResult).success).toBe(true);
+    expect(fakeSession.queueMessage).toHaveBeenCalledTimes(1);
+    expect(fakeSession.queueMessage.mock.calls[0]?.[0]).toBe("second");
+    expect(fakeSession.sendMessage).toHaveBeenCalledTimes(1);
+    expect(fakeSession.sendMessage.mock.calls[0]?.[0]).toBe("first");
+
+    firstSend.resolve(Ok(undefined));
+    expect((await firstResult).success).toBe(true);
+  });
+
+  test("entries queued behind a preflight send drain only once that send settles without a turn", async () => {
+    // Nothing else will drain them: the failed send never claimed PREPARING, so no stream
+    // end fires. Draining while the earlier send is still in preflight would let the queued
+    // entry jump ahead of it.
+    fakeSession.isBusy.mockReturnValue(false);
+    (workspaceService as unknown as { sessions: Map<string, AgentSession> }).sessions.set(
+      "test-workspace",
+      fakeSession as unknown as AgentSession
+    );
+    const firstSend = createDeferred<Result<void, SendMessageError>>();
+    fakeSession.sendMessage.mockImplementationOnce(() => firstSend.promise);
+
+    const firstResult = workspaceService.sendMessage("test-workspace", "first", {
+      model: "openai:gpt-4o-mini",
+      agentId: "exec",
+    });
+    await waitForCondition(() => fakeSession.sendMessage.mock.calls.length === 1);
+    await workspaceService.sendMessage("test-workspace", "second", {
+      model: "openai:gpt-4o-mini",
+      agentId: "exec",
+    });
+    expect(fakeSession.queueMessage).toHaveBeenCalledTimes(1);
+    expect(fakeSession.drainQueuedMessagesIfIdle).not.toHaveBeenCalled();
+
+    firstSend.resolve(Err({ type: "unknown", raw: "rejected before the turn was accepted" }));
+    expect((await firstResult).success).toBe(false);
+    expect(fakeSession.drainQueuedMessagesIfIdle).toHaveBeenCalledTimes(1);
   });
 
   test("the follow-up idle probe excludes the originating send after its session handoff", async () => {
@@ -9164,6 +9223,9 @@ describe("WorkspaceService pending auto-title", () => {
   let workspacePath: string;
   let fakeSession: {
     isBusy: ReturnType<typeof mock>;
+    hasQueuedMessages: ReturnType<typeof mock>;
+    hasQueuedOrDispatchingEntry: ReturnType<typeof mock>;
+    dropQueuedMessageWithOnlyDedupeKey: ReturnType<typeof mock>;
     queueMessage: ReturnType<typeof mock>;
     sendMessage: ReturnType<typeof mock>;
     resumeStream: ReturnType<typeof mock>;
@@ -9246,6 +9308,9 @@ describe("WorkspaceService pending auto-title", () => {
 
     fakeSession = {
       isBusy: mock(() => false),
+      hasQueuedMessages: mock(() => false),
+      hasQueuedOrDispatchingEntry: mock(() => false),
+      dropQueuedMessageWithOnlyDedupeKey: mock(() => false),
       queueMessage: mock(() => "tool-end" as const),
       sendMessage: mock(() => Promise.resolve(Ok(undefined))),
       resumeStream: mock(() => Promise.resolve(Ok({ started: true }))),

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -8532,6 +8532,83 @@ describe("WorkspaceService sendMessage status clearing", () => {
     expect(fakeSession.drainQueuedMessagesIfIdle).toHaveBeenCalledTimes(1);
   });
 
+  test("the oldest preflight failing drains the entries queued behind it while a younger preflight is live", async () => {
+    // Codex P1 (PRRT_kwDOPxxmWM6eaerl): waiting for every preflight to settle would let the
+    // younger send pass shouldQueue with no earlier ticket left and start ahead of the entry
+    // queued behind the failed one. Draining as soon as the head of the line settles makes
+    // the younger send observe the dispatched (busy) session instead.
+    fakeSession.isBusy.mockReturnValue(false);
+    (workspaceService as unknown as { sessions: Map<string, AgentSession> }).sessions.set(
+      "test-workspace",
+      fakeSession as unknown as AgentSession
+    );
+    const persistSettings = (
+      workspaceService as unknown as { maybePersistAISettingsFromOptions: ReturnType<typeof mock> }
+    ).maybePersistAISettingsFromOptions;
+    const firstSend = createDeferred<Result<void, SendMessageError>>();
+    fakeSession.sendMessage.mockImplementationOnce(() => firstSend.promise);
+    const sendOptions = { model: "openai:gpt-4o-mini", agentId: "exec" };
+
+    const firstResult = workspaceService.sendMessage("test-workspace", "first", sendOptions);
+    await waitForCondition(() => fakeSession.sendMessage.mock.calls.length === 1);
+    await workspaceService.sendMessage("test-workspace", "second", sendOptions);
+    expect(fakeSession.queueMessage).toHaveBeenCalledTimes(1);
+
+    const thirdPreflight = createDeferred<void>();
+    persistSettings.mockImplementationOnce(() => thirdPreflight.promise);
+    const thirdResult = workspaceService.sendMessage("test-workspace", "third", sendOptions);
+    await waitForCondition(() => persistSettings.mock.calls.length === 3);
+    expect(fakeSession.drainQueuedMessagesIfIdle).not.toHaveBeenCalled();
+
+    firstSend.resolve(Err({ type: "unknown", raw: "rejected before the turn was accepted" }));
+    expect((await firstResult).success).toBe(false);
+    expect(fakeSession.drainQueuedMessagesIfIdle).toHaveBeenCalledTimes(1);
+
+    thirdPreflight.resolve();
+    expect((await thirdResult).success).toBe(true);
+  });
+
+  test("manual input is not queued behind a requireIdle send in preflight, which yields to it", async () => {
+    // Codex P1 (PRRT_kwDOPxxmWM6eaerm): a heartbeat's ticket is older, but queueing the
+    // user's message behind it would let the heartbeat take the turn first. The maintenance
+    // send is supersedable: the manual send goes direct and the heartbeat's own
+    // preflight-count skip refuses it.
+    fakeSession.isBusy.mockReturnValue(false);
+    const persistSettings = (
+      workspaceService as unknown as { maybePersistAISettingsFromOptions: ReturnType<typeof mock> }
+    ).maybePersistAISettingsFromOptions;
+    const heartbeatPreflight = createDeferred<void>();
+    persistSettings.mockImplementationOnce(() => heartbeatPreflight.promise);
+    const sendOptions = { model: "openai:gpt-4o-mini", agentId: "exec" };
+
+    const heartbeatResult = workspaceService.sendMessage(
+      "test-workspace",
+      "check in",
+      sendOptions,
+      {
+        synthetic: true,
+        agentInitiated: true,
+        requireIdle: true,
+      }
+    );
+    await waitForCondition(() => persistSettings.mock.calls.length === 1);
+
+    const manualSend = createDeferred<Result<void, SendMessageError>>();
+    fakeSession.sendMessage.mockImplementationOnce(() => manualSend.promise);
+    const manualResult = workspaceService.sendMessage("test-workspace", "manual", sendOptions);
+    await waitForCondition(() => fakeSession.sendMessage.mock.calls.length === 1);
+    expect(fakeSession.sendMessage.mock.calls[0]?.[0]).toBe("manual");
+    expect(fakeSession.queueMessage).not.toHaveBeenCalled();
+
+    heartbeatPreflight.resolve();
+    expect((await heartbeatResult).success).toBe(false);
+    // The heartbeat never reached the session; only the manual send did.
+    expect(fakeSession.sendMessage).toHaveBeenCalledTimes(1);
+
+    manualSend.resolve(Ok(undefined));
+    expect((await manualResult).success).toBe(true);
+  });
+
   test("the follow-up idle probe excludes the originating send after its session handoff", async () => {
     // Codex P1 (PRRT_kwDOPxxmWM6cRi_J): preflightSendCounts stays positive
     // until the outer service call returns, so a probe reading it would let a

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -8609,6 +8609,87 @@ describe("WorkspaceService sendMessage status clearing", () => {
     expect((await manualResult).success).toBe(true);
   });
 
+  test("a failed send drains the entries queued behind it even when a supersedable preflight is older", async () => {
+    // Codex P1 (PRRT_kwDOPxxmWM6ebIHT): the requireIdle send is physically oldest but nobody
+    // queues behind it, so it must not decide who drains. Otherwise the entry queued behind
+    // the failed manual send waits until the maintenance preflight settles.
+    fakeSession.isBusy.mockReturnValue(false);
+    (workspaceService as unknown as { sessions: Map<string, AgentSession> }).sessions.set(
+      "test-workspace",
+      fakeSession as unknown as AgentSession
+    );
+    const persistSettings = (
+      workspaceService as unknown as { maybePersistAISettingsFromOptions: ReturnType<typeof mock> }
+    ).maybePersistAISettingsFromOptions;
+    const sendOptions = { model: "openai:gpt-4o-mini", agentId: "exec" };
+    const maintenancePreflight = createDeferred<void>();
+    persistSettings.mockImplementationOnce(() => maintenancePreflight.promise);
+    const maintenanceResult = workspaceService.sendMessage(
+      "test-workspace",
+      "check in",
+      sendOptions,
+      { synthetic: true, agentInitiated: true, requireIdle: true }
+    );
+    await waitForCondition(() => persistSettings.mock.calls.length === 1);
+
+    const firstManual = createDeferred<Result<void, SendMessageError>>();
+    fakeSession.sendMessage.mockImplementationOnce(() => firstManual.promise);
+    const firstManualResult = workspaceService.sendMessage("test-workspace", "first", sendOptions);
+    await waitForCondition(() => fakeSession.sendMessage.mock.calls.length === 1);
+    await workspaceService.sendMessage("test-workspace", "second", sendOptions);
+    expect(fakeSession.queueMessage).toHaveBeenCalledTimes(1);
+    expect(fakeSession.drainQueuedMessagesIfIdle).not.toHaveBeenCalled();
+
+    firstManual.resolve(Err({ type: "unknown", raw: "rejected before the turn was accepted" }));
+    expect((await firstManualResult).success).toBe(false);
+    expect(fakeSession.drainQueuedMessagesIfIdle).toHaveBeenCalledTimes(1);
+
+    maintenancePreflight.resolve();
+    await maintenanceResult;
+  });
+
+  test("a queue-mode heartbeat in preflight yields quietly to manual input instead of racing it", async () => {
+    // Codex P1 (PRRT_kwDOPxxmWM6ebIHa): queue-mode heartbeats set yieldToQueuedMessages, not
+    // requireIdle. The manual send must not queue behind the heartbeat, and the heartbeat
+    // must not start once that input is in preflight; its next slot fires anyway.
+    fakeSession.isBusy.mockReturnValue(false);
+    const persistSettings = (
+      workspaceService as unknown as { maybePersistAISettingsFromOptions: ReturnType<typeof mock> }
+    ).maybePersistAISettingsFromOptions;
+    const heartbeatPreflight = createDeferred<void>();
+    persistSettings.mockImplementationOnce(() => heartbeatPreflight.promise);
+    const sendOptions = { model: "openai:gpt-4o-mini", agentId: "exec" };
+
+    const heartbeatResult = workspaceService.sendMessage(
+      "test-workspace",
+      "check in",
+      { ...sendOptions, queueDispatchMode: "turn-end" },
+      {
+        synthetic: true,
+        agentInitiated: true,
+        skipAutoResumeReset: true,
+        queueDedupeKey: "heartbeat",
+        yieldToQueuedMessages: true,
+      }
+    );
+    await waitForCondition(() => persistSettings.mock.calls.length === 1);
+
+    const manualSend = createDeferred<Result<void, SendMessageError>>();
+    fakeSession.sendMessage.mockImplementationOnce(() => manualSend.promise);
+    const manualResult = workspaceService.sendMessage("test-workspace", "manual", sendOptions);
+    await waitForCondition(() => fakeSession.sendMessage.mock.calls.length === 1);
+    expect(fakeSession.sendMessage.mock.calls[0]?.[0]).toBe("manual");
+    expect(fakeSession.queueMessage).not.toHaveBeenCalled();
+
+    heartbeatPreflight.resolve();
+    // Superseded heartbeats report success so the scheduler does not record a failure.
+    expect((await heartbeatResult).success).toBe(true);
+    expect(fakeSession.sendMessage).toHaveBeenCalledTimes(1);
+
+    manualSend.resolve(Ok(undefined));
+    expect((await manualResult).success).toBe(true);
+  });
+
   test("the follow-up idle probe excludes the originating send after its session handoff", async () => {
     // Codex P1 (PRRT_kwDOPxxmWM6cRi_J): preflightSendCounts stays positive
     // until the outer service call returns, so a probe reading it would let a

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -8640,12 +8640,52 @@ describe("WorkspaceService sendMessage status clearing", () => {
     expect(fakeSession.queueMessage).toHaveBeenCalledTimes(1);
     expect(fakeSession.drainQueuedMessagesIfIdle).not.toHaveBeenCalled();
 
+    // Codex P1 (PRRT_kwDOPxxmWM6ebqSE): the maintenance send settling first (it yields to the
+    // manual send in preflight) must not drain either: "second" is queued behind "first",
+    // which is still live, and dispatching it now would start it ahead of "first".
+    maintenancePreflight.resolve();
+    expect((await maintenanceResult).success).toBe(false);
+    expect(fakeSession.drainQueuedMessagesIfIdle).not.toHaveBeenCalled();
+
     firstManual.resolve(Err({ type: "unknown", raw: "rejected before the turn was accepted" }));
     expect((await firstManualResult).success).toBe(false);
     expect(fakeSession.drainQueuedMessagesIfIdle).toHaveBeenCalledTimes(1);
+  });
 
-    maintenancePreflight.resolve();
-    await maintenanceResult;
+  test("sends reach the queue in arrival order even when a later one finishes preflight first", async () => {
+    // Codex P1 (PRRT_kwDOPxxmWM6ebqSR): with "first" in preflight, "third" can finish its
+    // pricing/settings awaits before "second"; enqueueing on completion order would make the
+    // user's third prompt dispatch before the second.
+    fakeSession.isBusy.mockReturnValue(false);
+    const persistSettings = (
+      workspaceService as unknown as { maybePersistAISettingsFromOptions: ReturnType<typeof mock> }
+    ).maybePersistAISettingsFromOptions;
+    const sendOptions = { model: "openai:gpt-4o-mini", agentId: "exec" };
+    const firstSend = createDeferred<Result<void, SendMessageError>>();
+    fakeSession.sendMessage.mockImplementationOnce(() => firstSend.promise);
+    const firstResult = workspaceService.sendMessage("test-workspace", "first", sendOptions);
+    await waitForCondition(() => fakeSession.sendMessage.mock.calls.length === 1);
+
+    const secondPreflight = createDeferred<void>();
+    persistSettings.mockImplementationOnce(() => secondPreflight.promise);
+    const secondResult = workspaceService.sendMessage("test-workspace", "second", sendOptions);
+    await waitForCondition(() => persistSettings.mock.calls.length === 2);
+    const thirdResult = workspaceService.sendMessage("test-workspace", "third", sendOptions);
+    await waitForCondition(() => persistSettings.mock.calls.length === 3);
+    await drainPendingDispatches();
+    // "third" finished its awaits but must wait for "second" to decide.
+    expect(fakeSession.queueMessage).not.toHaveBeenCalled();
+
+    secondPreflight.resolve();
+    expect((await secondResult).success).toBe(true);
+    expect((await thirdResult).success).toBe(true);
+    expect((fakeSession.queueMessage.mock.calls as unknown[][]).map((call) => call[0])).toEqual([
+      "second",
+      "third",
+    ]);
+
+    firstSend.resolve(Ok(undefined));
+    expect((await firstResult).success).toBe(true);
   });
 
   test("a queue-mode heartbeat in preflight yields quietly to manual input instead of racing it", async () => {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -2130,14 +2130,19 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
    * a follow-up redispatched from within the originating send's own turn
    * (e.g. its on-send compaction completing) must not veto itself, and once
    * handed off the session's own queue/turn-phase state governs visibility.
-   * Tickets are kept in arrival order (ticket -> supersedable) so a send can tell
-   * whether an EARLIER send is still in preflight (sendMessage queues behind it)
-   * without two simultaneous arrivals each deferring to the other. Supersedable
-   * tickets are maintenance sends that yield to user input (requireIdle skips and
-   * queue-mode heartbeats): they never count as "earlier" for anyone, and they yield
-   * to a manual send in preflight through preflightSendCounts.
+   * Tickets are kept in arrival order so a send can tell whether an EARLIER send is
+   * still in preflight (sendMessage queues behind it) without two simultaneous
+   * arrivals each deferring to the other, and so sends reach their queue-or-direct
+   * decision in arrival order (a later arrival must not enqueue first because its
+   * preflight awaits finished sooner). Supersedable tickets are maintenance sends that
+   * yield to user input (requireIdle skips and queue-mode heartbeats): they never count
+   * as "earlier" for anyone, nobody waits on them, and they yield to a manual send in
+   * preflight through preflightSendCounts.
    */
-  private readonly sessionInvisiblePreflights = new Map<string, Map<number, boolean>>();
+  private readonly sessionInvisiblePreflights = new Map<
+    string,
+    Map<number, { supersedable: boolean; decided: Promise<void>; markDecided: () => void }>
+  >();
   private nextSessionInvisiblePreflightTicket = 0;
 
   private hasSessionInvisiblePreflight(workspaceId: string): boolean {
@@ -2146,49 +2151,64 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
 
   /**
    * See sessionInvisiblePreflights. Release is idempotent. Disposal (scope exit of the
-   * service call) also drains messages queued behind this preflight when no blocking
-   * ticket preceded it (it was the head of the line that others queue behind): those
-   * entries have no stream end to drain them if this send settled without a turn
-   * (refused, rejected, startup failed). A younger send that settles first must not
-   * drain, or it would dispatch entries ahead of the older still-live preflight; the
-   * older send drains when it settles, and the drain is a no-op when a turn was
-   * handed off (the session is busy).
+   * service call) also drains messages queued behind this preflight when it is a
+   * blocking ticket with no blocking ticket before it (the head of the line that others
+   * queue behind): those entries have no stream end to drain them if this send settled
+   * without a turn (refused, rejected, startup failed). A younger send that settles
+   * first must not drain, or it would dispatch entries ahead of the older still-live
+   * preflight; the older send drains when it settles. Supersedable tickets never drain
+   * because nothing queues behind them, and the drain is a no-op when a turn was handed
+   * off (the session is busy).
    */
   private armSessionInvisiblePreflight(
     workspaceId: string,
     options?: { supersedable?: boolean }
-  ): { release: () => void; hasEarlierPreflight: () => boolean } & Disposable {
+  ): {
+    release: () => void;
+    hasEarlierPreflight: () => boolean;
+    /** Resolve once every earlier blocking ticket has reached its queue-or-direct decision. */
+    awaitEarlierDecisions: () => Promise<void>;
+    markDecided: () => void;
+  } & Disposable {
     const ticket = this.nextSessionInvisiblePreflightTicket++;
+    const supersedable = options?.supersedable === true;
     let tickets = this.sessionInvisiblePreflights.get(workspaceId);
     if (tickets == null) {
       tickets = new Map();
       this.sessionInvisiblePreflights.set(workspaceId, tickets);
     }
-    tickets.set(ticket, options?.supersedable === true);
+    let markDecided!: () => void;
+    const decided = new Promise<void>((resolve) => {
+      markDecided = resolve;
+    });
+    tickets.set(ticket, { supersedable, decided, markDecided });
     let released = false;
     let releasedAsHead = false;
     // Map iteration follows insertion order, so tickets before this one arrived earlier.
-    const hasEarlierPreflight = () => {
+    const earlierBlockingTickets = () => {
+      const earlier: Array<{ decided: Promise<void> }> = [];
       if (released) {
-        return false;
+        return earlier;
       }
-      for (const [liveTicket, supersedable] of this.sessionInvisiblePreflights.get(workspaceId) ??
-        []) {
+      for (const [liveTicket, entry] of this.sessionInvisiblePreflights.get(workspaceId) ?? []) {
         if (liveTicket === ticket) {
-          return false;
+          break;
         }
-        if (!supersedable) {
-          return true;
+        if (!entry.supersedable) {
+          earlier.push(entry);
         }
       }
-      return false;
+      return earlier;
     };
+    const hasEarlierPreflight = () => earlierBlockingTickets().length > 0;
     const release = () => {
       if (released) {
         return;
       }
-      releasedAsHead = !hasEarlierPreflight();
+      releasedAsHead = !supersedable && !hasEarlierPreflight();
       released = true;
+      // A send that leaves before deciding must not keep later arrivals waiting.
+      markDecided();
       const live = this.sessionInvisiblePreflights.get(workspaceId);
       live?.delete(ticket);
       if (live?.size === 0) {
@@ -2198,6 +2218,10 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
     return {
       release,
       hasEarlierPreflight,
+      awaitEarlierDecisions: async () => {
+        await Promise.all(earlierBlockingTickets().map((entry) => entry.decided));
+      },
+      markDecided,
       [Symbol.dispose]: () => {
         release();
         if (releasedAsHead) {
@@ -10745,6 +10769,12 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       // Persist last-used model + thinking level for cross-device consistency.
       await this.maybePersistAISettingsFromOptions(workspaceId, normalizedOptions, "send");
 
+      // Decide queue-or-direct in arrival order: a later send whose awaits above finished
+      // first would otherwise enqueue ahead of an earlier one. The decision below runs
+      // synchronously up to queueMessage / the session handoff.
+      await sessionInvisiblePreflight.awaitEarlierDecisions();
+      sessionInvisiblePreflight.markDecided();
+
       // A send between service entry and the session's PREPARING claim is invisible to
       // isBusy(). A later send admitted against that idle snapshot reaches StreamManager
       // while the earlier turn is streaming, and ensureStreamSafety aborts the earlier turn
@@ -11167,6 +11197,8 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
         },
       };
       using sessionInvisiblePreflight = this.armSessionInvisiblePreflight(workspaceId);
+      // A resume never queues, so later sends must not wait on its decision.
+      sessionInvisiblePreflight.markDecided();
 
       // Guard: avoid creating sessions for workspaces that don't exist anymore.
       if (!this.config.findWorkspace(workspaceId)) {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -2133,8 +2133,9 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
    * Tickets are kept in arrival order (ticket -> supersedable) so a send can tell
    * whether an EARLIER send is still in preflight (sendMessage queues behind it)
    * without two simultaneous arrivals each deferring to the other. Supersedable
-   * tickets are requireIdle maintenance sends (heartbeats, continuations): manual
-   * input never waits behind them, and they yield to it through preflightSendCounts.
+   * tickets are maintenance sends that yield to user input (requireIdle skips and
+   * queue-mode heartbeats): they never count as "earlier" for anyone, and they yield
+   * to a manual send in preflight through preflightSendCounts.
    */
   private readonly sessionInvisiblePreflights = new Map<string, Map<number, boolean>>();
   private nextSessionInvisiblePreflightTicket = 0;
@@ -2145,12 +2146,13 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
 
   /**
    * See sessionInvisiblePreflights. Release is idempotent. Disposal (scope exit of the
-   * service call) also drains messages queued behind this preflight when it was the head
-   * of the arrival line: those entries have no stream end to drain them if this send
-   * settled without a turn (refused, rejected, startup failed). A younger send that
-   * settles first must not drain, or it would dispatch entries ahead of the older
-   * still-live preflight; the older send drains when it settles, and the drain is a
-   * no-op when a turn was handed off (the session is busy).
+   * service call) also drains messages queued behind this preflight when no blocking
+   * ticket preceded it (it was the head of the line that others queue behind): those
+   * entries have no stream end to drain them if this send settled without a turn
+   * (refused, rejected, startup failed). A younger send that settles first must not
+   * drain, or it would dispatch entries ahead of the older still-live preflight; the
+   * older send drains when it settles, and the drain is a no-op when a turn was
+   * handed off (the session is busy).
    */
   private armSessionInvisiblePreflight(
     workspaceId: string,
@@ -2164,22 +2166,8 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
     }
     tickets.set(ticket, options?.supersedable === true);
     let released = false;
-    let releasedAsOldest = false;
-    // Map iteration follows insertion order, so the first live ticket is the oldest.
-    const isOldest = () =>
-      this.sessionInvisiblePreflights.get(workspaceId)?.keys().next().value === ticket;
-    const release = () => {
-      if (released) {
-        return;
-      }
-      released = true;
-      releasedAsOldest = isOldest();
-      const live = this.sessionInvisiblePreflights.get(workspaceId);
-      live?.delete(ticket);
-      if (live?.size === 0) {
-        this.sessionInvisiblePreflights.delete(workspaceId);
-      }
-    };
+    let releasedAsHead = false;
+    // Map iteration follows insertion order, so tickets before this one arrived earlier.
     const hasEarlierPreflight = () => {
       if (released) {
         return false;
@@ -2195,12 +2183,24 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       }
       return false;
     };
+    const release = () => {
+      if (released) {
+        return;
+      }
+      releasedAsHead = !hasEarlierPreflight();
+      released = true;
+      const live = this.sessionInvisiblePreflights.get(workspaceId);
+      live?.delete(ticket);
+      if (live?.size === 0) {
+        this.sessionInvisiblePreflights.delete(workspaceId);
+      }
+    };
     return {
       release,
       hasEarlierPreflight,
       [Symbol.dispose]: () => {
         release();
-        if (releasedAsOldest) {
+        if (releasedAsHead) {
           this.sessions.get(workspaceId)?.drainQueuedMessagesIfIdle();
         }
       },
@@ -10589,8 +10589,20 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
           }
         },
       };
+      // Maintenance sends that yield to user input: requireIdle skips and queue-mode
+      // heartbeats. Both must yield to a manual send in preflight rather than race it.
+      const yieldsToPreflightSends =
+        internal?.requireIdle === true || internal?.yieldToQueuedMessages === true;
+      // A queue-mode heartbeat superseded by input that arrived during its preparation is a
+      // quiet success: its next slot fires anyway.
+      const yieldToPreflightSend = (): Result<void, SendMessageError> => {
+        log.info("sendMessage: yielded to a send in preflight during send preparation", {
+          workspaceId,
+        });
+        return Ok(undefined);
+      };
       using sessionInvisiblePreflight = this.armSessionInvisiblePreflight(workspaceId, {
-        supersedable: internal?.requireIdle === true,
+        supersedable: yieldsToPreflightSends,
       });
 
       // Guard: avoid creating sessions for workspaces that don't exist anymore.
@@ -10742,7 +10754,7 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       const shouldQueue =
         !normalizedOptions?.editMessageId &&
         (session.isBusy() ||
-          (sessionInvisiblePreflight.hasEarlierPreflight() && internal?.requireIdle !== true));
+          (sessionInvisiblePreflight.hasEarlierPreflight() && !yieldsToPreflightSends));
 
       // Codex P1 (PRRT_kwDOPxxmWM6cGSPP): a goal-continuation dispatch closure
       // captured before a manual send entered preflight would otherwise win
@@ -10752,15 +10764,16 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       // synchronously at entry above), so any other in-preflight send makes
       // the count exceed 1; refusing is safe because idle-only callers
       // (continuations, heartbeats) treat this as a transient skip and retry.
-      if (
-        !shouldQueue &&
-        internal?.requireIdle &&
-        (this.preflightSendCounts.get(workspaceId) ?? 0) > 1
-      ) {
+      const hasOtherSendInPreflight = (this.preflightSendCounts.get(workspaceId) ?? 0) > 1;
+      if (!shouldQueue && internal?.requireIdle && hasOtherSendInPreflight) {
         return Err({
           type: "unknown",
           raw: IDLE_ONLY_BUSY_SKIP_MESSAGE,
         });
+      }
+      // Starting a queue-mode heartbeat here would race that input to PREPARING.
+      if (!shouldQueue && internal?.yieldToQueuedMessages === true && hasOtherSendInPreflight) {
+        return yieldToPreflightSend();
       }
 
       // Codex P1 (PRRT_kwDOPxxmWM6cJ6NI): the count check above is a one-shot
@@ -10770,9 +10783,11 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       // caller's staleness probe with a live preflight re-check so
       // AgentSession's admission gates (including the last gate before the
       // pre-turn batch becomes irrevocable) re-validate idleness; refusal
-      // rolls back the synthetic row and idle-only callers retry.
-      if (internal?.requireIdle) {
-        const callerAdmissionStale = internal.admissionStale;
+      // rolls back the synthetic row and idle-only callers retry. Queue-mode heartbeats
+      // carry the same probe so they cannot claim PREPARING against a manual send that
+      // entered preflight after their entry check (see the quiet yield below).
+      if (yieldsToPreflightSends) {
+        const callerAdmissionStale = internal?.admissionStale;
         internal = {
           ...internal,
           admissionStale: () =>
@@ -10785,6 +10800,9 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
         // Everything from here to queueMessage is synchronous, so a probe pass here cannot go
         // stale before the entry is enqueued.
         if (internal?.admissionStale?.() === true) {
+          if (internal.yieldToQueuedMessages === true) {
+            return yieldToPreflightSend();
+          }
           return Err({ type: "unknown", raw: SEND_ADMISSION_STALE_MESSAGE });
         }
         const taskStatus = this.agentTaskIntegration?.getAgentTaskStatus(workspaceId);
@@ -10993,6 +11011,14 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
         admissionEpochStale,
         admissionStale: internal?.admissionStale,
       });
+      if (
+        !result.success &&
+        internal?.yieldToQueuedMessages === true &&
+        result.error.type === "unknown" &&
+        result.error.raw === SEND_ADMISSION_STALE_MESSAGE
+      ) {
+        return yieldToPreflightSend();
+      }
       if (!result.success) {
         log.error("sendMessage handler: session returned error", {
           workspaceId,

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -2130,60 +2130,79 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
    * a follow-up redispatched from within the originating send's own turn
    * (e.g. its on-send compaction completing) must not veto itself, and once
    * handed off the session's own queue/turn-phase state governs visibility.
-   * Tickets are kept in arrival order so a send can tell whether an EARLIER
-   * send is still in preflight (sendMessage queues behind it) without two
-   * simultaneous arrivals each deferring to the other.
+   * Tickets are kept in arrival order (ticket -> supersedable) so a send can tell
+   * whether an EARLIER send is still in preflight (sendMessage queues behind it)
+   * without two simultaneous arrivals each deferring to the other. Supersedable
+   * tickets are requireIdle maintenance sends (heartbeats, continuations): manual
+   * input never waits behind them, and they yield to it through preflightSendCounts.
    */
-  private readonly sessionInvisiblePreflights = new Map<string, Set<number>>();
+  private readonly sessionInvisiblePreflights = new Map<string, Map<number, boolean>>();
   private nextSessionInvisiblePreflightTicket = 0;
 
   private hasSessionInvisiblePreflight(workspaceId: string): boolean {
     return (this.sessionInvisiblePreflights.get(workspaceId)?.size ?? 0) > 0;
   }
 
-  /** See sessionInvisiblePreflights. Release is idempotent. */
+  /**
+   * See sessionInvisiblePreflights. Release is idempotent. Disposal (scope exit of the
+   * service call) also drains messages queued behind this preflight when it was the head
+   * of the arrival line: those entries have no stream end to drain them if this send
+   * settled without a turn (refused, rejected, startup failed). A younger send that
+   * settles first must not drain, or it would dispatch entries ahead of the older
+   * still-live preflight; the older send drains when it settles, and the drain is a
+   * no-op when a turn was handed off (the session is busy).
+   */
   private armSessionInvisiblePreflight(
-    workspaceId: string
+    workspaceId: string,
+    options?: { supersedable?: boolean }
   ): { release: () => void; hasEarlierPreflight: () => boolean } & Disposable {
     const ticket = this.nextSessionInvisiblePreflightTicket++;
     let tickets = this.sessionInvisiblePreflights.get(workspaceId);
     if (tickets == null) {
-      tickets = new Set();
+      tickets = new Map();
       this.sessionInvisiblePreflights.set(workspaceId, tickets);
     }
-    tickets.add(ticket);
+    tickets.set(ticket, options?.supersedable === true);
     let released = false;
+    let releasedAsOldest = false;
+    // Map iteration follows insertion order, so the first live ticket is the oldest.
+    const isOldest = () =>
+      this.sessionInvisiblePreflights.get(workspaceId)?.keys().next().value === ticket;
     const release = () => {
       if (released) {
         return;
       }
       released = true;
+      releasedAsOldest = isOldest();
       const live = this.sessionInvisiblePreflights.get(workspaceId);
       live?.delete(ticket);
       if (live?.size === 0) {
         this.sessionInvisiblePreflights.delete(workspaceId);
       }
     };
-    // Set iteration follows insertion order, so the first live ticket is the oldest.
-    const hasEarlierPreflight = () =>
-      !released &&
-      this.sessionInvisiblePreflights.get(workspaceId)?.values().next().value !== ticket;
-    return { release, hasEarlierPreflight, [Symbol.dispose]: release };
-  }
-
-  /**
-   * Messages queued behind a send's preflight (sendMessage's hasEarlierPreflight) have no
-   * stream end to drain them when that send settles without a turn: refused, rejected, or
-   * startup failed. Declare BEFORE armSessionInvisiblePreflight so it disposes after the
-   * ticket is released and only the last live preflight drains.
-   */
-  private armQueuedBehindPreflightDrain(workspaceId: string): Disposable {
-    return {
-      [Symbol.dispose]: () => {
-        if (this.hasSessionInvisiblePreflight(workspaceId)) {
-          return;
+    const hasEarlierPreflight = () => {
+      if (released) {
+        return false;
+      }
+      for (const [liveTicket, supersedable] of this.sessionInvisiblePreflights.get(workspaceId) ??
+        []) {
+        if (liveTicket === ticket) {
+          return false;
         }
-        this.sessions.get(workspaceId)?.drainQueuedMessagesIfIdle();
+        if (!supersedable) {
+          return true;
+        }
+      }
+      return false;
+    };
+    return {
+      release,
+      hasEarlierPreflight,
+      [Symbol.dispose]: () => {
+        release();
+        if (releasedAsOldest) {
+          this.sessions.get(workspaceId)?.drainQueuedMessagesIfIdle();
+        }
       },
     };
   }
@@ -10551,7 +10570,6 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       const admissionEpoch = this.contextMutationEpochs.get(workspaceId) ?? 0;
       const admissionEpochStale = () =>
         (this.contextMutationEpochs.get(workspaceId) ?? 0) !== admissionEpoch;
-      using _drainQueuedBehindPreflight = this.armQueuedBehindPreflightDrain(workspaceId);
       // r41: count this send as in-preflight until it settles so refine
       // publication refuses to interleave with its pre-admission window
       // (context mutations instead refuse the send itself via the epoch
@@ -10571,7 +10589,9 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
           }
         },
       };
-      using sessionInvisiblePreflight = this.armSessionInvisiblePreflight(workspaceId);
+      using sessionInvisiblePreflight = this.armSessionInvisiblePreflight(workspaceId, {
+        supersedable: internal?.requireIdle === true,
+      });
 
       // Guard: avoid creating sessions for workspaces that don't exist anymore.
       const workspaceConfig = this.config.findWorkspace(workspaceId);
@@ -10717,7 +10737,8 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       // isBusy(). A later send admitted against that idle snapshot reaches StreamManager
       // while the earlier turn is streaming, and ensureStreamSafety aborts the earlier turn
       // to start the later one. Queue behind the earlier in-preflight send instead.
-      // requireIdle callers keep their skip semantics below; edits bypass the queue by design.
+      // requireIdle callers keep their skip semantics below (and are never waited on, see
+      // sessionInvisiblePreflights); edits bypass the queue by design.
       const shouldQueue =
         !normalizedOptions?.editMessageId &&
         (session.isBusy() ||
@@ -11105,7 +11126,6 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       // (mirrors sendMessage): the archive gate refuses while a resume that already passed
       // these guards is still doing pre-admission work, so neither side can slip past the
       // other's snapshot.
-      using _drainQueuedBehindPreflight = this.armQueuedBehindPreflightDrain(workspaceId);
       this.preflightSendCounts.set(
         workspaceId,
         (this.preflightSendCounts.get(workspaceId) ?? 0) + 1

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -2130,29 +2130,62 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
    * a follow-up redispatched from within the originating send's own turn
    * (e.g. its on-send compaction completing) must not veto itself, and once
    * handed off the session's own queue/turn-phase state governs visibility.
+   * Tickets are kept in arrival order so a send can tell whether an EARLIER
+   * send is still in preflight (sendMessage queues behind it) without two
+   * simultaneous arrivals each deferring to the other.
    */
-  private readonly sessionInvisiblePreflightCounts = new Map<string, number>();
+  private readonly sessionInvisiblePreflights = new Map<string, Set<number>>();
+  private nextSessionInvisiblePreflightTicket = 0;
 
-  /** See sessionInvisiblePreflightCounts. Release is idempotent. */
-  private armSessionInvisiblePreflight(workspaceId: string): { release: () => void } & Disposable {
-    this.sessionInvisiblePreflightCounts.set(
-      workspaceId,
-      (this.sessionInvisiblePreflightCounts.get(workspaceId) ?? 0) + 1
-    );
+  private hasSessionInvisiblePreflight(workspaceId: string): boolean {
+    return (this.sessionInvisiblePreflights.get(workspaceId)?.size ?? 0) > 0;
+  }
+
+  /** See sessionInvisiblePreflights. Release is idempotent. */
+  private armSessionInvisiblePreflight(
+    workspaceId: string
+  ): { release: () => void; hasEarlierPreflight: () => boolean } & Disposable {
+    const ticket = this.nextSessionInvisiblePreflightTicket++;
+    let tickets = this.sessionInvisiblePreflights.get(workspaceId);
+    if (tickets == null) {
+      tickets = new Set();
+      this.sessionInvisiblePreflights.set(workspaceId, tickets);
+    }
+    tickets.add(ticket);
     let released = false;
     const release = () => {
       if (released) {
         return;
       }
       released = true;
-      const remaining = (this.sessionInvisiblePreflightCounts.get(workspaceId) ?? 1) - 1;
-      if (remaining <= 0) {
-        this.sessionInvisiblePreflightCounts.delete(workspaceId);
-      } else {
-        this.sessionInvisiblePreflightCounts.set(workspaceId, remaining);
+      const live = this.sessionInvisiblePreflights.get(workspaceId);
+      live?.delete(ticket);
+      if (live?.size === 0) {
+        this.sessionInvisiblePreflights.delete(workspaceId);
       }
     };
-    return { release, [Symbol.dispose]: release };
+    // Set iteration follows insertion order, so the first live ticket is the oldest.
+    const hasEarlierPreflight = () =>
+      !released &&
+      this.sessionInvisiblePreflights.get(workspaceId)?.values().next().value !== ticket;
+    return { release, hasEarlierPreflight, [Symbol.dispose]: release };
+  }
+
+  /**
+   * Messages queued behind a send's preflight (sendMessage's hasEarlierPreflight) have no
+   * stream end to drain them when that send settles without a turn: refused, rejected, or
+   * startup failed. Declare BEFORE armSessionInvisiblePreflight so it disposes after the
+   * ticket is released and only the last live preflight drains.
+   */
+  private armQueuedBehindPreflightDrain(workspaceId: string): Disposable {
+    return {
+      [Symbol.dispose]: () => {
+        if (this.hasSessionInvisiblePreflight(workspaceId)) {
+          return;
+        }
+        this.sessions.get(workspaceId)?.drainQueuedMessagesIfIdle();
+      },
+    };
   }
   // In-flight renderer executeBash requests per workspace. Incremented in the same
   // synchronous block as executeBash's archivingWorkspaces check (mirroring
@@ -3935,8 +3968,7 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       // counter, not preflightSendCounts — the originating send's reservation
       // is released at its queue/session handoff so a follow-up dispatched
       // from within that turn does not veto itself.
-      hasExternalSendPreflight: () =>
-        (this.sessionInvisiblePreflightCounts.get(workspaceId) ?? 0) > 0,
+      hasExternalSendPreflight: () => this.hasSessionInvisiblePreflight(workspaceId),
     });
   }
 
@@ -10519,6 +10551,7 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       const admissionEpoch = this.contextMutationEpochs.get(workspaceId) ?? 0;
       const admissionEpochStale = () =>
         (this.contextMutationEpochs.get(workspaceId) ?? 0) !== admissionEpoch;
+      using _drainQueuedBehindPreflight = this.armQueuedBehindPreflightDrain(workspaceId);
       // r41: count this send as in-preflight until it settles so refine
       // publication refuses to interleave with its pre-admission window
       // (context mutations instead refuse the send itself via the epoch
@@ -10680,7 +10713,15 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       // Persist last-used model + thinking level for cross-device consistency.
       await this.maybePersistAISettingsFromOptions(workspaceId, normalizedOptions, "send");
 
-      const shouldQueue = !normalizedOptions?.editMessageId && session.isBusy();
+      // A send between service entry and the session's PREPARING claim is invisible to
+      // isBusy(). A later send admitted against that idle snapshot reaches StreamManager
+      // while the earlier turn is streaming, and ensureStreamSafety aborts the earlier turn
+      // to start the later one. Queue behind the earlier in-preflight send instead.
+      // requireIdle callers keep their skip semantics below; edits bypass the queue by design.
+      const shouldQueue =
+        !normalizedOptions?.editMessageId &&
+        (session.isBusy() ||
+          (sessionInvisiblePreflight.hasEarlierPreflight() && internal?.requireIdle !== true));
 
       // Codex P1 (PRRT_kwDOPxxmWM6cGSPP): a goal-continuation dispatch closure
       // captured before a manual send entered preflight would otherwise win
@@ -11064,6 +11105,7 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       // (mirrors sendMessage): the archive gate refuses while a resume that already passed
       // these guards is still doing pre-admission work, so neither side can slip past the
       // other's snapshot.
+      using _drainQueuedBehindPreflight = this.armQueuedBehindPreflightDrain(workspaceId);
       this.preflightSendCounts.set(
         workspaceId,
         (this.preflightSendCounts.get(workspaceId) ?? 0) + 1


### PR DESCRIPTION
## Summary

Two prompts sent seconds apart could both start a turn: the second one's stream startup aborted the first one's live stream (`abortReason: "system"`), committing an empty assistant row for the first prompt. `WorkspaceService.sendMessage` now queues a send that arrives while an earlier send is still in its pre-admission window, and drains anything queued behind a send that never became a turn.

## Background

`shouldQueue` was decided from `session.isBusy()` alone, which only turns true once `AgentSession.sendMessage` claims `PREPARING`. Everything before that (pricing gate, settings persistence, history appends, goal sync) runs against an idle-looking session. Under load that window was tens of seconds. Observed in a dogfood workspace: `continue` prompts at 21:53:17 and 21:53:28 both went direct, two `[stream-startup]` breadcrumb sequences interleaved in `mux.log`, and when the second reached `StreamManager.startStream`, `ensureStreamSafety` killed the first stream 44s in with no output (`turn.interrupted reason=system`, `retry.abandoned reason=aborted`).

The existing `sessionInvisiblePreflightCounts` already modeled exactly this window for the session's idle probes (goal continuations, heartbeats), but manual sends did not consult it.

## Implementation

- `workspaceService.ts`: the session-invisible preflight counter becomes a set of arrival-ordered tickets. A later send queues while an earlier ticket is still live (`hasEarlierPreflight()`), so two simultaneous arrivals cannot each defer to the other and the first-arrived send wins. `requireIdle` callers keep their existing skip semantics; edits still bypass the queue by design.
- `armQueuedBehindPreflightDrain` (used by `sendMessage` and `resumeStream`) drains entries queued behind a preflight that settled without a turn (refused, rejected, startup failed). Without it those entries would sit in the queue with no stream end to drain them. It only fires from the last live preflight.
- `agentSession.ts`: `drainQueuedMessagesIfIdle()` yields to a busy session, a pending auto-retry, or the edit flow's claim on the next dispatch, matching the existing stream-end drain contracts.

## Validation

- Red-green: both new tests in `workspaceService.test.ts` fail with the production change reverted and pass with it. The first test issues two sends back to back (both inside preflight awaits) and asserts `first` is dispatched and `second` is queued, which also rejects a naive "count > 1" implementation that inverts order. The second asserts the drain runs only after the earlier send settles with a failure, never while it is still in preflight.
- Two existing fixtures gained the queue-branch fake methods now reachable; the auto-title concurrency test still asserts the first send claims the title.

## Risks

Low to moderate, scoped to send admission. Behavior change: a message arriving during another send's preflight is now queued (visible in the composer queue) instead of racing it. A manual send arriving during a heartbeat's short preflight will wait behind the heartbeat turn rather than kill it; making `requireIdle` sends yield to a message queued behind them is a possible follow-up. The drain is guarded by `isBusy`, `hasPendingAutoRetry`, and the edit-flow deferral, so it cannot dispatch during a retry backoff or while an edit is truncating.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$17.79`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=17.79 -->
