### PR TITLE
🤖 fix: keep the phone-width sidebar hamburger inside its button

### DIFF
--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -1320,6 +1320,21 @@ body,
   }
 }
 
+/* Touch targets widen this button to 44px (see the coarse-pointer block above), so centering
+   would drift the icon to 22px; anchor the box to the header edge to keep it on the 12px gutter.
+   Fine pointers keep the 24px box, where this inset would push the icon out of the box and paint
+   the hover pill against the window edge. */
+@media (max-width: 768px) and (pointer: coarse) {
+  .mobile-menu-btn {
+    justify-content: flex-start !important;
+    padding-left: 12px !important;
+  }
+
+  .mobile-sticky-header:has(.mobile-menu-btn) {
+    padding-left: 0 !important;
+  }
+}
+
 /* Hide right sidebar when the workspace shell is too narrow to fit
    ChatPane(min 384px) + RightSidebar(min 300px) side-by-side. */
 @container (max-width: 684px) {

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -1248,12 +1248,12 @@ body,
 @media (max-width: 768px) {
   .mobile-menu-btn {
     display: inline-flex !important;
-    justify-content: flex-start !important;
-    padding-left: 12px !important;
   }
 
+  /* The collapsed-left-sidebar header inset reserves room for the desktop reopen affordance; at
+     phone widths this button is that affordance, so fall back to the header's ordinary gutter. */
   .mobile-sticky-header:has(.mobile-menu-btn) {
-    padding-left: 0 !important;
+    padding-left: 0.5rem !important;
   }
 
   /* Hand the bottom inset to a column that reserves its own clearance (see ChatPane and


### PR DESCRIPTION
## Summary

At phone widths (`max-width: 768px`) the "Open sidebar" hamburger's hover pill sat glued to the window's left edge with the icon spilling out of its right side into the header title. This drops the CSS hack that caused it so the hamburger is an ordinary centered icon button again.

## Background

#1935 aligned the hamburger icon to a 12px gutter by zeroing the header's left padding and forcing `padding-left: 12px` + `justify-content: flex-start` onto the button. The button is a fixed 24px box, so the icon (14 to 16px) ended up at x=12..28 while the box stayed at x=0..24: the hover background hugged the edge and the glyph overflowed the box on the right. Follow-up to #4046, which only fixed the tooltip label in the same screenshot.

## Implementation

Remove the two button overrides from the phone-width default. The header's own `px-2` gutter plus normal centering puts the icon at x=12 (16px icons) or x=13 (the 14px icon in `WorkspaceMenuBar`), so the #1935 alignment is preserved while the box encloses the icon (x=8..32).

On coarse pointers the touch-target rule widens the button to 44px, where centering would drift the icon to x=22, so a following `(max-width: 768px) and (pointer: coarse)` block restores the original gutter geometry (header padding 0, button `padding-left: 12px`, `flex-start`). Real phones are unchanged; only fine-pointer narrow windows get the corrected layout.

The `.mobile-sticky-header:has(.mobile-menu-btn)` override stays, but at `0.5rem` instead of `0`. It exists because `WorkspaceMenuBar` applies a 60px inline inset when the left sidebar is collapsed (room for the desktop reopen affordance); at phone widths the hamburger itself is that affordance, so the header should fall back to its normal gutter.

## Validation

- Playwright geometry of the "Open sidebar menu" button in `App/PhoneViewports/IPhone16e`, fine pointer (390px viewport) vs coarse pointer (`isMobile` + `hasTouch`, so `(pointer: coarse)` matches, which Pixel cannot emulate):

  | CSS     | coarse pointer       | fine pointer                         |
  | ------- | -------------------- | ------------------------------------ |
  | main    | box 0..44, icon x=12 | box 0..24, icon x=12 (overflows box) |
  | this PR | box 0..44, icon x=12 | box 8..32, icon x=12                 |

- Screenshots with the hover surface forced visible reproduce the reported clipped pill on `main` and show the enclosed pill on this branch.
- `test-storybook` for `App.phoneViewports` (8 stories) and `make static-check` pass.

## Risks

Low; CSS only, scoped to `max-width: 768px` and the five `mobile-menu-btn` call sites (workspace, project, scratch, settings, analytics headers). Pixel snapshots for phone stories will shift by a few pixels around the hamburger.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$45.36`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=45.36 -->
