### PR TITLE
🤖 fix: surface slow server responses in the connection indicator

### DIFF
--- a/src/browser/components/ConnectionStatusToast/ConnectionStatusToast.tsx
+++ b/src/browser/components/ConnectionStatusToast/ConnectionStatusToast.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useAPI } from "@/browser/contexts/API";
+import { formatDuration } from "@/common/utils/formatDuration";
 
 const wrapperClassName =
   "pointer-events-none absolute right-[15px] bottom-full left-[15px] z-[1000] mb-2 [&>*]:pointer-events-auto";
@@ -42,7 +43,11 @@ export const ConnectionStatusToast: React.FC<ConnectionStatusToastProps> = ({ wr
         <span className="bg-warning inline-block h-2 w-2 animate-pulse rounded-full" />
         <span>
           {apiState.status === "degraded" ? (
-            "Connection unstable — messages may be delayed"
+            <>
+              Server is slow to respond (
+              <span className="counter-nums">{formatDuration(apiState.latencyMs, "precise")}</span>
+              ); messages may be delayed
+            </>
           ) : (
             <>
               Reconnecting to server

--- a/src/browser/components/ConnectionStatusToast/ConnectionStatusToast.tsx
+++ b/src/browser/components/ConnectionStatusToast/ConnectionStatusToast.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useAPI } from "@/browser/contexts/API";
+import { useAPI, useConnectionLatencyMs } from "@/browser/contexts/API";
 import { formatDuration } from "@/common/utils/formatDuration";
 
 const wrapperClassName =
@@ -22,6 +22,7 @@ interface ConnectionStatusToastProps {
 
 export const ConnectionStatusToast: React.FC<ConnectionStatusToastProps> = ({ wrap = true }) => {
   const apiState = useAPI();
+  const latencyMs = useConnectionLatencyMs();
 
   // Don't show anything when connected or during initial connection.
   // Auth required is handled by a separate modal flow.
@@ -44,9 +45,16 @@ export const ConnectionStatusToast: React.FC<ConnectionStatusToastProps> = ({ wr
         <span>
           {apiState.status === "degraded" ? (
             <>
-              Server is slow to respond (
-              <span className="counter-nums">{formatDuration(apiState.latencyMs, "precise")}</span>
-              ); messages may be delayed
+              Server is slow to respond
+              {latencyMs !== null && (
+                // The figure changes every liveness tick; keep it out of the accessibility tree so
+                // the polite live region does not re-announce the whole warning each time.
+                <span aria-hidden="true">
+                  {" "}
+                  (<span className="counter-nums">{formatDuration(latencyMs, "precise")}</span>)
+                </span>
+              )}
+              ; messages may be delayed
             </>
           ) : (
             <>

--- a/src/browser/contexts/API.test.tsx
+++ b/src/browser/contexts/API.test.tsx
@@ -712,6 +712,39 @@ describe("API reconnection", () => {
   );
 
   test(
+    "reconnects on a late tick past the probe age limit instead of re-probing a silent socket",
+    async () => {
+      const states: ObservedState[] = [];
+      const pingCalls = installLivenessPing(neverSettlingPong);
+      const realNow = Date.now;
+
+      try {
+        await connectFirstSocket(states);
+        await waitFor(() => {
+          expect(pingCalls()).toBe(2);
+        });
+
+        // Emulate a throttled tab whose next interval fires long after the probe was sent.
+        const skewMs = 31000;
+        Date.now = () => realNow() + skewMs;
+
+        await waitFor(
+          () => {
+            expect(MockWebSocket.instances.length).toBe(2);
+          },
+          { timeout: 8000 }
+        );
+      } finally {
+        Date.now = realNow;
+      }
+
+      // The stalled probe was not replaced on the old socket before reconnecting.
+      expect(pingCalls()).toBe(2);
+    },
+    { timeout: 20000 }
+  );
+
+  test(
     "reconnects after repeated rejected probes so a lost session reaches auth_required",
     async () => {
       const states: ObservedState[] = [];

--- a/src/browser/contexts/API.test.tsx
+++ b/src/browser/contexts/API.test.tsx
@@ -716,7 +716,7 @@ describe("API reconnection", () => {
     async () => {
       const states: ObservedState[] = [];
       const pingCalls = installLivenessPing(neverSettlingPong);
-      const realNow = Date.now;
+      const realNow = performance.now.bind(performance);
 
       try {
         await connectFirstSocket(states);
@@ -726,7 +726,7 @@ describe("API reconnection", () => {
 
         // Emulate a throttled tab whose next interval fires long after the probe was sent.
         const skewMs = 31000;
-        Date.now = () => realNow() + skewMs;
+        performance.now = () => realNow() + skewMs;
 
         await waitFor(
           () => {
@@ -735,11 +735,36 @@ describe("API reconnection", () => {
           { timeout: 8000 }
         );
       } finally {
-        Date.now = realNow;
+        performance.now = realNow;
       }
 
       // The stalled probe was not replaced on the old socket before reconnecting.
       expect(pingCalls()).toBe(2);
+    },
+    { timeout: 20000 }
+  );
+
+  test(
+    "still degrades on a stalled probe when the wall clock steps backwards",
+    async () => {
+      const states: ObservedState[] = [];
+      installLivenessPing(neverSettlingPong);
+      const realDateNow = Date.now;
+
+      try {
+        await connectFirstSocket(states);
+        // A clock correction after the probe was sent must not make it look young.
+        Date.now = () => realDateNow() - 60000;
+
+        await waitFor(
+          () => {
+            expect(states.some((s) => s.status === "degraded")).toBe(true);
+          },
+          { timeout: 15000 }
+        );
+      } finally {
+        Date.now = realDateNow;
+      }
     },
     { timeout: 20000 }
   );

--- a/src/browser/contexts/API.test.tsx
+++ b/src/browser/contexts/API.test.tsx
@@ -785,6 +785,8 @@ describe("API reconnection", () => {
         },
         { timeout: 16000 }
       );
+      // Prompt rejections are not slowness either: no "slow to respond" indicator on the way.
+      expect(states.some((s) => s.status === "degraded")).toBe(false);
 
       act(() => {
         MockWebSocket.lastInstance()!.simulateOpen();

--- a/src/browser/contexts/API.test.tsx
+++ b/src/browser/contexts/API.test.tsx
@@ -675,9 +675,14 @@ describe("API reconnection", () => {
         { timeout: 22000 }
       );
 
-      const statuses = states.map((s) => s.status);
-      expect(statuses.some((s) => s === "reconnecting" || s === "connecting")).toBe(true);
-      expect(statuses.filter((s) => s === "auth_required")).toHaveLength(0);
+      // The forced reconnect must stay visible as "reconnecting" through the replacement
+      // socket's handshake; "connecting" renders no banner and is reserved for the initial load.
+      const statusesAfterConnected = states
+        .map((s) => s.status)
+        .slice(states.findIndex((s) => s.status === "connected") + 1);
+      expect(statusesAfterConnected).toContain("reconnecting");
+      expect(statusesAfterConnected).not.toContain("connecting");
+      expect(statusesAfterConnected).not.toContain("auth_required");
 
       // The replacement socket's auth-check pong is the next ping call.
       pingImpl = () => Promise.resolve("pong");

--- a/src/browser/contexts/API.test.tsx
+++ b/src/browser/contexts/API.test.tsx
@@ -109,16 +109,26 @@ import type {
 const RealAPIModule: {
   APIProvider: typeof APIProviderType;
   useAPI: () => _UseAPIResult;
+  useConnectionLatencyMs: () => number | null;
 } = require("./API?real=1");
 /* eslint-enable @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment */
-const { APIProvider, useAPI } = RealAPIModule;
+const { APIProvider, useAPI, useConnectionLatencyMs } = RealAPIModule;
 type APIClient = _APIClient;
 type UseAPIResult = _UseAPIResult;
 
+// Each observation carries the API context value by reference (apiState) plus the latency
+// published through the separate latency context.
+interface ObservedState {
+  status: UseAPIResult["status"];
+  apiState: UseAPIResult;
+  latencyMs: number | null;
+}
+
 // Test component to observe API state
-function APIStateObserver(props: { onState: (state: UseAPIResult) => void }) {
+function APIStateObserver(props: { onState: (state: ObservedState) => void }) {
   const apiState = useAPI();
-  props.onState(apiState);
+  const latencyMs = useConnectionLatencyMs();
+  props.onState({ status: apiState.status, apiState, latencyMs });
   return null;
 }
 
@@ -203,7 +213,7 @@ describe("API reconnection", () => {
       <APIProvider client={injectedClient as APIClient}>
         <APIStateObserver
           onState={(state) => {
-            latestState = state;
+            latestState = state.apiState;
             states.push(state.status);
           }}
         />
@@ -530,7 +540,7 @@ describe("API reconnection", () => {
 
   const neverSettlingPong = () => new Promise<string>(() => undefined);
 
-  async function connectFirstSocket(states: UseAPIResult[]): Promise<MockWebSocket> {
+  async function connectFirstSocket(states: ObservedState[]): Promise<MockWebSocket> {
     render(
       <APIProvider createWebSocket={createMockWebSocket}>
         <APIStateObserver onState={(s) => states.push(s)} />
@@ -558,10 +568,8 @@ describe("API reconnection", () => {
     return () => clearInterval(interval);
   }
 
-  function latestDegraded(states: UseAPIResult[]): Extract<UseAPIResult, { status: "degraded" }> {
-    const degraded = states.filter(
-      (s): s is Extract<UseAPIResult, { status: "degraded" }> => s.status === "degraded"
-    );
+  function latestDegraded(states: ObservedState[]): ObservedState {
+    const degraded = states.filter((s) => s.status === "degraded");
     expect(degraded.length).toBeGreaterThan(0);
     return degraded[degraded.length - 1];
   }
@@ -569,7 +577,7 @@ describe("API reconnection", () => {
   test(
     "marks the connection degraded when pongs are slow even while stream frames keep arriving",
     async () => {
-      const states: UseAPIResult[] = [];
+      const states: ObservedState[] = [];
       installLivenessPing(delayedPong(3000));
 
       const ws1 = await connectFirstSocket(states);
@@ -586,7 +594,7 @@ describe("API reconnection", () => {
         stopFrames();
       }
 
-      expect(latestDegraded(states).latencyMs).toBeGreaterThan(2000);
+      expect(latestDegraded(states).latencyMs ?? 0).toBeGreaterThan(2000);
       expect(states.filter((s) => s.status === "reconnecting")).toHaveLength(0);
       expect(MockWebSocket.instances).toHaveLength(1);
     },
@@ -596,7 +604,7 @@ describe("API reconnection", () => {
   test(
     "returns to connected after one fast probe once the server speeds up",
     async () => {
-      const states: UseAPIResult[] = [];
+      const states: ObservedState[] = [];
       let livenessPing: () => Promise<string> = delayedPong(3000);
       installLivenessPing(() => livenessPing());
 
@@ -625,9 +633,9 @@ describe("API reconnection", () => {
   );
 
   test(
-    "keeps one probe outstanding and grows the reported latency while a ping stalls under stream traffic",
+    "keeps one probe outstanding and grows the reported latency without republishing the API context while a ping stalls under stream traffic",
     async () => {
-      const states: UseAPIResult[] = [];
+      const states: ObservedState[] = [];
       const pingCalls = installLivenessPing(neverSettlingPong);
 
       const ws1 = await connectFirstSocket(states);
@@ -640,14 +648,19 @@ describe("API reconnection", () => {
           },
           { timeout: 20000 }
         );
-        const firstLatency = latestDegraded(states).latencyMs;
+        const firstLatency = latestDegraded(states).latencyMs ?? 0;
 
         await waitFor(
           () => {
-            expect(latestDegraded(states).latencyMs).toBeGreaterThan(firstLatency);
+            expect(latestDegraded(states).latencyMs ?? 0).toBeGreaterThan(firstLatency);
           },
           { timeout: 10000 }
         );
+        // Latency ticks flow through the narrow latency context only: every degraded
+        // observation shares one API context value, so useAPI() consumers do not re-render.
+        const degradedObservations = states.filter((s) => s.status === "degraded");
+        expect(new Set(degradedObservations.map((s) => s.latencyMs)).size).toBeGreaterThan(1);
+        expect(new Set(degradedObservations.map((s) => s.apiState)).size).toBe(1);
       } finally {
         stopFrames();
       }
@@ -663,7 +676,7 @@ describe("API reconnection", () => {
   test(
     "reconnects only when a probe stalls with no inbound traffic at all",
     async () => {
-      const states: UseAPIResult[] = [];
+      const states: ObservedState[] = [];
       installLivenessPing(neverSettlingPong);
 
       await connectFirstSocket(states);
@@ -699,9 +712,38 @@ describe("API reconnection", () => {
   );
 
   test(
+    "reconnects after repeated rejected probes so a lost session reaches auth_required",
+    async () => {
+      const states: ObservedState[] = [];
+      installLivenessPing(() => Promise.reject(new Error("401 Unauthorized")));
+
+      await connectFirstSocket(states);
+
+      // Rejections are answers, not silence: the transport is alive, so only the rejected-probe
+      // counter can drive this reconnect.
+      await waitFor(
+        () => {
+          expect(MockWebSocket.instances.length).toBe(2);
+        },
+        { timeout: 16000 }
+      );
+
+      act(() => {
+        MockWebSocket.lastInstance()!.simulateOpen();
+      });
+
+      await waitFor(() => {
+        expect(states.some((s) => s.status === "auth_required")).toBe(true);
+      });
+      expect(clearStoredAuthTokenMock).toHaveBeenCalled();
+    },
+    { timeout: 25000 }
+  );
+
+  test(
     "keeps probing at the liveness interval while stream frames flow and pongs are fast",
     async () => {
-      const states: UseAPIResult[] = [];
+      const states: ObservedState[] = [];
       const pingCalls = installLivenessPing(() => Promise.resolve("pong"));
 
       const ws1 = await connectFirstSocket(states);

--- a/src/browser/contexts/API.test.tsx
+++ b/src/browser/contexts/API.test.tsx
@@ -52,10 +52,6 @@ class MockWebSocket {
   }
 }
 
-function createOrpcPongResponseFrame(id: number): string {
-  return JSON.stringify({ i: id, p: { b: "pong" } });
-}
-
 const originalFetch = globalThis.fetch;
 let fetchImpl: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> = () =>
   Promise.resolve({
@@ -517,165 +513,209 @@ describe("API reconnection", () => {
     const authRequiredAfterConnected = states.slice(states.indexOf("connected") + 1);
     expect(authRequiredAfterConnected.filter((s) => s === "auth_required")).toHaveLength(0);
   });
+
+  // Liveness harness: the auth-check ping resolves immediately so the provider reaches
+  // "connected"; every later (liveness) ping goes through `livenessPing`.
+  function installLivenessPing(livenessPing: () => Promise<string>): () => number {
+    let pingCallCount = 0;
+    pingImpl = () => {
+      pingCallCount++;
+      return pingCallCount === 1 ? Promise.resolve("pong") : livenessPing();
+    };
+    return () => pingCallCount;
+  }
+
+  const delayedPong = (ms: number) => () =>
+    new Promise<string>((resolve) => setTimeout(() => resolve("pong"), ms));
+
+  const neverSettlingPong = () => new Promise<string>(() => undefined);
+
+  async function connectFirstSocket(states: UseAPIResult[]): Promise<MockWebSocket> {
+    render(
+      <APIProvider createWebSocket={createMockWebSocket}>
+        <APIStateObserver onState={(s) => states.push(s)} />
+      </APIProvider>
+    );
+
+    const ws1 = MockWebSocket.lastInstance();
+    expect(ws1).toBeDefined();
+
+    act(() => {
+      ws1!.simulateOpen();
+    });
+
+    await waitFor(() => {
+      expect(states.some((s) => s.status === "connected")).toBe(true);
+    });
+
+    return ws1!;
+  }
+
+  function streamFramesEvery(ws: MockWebSocket, ms: number): () => void {
+    const interval = setInterval(() => {
+      ws.simulateMessage({ type: "stream-delta" });
+    }, ms);
+    return () => clearInterval(interval);
+  }
+
+  function latestDegraded(states: UseAPIResult[]): Extract<UseAPIResult, { status: "degraded" }> {
+    const degraded = states.filter(
+      (s): s is Extract<UseAPIResult, { status: "degraded" }> => s.status === "degraded"
+    );
+    expect(degraded.length).toBeGreaterThan(0);
+    return degraded[degraded.length - 1];
+  }
+
   test(
-    "treats active inbound traffic as healthy and skips liveness pings",
+    "marks the connection degraded when pongs are slow even while stream frames keep arriving",
     async () => {
-      let pingCallCount = 0;
-      pingImpl = () => {
-        pingCallCount++;
-        return Promise.resolve("pong");
-      };
+      const states: UseAPIResult[] = [];
+      installLivenessPing(delayedPong(3000));
 
-      render(
-        <APIProvider createWebSocket={createMockWebSocket}>
-          <APIStateObserver onState={() => undefined} />
-        </APIProvider>
-      );
-
-      const ws1 = MockWebSocket.lastInstance();
-      expect(ws1).toBeDefined();
-
-      await act(async () => {
-        ws1!.simulateOpen();
-        await new Promise((r) => setTimeout(r, 10));
-      });
-
-      // Initial auth-check ping should run once on connect.
-      expect(pingCallCount).toBe(1);
-
-      // Keep inbound traffic flowing so the provider can infer liveness without adding
-      // more ping load to an already busy socket.
-      const messageInterval = setInterval(() => {
-        ws1!.simulateMessage({ type: "stream-delta" });
-      }, 250);
+      const ws1 = await connectFirstSocket(states);
+      const stopFrames = streamFramesEvery(ws1, 250);
 
       try {
-        await new Promise((r) => setTimeout(r, 6200));
-        expect(pingCallCount).toBe(1);
+        await waitFor(
+          () => {
+            expect(states.some((s) => s.status === "degraded")).toBe(true);
+          },
+          { timeout: 20000 }
+        );
       } finally {
-        clearInterval(messageInterval);
+        stopFrames();
       }
 
-      // Once traffic stops, periodic liveness pings should resume.
-      await waitFor(
-        () => {
-          expect(pingCallCount).toBeGreaterThan(1);
-        },
-        { timeout: 6000 }
-      );
+      expect(latestDegraded(states).latencyMs).toBeGreaterThan(2000);
+      expect(states.filter((s) => s.status === "reconnecting")).toHaveLength(0);
+      expect(MockWebSocket.instances).toHaveLength(1);
     },
-    { timeout: 15000 }
-  );
-  test(
-    "counts stream traffic while liveness probes are in flight",
-    async () => {
-      let pingCallCount = 0;
-      let isAuthCheck = true;
-
-      pingImpl = () => {
-        pingCallCount++;
-
-        if (isAuthCheck) {
-          isAuthCheck = false;
-          return Promise.resolve("pong");
-        }
-
-        // Keep liveness probes pending long enough to overlap with the next interval.
-        return new Promise((resolve) => {
-          setTimeout(() => {
-            resolve("pong");
-          }, 9000);
-        });
-      };
-
-      render(
-        <APIProvider createWebSocket={createMockWebSocket}>
-          <APIStateObserver onState={() => undefined} />
-        </APIProvider>
-      );
-
-      const ws1 = MockWebSocket.lastInstance();
-      expect(ws1).toBeDefined();
-
-      await act(async () => {
-        ws1!.simulateOpen();
-        await new Promise((r) => setTimeout(r, 10));
-      });
-
-      await waitFor(
-        () => {
-          expect(pingCallCount).toBeGreaterThanOrEqual(2);
-        },
-        { timeout: 7000 }
-      );
-
-      const pingCallsWhenProbeStarted = pingCallCount;
-
-      const messageInterval = setInterval(() => {
-        ws1!.simulateMessage({ type: "stream-delta" });
-      }, 250);
-
-      try {
-        await new Promise((r) => setTimeout(r, 6000));
-      } finally {
-        clearInterval(messageInterval);
-      }
-
-      // Stream traffic during an in-flight probe should keep the connection healthy and
-      // suppress additional liveness probes for the next interval.
-      expect(pingCallCount).toBe(pingCallsWhenProbeStarted);
-    },
-    { timeout: 20000 }
+    { timeout: 25000 }
   );
 
   test(
-    "does not treat delayed liveness ping replies as stream traffic",
+    "returns to connected after one fast probe once the server speeds up",
     async () => {
-      const states: string[] = [];
-      let pingCallCount = 0;
-      let activeSocket: MockWebSocket | null = null;
+      const states: UseAPIResult[] = [];
+      let livenessPing: () => Promise<string> = delayedPong(3000);
+      installLivenessPing(() => livenessPing());
 
-      pingImpl = () => {
-        pingCallCount++;
+      await connectFirstSocket(states);
 
-        // Simulate a slow liveness probe where the response arrives after timeout.
-        // The delayed reply is emitted as a WS message to mimic network delivery.
-        return new Promise((resolve) => {
-          setTimeout(() => {
-            activeSocket?.simulateMessage(createOrpcPongResponseFrame(pingCallCount));
-            resolve("pong");
-          }, 3500);
-        });
-      };
-
-      render(
-        <APIProvider createWebSocket={createMockWebSocket}>
-          <APIStateObserver onState={(s) => states.push(s.status)} />
-        </APIProvider>
+      await waitFor(
+        () => {
+          expect(states.some((s) => s.status === "degraded")).toBe(true);
+        },
+        { timeout: 20000 }
       );
 
-      const ws1 = MockWebSocket.lastInstance();
-      expect(ws1).toBeDefined();
-      activeSocket = ws1!;
+      livenessPing = () => Promise.resolve("pong");
+      const degradedIndex = states.length;
 
+      await waitFor(
+        () => {
+          expect(states.slice(degradedIndex).some((s) => s.status === "connected")).toBe(true);
+        },
+        { timeout: 12000 }
+      );
+
+      expect(MockWebSocket.instances).toHaveLength(1);
+    },
+    { timeout: 25000 }
+  );
+
+  test(
+    "keeps one probe outstanding and grows the reported latency while a ping stalls under stream traffic",
+    async () => {
+      const states: UseAPIResult[] = [];
+      const pingCalls = installLivenessPing(neverSettlingPong);
+
+      const ws1 = await connectFirstSocket(states);
+      const stopFrames = streamFramesEvery(ws1, 250);
+
+      try {
+        await waitFor(
+          () => {
+            expect(states.some((s) => s.status === "degraded")).toBe(true);
+          },
+          { timeout: 20000 }
+        );
+        const firstLatency = latestDegraded(states).latencyMs;
+
+        await waitFor(
+          () => {
+            expect(latestDegraded(states).latencyMs).toBeGreaterThan(firstLatency);
+          },
+          { timeout: 10000 }
+        );
+      } finally {
+        stopFrames();
+      }
+
+      // Auth-check plus exactly one liveness probe: a stalled probe is never re-sent before
+      // it is abandoned, and inbound frames must not trigger a reconnect.
+      expect(pingCalls()).toBe(2);
+      expect(MockWebSocket.instances).toHaveLength(1);
+    },
+    { timeout: 25000 }
+  );
+
+  test(
+    "reconnects only when a probe stalls with no inbound traffic at all",
+    async () => {
+      const states: UseAPIResult[] = [];
+      installLivenessPing(neverSettlingPong);
+
+      await connectFirstSocket(states);
+
+      await waitFor(
+        () => {
+          expect(MockWebSocket.instances.length).toBe(2);
+        },
+        { timeout: 22000 }
+      );
+
+      const statuses = states.map((s) => s.status);
+      expect(statuses.some((s) => s === "reconnecting" || s === "connecting")).toBe(true);
+      expect(statuses.filter((s) => s === "auth_required")).toHaveLength(0);
+
+      // The replacement socket's auth-check pong is the next ping call.
+      pingImpl = () => Promise.resolve("pong");
+      const reconnectIndex = states.length;
       act(() => {
-        ws1!.simulateOpen();
+        MockWebSocket.lastInstance()!.simulateOpen();
       });
 
-      await waitFor(
-        () => {
-          expect(states).toContain("connected");
-        },
-        { timeout: 7000 }
-      );
+      await waitFor(() => {
+        expect(states.slice(reconnectIndex).some((s) => s.status === "connected")).toBe(true);
+      });
+    },
+    { timeout: 25000 }
+  );
 
-      const pingCallsAfterAuthCheck = pingCallCount;
-      expect(pingCallsAfterAuthCheck).toBe(1);
+  test(
+    "keeps probing at the liveness interval while stream frames flow and pongs are fast",
+    async () => {
+      const states: UseAPIResult[] = [];
+      const pingCalls = installLivenessPing(() => Promise.resolve("pong"));
 
-      // Wait long enough for two liveness intervals. If delayed ping replies were counted
-      // as stream traffic, the second interval would be skipped and this count would stay low.
-      await new Promise((r) => setTimeout(r, 12000));
-      expect(pingCallCount).toBeGreaterThanOrEqual(pingCallsAfterAuthCheck + 2);
+      const ws1 = await connectFirstSocket(states);
+      const stopFrames = streamFramesEvery(ws1, 250);
+
+      try {
+        // Auth-check, the immediate first probe, then one probe per interval.
+        await waitFor(
+          () => {
+            expect(pingCalls()).toBeGreaterThanOrEqual(4);
+          },
+          { timeout: 15000 }
+        );
+      } finally {
+        stopFrames();
+      }
+
+      expect(states.filter((s) => s.status === "degraded")).toHaveLength(0);
+      expect(MockWebSocket.instances).toHaveLength(1);
     },
     { timeout: 25000 }
   );

--- a/src/browser/contexts/API.tsx
+++ b/src/browser/contexts/API.tsx
@@ -26,7 +26,7 @@ export type { APIClient };
 export type APIState =
   | { status: "connecting"; api: null; error: null }
   | { status: "connected"; api: APIClient; error: null }
-  | { status: "degraded"; api: APIClient; error: null } // Connected but pings failing
+  | { status: "degraded"; api: APIClient; error: null; latencyMs: number } // Connected but the backend answers slowly
   | { status: "reconnecting"; api: null; error: null; attempt: number }
   | { status: "auth_required"; api: null; error: string | null }
   | { status: "error"; api: null; error: string };
@@ -43,7 +43,7 @@ export type UseAPIResult = APIState & APIStateMethods;
 type ConnectionState =
   | { status: "connecting" }
   | { status: "connected"; client: APIClient; cleanup: () => void }
-  | { status: "degraded"; client: APIClient; cleanup: () => void } // Pings failing
+  | { status: "degraded"; client: APIClient; cleanup: () => void; latencyMs: number } // Backend slow
   | { status: "reconnecting"; attempt: number }
   | { status: "auth_required"; error?: string }
   | { status: "error"; error: string };
@@ -58,11 +58,19 @@ const MAX_DELAY_MS = 10000;
 // infer whether auth is required, but the probe must never block reconnect progress.
 const AUTH_PROBE_TIMEOUT_MS = 2000;
 
-// Liveness check constants
-const LIVENESS_INTERVAL_MS = 5000; // Check every 5 seconds
-const LIVENESS_TIMEOUT_MS = 3000; // Ping must respond within 3 seconds
-const CONSECUTIVE_FAILURES_FOR_DEGRADED = 2; // Mark degraded after N failures
-const CONSECUTIVE_FAILURES_FOR_RECONNECT = 3; // Force reconnect after N failures (WS may be half-open)
+// Liveness check constants. The probe measures backend round-trip time: a connection whose
+// transport is alive but whose server answers slowly must still surface as degraded.
+const LIVENESS_INTERVAL_MS = 5000;
+// A probe whose RTT (or pending age at tick time) exceeds this is one "slow" observation.
+const SLOW_RESPONSE_MS = 2000;
+// A single slow ping is transient; require consecutive slow observations before degrading.
+const SLOW_OBSERVATIONS_FOR_DEGRADED = 2;
+// Browser WebSocket only: force reconnect when a probe has been outstanding this long AND no
+// inbound frame of any kind arrived meanwhile (the socket may be half-open).
+const SILENCE_FOR_RECONNECT_MS = 15000;
+// Abandon an outstanding probe older than this so a single lost ping cannot pin the
+// indicator on "degraded" after the backend recovers.
+const MAX_PROBE_AGE_MS = 30000;
 
 // Exported so hooks that need to tolerate being mounted outside an
 // APIProvider (e.g., `useGoalDefaults`, `useGoalBoard`) can read the
@@ -90,56 +98,6 @@ function closeWebSocketSafely(ws: WebSocket) {
     // Some browsers throw if close() is called while already closing/closed.
     // Since our cleanup can be invoked from multiple code paths, treat close as idempotent.
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function tryParseJSONFramePayload(data: unknown): Record<string, unknown> | null {
-  if (typeof data !== "string" && !(data instanceof ArrayBuffer) && !ArrayBuffer.isView(data)) {
-    return null;
-  }
-
-  const rawPayload =
-    typeof data === "string"
-      ? data
-      : new TextDecoder().decode(
-          data instanceof ArrayBuffer
-            ? new Uint8Array(data)
-            : new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
-        );
-
-  try {
-    const parsed: unknown = JSON.parse(rawPayload);
-    return isRecord(parsed) ? parsed : null;
-  } catch {
-    return null;
-  }
-}
-
-function isLikelyOrpcPongResponseFrame(data: unknown): boolean {
-  const payload = tryParseJSONFramePayload(data);
-  if (!payload) {
-    return false;
-  }
-
-  // Defensive guard: ORPC frames should always carry a numeric request id.
-  if (typeof payload.i !== "number") {
-    return false;
-  }
-
-  // Event iterator and abort frames are never ping responses.
-  if (payload.t === 3 || payload.t === 4) {
-    return false;
-  }
-
-  if (!isRecord(payload.p)) {
-    return false;
-  }
-
-  // ORPC encodes normal response bodies at payload.p.b.
-  return payload.p.b === "pong";
 }
 
 function createElectronClient(): { client: APIClient; cleanup: () => void } {
@@ -205,10 +163,10 @@ function ManagedAPIProvider(props: Omit<APIProviderProps, "client">) {
   const reconnectAttemptRef = useRef(0);
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scheduleReconnectRef = useRef<(() => void) | null>(null);
-  const consecutivePingFailuresRef = useRef(0);
+  const consecutiveSlowProbesRef = useRef(0);
   const connectionIdRef = useRef(0);
   const forceReconnectInProgressRef = useRef(false);
-  const livenessPingsInFlightCountRef = useRef(0);
+  const outstandingProbeRef = useRef<{ sentAt: number; connectionId: number } | null>(null);
   const lastInboundBrowserFrameAtRef = useRef(0);
 
   // When we decide the user needs to provide a token, stop the reconnect loop.
@@ -227,10 +185,11 @@ function ManagedAPIProvider(props: Omit<APIProviderProps, "client">) {
   const connect = useCallback(
     (token: string | null) => {
       const connectionId = ++connectionIdRef.current;
-      // Reset per-connection inbound traffic tracking so stale timestamps from a prior
-      // socket cannot suppress liveness pings on the next connection.
+      // Reset per-connection liveness bookkeeping so a prior socket's frames or probes
+      // cannot influence the next connection.
       lastInboundBrowserFrameAtRef.current = 0;
-      livenessPingsInFlightCountRef.current = 0;
+      outstandingProbeRef.current = null;
+      consecutiveSlowProbesRef.current = 0;
 
       authRequiredRef.current = false;
 
@@ -254,22 +213,10 @@ function ManagedAPIProvider(props: Omit<APIProviderProps, "client">) {
 
       setState({ status: "connecting" });
       const { client, cleanup, ws } = createBrowserClient(token, wsFactory);
-      ws.addEventListener("message", (event) => {
-        // User rationale: during large catch-up streams, ORPC ping responses can be delayed
-        // behind data frames. Treat inbound non-probe traffic as proof of liveness to avoid
-        // unnecessary reconnect loops for healthy-but-busy connections.
+      ws.addEventListener("message", () => {
+        // Inbound frames prove the transport is alive, not that the backend is responsive:
+        // they only suppress the total-silence reconnect and never skip or satisfy a probe.
         if (connectionId !== connectionIdRef.current) {
-          return;
-        }
-
-        // Keep counting stream frames while liveness probes are in flight; otherwise a slow
-        // probe could incorrectly hide active traffic and trigger false reconnects.
-        //
-        // Only ignore frames that look like ORPC "pong" responses from those probes.
-        const isLikelyProbeReply =
-          livenessPingsInFlightCountRef.current > 0 && isLikelyOrpcPongResponseFrame(event.data);
-
-        if (isLikelyProbeReply) {
           return;
         }
 
@@ -295,7 +242,7 @@ function ManagedAPIProvider(props: Omit<APIProviderProps, "client">) {
             authRequiredRef.current = false;
             hasConnectedRef.current = true;
             reconnectAttemptRef.current = 0;
-            consecutivePingFailuresRef.current = 0;
+            consecutiveSlowProbesRef.current = 0;
             forceReconnectInProgressRef.current = false;
             window.__ORPC_CLIENT__ = client;
             cleanupRef.current = cleanup;
@@ -492,131 +439,116 @@ function ManagedAPIProvider(props: Omit<APIProviderProps, "client">) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Liveness check: periodic ping to detect degraded connections.
-  // Only runs for managed browser WebSocket connections.
+  // Liveness check: probe the backend's round-trip time to detect a slow server, for both
+  // browser WebSocket and Electron MessagePort clients. Keyed on the live client identity
+  // rather than the whole state object: degraded <-> connected transitions keep the same
+  // client, so per-tick latency updates must not restart the interval or the outstanding probe.
+  const isLive = state.status === "connected" || state.status === "degraded";
+  const liveClient = isLive ? state.client : null;
+  const liveCleanup = isLive ? state.cleanup : null;
   useEffect(() => {
-    // Only check liveness for connected/degraded browser connections.
-    if (state.status !== "connected" && state.status !== "degraded") return;
-    // Skip for Electron (MessagePort) clients.
-    if (!props.createWebSocket && window.api) return;
-
-    const client = state.client;
-    const cleanup = state.cleanup;
+    if (!liveClient || !liveCleanup) return;
+    const client = liveClient;
+    const cleanup = liveCleanup;
+    // Electron has no socket to reconnect and no inbound-frame signal, so it only gets
+    // RTT-based degraded detection.
+    const isBrowserWebSocket = Boolean(props.createWebSocket) || !window.api;
     let effectDisposed = false;
 
-    const markConnectionHealthy = () => {
-      if (effectDisposed) {
-        return;
-      }
+    const recordSlowObservation = (latencyMs: number) => {
+      consecutiveSlowProbesRef.current += 1;
+      if (consecutiveSlowProbesRef.current < SLOW_OBSERVATIONS_FOR_DEGRADED) return;
+      setState((prev) =>
+        (prev.status === "connected" || prev.status === "degraded") && prev.client === client
+          ? { status: "degraded", client, cleanup, latencyMs }
+          : prev
+      );
+    };
 
-      consecutivePingFailuresRef.current = 0;
+    const recordFastObservation = () => {
+      consecutiveSlowProbesRef.current = 0;
       forceReconnectInProgressRef.current = false;
-      if (state.status === "degraded") {
-        setState({ status: "connected", client, cleanup });
-      }
+      setState((prev) =>
+        prev.status === "degraded" && prev.client === client
+          ? { status: "connected", client, cleanup }
+          : prev
+      );
     };
 
-    const checkLiveness = async () => {
-      if (effectDisposed) {
-        return;
-      }
+    const sendProbe = () => {
+      const probe = { sentAt: Date.now(), connectionId: connectionIdRef.current };
+      outstandingProbeRef.current = probe;
 
-      const timeSinceLastInboundFrameMs = Date.now() - lastInboundBrowserFrameAtRef.current;
-      const hasRecentInboundTraffic =
-        lastInboundBrowserFrameAtRef.current > 0 &&
-        timeSinceLastInboundFrameMs >= 0 &&
-        timeSinceLastInboundFrameMs <= LIVENESS_TIMEOUT_MS;
-
-      if (hasRecentInboundTraffic) {
-        // User rationale: if we're still receiving stream frames, the connection is alive
-        // even when application-level ping responses are delayed behind backlog.
-        markConnectionHealthy();
-        return;
-      }
-
-      try {
-        // Race ping against timeout
-        const livenessPingConnectionId = connectionIdRef.current;
-        const pingPromise = client.general.ping("liveness");
-        livenessPingsInFlightCountRef.current += 1;
-        const finalizeLivenessProbe = () => {
-          // Ignore stale probes from an older socket after reconnect.
-          if (livenessPingConnectionId !== connectionIdRef.current) {
-            return;
-          }
-
-          // Multiple probes can overlap when a ping exceeds LIVENESS_INTERVAL_MS.
-          // Track count instead of boolean so one delayed probe cannot clear
-          // in-flight state for a newer still-pending probe.
-          livenessPingsInFlightCountRef.current = Math.max(
-            0,
-            livenessPingsInFlightCountRef.current - 1
-          );
-        };
-
-        // Handle both resolve/reject explicitly to avoid an unhandled rejection chain.
-        void pingPromise.then(finalizeLivenessProbe, finalizeLivenessProbe);
-
-        let timeoutId: ReturnType<typeof setTimeout> | undefined;
-        try {
-          const timeoutPromise = new Promise<never>((_, reject) => {
-            timeoutId = setTimeout(() => reject(new Error("Ping timeout")), LIVENESS_TIMEOUT_MS);
-          });
-
-          await Promise.race([pingPromise, timeoutPromise]);
-        } finally {
-          if (timeoutId) {
-            clearTimeout(timeoutId);
-          }
-        }
-
-        if (effectDisposed) {
-          return;
-        }
-
-        // Ping succeeded - reset failure count and restore connected state if degraded
-        markConnectionHealthy();
-      } catch {
-        if (effectDisposed) {
-          return;
-        }
-
-        // Ping failed
-        consecutivePingFailuresRef.current++;
-
+      const settle = (resolved: boolean) => {
+        // Ignore settlements from a superseded socket, a disposed effect, or an abandoned probe.
         if (
-          consecutivePingFailuresRef.current >= CONSECUTIVE_FAILURES_FOR_RECONNECT &&
-          !forceReconnectInProgressRef.current
+          effectDisposed ||
+          probe.connectionId !== connectionIdRef.current ||
+          outstandingProbeRef.current !== probe
         ) {
-          forceReconnectInProgressRef.current = true;
-          console.warn(
-            `[APIProvider] Liveness ping failed ${consecutivePingFailuresRef.current} times; reconnecting...`
-          );
-          cleanup();
-          if (effectDisposed) {
-            return;
-          }
-          connect(authToken);
           return;
         }
-
-        if (
-          consecutivePingFailuresRef.current >= CONSECUTIVE_FAILURES_FOR_DEGRADED &&
-          state.status === "connected"
-        ) {
-          setState({ status: "degraded", client, cleanup });
+        outstandingProbeRef.current = null;
+        const rtt = Date.now() - probe.sentAt;
+        if (resolved && rtt <= SLOW_RESPONSE_MS) {
+          recordFastObservation();
+        } else {
+          recordSlowObservation(rtt);
         }
-      }
+      };
+
+      client.general.ping("liveness").then(
+        () => settle(true),
+        () => settle(false)
+      );
     };
 
-    const intervalId = setInterval(() => {
-      void checkLiveness();
-    }, LIVENESS_INTERVAL_MS);
+    const tick = () => {
+      if (effectDisposed) return;
+      const now = Date.now();
+      const outstanding = outstandingProbeRef.current;
+
+      if (outstanding) {
+        const pendingMs = now - outstanding.sentAt;
+        if (pendingMs <= MAX_PROBE_AGE_MS) {
+          // At most one probe in flight; a pending probe past the slow threshold is itself a
+          // slow observation, with the pending age as the live latency figure.
+          if (pendingMs > SLOW_RESPONSE_MS) {
+            recordSlowObservation(pendingMs);
+
+            const silentMs = now - lastInboundBrowserFrameAtRef.current;
+            if (
+              isBrowserWebSocket &&
+              pendingMs >= SILENCE_FOR_RECONNECT_MS &&
+              silentMs >= SILENCE_FOR_RECONNECT_MS &&
+              !forceReconnectInProgressRef.current
+            ) {
+              forceReconnectInProgressRef.current = true;
+              console.warn(
+                `[APIProvider] Liveness probe outstanding for ${pendingMs}ms with no inbound traffic; reconnecting...`
+              );
+              cleanup();
+              if (effectDisposed) return;
+              connect(authToken);
+            }
+          }
+          return;
+        }
+        // Presume the probe lost; its eventual settlement is ignored via the identity check.
+        outstandingProbeRef.current = null;
+      }
+
+      sendProbe();
+    };
+
+    tick();
+    const intervalId = setInterval(tick, LIVENESS_INTERVAL_MS);
     return () => {
       effectDisposed = true;
       clearInterval(intervalId);
+      outstandingProbeRef.current = null;
     };
-  }, [state, props.createWebSocket, connect, authToken]);
+  }, [liveClient, liveCleanup, props.createWebSocket, connect, authToken]);
 
   const authenticate = useCallback(
     (token: string) => {
@@ -642,7 +574,13 @@ function ManagedAPIProvider(props: Omit<APIProviderProps, "client">) {
       case "connected":
         return { status: "connected", api: state.client, error: null, ...base };
       case "degraded":
-        return { status: "degraded", api: state.client, error: null, ...base };
+        return {
+          status: "degraded",
+          api: state.client,
+          error: null,
+          latencyMs: state.latencyMs,
+          ...base,
+        };
       case "reconnecting":
         return { status: "reconnecting", api: null, error: null, attempt: state.attempt, ...base };
       case "auth_required":

--- a/src/browser/contexts/API.tsx
+++ b/src/browser/contexts/API.tsx
@@ -176,6 +176,8 @@ function ManagedAPIProvider(props: Omit<APIProviderProps, "client">) {
   const [latencyMs, setLatencyMs] = useState<number | null>(null);
   const connectionIdRef = useRef(0);
   const forceReconnectInProgressRef = useRef(false);
+  // Probe ages, RTT, and silence use performance.now(): it is monotonic, whereas a wall-clock
+  // correction could make a stalled probe look young or a slow probe look fast.
   const outstandingProbeRef = useRef<{ sentAt: number; connectionId: number } | null>(null);
   const lastInboundBrowserFrameAtRef = useRef(0);
 
@@ -196,8 +198,9 @@ function ManagedAPIProvider(props: Omit<APIProviderProps, "client">) {
     (token: string | null) => {
       const connectionId = ++connectionIdRef.current;
       // Reset per-connection liveness bookkeeping so a prior socket's frames or probes
-      // cannot influence the next connection.
-      lastInboundBrowserFrameAtRef.current = 0;
+      // cannot influence the next connection. Silence is measured from the connect time until
+      // the first frame arrives.
+      lastInboundBrowserFrameAtRef.current = performance.now();
       outstandingProbeRef.current = null;
       consecutiveSlowProbesRef.current = 0;
       consecutiveRejectedProbesRef.current = 0;
@@ -239,7 +242,7 @@ function ManagedAPIProvider(props: Omit<APIProviderProps, "client">) {
           return;
         }
 
-        lastInboundBrowserFrameAtRef.current = Date.now();
+        lastInboundBrowserFrameAtRef.current = performance.now();
       });
 
       ws.addEventListener("open", () => {
@@ -508,7 +511,7 @@ function ManagedAPIProvider(props: Omit<APIProviderProps, "client">) {
     };
 
     const sendProbe = () => {
-      const probe = { sentAt: Date.now(), connectionId: connectionIdRef.current };
+      const probe = { sentAt: performance.now(), connectionId: connectionIdRef.current };
       outstandingProbeRef.current = probe;
 
       const settle = (resolved: boolean) => {
@@ -521,7 +524,7 @@ function ManagedAPIProvider(props: Omit<APIProviderProps, "client">) {
           return;
         }
         outstandingProbeRef.current = null;
-        const rtt = Date.now() - probe.sentAt;
+        const rtt = performance.now() - probe.sentAt;
         if (resolved) {
           consecutiveRejectedProbesRef.current = 0;
           if (rtt <= SLOW_RESPONSE_MS) {
@@ -549,7 +552,7 @@ function ManagedAPIProvider(props: Omit<APIProviderProps, "client">) {
 
     const tick = () => {
       if (effectDisposed) return;
-      const now = Date.now();
+      const now = performance.now();
       const outstanding = outstandingProbeRef.current;
 
       if (outstanding) {

--- a/src/browser/contexts/API.tsx
+++ b/src/browser/contexts/API.tsx
@@ -534,14 +534,11 @@ function ManagedAPIProvider(props: Omit<APIProviderProps, "client">) {
           recordSlowObservation(rtt);
           return;
         }
+        // A rejection is a prompt answer, not slowness: it never feeds the latency indicator.
         consecutiveRejectedProbesRef.current += 1;
-        if (
-          consecutiveRejectedProbesRef.current >= REJECTED_PROBES_FOR_RECONNECT &&
-          forceReconnect(`Liveness probe rejected ${consecutiveRejectedProbesRef.current} times`)
-        ) {
-          return;
+        if (consecutiveRejectedProbesRef.current >= REJECTED_PROBES_FOR_RECONNECT) {
+          forceReconnect(`Liveness probe rejected ${consecutiveRejectedProbesRef.current} times`);
         }
-        recordSlowObservation(rtt);
       };
 
       client.general.ping("liveness").then(

--- a/src/browser/contexts/API.tsx
+++ b/src/browser/contexts/API.tsx
@@ -26,7 +26,7 @@ export type { APIClient };
 export type APIState =
   | { status: "connecting"; api: null; error: null }
   | { status: "connected"; api: APIClient; error: null }
-  | { status: "degraded"; api: APIClient; error: null; latencyMs: number } // Connected but the backend answers slowly
+  | { status: "degraded"; api: APIClient; error: null } // Connected but the backend answers slowly
   | { status: "reconnecting"; api: null; error: null; attempt: number }
   | { status: "auth_required"; api: null; error: string | null }
   | { status: "error"; api: null; error: string };
@@ -43,7 +43,7 @@ export type UseAPIResult = APIState & APIStateMethods;
 type ConnectionState =
   | { status: "connecting" }
   | { status: "connected"; client: APIClient; cleanup: () => void }
-  | { status: "degraded"; client: APIClient; cleanup: () => void; latencyMs: number } // Backend slow
+  | { status: "degraded"; client: APIClient; cleanup: () => void } // Backend slow
   | { status: "reconnecting"; attempt: number }
   | { status: "auth_required"; error?: string }
   | { status: "error"; error: string };
@@ -71,6 +71,10 @@ const SILENCE_FOR_RECONNECT_MS = 15000;
 // Abandon an outstanding probe older than this so a single lost ping cannot pin the
 // indicator on "degraded" after the backend recovers.
 const MAX_PROBE_AGE_MS = 30000;
+// Browser WebSocket only: a probe that is rejected outright (not slow) means the server is
+// answering but refusing us, e.g. an expired session. Reconnect after this many in a row so
+// the handshake's auth-check can surface auth_required instead of pinning "degraded".
+const REJECTED_PROBES_FOR_RECONNECT = 3;
 
 // Exported so hooks that need to tolerate being mounted outside an
 // APIProvider (e.g., `useGoalDefaults`, `useGoalBoard`) can read the
@@ -78,6 +82,10 @@ const MAX_PROBE_AGE_MS = 30000;
 // canonical `useAPI()` below still throws — keep using it whenever
 // API access is required, not optional.
 export const APIContext = createContext<UseAPIResult | null>(null);
+
+// The live latency figure changes on every liveness tick while degraded. It lives in its own
+// context so those ticks re-render only the indicator, not every useAPI() consumer.
+const ConnectionLatencyContext = createContext<number | null>(null);
 
 interface APIProviderProps {
   children: React.ReactNode;
@@ -164,6 +172,8 @@ function ManagedAPIProvider(props: Omit<APIProviderProps, "client">) {
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scheduleReconnectRef = useRef<(() => void) | null>(null);
   const consecutiveSlowProbesRef = useRef(0);
+  const consecutiveRejectedProbesRef = useRef(0);
+  const [latencyMs, setLatencyMs] = useState<number | null>(null);
   const connectionIdRef = useRef(0);
   const forceReconnectInProgressRef = useRef(false);
   const outstandingProbeRef = useRef<{ sentAt: number; connectionId: number } | null>(null);
@@ -190,6 +200,8 @@ function ManagedAPIProvider(props: Omit<APIProviderProps, "client">) {
       lastInboundBrowserFrameAtRef.current = 0;
       outstandingProbeRef.current = null;
       consecutiveSlowProbesRef.current = 0;
+      consecutiveRejectedProbesRef.current = 0;
+      setLatencyMs(null);
 
       authRequiredRef.current = false;
 
@@ -462,12 +474,24 @@ function ManagedAPIProvider(props: Omit<APIProviderProps, "client">) {
     const isBrowserWebSocket = Boolean(props.createWebSocket) || !window.api;
     let effectDisposed = false;
 
-    const recordSlowObservation = (latencyMs: number) => {
+    const forceReconnect = (reason: string) => {
+      if (!isBrowserWebSocket || forceReconnectInProgressRef.current) return false;
+      forceReconnectInProgressRef.current = true;
+      console.warn(`[APIProvider] ${reason}; reconnecting...`);
+      cleanup();
+      if (!effectDisposed) connect(authToken);
+      return true;
+    };
+
+    const recordSlowObservation = (observedLatencyMs: number) => {
       consecutiveSlowProbesRef.current += 1;
       if (consecutiveSlowProbesRef.current < SLOW_OBSERVATIONS_FOR_DEGRADED) return;
+      setLatencyMs(observedLatencyMs);
+      // Returning prev while already degraded keeps the API context value stable, so only the
+      // latency context consumers re-render on later ticks.
       setState((prev) =>
-        (prev.status === "connected" || prev.status === "degraded") && prev.client === client
-          ? { status: "degraded", client, cleanup, latencyMs }
+        prev.status === "connected" && prev.client === client
+          ? { status: "degraded", client, cleanup }
           : prev
       );
     };
@@ -475,6 +499,7 @@ function ManagedAPIProvider(props: Omit<APIProviderProps, "client">) {
     const recordFastObservation = () => {
       consecutiveSlowProbesRef.current = 0;
       forceReconnectInProgressRef.current = false;
+      setLatencyMs(null);
       setState((prev) =>
         prev.status === "degraded" && prev.client === client
           ? { status: "connected", client, cleanup }
@@ -497,11 +522,23 @@ function ManagedAPIProvider(props: Omit<APIProviderProps, "client">) {
         }
         outstandingProbeRef.current = null;
         const rtt = Date.now() - probe.sentAt;
-        if (resolved && rtt <= SLOW_RESPONSE_MS) {
-          recordFastObservation();
-        } else {
+        if (resolved) {
+          consecutiveRejectedProbesRef.current = 0;
+          if (rtt <= SLOW_RESPONSE_MS) {
+            recordFastObservation();
+            return;
+          }
           recordSlowObservation(rtt);
+          return;
         }
+        consecutiveRejectedProbesRef.current += 1;
+        if (
+          consecutiveRejectedProbesRef.current >= REJECTED_PROBES_FOR_RECONNECT &&
+          forceReconnect(`Liveness probe rejected ${consecutiveRejectedProbesRef.current} times`)
+        ) {
+          return;
+        }
+        recordSlowObservation(rtt);
       };
 
       client.general.ping("liveness").then(
@@ -524,19 +561,10 @@ function ManagedAPIProvider(props: Omit<APIProviderProps, "client">) {
             recordSlowObservation(pendingMs);
 
             const silentMs = now - lastInboundBrowserFrameAtRef.current;
-            if (
-              isBrowserWebSocket &&
-              pendingMs >= SILENCE_FOR_RECONNECT_MS &&
-              silentMs >= SILENCE_FOR_RECONNECT_MS &&
-              !forceReconnectInProgressRef.current
-            ) {
-              forceReconnectInProgressRef.current = true;
-              console.warn(
-                `[APIProvider] Liveness probe outstanding for ${pendingMs}ms with no inbound traffic; reconnecting...`
+            if (pendingMs >= SILENCE_FOR_RECONNECT_MS && silentMs >= SILENCE_FOR_RECONNECT_MS) {
+              forceReconnect(
+                `Liveness probe outstanding for ${pendingMs}ms with no inbound traffic`
               );
-              cleanup();
-              if (effectDisposed) return;
-              connect(authToken);
             }
           }
           return;
@@ -581,13 +609,7 @@ function ManagedAPIProvider(props: Omit<APIProviderProps, "client">) {
       case "connected":
         return { status: "connected", api: state.client, error: null, ...base };
       case "degraded":
-        return {
-          status: "degraded",
-          api: state.client,
-          error: null,
-          latencyMs: state.latencyMs,
-          ...base,
-        };
+        return { status: "degraded", api: state.client, error: null, ...base };
       case "reconnecting":
         return { status: "reconnecting", api: null, error: null, attempt: state.attempt, ...base };
       case "auth_required":
@@ -598,7 +620,13 @@ function ManagedAPIProvider(props: Omit<APIProviderProps, "client">) {
   }, [state, authenticate, retry]);
 
   // Always render children - consumers handle their own loading/error states
-  return <APIContext.Provider value={value}>{props.children}</APIContext.Provider>;
+  return (
+    <APIContext.Provider value={value}>
+      <ConnectionLatencyContext.Provider value={latencyMs}>
+        {props.children}
+      </ConnectionLatencyContext.Provider>
+    </APIContext.Provider>
+  );
 }
 
 function InjectedClientAPIProvider(
@@ -651,3 +679,6 @@ export const useAPI = (): UseAPIResult => {
  * test harnesses) and should degrade gracefully rather than crash.
  */
 export const useOptionalAPI = (): UseAPIResult | null => useContext(APIContext);
+
+/** Last measured backend round-trip time while the connection is degraded, else null. */
+export const useConnectionLatencyMs = (): number | null => useContext(ConnectionLatencyContext);

--- a/src/browser/contexts/API.tsx
+++ b/src/browser/contexts/API.tsx
@@ -554,18 +554,22 @@ function ManagedAPIProvider(props: Omit<APIProviderProps, "client">) {
 
       if (outstanding) {
         const pendingMs = now - outstanding.sentAt;
+        // Silence is checked before the probe is aged out: a throttled or suspended tab can
+        // fire its next tick past MAX_PROBE_AGE_MS, and a half-open socket must reconnect on
+        // that tick rather than merely re-probe.
+        const silentMs = now - lastInboundBrowserFrameAtRef.current;
+        if (
+          pendingMs >= SILENCE_FOR_RECONNECT_MS &&
+          silentMs >= SILENCE_FOR_RECONNECT_MS &&
+          forceReconnect(`Liveness probe outstanding for ${pendingMs}ms with no inbound traffic`)
+        ) {
+          return;
+        }
         if (pendingMs <= MAX_PROBE_AGE_MS) {
           // At most one probe in flight; a pending probe past the slow threshold is itself a
           // slow observation, with the pending age as the live latency figure.
           if (pendingMs > SLOW_RESPONSE_MS) {
             recordSlowObservation(pendingMs);
-
-            const silentMs = now - lastInboundBrowserFrameAtRef.current;
-            if (pendingMs >= SILENCE_FOR_RECONNECT_MS && silentMs >= SILENCE_FOR_RECONNECT_MS) {
-              forceReconnect(
-                `Liveness probe outstanding for ${pendingMs}ms with no inbound traffic`
-              );
-            }
           }
           return;
         }

--- a/src/browser/contexts/API.tsx
+++ b/src/browser/contexts/API.tsx
@@ -211,7 +211,14 @@ function ManagedAPIProvider(props: Omit<APIProviderProps, "client">) {
         return;
       }
 
-      setState({ status: "connecting" });
+      // Once a session has been connected, any new attempt is a reconnect from the user's
+      // perspective: keep the "Reconnecting to server" banner up through the handshake instead
+      // of dropping to "connecting", which renders nothing and is meant for the initial load.
+      setState(
+        hasConnectedRef.current
+          ? { status: "reconnecting", attempt: Math.max(1, reconnectAttemptRef.current) }
+          : { status: "connecting" }
+      );
       const { client, cleanup, ws } = createBrowserClient(token, wsFactory);
       ws.addEventListener("message", () => {
         // Inbound frames prove the transport is alive, not that the backend is responsive:

--- a/src/browser/contexts/ExperimentsContext.tsx
+++ b/src/browser/contexts/ExperimentsContext.tsx
@@ -186,7 +186,8 @@ export function ExperimentsProvider(props: { children: React.ReactNode }) {
 
   const persistOverride = useCallback(
     async (experimentId: ExperimentId, enabled: boolean) => {
-      if (apiState.status !== "connected" || !apiState.api) {
+      // A degraded (slow) connection still has a usable api; only a missing api means offline.
+      if (!apiState.api) {
         return;
       }
 
@@ -196,7 +197,7 @@ export function ExperimentsProvider(props: { children: React.ReactNode }) {
         // Best effort
       }
     },
-    [apiState.status, apiState.api]
+    [apiState.api]
   );
 
   const setExperiment = useCallback(
@@ -209,7 +210,7 @@ export function ExperimentsProvider(props: { children: React.ReactNode }) {
   );
 
   useEffect(() => {
-    if (apiState.status !== "connected" || !apiState.api) {
+    if (!apiState.api) {
       setBackendOverrides(null);
       return;
     }
@@ -252,7 +253,7 @@ export function ExperimentsProvider(props: { children: React.ReactNode }) {
     return () => {
       cancelled = true;
     };
-  }, [apiState.status, apiState.api]);
+  }, [apiState.api]);
 
   return (
     <ExperimentsContext.Provider value={{ setExperiment, backendOverrides }}>

--- a/src/browser/features/RightSidebar/RightSidebar.tsx
+++ b/src/browser/features/RightSidebar/RightSidebar.tsx
@@ -1066,7 +1066,8 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
       return;
     }
 
-    if (apiState.status !== "connected" || !api) {
+    // A degraded (slow) connection still has a usable api; only a missing api means offline.
+    if (!api) {
       setDesktopAvailable(null);
       return;
     }
@@ -1089,7 +1090,7 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [api, apiState.status, desktopExperimentEnabled, workspaceId]);
+  }, [api, desktopExperimentEnabled, workspaceId]);
 
   React.useEffect(() => {
     if (desktopAvailable == null) {


### PR DESCRIPTION
## Summary

The browser connection indicator never reflected a slow backend: with agent streams flowing, the liveness probe was skipped entirely, round-trip time was never measured, and a dead pong-frame heuristic reset the failure counter, so `degraded` was unreachable while the server answered at all. The liveness check now measures probe RTT and shows "Server is slow to respond (N.Ns); messages may be delayed" while the backend is slow, and a forced reconnect stays visible as "Reconnecting to server".

## Background

On a memory-starved host (cgroup at its 32 GB limit, heavy reclaim, one OOM kill) message sends took many seconds and pre-stream preparation ran 2 s to over 400 s, yet the UI stayed on "connected". Three defects in `src/browser/contexts/API.tsx` combined:

1. `hasRecentInboundTraffic` skipped the ping and marked the connection healthy whenever any frame arrived in the last 3 s, so an active stream hid the stall.
2. Only a hard 3 s timeout counted as a failure; a 2.9 s ping was "healthy".
3. `isLikelyOrpcPongResponseFrame` checked `payload.p.b === "pong"`, but the server returns `Pong: <input>` wrapped in oRPC's `{json, meta}`, so late pongs counted as inbound traffic and reset the failure counter on the next tick.

## Implementation

- Probe every 5 s regardless of inbound traffic, with at most one probe outstanding (abandoned after 30 s). A probe whose RTT, or pending age at tick time, exceeds 2 s is one slow observation; two consecutive slow observations enter `degraded`, and one fast probe restores `connected`.
- The live latency is published through a separate `ConnectionLatencyContext` (`useConnectionLatencyMs`) rather than the API context, so per-tick updates re-render only the toast and every `useAPI()` consumer keeps a referentially stable value. `degraded` itself carries no latency field.
- Inbound frames now only prove the transport is alive: they suppress the forced reconnect, which requires 15 s of total silence with a probe outstanding (browser WebSocket only), and never skip or satisfy a probe. Three consecutive rejected (not slow) probes also force a reconnect so an expired session still reaches `auth_required`; rejections never feed the latency indicator. The silence check runs before an overdue probe is aged out, so a throttled tab's late tick still reconnects a half-open socket. All probe timing uses the monotonic `performance.now()`, so a wall-clock correction cannot make a stalled probe look young. The pong-frame parser and in-flight counter are deleted.
- The effect is keyed on the live client identity rather than the whole state object, so latency ticks do not restart the interval or the outstanding probe. Electron MessagePort clients get the same RTT-based degraded detection without a reconnect path.
- `connect()` after a prior successful connection reports `reconnecting` instead of `connecting`, so the banner stays up through the replacement socket's handshake instead of going blank (found by remote UAT).
- `ConnectionStatusToast` renders the latency with `formatDuration(…, "precise")` inside `counter-nums`; the changing figure is `aria-hidden` so the polite live region announces the warning once.
- `ExperimentsContext` and `RightSidebar` key on `api` availability instead of `status === "connected"`, so a degraded (slow but usable) connection is not treated as offline.

## Validation

- Remote dogfood UAT (Coder Agents, browser client, backend paused with SIGSTOP/SIGCONT), two rounds: the toast appeared during an active stream at 10 s and updated to 13 s, cleared 2.3 s after resume, a 14 s stall caused no WebSocket reconnect and no lost stream tokens, rapid 1 s stalls and a single 1.5 s stall showed nothing, the toast sat above the composer at 1280 px and 390 px, and (round 2) 25 s of silence showed "Reconnecting to server" from the 16 s mark until recovery with zero blank samples, then the client stayed usable without a reload.
- `API.test.tsx` replaces the three tests that encoded the old "skip the probe while traffic flows" rationale with behavioral ones: slow pongs under stream traffic degrade without reconnecting, a fast probe recovers, a stalled probe stays single and grows the reported latency without republishing the API context value, total silence reconnects through `reconnecting`, repeated rejected probes reconnect into `auth_required` without ever showing the slow indicator, a late tick past the probe age limit reconnects instead of re-probing, a backward wall-clock step still degrades a stalled probe, and fast pongs under traffic keep probing. Each guard was checked red with its fix toggled off.

## Risks

Medium, scoped to the browser connection state machine. A slow-but-alive server no longer triggers a reconnect at all (previously three 3 s timeouts did when no frames arrived), so a server that answers every ping in 3 s to 15 s shows the slow toast instead of reconnecting; this is intentional to avoid reconnect storms against an overloaded backend. Any connect after a prior successful connection now shows "Reconnecting to server" rather than nothing, including the Retry button path. Detection latency is 7 s to 13 s after slowness starts (5 s interval, two observations).

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$51.20`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=51.20 -->
