### PR TITLE
🤖 feat: make Gemini 3.8 Flash the default Gemini Flash model

### DIFF
--- a/.github/workflows/nightly-terminal-bench.yml
+++ b/.github/workflows/nightly-terminal-bench.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       models:
-        description: 'Models to test (comma-separated, or "all" for opus-5 + gpt-5.6-sol + google/gemini-3-pro-preview + google/gemini-3-flash-preview + google/gemini-3.7-flash)'
+        description: 'Models to test (comma-separated, or "all" for opus-5 + gpt-5.6-sol + google/gemini-3-pro-preview + google/gemini-3-flash-preview + google/gemini-3.8-flash)'
         required: false
         default: "all"
         type: string
@@ -129,7 +129,7 @@ jobs:
           INPUT_MODELS: ${{ inputs.models }}
         run: |
           if [ "$INPUT_MODELS" = "all" ] || [ -z "$INPUT_MODELS" ]; then
-            echo 'models=["anthropic/claude-opus-5","openai/gpt-5.6-sol","google/gemini-3-pro-preview","google/gemini-3-flash-preview","google/gemini-3.7-flash"]' >> "$GITHUB_OUTPUT"
+            echo 'models=["anthropic/claude-opus-5","openai/gpt-5.6-sol","google/gemini-3-pro-preview","google/gemini-3-flash-preview","google/gemini-3.8-flash"]' >> "$GITHUB_OUTPUT"
           else
             # Convert comma-separated to JSON array
             models_json=$(echo "$INPUT_MODELS" | jq -R -s -c 'split(",") | map(gsub("^\\s+|\\s+$"; ""))')

--- a/docs/config/models.mdx
+++ b/docs/config/models.mdx
@@ -29,7 +29,7 @@ Xum ships with curated models kept up to date with the frontier. Use any custom 
 | Codex Mini 5.1         | openai:gpt-5.1-codex-mini     | `codex-mini`                                                 |         |
 | Codex Max 5.1          | openai:gpt-5.1-codex-max      | `codex-max`                                                  |         |
 | Gemini 3.1 Pro Preview | google:gemini-3.1-pro-preview | `gemini`, `gemini-pro`                                       |         |
-| Gemini 3.7 Flash       | google:gemini-3.7-flash       | `gemini-flash`                                               |         |
+| Gemini 3.8 Flash       | google:gemini-3.8-flash       | `gemini-flash`                                               |         |
 | Grok 4.6               | xai:grok-4.6                  | `grok`, `grok-4.6`                                           |         |
 | DeepSeek V4 Pro        | deepseek:deepseek-v4-pro      | `deepseek`, `deepseek-pro`, `deepseek-v4`, `deepseek-v4-pro` |         |
 | DeepSeek V4 Flash      | deepseek:deepseek-v4-flash    | `deepseek-flash`, `deepseek-v4-flash`                        |         |

--- a/src/browser/components/ModelSelector/modelFilter.test.ts
+++ b/src/browser/components/ModelSelector/modelFilter.test.ts
@@ -3,17 +3,17 @@ import { modelMatchesQuery } from "./modelFilter";
 
 describe("modelMatchesQuery", () => {
   test("matches model string substrings", () => {
-    expect(modelMatchesQuery("google:gemini-3.7-flash", "3.7")).toBe(true);
-    expect(modelMatchesQuery("google:gemini-3.7-flash", "sonnet")).toBe(false);
+    expect(modelMatchesQuery("google:gemini-3.8-flash", "3.8")).toBe(true);
+    expect(modelMatchesQuery("google:gemini-3.8-flash", "sonnet")).toBe(false);
   });
 
   test("matches documented aliases that are not model string substrings", () => {
-    expect(modelMatchesQuery("google:gemini-3.7-flash", "gemini-flash")).toBe(true);
+    expect(modelMatchesQuery("google:gemini-3.8-flash", "gemini-flash")).toBe(true);
     expect(modelMatchesQuery("deepseek:deepseek-v4-pro", "deepseek-pro")).toBe(true);
   });
 
   test("matches aliases for gateway-prefixed model strings", () => {
-    expect(modelMatchesQuery("mux-gateway:google/gemini-3.7-flash", "gemini-flash")).toBe(true);
+    expect(modelMatchesQuery("mux-gateway:google/gemini-3.8-flash", "gemini-flash")).toBe(true);
   });
 
   test("does not match aliases belonging to other models", () => {

--- a/src/common/constants/knownModels.test.ts
+++ b/src/common/constants/knownModels.test.ts
@@ -19,8 +19,8 @@ describe("Known Models Integration", () => {
     }
   });
 
-  test("gemini-flash resolves to the stable Gemini 3.7 Flash model", () => {
-    expect(MODEL_ABBREVIATIONS["gemini-flash"]).toBe("google:gemini-3.7-flash");
+  test("gemini-flash resolves to the stable Gemini 3.8 Flash model", () => {
+    expect(MODEL_ABBREVIATIONS["gemini-flash"]).toBe("google:gemini-3.8-flash");
   });
 
   test("gpt alias tracks the GPT-5.6 flagship tier alongside the tier aliases", () => {

--- a/src/common/constants/knownModels.ts
+++ b/src/common/constants/knownModels.ts
@@ -180,8 +180,7 @@ const MODEL_DEFINITIONS = {
     aliases: ["gemini", "gemini-pro"],
     tokenizerOverride: "google/gemini-2.5-pro",
   },
-  // Gemini Flash alias tracks the latest stable Flash tier (3.8 Flash; model ID
-  // `gemini-3.8-flash` prepared ahead of Google's official release announcement).
+  // Gemini Flash alias tracks the latest stable Flash tier (3.8 Flash, GA September 2, 2026).
   // Older Flash tiers stay usable as custom model strings (e.g. `google:gemini-3.7-flash`).
   GEMINI_FLASH: {
     provider: "google",

--- a/src/common/constants/knownModels.ts
+++ b/src/common/constants/knownModels.ts
@@ -180,11 +180,12 @@ const MODEL_DEFINITIONS = {
     aliases: ["gemini", "gemini-pro"],
     tokenizerOverride: "google/gemini-2.5-pro",
   },
-  // Gemini Flash alias tracks the latest stable Flash tier (3.7 Flash, GA August 13, 2026).
-  // Older Flash tiers stay usable as custom model strings (e.g. `google:gemini-3.6-flash`).
+  // Gemini Flash alias tracks the latest stable Flash tier (3.8 Flash; model ID
+  // `gemini-3.8-flash` prepared ahead of Google's official release announcement).
+  // Older Flash tiers stay usable as custom model strings (e.g. `google:gemini-3.7-flash`).
   GEMINI_FLASH: {
     provider: "google",
-    providerModelId: "gemini-3.7-flash",
+    providerModelId: "gemini-3.8-flash",
     aliases: ["gemini-flash"],
     tokenizerOverride: "google/gemini-2.5-pro",
   },

--- a/src/common/utils/ai/modelParameterOverrides.test.ts
+++ b/src/common/utils/ai/modelParameterOverrides.test.ts
@@ -466,6 +466,29 @@ describe("resolveModelParameterOverrides", () => {
     });
   });
 
+  it("strips deprecated sampling parameters for Gemini 3.8 Flash", () => {
+    const providersConfig = withGoogleModelParameters({
+      "*": {
+        max_output_tokens: 32768,
+        temperature: 0.7,
+        top_p: 0.9,
+        top_k: 40,
+      },
+    });
+
+    const result = resolveModelParameterOverrides(
+      providersConfig,
+      "google",
+      "google:gemini-3.8-flash"
+    );
+
+    expect(result).toEqual({
+      standard: {
+        maxOutputTokens: 32768,
+      },
+    });
+  });
+
   it("strips deprecated sampling parameters for Gemini 3.5 Flash-Lite", () => {
     const providersConfig = withGoogleModelParameters({
       "gemini-3.5-flash-lite": {
@@ -497,8 +520,8 @@ describe("resolveModelParameterOverrides", () => {
     const result = resolveModelParameterOverrides(
       providersConfig,
       "google",
-      "google:gemini-3.7-flash",
-      "mux-gateway:google/gemini-3.7-flash"
+      "google:gemini-3.8-flash",
+      "mux-gateway:google/gemini-3.8-flash"
     );
 
     expect(result).toEqual({ standard: {} });
@@ -507,7 +530,7 @@ describe("resolveModelParameterOverrides", () => {
   it("strips sampling parameters for custom entries mapped to a sampling-rejecting model", () => {
     const providersConfig = asProvidersConfig({
       google: {
-        models: [{ id: "team-flash", mappedToModel: "google:gemini-3.7-flash" }],
+        models: [{ id: "team-flash", mappedToModel: "google:gemini-3.8-flash" }],
         modelParameters: {
           "*": {
             temperature: 0.7,

--- a/src/common/utils/ai/modelParameterOverrides.ts
+++ b/src/common/utils/ai/modelParameterOverrides.ts
@@ -17,7 +17,7 @@ export interface ResolvedModelParameterOverrides {
 const SAMPLING_CALL_SETTINGS = ["temperature", "topP", "topK"] as const;
 
 /**
- * Gemini 3.7/3.6 Flash and Gemini 3.5 Flash-Lite deprecate the sampling parameters
+ * Gemini 3.8/3.7/3.6 Flash and Gemini 3.5 Flash-Lite deprecate the sampling parameters
  * temperature/top_p/top_k; Google's migration guides require stripping them from
  * generation configs, so forwarding user overrides would break existing setups
  * (e.g. a wildcard temperature) when the gemini-flash alias repoints.
@@ -25,6 +25,7 @@ const SAMPLING_CALL_SETTINGS = ["temperature", "topP", "topK"] as const;
 export function modelRejectsSamplingParameters(modelString: string): boolean {
   const bareModelId = stripModelProviderPrefixes(modelString);
   return (
+    bareModelId.startsWith("gemini-3.8-flash") ||
     bareModelId.startsWith("gemini-3.7-flash") ||
     bareModelId.startsWith("gemini-3.6-flash") ||
     bareModelId.startsWith("gemini-3.5-flash-lite")
@@ -101,7 +102,7 @@ export function resolveModelParameterOverrides(
   }
 
   // Resolve mappedToModel aliases so custom entries pointing at a
-  // sampling-rejecting model (e.g. team-flash -> gemini-3.7-flash) are stripped too.
+  // sampling-rejecting model (e.g. team-flash -> gemini-3.8-flash) are stripped too.
   const capabilityModelString = resolveModelForMetadata(
     effectiveModelString ?? canonicalModelString,
     providersConfig

--- a/src/common/utils/ai/providerOptions.test.ts
+++ b/src/common/utils/ai/providerOptions.test.ts
@@ -1760,6 +1760,40 @@ describe("buildProviderOptions - Google", () => {
     });
   });
 
+  test("maps Gemini 3.8 Flash off to minimal thinking without thoughts", () => {
+    expect(buildProviderOptions("google:gemini-3.8-flash", "off")).toEqual({
+      google: {
+        thinkingConfig: {
+          thinkingLevel: "minimal",
+        },
+      },
+    });
+  });
+
+  test("maps Gemini 3.8 Flash low/medium/high to the matching thinkingLevel with thoughts", () => {
+    for (const level of ["low", "medium", "high"] as const) {
+      expect(buildProviderOptions("google:gemini-3.8-flash", level)).toEqual({
+        google: {
+          thinkingConfig: {
+            includeThoughts: true,
+            thinkingLevel: level,
+          },
+        },
+      });
+    }
+  });
+
+  test("maps gateway-routed Gemini 3.8 Flash to thinkingLevel config", () => {
+    expect(buildProviderOptions("mux-gateway:google/gemini-3.8-flash", "high")).toEqual({
+      google: {
+        thinkingConfig: {
+          includeThoughts: true,
+          thinkingLevel: "high",
+        },
+      },
+    });
+  });
+
   test("maps Gemini 3.5 Flash medium to thinkingLevel medium with thoughts", () => {
     expect(buildProviderOptions("mux-gateway:google/gemini-3.5-flash", "medium")).toEqual({
       google: {

--- a/src/common/utils/ai/providerOptions.test.ts
+++ b/src/common/utils/ai/providerOptions.test.ts
@@ -1760,13 +1760,19 @@ describe("buildProviderOptions - Google", () => {
     });
   });
 
-  test("maps Gemini 3.8 Flash off to minimal thinking without thoughts", () => {
+  test("clamps Gemini 3.8 Flash off to low thinking because the API rejects minimal", () => {
+    // Policy already excludes "off" for 3.8 Flash; this guards callers that bypass it.
     expect(buildProviderOptions("google:gemini-3.8-flash", "off")).toEqual({
       google: {
         thinkingConfig: {
-          thinkingLevel: "minimal",
+          includeThoughts: true,
+          thinkingLevel: "low",
         },
       },
+    });
+    // Older Flash tiers keep the minimal mapping.
+    expect(buildProviderOptions("google:gemini-3.7-flash", "off")).toEqual({
+      google: { thinkingConfig: { thinkingLevel: "minimal" } },
     });
   });
 

--- a/src/common/utils/ai/providerOptions.ts
+++ b/src/common/utils/ai/providerOptions.ts
@@ -34,7 +34,10 @@ import {
   openaiSupportsProMode,
   OPENROUTER_REASONING_EFFORT,
 } from "@/common/types/thinking";
-import { isGeminiFlashThinkingLevelModelName } from "@/common/utils/thinking/policy";
+import {
+  isGeminiFlashMinimalRejectingModelName,
+  isGeminiFlashThinkingLevelModelName,
+} from "@/common/utils/thinking/policy";
 import { openaiExplicitPromptCachingAvailable } from "@/common/utils/ai/cacheStrategy";
 import { resolveModelForMetadata } from "@/common/utils/providers/modelEntries";
 import { log } from "@/node/services/log";
@@ -550,7 +553,11 @@ export function buildProviderOptions(
     if (isGeminiFlashThinkingModel && effectiveThinking === "off") {
       // Gemini Flash chat models default to medium and do not support true thinking-off;
       // send minimal explicitly so Xum's "off" setting means lowest-effort behavior.
-      thinkingConfig = { thinkingLevel: "minimal" };
+      // Gemini 3.8 Flash rejects "minimal" with a 400 (policy already excludes "off");
+      // clamp to "low" here too so a caller bypassing policy cannot trigger the error.
+      thinkingConfig = isGeminiFlashMinimalRejectingModelName(capBareModelName)
+        ? { includeThoughts: true, thinkingLevel: "low" }
+        : { thinkingLevel: "minimal" };
     } else if (effectiveThinking !== "off") {
       thinkingConfig = {
         includeThoughts: true,

--- a/src/common/utils/thinking/policy.test.ts
+++ b/src/common/utils/thinking/policy.test.ts
@@ -489,6 +489,19 @@ describe("getThinkingPolicyForModel", () => {
     expect(resolveEffectiveThinkingLevel("anthropic:claude-sonnet-4-5", "high")).toBe("high");
   });
 
+  test("resolveEffectiveThinkingLevel clamps unset/off for Gemini 3.8 Flash but not older Flash", () => {
+    // 3.8 Flash rejects "minimal": the tracked level must already be "low" so the
+    // request envelope and debug snapshots agree with what the Google adapter sends.
+    for (const model of ["google:gemini-3.8-flash", "mux-gateway:google/gemini-3.8-flash"]) {
+      expect(resolveEffectiveThinkingLevel(model, undefined)).toBe("low");
+      expect(resolveEffectiveThinkingLevel(model, "off")).toBe("low");
+      expect(resolveEffectiveThinkingLevel(model, "high")).toBe("high");
+    }
+    // Older Flash tiers still express "off" as minimal, so nothing is forced.
+    expect(resolveEffectiveThinkingLevel("google:gemini-3.7-flash", undefined)).toBe("off");
+    expect(resolveEffectiveThinkingLevel("google:gemini-3.8-flash-lite", undefined)).toBe("off");
+  });
+
   test("resolveEffectiveThinkingLevel resolves mappedToModel aliases before the Mythos check", () => {
     // A configured alias entry mapped to a Mythos-class model must follow the same
     // no-disabled-thinking rule as the canonical id, matching buildProviderOptions'

--- a/src/common/utils/thinking/policy.test.ts
+++ b/src/common/utils/thinking/policy.test.ts
@@ -644,6 +644,17 @@ describe("getThinkingPolicyForModel", () => {
     }
   });
 
+  test("returns off/low/medium/high for stable Gemini 3.8 Flash", () => {
+    for (const model of [
+      "google:gemini-3.8-flash",
+      "mux-gateway:google/gemini-3.8-flash",
+      "openrouter:google/gemini-3.8-flash",
+      "google:gemini-3.8-flash-001",
+    ]) {
+      expect(getThinkingPolicyForModel(model)).toEqual(["off", "low", "medium", "high"]);
+    }
+  });
+
   test("returns off/low/medium/high for stable Gemini 3.5 Flash behind OpenRouter", () => {
     expect(getThinkingPolicyForModel("openrouter:google/gemini-3.5-flash")).toEqual([
       "off",
@@ -711,6 +722,13 @@ describe("isGeminiFlashThinkingLevelModelName", () => {
     expect(isGeminiFlashThinkingLevelModelName("gemini-3.5-flash-lite")).toBe(false);
     expect(isGeminiFlashThinkingLevelModelName("gemini-3.6-flash-lite")).toBe(false);
     expect(isGeminiFlashThinkingLevelModelName("gemini-3.7-flash-lite")).toBe(false);
+    expect(isGeminiFlashThinkingLevelModelName("gemini-3.8-flash-lite")).toBe(false);
+  });
+
+  test("classifies stable Gemini 3.8 Flash IDs as Flash thinking-level chat models", () => {
+    expect(isGeminiFlashThinkingLevelModelName("gemini-3.8-flash")).toBe(true);
+    expect(isGeminiFlashThinkingLevelModelName("Gemini-3.8-Flash ")).toBe(true);
+    expect(isGeminiFlashThinkingLevelModelName("gemini-3.8-flash-001")).toBe(true);
   });
 });
 

--- a/src/common/utils/thinking/policy.test.ts
+++ b/src/common/utils/thinking/policy.test.ts
@@ -5,6 +5,7 @@ import {
   enforceThinkingPolicy,
   resolveThinkingInput,
   isGeminiFlashThinkingLevelModelName,
+  isGeminiFlashMinimalRejectingModelName,
   getDefaultMinimumThinkingLevel,
   lookupMinThinkingLevelOverride,
   resolveMinimumThinkingLevel,
@@ -644,15 +645,19 @@ describe("getThinkingPolicyForModel", () => {
     }
   });
 
-  test("returns off/low/medium/high for stable Gemini 3.8 Flash", () => {
+  test("returns low/medium/high (no off) for Gemini 3.8 Flash, which rejects minimal", () => {
     for (const model of [
       "google:gemini-3.8-flash",
       "mux-gateway:google/gemini-3.8-flash",
       "openrouter:google/gemini-3.8-flash",
       "google:gemini-3.8-flash-001",
     ]) {
-      expect(getThinkingPolicyForModel(model)).toEqual(["off", "low", "medium", "high"]);
+      expect(getThinkingPolicyForModel(model)).toEqual(["low", "medium", "high"]);
+      expect(enforceThinkingPolicy(model, "off")).toBe("low");
+      expect(enforceThinkingPolicy(model, "xhigh")).toBe("high");
     }
+    // Still a recognized reasoning model: defaults to the medium floor like other Flash tiers.
+    expect(getDefaultMinimumThinkingLevel("google:gemini-3.8-flash")).toBe("medium");
   });
 
   test("returns off/low/medium/high for stable Gemini 3.5 Flash behind OpenRouter", () => {
@@ -729,6 +734,17 @@ describe("isGeminiFlashThinkingLevelModelName", () => {
     expect(isGeminiFlashThinkingLevelModelName("gemini-3.8-flash")).toBe(true);
     expect(isGeminiFlashThinkingLevelModelName("Gemini-3.8-Flash ")).toBe(true);
     expect(isGeminiFlashThinkingLevelModelName("gemini-3.8-flash-001")).toBe(true);
+  });
+});
+
+describe("isGeminiFlashMinimalRejectingModelName", () => {
+  test("matches only Gemini 3.8 Flash chat IDs, not older Flash tiers or Lite variants", () => {
+    expect(isGeminiFlashMinimalRejectingModelName("gemini-3.8-flash")).toBe(true);
+    expect(isGeminiFlashMinimalRejectingModelName("Gemini-3.8-Flash ")).toBe(true);
+    expect(isGeminiFlashMinimalRejectingModelName("gemini-3.8-flash-001")).toBe(true);
+    expect(isGeminiFlashMinimalRejectingModelName("gemini-3.8-flash-lite")).toBe(false);
+    expect(isGeminiFlashMinimalRejectingModelName("gemini-3.7-flash")).toBe(false);
+    expect(isGeminiFlashMinimalRejectingModelName("gemini-3-flash")).toBe(false);
   });
 });
 

--- a/src/common/utils/thinking/policy.ts
+++ b/src/common/utils/thinking/policy.ts
@@ -53,7 +53,21 @@ export function isGeminiFlashThinkingLevelModelName(modelName: string): boolean 
       !normalized.startsWith("gemini-3.6-flash-lite")) ||
     (normalized.startsWith("gemini-3.7-flash") &&
       !normalized.startsWith("gemini-3.7-flash-lite")) ||
-    (normalized.startsWith("gemini-3.8-flash") && !normalized.startsWith("gemini-3.8-flash-lite"))
+    isGeminiFlashMinimalRejectingModelName(normalized)
+  );
+}
+
+/**
+ * True for Gemini Flash thinking-level models that reject `thinkingLevel: "minimal"`.
+ * Gemini 3.8 Flash only accepts low/medium/high; sending MINIMAL returns an API
+ * validation error ("Thinking level MINIMAL is not supported for this model"), so Xum
+ * cannot expose "off" for it the way it does for 3–3.7 Flash.
+ * @param modelName Provider model ID without the provider prefix.
+ */
+export function isGeminiFlashMinimalRejectingModelName(modelName: string): boolean {
+  const normalized = modelName.trim().toLowerCase();
+  return (
+    normalized.startsWith("gemini-3.8-flash") && !normalized.startsWith("gemini-3.8-flash-lite")
   );
 }
 
@@ -70,7 +84,8 @@ export function isGeminiFlashThinkingLevelModelName(modelName: string): boolean 
  *   ["off", "low", "medium", "high", "xhigh", "max"] (6 levels; native max at GA)
  * - openai:gpt-5.2-pro / openai:gpt-5.5-pro → ["medium", "high", "xhigh"] (3 levels)
  * - openai:gpt-5-pro → ["high"] (only supported level, legacy)
- * - Gemini Flash chat variants → ["off", "low", "medium", "high"]
+ * - Gemini 3.8 Flash → ["low", "medium", "high"] (API rejects minimal, so no "off")
+ * - Older Gemini Flash chat variants → ["off", "low", "medium", "high"]
  * - gemini-3 Pro variants → ["low", "high"] (thinking level only)
  * - xai:grok-4.6 → ["low", "medium", "high", "xhigh"] (reasoning cannot be disabled)
  * - xai:grok-4.5 → ["low", "medium", "high"] (reasoning cannot be disabled)
@@ -172,7 +187,12 @@ function getExplicitThinkingPolicy(modelString: string): ThinkingPolicy | null {
     return ["high"];
   }
 
-  // Gemini Flash chat models support minimal/low/medium/high. Xum exposes minimal as "off".
+  // Gemini 3.8 Flash rejects "minimal", so thinking cannot be disabled; "off" clamps to "low".
+  if (isGeminiFlashMinimalRejectingModelName(withoutProviderNamespace)) {
+    return ["low", "medium", "high"];
+  }
+
+  // Older Gemini Flash chat models support minimal/low/medium/high. Xum exposes minimal as "off".
   if (isGeminiFlashThinkingLevelModelName(withoutProviderNamespace)) {
     return ["off", "low", "medium", "high"];
   }

--- a/src/common/utils/thinking/policy.ts
+++ b/src/common/utils/thinking/policy.ts
@@ -334,7 +334,11 @@ export function resolveEffectiveThinkingLevel(
 ): ThinkingLevel {
   const level = requested ?? THINKING_LEVEL_OFF;
   const capabilityModel = resolveModelForMetadata(modelString, providersConfig ?? null);
-  return anthropicRejectsDisabledThinking(capabilityModel) || isGlm53Model(capabilityModel)
+  // Gemini 3.8 Flash rejects "minimal", so an unset/"off" level must clamp here too;
+  // otherwise the tracked level would say "off" while the adapter sends "low".
+  return anthropicRejectsDisabledThinking(capabilityModel) ||
+    isGlm53Model(capabilityModel) ||
+    isGeminiFlashMinimalRejectingModelName(stripModelProviderPrefixes(capabilityModel))
     ? enforceThinkingPolicy(capabilityModel, level)
     : level;
 }

--- a/src/common/utils/thinking/policy.ts
+++ b/src/common/utils/thinking/policy.ts
@@ -51,7 +51,9 @@ export function isGeminiFlashThinkingLevelModelName(modelName: string): boolean 
       !normalized.startsWith("gemini-3.5-flash-lite")) ||
     (normalized.startsWith("gemini-3.6-flash") &&
       !normalized.startsWith("gemini-3.6-flash-lite")) ||
-    (normalized.startsWith("gemini-3.7-flash") && !normalized.startsWith("gemini-3.7-flash-lite"))
+    (normalized.startsWith("gemini-3.7-flash") &&
+      !normalized.startsWith("gemini-3.7-flash-lite")) ||
+    (normalized.startsWith("gemini-3.8-flash") && !normalized.startsWith("gemini-3.8-flash-lite"))
   );
 }
 

--- a/src/common/utils/tokens/modelStats.test.ts
+++ b/src/common/utils/tokens/modelStats.test.ts
@@ -107,8 +107,17 @@ describe("getModelStats", () => {
     expect(stats.tiered_pricing_threshold_tokens).toBeUndefined();
   });
 
-  test("resolves Gemini 3.7 Flash with the billed introductory pricing and limits", () => {
+  test("resolves Gemini 3.8 Flash with the standard list pricing and limits", () => {
     const stats = expectStats(KNOWN_MODELS.GEMINI_FLASH.id);
+    expect(stats.max_input_tokens).toBe(1048576);
+    expect(stats.max_output_tokens).toBe(65536);
+    expect(stats.input_cost_per_token).toBe(0.0000015);
+    expect(stats.output_cost_per_token).toBe(0.0000075);
+    expect(stats.cache_read_input_token_cost).toBe(0.00000015);
+  });
+
+  test("keeps Gemini 3.7 Flash resolvable as a custom model string with its introductory pricing", () => {
+    const stats = expectStats("google:gemini-3.7-flash");
     expect(stats.max_input_tokens).toBe(1048576);
     expect(stats.max_output_tokens).toBe(65536);
     expect(stats.input_cost_per_token).toBe(0.00000075);

--- a/src/common/utils/tokens/modelStats.test.ts
+++ b/src/common/utils/tokens/modelStats.test.ts
@@ -107,13 +107,13 @@ describe("getModelStats", () => {
     expect(stats.tiered_pricing_threshold_tokens).toBeUndefined();
   });
 
-  test("resolves Gemini 3.8 Flash with the standard list pricing and limits", () => {
+  test("resolves Gemini 3.8 Flash with the billed introductory pricing and limits", () => {
     const stats = expectStats(KNOWN_MODELS.GEMINI_FLASH.id);
     expect(stats.max_input_tokens).toBe(1048576);
     expect(stats.max_output_tokens).toBe(65536);
-    expect(stats.input_cost_per_token).toBe(0.0000015);
-    expect(stats.output_cost_per_token).toBe(0.0000075);
-    expect(stats.cache_read_input_token_cost).toBe(0.00000015);
+    expect(stats.input_cost_per_token).toBe(0.00000075);
+    expect(stats.output_cost_per_token).toBe(0.00000375);
+    expect(stats.cache_read_input_token_cost).toBe(0.000000075);
   });
 
   test("keeps Gemini 3.7 Flash resolvable as a custom model string with its introductory pricing", () => {

--- a/src/common/utils/tokens/models-extra.ts
+++ b/src/common/utils/tokens/models-extra.ts
@@ -602,6 +602,29 @@ export const modelsExtra: Record<string, ModelData> = {
     supports_response_schema: true,
   },
 
+  // Gemini 3.8 Flash - prepared ahead of Google's official release. Assumes the
+  // stable `gemini-3.8-flash` model ID keeps the Flash-tier limits (1M context,
+  // 65K max output) and the standard list rates carried since 3.6 Flash
+  // ($1.50/M input, $7.50/M output incl. thinking, $0.15/M cached input).
+  // TODO: verify limits and pricing against the Gemini API model/pricing docs once
+  // Google publishes them; adjust if 3.8 Flash launches with an intro rate like 3.7.
+  "gemini-3.8-flash": {
+    max_input_tokens: 1048576,
+    max_output_tokens: 65536,
+    input_cost_per_token: 0.0000015, // $1.50 per million input tokens
+    output_cost_per_token: 0.0000075, // $7.50 per million output tokens, including thinking tokens
+    cache_read_input_token_cost: 0.00000015, // $0.15 per million cached input tokens
+    litellm_provider: "vertex_ai-language-models",
+    mode: "chat",
+    supports_function_calling: true,
+    supports_vision: true,
+    supports_pdf_input: true,
+    supports_audio_input: true,
+    supports_video_input: true,
+    supports_reasoning: true,
+    supports_response_schema: true,
+  },
+
   // Gemini 3.1 Pro Preview - Released February 19, 2026
   // Tiered pricing: ≤200K tokens $2/M input, $12/M output; >200K tokens $4/M input, $18/M output
   // 1M input context, ~64K max output tokens

--- a/src/common/utils/tokens/models-extra.ts
+++ b/src/common/utils/tokens/models-extra.ts
@@ -602,18 +602,19 @@ export const modelsExtra: Record<string, ModelData> = {
     supports_response_schema: true,
   },
 
-  // Gemini 3.8 Flash - prepared ahead of Google's official release. Assumes the
-  // stable `gemini-3.8-flash` model ID keeps the Flash-tier limits (1M context,
-  // 65K max output) and the standard list rates carried since 3.6 Flash
-  // ($1.50/M input, $7.50/M output incl. thinking, $0.15/M cached input).
-  // TODO: verify limits and pricing against the Gemini API model/pricing docs once
-  // Google publishes them; adjust if 3.8 Flash launches with an intro rate like 3.7.
+  // Gemini 3.8 Flash - GA on September 2, 2026. Stable `gemini-3.8-flash` model ID with
+  // 1M context, 64K max output (DeepMind model card). Like 3.7 Flash, we encode the
+  // introductory rates Google actually bills through December 31, 2026 ($0.75/M input,
+  // $3.75/M output, $0.075/M cached input) so displayed costs and goal budgets match
+  // real charges. TODO(2027-01-01): raise to the standard list rates ($1.50/$7.50/$0.15)
+  // when the intro pricing expires. Source: Gemini API pricing docs as of 2026-09-02.
+  // Note: 3.8 Flash rejects thinkingLevel "minimal" (see isGeminiFlashMinimalRejectingModelName).
   "gemini-3.8-flash": {
     max_input_tokens: 1048576,
     max_output_tokens: 65536,
-    input_cost_per_token: 0.0000015, // $1.50 per million input tokens
-    output_cost_per_token: 0.0000075, // $7.50 per million output tokens, including thinking tokens
-    cache_read_input_token_cost: 0.00000015, // $0.15 per million cached input tokens
+    input_cost_per_token: 0.00000075, // $0.75 per million input tokens (intro rate)
+    output_cost_per_token: 0.00000375, // $3.75 per million output tokens, including thinking tokens (intro rate)
+    cache_read_input_token_cost: 0.000000075, // $0.075 per million cached input tokens (intro rate)
     litellm_provider: "vertex_ai-language-models",
     mode: "chat",
     supports_function_calling: true,

--- a/src/node/services/agentSkills/builtInSkillContent.generated.ts
+++ b/src/node/services/agentSkills/builtInSkillContent.generated.ts
@@ -3866,7 +3866,7 @@ export const BUILTIN_SKILL_FILES: Record<string, Record<string, string>> = {
       "| Codex Mini 5.1         | openai:gpt-5.1-codex-mini     | `codex-mini`                                                 |         |",
       "| Codex Max 5.1          | openai:gpt-5.1-codex-max      | `codex-max`                                                  |         |",
       "| Gemini 3.1 Pro Preview | google:gemini-3.1-pro-preview | `gemini`, `gemini-pro`                                       |         |",
-      "| Gemini 3.7 Flash       | google:gemini-3.7-flash       | `gemini-flash`                                               |         |",
+      "| Gemini 3.8 Flash       | google:gemini-3.8-flash       | `gemini-flash`                                               |         |",
       "| Grok 4.6               | xai:grok-4.6                  | `grok`, `grok-4.6`                                           |         |",
       "| DeepSeek V4 Pro        | deepseek:deepseek-v4-pro      | `deepseek`, `deepseek-pro`, `deepseek-v4`, `deepseek-v4-pro` |         |",
       "| DeepSeek V4 Flash      | deepseek:deepseek-v4-flash    | `deepseek-flash`, `deepseek-v4-flash`                        |         |",


### PR DESCRIPTION
## Summary

Repoints the `gemini-flash` alias to **Gemini 3.8 Flash** (`gemini-3.8-flash`, GA September 2, 2026), following the same blueprint as the Gemini 3.7 Flash upgrade (#3845). Older Flash tiers remain usable as custom model strings (e.g. `google:gemini-3.7-flash`, `google:gemini-3.6-flash`).

> [!NOTE]
> This PR was prepared ahead of the release behind a merge gate. Google released Gemini 3.8 Flash on 2026-09-02; the assumptions were then verified against the live API and Google's docs, and two of them turned out to be wrong and were corrected (see **Launch-day corrections**). The gate is lifted.

## Implementation

- **`knownModels.ts`** — `GEMINI_FLASH.providerModelId` → `gemini-3.8-flash` (alias `gemini-flash`, tokenizer override `google/gemini-2.5-pro` unchanged)
- **`thinking/policy.ts`** — `isGeminiFlashThinkingLevelModelName` recognizes `gemini-3.8-flash` (excluding a future `-lite`); new `isGeminiFlashMinimalRejectingModelName` gives 3.8 Flash a `low/medium/high` policy (no `off`, see below)
- **`providerOptions.ts`** — Google adapter clamps a bypassed `off` to `thinkingLevel: "low"` for 3.8 Flash instead of `"minimal"`
- **`modelParameterOverrides.ts`** — `modelRejectsSamplingParameters` strips deprecated `temperature`/`topP`/`topK` for `gemini-3.8-flash`
- **`models-extra.ts`** — new stats entry: 1M context, 65K max output, intro pricing $0.75/M input, $3.75/M output (incl. thinking), $0.075/M cached input; the `gemini-3.7-flash` and `gemini-3.6-flash` entries are retained
- **Docs/CI** — `docs/config/models.mdx` model table and `nightly-terminal-bench.yml` default matrix updated to `google/gemini-3.8-flash`
- **Generated** — `builtInSkillContent.generated.ts` regenerated from the docs

Gateway stream normalization, the provider model factory, `DEFAULT_MODEL_FALLBACKS`, and `LEGACY_TOKENIZER_MODEL_OVERRIDES` need no changes (generic over the `google/` prefix; Gemini Flash participates in neither fallback chains nor legacy tokenizer overrides).

### Launch-day corrections

| Assumption (pre-release) | Verified at launch | Change |
| --- | --- | --- |
| `off` → Google `thinkingLevel: "minimal"` like 3–3.7 Flash | **3.8 Flash rejects MINIMAL**: live API returns `400 INVALID_ARGUMENT "Thinking level MINIMAL is not supported for this model"`; Google Cloud docs list only LOW/MEDIUM/HIGH | Policy is `["low","medium","high"]` so `off` clamps to `low` (same pattern as Grok 4.6 / Mythos, whose reasoning cannot be disabled); provider adapter also clamps defensively |
| Standard list rates $1.50/$7.50/$0.15 | Google bills a half-off introductory rate through Dec 31, 2026 | Encode the billed intro rate like #3845 did, with a `TODO(2027-01-01)` to restore list rates |
| Stable id `gemini-3.8-flash`, 1M context, 65K output, sampling params rejected, full multimodal + reasoning | Confirmed (`modelVersion: "gemini-3.8-flash"` in API responses; model card lists 1M/64K) | none |

## Validation

- 352 tests pass across the 6 touched suites: alias resolution, model stats (3.8 intro pricing + `google:gemini-3.7-flash` still resolvable as a custom model string), thinking policy (gateway/OpenRouter/versioned/`-lite` variants; `off`→`low` and `xhigh`→`high` clamps; medium default floor; new predicate), sampling rejection incl. gateway-routed and `mappedToModel` entries, provider options (`off` clamp vs 3.7's `minimal`, low/medium/high, gateway routing), model filter
- `streamManager.test.ts` multi-hop fallback tests (reference `KNOWN_MODELS.GEMINI_FLASH.id` symbolically) still pass; `make static-check` green
- **Live API probe** (`generateContent` on `gemini-3.8-flash`): `thinkingLevel=MINIMAL` → 400 as above; `thinkingLevel=LOW` → 200, `modelVersion: "gemini-3.8-flash"`, 77 thought tokens
- **Dogfood** in a `make dev-server-sandbox` instance driven with agent-browser (screenshots + recording in the PR comment below): `gemini-flash` search resolves to "Gemini 3.8 Flash"; the reasoning-effort menu offers no "Off"; a real message round-trips through the Google API with `thinkingConfig: { includeThoughts: true, thinkingLevel: "medium" }` (server debug log), the Context panel shows the 1.0M window, and the Cost panel shows $0.03 for 40.2k input tokens (= the $0.75/M intro rate)

## Risks

Low, additive metadata plus an alias repoint. Prior Flash tiers keep their entries and predicates, so explicit `google:gemini-3.7-flash` / `google:gemini-3.6-flash` model strings are unaffected. Behavior change for users on the `gemini-flash` alias: thinking can no longer be turned fully off (the API does not allow it); a persisted `off` preference clamps to `low` via `enforceThinkingPolicy` rather than failing the request.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh -->
