### PR TITLE
🤖 refactor: Effect Phase 11 PR 5 — DesktopLive group layers + DesktopWiringLive; thin ServiceContainer; StreamManager runner param

### DIFF
--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -128,6 +128,7 @@ import { getTotalCost } from "@/common/utils/tokens/usageAggregator";
 import type { CompactionCompletionMetadata } from "@/common/types/compaction";
 import { CompactionHandler } from "./compactionHandler";
 import { RetryManager, type RetryFailureError, type RetryStatusEvent } from "./retryManager";
+import type { EffectRunner } from "./di/effectRunner";
 import type { TelemetryService } from "./telemetryService";
 import type { BackgroundProcessManager } from "./backgroundProcessManager";
 
@@ -543,6 +544,13 @@ export interface AgentSessionStreamManager {
   isStreaming(workspaceId: string): boolean;
   getStreamInfo(workspaceId: string): AgentSessionActiveStreamInfo | undefined;
   replayStream(workspaceId: string, options?: { afterTimestamp?: number }): Promise<void>;
+  /**
+   * The runner the stream manager's clock-driven fibers use; the session's
+   * `RetryManager` schedules its backoff on the same clock. Absent on test
+   * doubles and the AIService fallback, which leaves RetryManager on the
+   * global runtime.
+   */
+  readonly effectRunner?: EffectRunner;
 }
 
 /** Keeps AgentSession coupled only to the AI operations and events it consumes. */
@@ -952,7 +960,8 @@ export class AgentSession {
       async () => {
         await this.retryActiveStream();
       },
-      (event) => this.handleRetryStatusChange(event)
+      (event) => this.handleRetryStatusChange(event),
+      this.streamManager.effectRunner
     );
 
     this.attachAiListeners();

--- a/src/node/services/di/layers/app.ts
+++ b/src/node/services/di/layers/app.ts
@@ -4,7 +4,7 @@ import { AppFiberScopeLive } from "@/node/services/di/appFiberScope";
 import { EffectRunnerLive } from "@/node/services/di/effectRunner";
 import type { AppTags } from "@/node/services/di/tags";
 import { CoreLive, MemoryMetaLive } from "./core";
-import { CoreOptionsFromDesktopLive, CrossCuttingLive } from "./desktop";
+import { CoreOptionsFromDesktopLive, CrossCuttingLive, DesktopLive } from "./desktop";
 import { StoresLive } from "./stores";
 
 /**
@@ -20,14 +20,16 @@ import { StoresLive } from "./stores";
  * captures its building context, so placing it there keeps that context to the
  * stores plus references (`Clock`, …). Above them the graph replays the
  * constructor's former order: memory metadata, the cross-cutting services, the
- * core options derived from them, then the staged core graph (which reads
- * `MemoryMeta` and `WorkspaceMcpOverrides` from those layers directly).
+ * core options derived from them, the staged core graph (which reads
+ * `MemoryMeta` and `WorkspaceMcpOverrides` from those layers directly), and
+ * finally the desktop group layers with their wiring.
  */
 export function AppLive(stores: ConfigStores): Layer.Layer<AppTags> {
   const runtimeSeams = AppFiberScopeLive.pipe(
     Layer.provideMerge(EffectRunnerLive.pipe(Layer.provideMerge(StoresLive(stores))))
   );
-  return CoreLive.pipe(
+  return DesktopLive.pipe(
+    Layer.provideMerge(CoreLive),
     Layer.provideMerge(CoreOptionsFromDesktopLive),
     Layer.provideMerge(CrossCuttingLive),
     Layer.provideMerge(MemoryMetaLive),

--- a/src/node/services/di/layers/core.ts
+++ b/src/node/services/di/layers/core.ts
@@ -13,7 +13,7 @@ import { AIService } from "@/node/services/aiService";
 import { BackgroundProcessManager } from "@/node/services/backgroundProcessManager";
 import type { CoreOptions, CoreServices, CoreServicesOptions } from "@/node/services/coreServices";
 import { AppFiberScopeLive } from "@/node/services/di/appFiberScope";
-import { EffectRunnerLive } from "@/node/services/di/effectRunner";
+import { EffectRunnerLive, EffectRunnerTag } from "@/node/services/di/effectRunner";
 import {
   AI,
   BackgroundProcessManagerTag,
@@ -90,11 +90,18 @@ export class CoreOptionsTag extends Context.Service<CoreOptionsTag, CoreOptions>
 
 /**
  * What the roots must provide beneath `CoreLive`: the stores, the options,
- * and the two always-present collaborators the desktop builds elsewhere
- * (`MemoryMetaLive`; `WorkspaceMcpOverrides` from `CrossCuttingLive`). CLI
- * roots supply the defaults (`MemoryMetaLive`, `WorkspaceMcpOverridesDefaultLive`).
+ * the runtime's `EffectRunner` (the base seam in both roots; StreamManager's
+ * clock-driven fibers run through it), and the two always-present
+ * collaborators the desktop builds elsewhere (`MemoryMetaLive`;
+ * `WorkspaceMcpOverrides` from `CrossCuttingLive`). CLI roots supply the
+ * defaults (`MemoryMetaLive`, `WorkspaceMcpOverridesDefaultLive`).
  */
-export type CoreInputTags = StoreTags | CoreOptionsTag | MemoryMeta | WorkspaceMcpOverrides;
+export type CoreInputTags =
+  | StoreTags
+  | CoreOptionsTag
+  | EffectRunnerTag
+  | MemoryMeta
+  | WorkspaceMcpOverrides;
 
 /** Memory metadata sidecar; scope root derives from the xum home (`config.rootDir`). */
 export const MemoryMetaLive: Layer.Layer<MemoryMeta, never, ConfigTag> = Layer.effect(
@@ -220,8 +227,13 @@ export const StreamManagerLive = Layer.effect(
   StreamManagerTag,
   Effect.gen(function* () {
     const providerService = yield* Provider;
-    return new StreamManager(yield* History, yield* SessionUsage, () =>
-      providerService.getConfig()
+    return new StreamManager(
+      yield* History,
+      yield* SessionUsage,
+      () => providerService.getConfig(),
+      // Default event sink: AIService installs itself as the sink (S3).
+      undefined,
+      yield* EffectRunnerTag
     );
   })
 );

--- a/src/node/services/di/layers/desktop.ts
+++ b/src/node/services/di/layers/desktop.ts
@@ -1,30 +1,179 @@
 import * as path from "path";
 import { Context, Effect, Layer } from "effect";
-import { AnalyticsService } from "@/node/services/analytics/analyticsService";
-import { DevToolsService } from "@/node/services/devToolsService";
+import { DEFAULT_CODER_ARCHIVE_BEHAVIOR } from "@/common/config/coderArchiveBehavior";
+import { DEFAULT_WORKTREE_ARCHIVE_BEHAVIOR } from "@/common/config/worktreeArchiveBehavior";
+import { EXPERIMENT_IDS } from "@/common/constants/experiments";
+import type {
+  ErrorEvent,
+  ReasoningDeltaEvent,
+  StreamAbortEvent,
+  StreamDeltaEvent,
+  StreamEndEvent,
+  StreamStartEvent,
+  ToolCallDeltaEvent,
+  ToolCallEndEvent,
+  ToolCallStartEvent,
+} from "@/common/types/stream";
 import {
+  createCoderArchiveHook,
+  createCoderUnarchiveHook,
+} from "@/node/runtime/coderLifecycleHooks";
+import { setGlobalCoderService } from "@/node/runtime/runtimeFactory";
+import {
+  createRuntimeForWorkspace,
+  resolveWorkspaceExecutionPath,
+} from "@/node/runtime/runtimeHelpers";
+import { setSshPromptService as setSSH2SshPromptService } from "@/node/runtime/SSH2ConnectionPool";
+import { setSshPromptService } from "@/node/runtime/sshConnectionPool";
+import { createWorktreeArchiveHook } from "@/node/runtime/worktreeLifecycleHooks";
+import { AgentPluginInstallService } from "@/node/services/agentPlugins/installService";
+import { AgentStatusService } from "@/node/services/agentStatusService";
+import {
+  AnalyticsService,
+  type IngestWorkspaceMeta,
+} from "@/node/services/analytics/analyticsService";
+import { createBackupGitRepo, createBackupPayloadStore } from "@/node/services/backup/adapters";
+import { BackupService } from "@/node/services/backup/backupService";
+import { AgentBrowserSessionDiscoveryService } from "@/node/services/browser/AgentBrowserSessionDiscoveryService";
+import { BrowserBridgeServer } from "@/node/services/browser/BrowserBridgeServer";
+import { BrowserBridgeTokenManager } from "@/node/services/browser/BrowserBridgeTokenManager";
+import { BrowserControlService } from "@/node/services/browser/BrowserControlService";
+import { BrowserSessionStateHub } from "@/node/services/browser/BrowserSessionStateHub";
+import { CoderOauthService } from "@/node/services/coderOauthService";
+import { coderService as coderServiceSingleton } from "@/node/services/coderService";
+import { CodexOauthService } from "@/node/services/codexOauthService";
+import { CopilotOauthService } from "@/node/services/copilotOauthService";
+import { DesktopBridgeServer } from "@/node/services/desktop/DesktopBridgeServer";
+import { DesktopSessionManager } from "@/node/services/desktop/DesktopSessionManager";
+import { DesktopTokenManager } from "@/node/services/desktop/DesktopTokenManager";
+import { DevToolsService } from "@/node/services/devToolsService";
+import { EffectRunnerTag } from "@/node/services/di/effectRunner";
+import {
+  AgentBrowserSessionDiscovery,
+  AgentPluginInstall,
+  AgentStatus,
+  AI,
   Analytics,
+  BackgroundProcessManagerTag,
+  Backup,
+  BrowserBridgeServerTag,
+  BrowserBridgeTokenManagerTag,
+  BrowserControl,
+  BrowserSessionStateHubTag,
+  Coder,
+  CoderOauth,
+  CodexOauth,
   ConfigTag,
+  CopilotOauth,
+  DesktopBridgeServerTag,
+  DesktopSessionManagerTag,
+  DesktopTokenManagerTag,
   DevTools,
+  Editor,
   Experiments,
+  ExtensionMetadata,
+  FileLeaseManagerTag,
+  Heartbeat,
+  History,
+  IdleCompaction,
+  IdleDispatcherTag,
+  Instructions,
+  MCPConfig,
+  McpOauth,
+  MCPServerManagerTag,
+  Memory,
+  MemoryConsolidation,
+  MemoryMeta,
+  MenuEvent,
+  MuxGatewayOauth,
+  MuxGovernorOauth,
   Policy,
+  Project,
+  Provider,
+  ProvidersConfigStoreTag,
+  PTY,
+  QuickJSRuntimeFactoryTag,
+  Refine,
+  SecretsStoreTag,
+  Server,
+  ServerAuth,
   SessionTiming,
+  SessionUsage,
+  SshPrompt,
+  Task,
   Telemetry,
+  Terminal,
+  Timeline,
+  Tokenizer,
+  TurnRequestBuilderBindingsTag,
+  Update,
+  Voice,
+  WindowTag,
+  Workspace,
+  WorkspaceGoal,
+  WorkspaceLifecycleHooksTag,
   WorkspaceMcpOverrides,
+  WorktreeArchiveSnapshot,
+  type BrowserTags,
+  type CoreTags,
   type CrossCuttingTags,
+  type DesktopBridgeTags,
+  type DesktopTags,
+  type MiscDesktopTags,
+  type OauthTags,
+  type StoreTags,
+  type TerminalEditorTags,
+  type WorkerTags,
 } from "@/node/services/di/tags";
+import { EditorService } from "@/node/services/editorService";
 import { ExperimentsService } from "@/node/services/experimentsService";
+import { HeartbeatService } from "@/node/services/heartbeatService";
+import { IdleCompactionService } from "@/node/services/idleCompactionService";
+import { InstructionsService } from "@/node/services/instructionsService";
+import { McpOauthService } from "@/node/services/mcpOauthService";
+import { MenuEventService } from "@/node/services/menuEventService";
+import { MuxGatewayOauthService } from "@/node/services/muxGatewayOauthService";
+import { MuxGovernorOauthService } from "@/node/services/muxGovernorOauthService";
 import { PolicyService } from "@/node/services/policyService";
+import { ProjectService } from "@/node/services/projectService";
+import { QuickJSRuntimeFactory } from "@/node/services/ptc/quickjsRuntime";
+import { PTYService } from "@/node/services/ptyService";
+import { RefineService } from "@/node/services/refinement/refineService";
+import { ServerAuthService } from "@/node/services/serverAuthService";
+import { ServerService } from "@/node/services/serverService";
 import { SessionTimingService } from "@/node/services/sessionTimingService";
+import { SshPromptService } from "@/node/services/sshPromptService";
 import { TelemetryService } from "@/node/services/telemetryService";
+import { TerminalService } from "@/node/services/terminalService";
+import { TimelineService } from "@/node/services/timelineService";
+import { TokenizerService } from "@/node/services/tokenizerService";
+import { UpdateService } from "@/node/services/updateService";
+import { VoiceService } from "@/node/services/voiceService";
+import { WindowService } from "@/node/services/windowService";
+import { WorkspaceLifecycleHooks } from "@/node/services/workspaceLifecycleHooks";
 import { WorkspaceMcpOverridesService } from "@/node/services/workspaceMcpOverridesService";
+import { WorktreeArchiveSnapshotService } from "@/node/services/worktreeArchiveSnapshotService";
 import { CoreOptionsTag } from "./core";
 
 /**
- * Desktop/server-only layers (`ServiceContainer` roots). Only the services the
- * core graph's options derive from live here so far; the remaining desktop
- * constructions stay in the `ServiceContainer` constructor until they get
- * their own group layers.
+ * Desktop/server-only layers (`ServiceContainer` roots; Effect migration
+ * Phase 11).
+ *
+ * `CrossCuttingLive` and `CoreOptionsFromDesktopLive` sit beneath the core
+ * graph (its options derive from them). The remaining desktop services are
+ * built above the core graph by six **group layers** — one `Layer.effectContext`
+ * per group, constructing several services in the order the `ServiceContainer`
+ * constructor used — rather than one layer per service: cold build cost grows
+ * with the number of layers, and the desktop tail has no per-service swap
+ * needs. Groups that depend on each other are staged with
+ * `Layer.provideMerge`; only true siblings share a `Layer.mergeAll`
+ * (siblings may build in any order, so nothing relies on sibling order).
+ * Bodies are synchronous and register no finalizers (DI contract in
+ * `../appRuntime.ts`); teardown stays explicit in `ServiceContainer.dispose()`.
+ *
+ * The former constructor's post-construction wiring — setters, event
+ * listeners, global registrations — is replayed, statement for statement in
+ * its original order, by `DesktopWiringLive` once every service exists.
  */
 
 /**
@@ -83,3 +232,598 @@ export const CoreOptionsFromDesktopLive: Layer.Layer<
     };
   })
 );
+
+// ---------------------------------------------------------------------------
+// Desktop group layers. Requirements (the `R` annotations) are the DAG: the
+// four base groups need only stores, cross-cutting and core services; OAuth
+// additionally needs the WindowService (Misc); the workers need the
+// WindowService (Misc) and the TokenizerService (TerminalEditor).
+// ---------------------------------------------------------------------------
+
+/** Browser automation bridge: token manager → discovery → control → state hub → server. */
+export const BrowserLive: Layer.Layer<BrowserTags, never, ConfigTag> = Layer.effectContext(
+  Effect.map(ConfigTag, (config) => {
+    const browserBridgeTokenManager = new BrowserBridgeTokenManager();
+    const browserSessionDiscoveryService = new AgentBrowserSessionDiscoveryService({
+      resolveWorkspaceCandidatePathsFn: async (workspaceId: string) => {
+        const allWorkspaceMetadata = await config.getAllWorkspaceMetadata();
+        const workspaceMetadata =
+          allWorkspaceMetadata.find((candidate) => candidate.id === workspaceId) ?? null;
+        if (workspaceMetadata == null) {
+          return [];
+        }
+
+        const runtime = createRuntimeForWorkspace(workspaceMetadata);
+        const workspacePath = resolveWorkspaceExecutionPath(workspaceMetadata, runtime);
+        return [workspaceMetadata.projectPath, workspacePath].filter(
+          (candidatePath): candidatePath is string => candidatePath.trim().length > 0
+        );
+      },
+    });
+    const browserControlService = new BrowserControlService({
+      browserSessionDiscoveryService,
+      resolveSessionEnvFn: () => Promise.resolve(process.env),
+    });
+    const browserSessionStateHub = new BrowserSessionStateHub({
+      browserControlService,
+    });
+    const browserBridgeServer = new BrowserBridgeServer({
+      browserSessionDiscoveryService,
+      browserBridgeTokenManager,
+      browserSessionStateHub,
+    });
+    return Context.empty().pipe(
+      Context.add(BrowserBridgeTokenManagerTag, browserBridgeTokenManager),
+      Context.add(AgentBrowserSessionDiscovery, browserSessionDiscoveryService),
+      Context.add(BrowserControl, browserControlService),
+      Context.add(BrowserSessionStateHubTag, browserSessionStateHub),
+      Context.add(BrowserBridgeServerTag, browserBridgeServer)
+    );
+  })
+);
+
+/** Desktop companion bridge: session manager → token manager → server. */
+export const DesktopBridgeLive: Layer.Layer<
+  DesktopBridgeTags,
+  never,
+  ConfigTag | Experiments | Workspace
+> = Layer.effectContext(
+  Effect.gen(function* () {
+    const desktopSessionManager = new DesktopSessionManager({
+      config: yield* ConfigTag,
+      experimentsService: yield* Experiments,
+      workspaceService: yield* Workspace,
+    });
+    const desktopTokenManager = new DesktopTokenManager();
+    const desktopBridgeServer = new DesktopBridgeServer({
+      desktopSessionManager,
+      desktopTokenManager,
+    });
+    return Context.empty().pipe(
+      Context.add(DesktopSessionManagerTag, desktopSessionManager),
+      Context.add(DesktopTokenManagerTag, desktopTokenManager),
+      Context.add(DesktopBridgeServerTag, desktopBridgeServer)
+    );
+  })
+);
+
+/** Terminal (PTY → terminal), editor, and token budgeting (tokenizer → instructions). */
+export const TerminalEditorLive: Layer.Layer<
+  TerminalEditorTags,
+  never,
+  ConfigTag | SecretsStoreTag | Workspace | SessionUsage | AI | Provider
+> = Layer.effectContext(
+  Effect.gen(function* () {
+    const config = yield* ConfigTag;
+    const aiService = yield* AI;
+    // Terminal services - PTYService is cross-platform
+    const ptyService = new PTYService();
+    const terminalService = new TerminalService(config, ptyService, yield* SecretsStoreTag);
+    // Editor service for opening workspaces in code editors
+    const editorService = new EditorService(config, yield* Workspace);
+    const tokenizerService = new TokenizerService(yield* SessionUsage, aiService, yield* Provider);
+    const instructionsService = new InstructionsService(config, aiService, tokenizerService);
+    return Context.empty().pipe(
+      Context.add(PTY, ptyService),
+      Context.add(Terminal, terminalService),
+      Context.add(Editor, editorService),
+      Context.add(Tokenizer, tokenizerService),
+      Context.add(Instructions, instructionsService)
+    );
+  })
+);
+
+/**
+ * The remaining desktop services: leaves over the stores/core/cross-cutting
+ * graph, plus `ProjectService` (needs `SshPromptService`, built first here).
+ */
+export const MiscDesktopLive: Layer.Layer<
+  MiscDesktopTags,
+  never,
+  | ConfigTag
+  | SecretsStoreTag
+  | ProvidersConfigStoreTag
+  | Experiments
+  | Policy
+  | Provider
+  | MCPServerManagerTag
+  | WorkspaceMcpOverrides
+> = Layer.effectContext(
+  Effect.gen(function* () {
+    const config = yield* ConfigTag;
+    const experimentsService = yield* Experiments;
+    const policyService = yield* Policy;
+    const providerService = yield* Provider;
+    const providersConfigStore = yield* ProvidersConfigStoreTag;
+    const workflowRuntimeFactory = new QuickJSRuntimeFactory();
+    const sshPromptService = new SshPromptService();
+    const windowService = new WindowService();
+    const backupService = new BackupService(config, {
+      gitRepo: createBackupGitRepo({
+        cacheRoot: path.join(config.rootDir, "backup-cache"),
+      }),
+      payload: createBackupPayloadStore({ config }),
+    });
+    // Managed Agent Plugin installer (agent-plugins experiment). Gated on the
+    // backend ExperimentsService exactly like the plugin MCP provider; the
+    // MCP manager dependency lets update/uninstall recycle running plugin
+    // servers whose content changed behind an unchanged command line.
+    const agentPluginInstallService = new AgentPluginInstallService(config, {
+      isEnabled: () => experimentsService.isExperimentEnabled(EXPERIMENT_IDS.AGENT_PLUGINS),
+      mcpServerManager: yield* MCPServerManagerTag,
+      workspaceMcpOverridesService: yield* WorkspaceMcpOverrides,
+    });
+    const projectService = new ProjectService(config, sshPromptService, yield* SecretsStoreTag);
+    const updateService = new UpdateService(config);
+    const serverService = new ServerService();
+    const menuEventService = new MenuEventService();
+    const voiceService = new VoiceService(
+      config,
+      providerService,
+      policyService,
+      providersConfigStore
+    );
+    const serverAuthService = new ServerAuthService(config);
+    const workspaceLifecycleHooks = new WorkspaceLifecycleHooks();
+    const worktreeArchiveSnapshotService = new WorktreeArchiveSnapshotService(config);
+    return Context.empty().pipe(
+      Context.add(QuickJSRuntimeFactoryTag, workflowRuntimeFactory),
+      Context.add(SshPrompt, sshPromptService),
+      Context.add(WindowTag, windowService),
+      Context.add(Backup, backupService),
+      Context.add(AgentPluginInstall, agentPluginInstallService),
+      Context.add(Project, projectService),
+      Context.add(Update, updateService),
+      Context.add(Server, serverService),
+      Context.add(MenuEvent, menuEventService),
+      Context.add(Voice, voiceService),
+      Context.add(Coder, coderServiceSingleton),
+      Context.add(ServerAuth, serverAuthService),
+      Context.add(WorkspaceLifecycleHooksTag, workspaceLifecycleHooks),
+      Context.add(WorktreeArchiveSnapshot, worktreeArchiveSnapshotService)
+    );
+  })
+);
+
+/** OAuth flows; every one hands off to the browser through the WindowService (Misc). */
+export const OauthLive: Layer.Layer<
+  OauthTags,
+  never,
+  | ConfigTag
+  | ProvidersConfigStoreTag
+  | FileLeaseManagerTag
+  | MCPConfig
+  | Provider
+  | Policy
+  | Telemetry
+  | WindowTag
+> = Layer.effectContext(
+  Effect.gen(function* () {
+    const config = yield* ConfigTag;
+    const windowService = yield* WindowTag;
+    const providersConfigStore = yield* ProvidersConfigStoreTag;
+    const providerService = yield* Provider;
+    const policyService = yield* Policy;
+    const mcpOauthService = new McpOauthService(
+      config,
+      yield* MCPConfig,
+      windowService,
+      yield* Telemetry
+    );
+    const muxGatewayOauthService = new MuxGatewayOauthService(
+      providersConfigStore,
+      providerService,
+      windowService
+    );
+    const muxGovernorOauthService = new MuxGovernorOauthService(
+      config,
+      windowService,
+      policyService
+    );
+    const codexOauthService = new CodexOauthService(
+      providersConfigStore,
+      providerService,
+      windowService
+    );
+    const coderOauthService = new CoderOauthService(
+      providersConfigStore,
+      yield* FileLeaseManagerTag,
+      providerService,
+      windowService,
+      // Policy-aware: an enforced forcedBaseUrl overrides the deployment URL
+      // for logins, refreshes, and issuer checks.
+      policyService
+    );
+    const copilotOauthService = new CopilotOauthService(providerService, windowService);
+    return Context.empty().pipe(
+      Context.add(McpOauth, mcpOauthService),
+      Context.add(MuxGatewayOauth, muxGatewayOauthService),
+      Context.add(MuxGovernorOauth, muxGovernorOauthService),
+      Context.add(CodexOauth, codexOauthService),
+      Context.add(CoderOauth, coderOauthService),
+      Context.add(CopilotOauth, copilotOauthService)
+    );
+  })
+);
+
+/**
+ * Clock-driven workers (through the runtime's `EffectRunner`) and the
+ * timeline/refine pair: idle compaction → heartbeat → timeline → refine →
+ * agent status. `start()`/`stop()` stay with `ServiceContainer`.
+ */
+export const WorkersLive: Layer.Layer<
+  WorkerTags,
+  never,
+  | ConfigTag
+  | EffectRunnerTag
+  | Experiments
+  | History
+  | ExtensionMetadata
+  | Workspace
+  | Task
+  | IdleDispatcherTag
+  | Memory
+  | MemoryMeta
+  | AI
+  | SessionUsage
+  | Tokenizer
+  | WindowTag
+> = Layer.effectContext(
+  Effect.gen(function* () {
+    const config = yield* ConfigTag;
+    // Clock-driven workers run their lifecycle fibers through the runtime's
+    // context-bound runner (unsupervised; see di/effectRunner.ts).
+    const effectRunner = yield* EffectRunnerTag;
+    const experimentsService = yield* Experiments;
+    const historyService = yield* History;
+    const extensionMetadata = yield* ExtensionMetadata;
+    const workspaceService = yield* Workspace;
+    const aiService = yield* AI;
+    const sessionUsageService = yield* SessionUsage;
+    // Idle compaction service - auto-compacts workspaces after configured idle period
+    const idleCompactionService = new IdleCompactionService(
+      config,
+      historyService,
+      extensionMetadata,
+      (workspaceId) => workspaceService.executeIdleCompaction(workspaceId),
+      effectRunner
+    );
+    // IdleDispatcher + goal continuation bridge are owned by the core graph
+    // so the wiring works for `xum run` too. Share the same dispatcher with
+    // HeartbeatService — its priority ordering ensures an active goal
+    // suppresses background heartbeats.
+    const heartbeatService = new HeartbeatService(
+      config,
+      extensionMetadata,
+      workspaceService,
+      yield* Task,
+      yield* IdleDispatcherTag,
+      effectRunner
+    );
+    const timelineService = new TimelineService(config, historyService, experimentsService);
+    // /refine trajectory distillation (RLM r11). Chat emission routes through
+    // WorkspaceService so a live session renders the appended summary row
+    // immediately (the row itself is already durable in chat.jsonl).
+    const refineService = new RefineService(
+      config,
+      yield* Memory,
+      yield* MemoryMeta,
+      historyService,
+      aiService,
+      experimentsService,
+      {
+        timelineService,
+        sessionUsageService,
+        emitChatMessage: (workspaceId, message) =>
+          workspaceService.emitChatEvent(workspaceId, { ...message, type: "message" }),
+        // r40: refine row publication and apply mutations must not interleave
+        // with a concurrent turn's PREPARING snapshot or split its
+        // user/assistant pair — hold the session's turn-admission block while
+        // they land, failing closed when a turn is active.
+        acquireTurnExclusion: (workspaceId) =>
+          workspaceService.acquireIdleTurnExclusion(workspaceId),
+      }
+    );
+    // AgentStatusService depends on tokenizer + window focus state; instantiate
+    // after both are constructed so the small-model status loop can run with
+    // accurate token budgeting and focus-aware cadence.
+    const agentStatusService = new AgentStatusService(
+      config,
+      historyService,
+      yield* Tokenizer,
+      extensionMetadata,
+      workspaceService,
+      yield* WindowTag,
+      aiService,
+      // Status generation spends tokens outside StreamManager; give it a cost
+      // telemetry sink so that spend shows up in per-workspace usage, and an
+      // ingest trigger so the headless-usage sidecar reaches dashboard totals
+      // even when the workspace has no further stream activity.
+      {
+        sessionUsageService,
+        requestAnalyticsIngest: (workspaceId) => {
+          workspaceService.emit("analyticsIngest", { workspaceId });
+        },
+      }
+    );
+    return Context.empty().pipe(
+      Context.add(IdleCompaction, idleCompactionService),
+      Context.add(Heartbeat, heartbeatService),
+      Context.add(Timeline, timelineService),
+      Context.add(Refine, refineService),
+      Context.add(AgentStatus, agentStatusService)
+    );
+  })
+);
+
+// ---------------------------------------------------------------------------
+// Wiring — the former `ServiceContainer` constructor's post-construction
+// statements (setters, event listeners, global registrations), in their
+// original order, once every desktop service exists. Runs after `CoreLive`'s
+// wiring, so the analytics listeners below keep their position after the core
+// listeners. Synchronous statements only: no finalizers, no forks (I5).
+// ---------------------------------------------------------------------------
+
+export const DesktopWiringLive: Layer.Layer<
+  never,
+  never,
+  ConfigTag | CrossCuttingTags | CoreTags | DesktopTags
+> = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const config = yield* ConfigTag;
+    const analyticsService = yield* Analytics;
+    const sessionTimingService = yield* SessionTiming;
+    const turnRequestBuilderBindings = yield* TurnRequestBuilderBindingsTag;
+    const aiService = yield* AI;
+    const workspaceService = yield* Workspace;
+    const taskService = yield* Task;
+    const workspaceGoalService = yield* WorkspaceGoal;
+    const mcpServerManager = yield* MCPServerManagerTag;
+    const memoryConsolidationService = yield* MemoryConsolidation;
+    const backgroundProcessManager = yield* BackgroundProcessManagerTag;
+    const coderService = yield* Coder;
+    const backupService = yield* Backup;
+    const memoryService = yield* Memory;
+    const projectService = yield* Project;
+    const sshPromptService = yield* SshPrompt;
+    const desktopSessionManager = yield* DesktopSessionManagerTag;
+    const idleCompactionService = yield* IdleCompaction;
+    const heartbeatService = yield* Heartbeat;
+    const timelineService = yield* Timeline;
+    const refineService = yield* Refine;
+    const mcpOauthService = yield* McpOauth;
+    const codexOauthService = yield* CodexOauth;
+    const coderOauthService = yield* CoderOauth;
+    const terminalService = yield* Terminal;
+    const workspaceLifecycleHooks = yield* WorkspaceLifecycleHooksTag;
+    const worktreeArchiveSnapshotService = yield* WorktreeArchiveSnapshot;
+
+    turnRequestBuilderBindings.analyticsService = analyticsService;
+
+    projectService.setWorkspaceService(workspaceService);
+    projectService.setWorkspaceMetadataRefresher(workspaceService);
+    projectService.setMcpServerManager(mcpServerManager);
+    // Backup restores register approved project imports through the same create() path the
+    // UI uses; setter injection because BackupService is constructed before ProjectService.
+    backupService.setProjectService(projectService);
+    // Restored project memory is written directly, so the service announces it through
+    // MemoryService for the memory browser's change subscription.
+    backupService.setMemoryNotifier(memoryService);
+    turnRequestBuilderBindings.desktopSessionManager = desktopSessionManager;
+
+    // Forward terminal idle-compaction outcomes so the loop stops re-attempting a
+    // persistently failing workspace (immediately on model_not_found, otherwise after
+    // two consecutive failures).
+    workspaceService.setIdleCompactionOutcomeListener((workspaceId, outcome) =>
+      idleCompactionService.recordOutcome(workspaceId, outcome)
+    );
+
+    // Removal must be able to abort + drain a running /refine pass before it
+    // deletes the session directory (post-construction wiring: RefineService
+    // is built after WorkspaceService).
+    workspaceService.setRefinePassCanceller(refineService);
+    workspaceService.setTimelineRecorder(timelineService);
+    taskService.setTimelineRecorder(timelineService);
+    heartbeatService.setTimelineRecorder(timelineService);
+    workspaceGoalService.setTimelineRecorder(timelineService);
+    turnRequestBuilderBindings.timelineService = timelineService;
+    timelineService.subscribeToWorkspace(workspaceService);
+
+    mcpServerManager.setMcpOauthService(mcpOauthService);
+    turnRequestBuilderBindings.codexOauthService = codexOauthService;
+    turnRequestBuilderBindings.coderOauthService = coderOauthService;
+
+    // Wire terminal service to workspace service for cleanup on removal
+    workspaceService.setTerminalService(terminalService);
+    workspaceService.setDesktopSessionManager(desktopSessionManager);
+    // Plugin-override pruning is wired inside the core graph (shared with
+    // headless CLI registration), using the WorkspaceMcpOverridesService.
+
+    workspaceService.setWorktreeArchiveSnapshotService(worktreeArchiveSnapshotService);
+    const getArchiveBehavior = () =>
+      config.loadConfigOrDefault().coderWorkspaceArchiveBehavior ?? DEFAULT_CODER_ARCHIVE_BEHAVIOR;
+    workspaceLifecycleHooks.registerBeforeArchive(
+      createCoderArchiveHook({
+        coderService,
+        getArchiveBehavior,
+        // Model-driven archives probe the remote spawn-record layout before stopping a
+        // running Coder workspace: detached jobs surviving an unclean Xum exit live only in
+        // those records, which the host-local crash-orphan scans cannot see.
+        hasUnsettledRemoteBackgroundJobs: async (workspaceMetadata) => {
+          const runtime = createRuntimeForWorkspace(workspaceMetadata);
+          return await backgroundProcessManager.hasUnsettledRemoteSpawnRecords(
+            runtime,
+            workspaceMetadata.id
+          );
+        },
+      })
+    );
+    workspaceLifecycleHooks.registerAfterUnarchive(
+      createCoderUnarchiveHook({
+        coderService,
+        getArchiveBehavior,
+      })
+    );
+    const getWorktreeArchiveBehavior = () =>
+      config.loadConfigOrDefault().worktreeArchiveBehavior ?? DEFAULT_WORKTREE_ARCHIVE_BEHAVIOR;
+    workspaceLifecycleHooks.registerAfterArchive(
+      createWorktreeArchiveHook({ getWorktreeArchiveBehavior })
+    );
+    workspaceService.setWorkspaceLifecycleHooks(workspaceLifecycleHooks);
+
+    // Register globally so all createRuntime calls can create CoderSSHRuntime
+    setGlobalCoderService(coderService);
+    setSshPromptService(sshPromptService);
+    setSSH2SshPromptService(sshPromptService);
+
+    // Backend timing stats.
+    aiService.on("stream-start", (data: StreamStartEvent) =>
+      sessionTimingService.handleStreamStart(data)
+    );
+    aiService.on("stream-delta", (data: StreamDeltaEvent) =>
+      sessionTimingService.handleStreamDelta(data)
+    );
+    aiService.on("reasoning-delta", (data: ReasoningDeltaEvent) =>
+      sessionTimingService.handleReasoningDelta(data)
+    );
+    aiService.on("tool-call-start", (data: ToolCallStartEvent) =>
+      sessionTimingService.handleToolCallStart(data)
+    );
+    aiService.on("tool-call-delta", (data: ToolCallDeltaEvent) =>
+      sessionTimingService.handleToolCallDelta(data)
+    );
+    aiService.on("tool-call-end", (data: ToolCallEndEvent) =>
+      sessionTimingService.handleToolCallEnd(data)
+    );
+    // Newly created sub-agent workspaces are ingested here before a full rebuild,
+    // so keep workspaceName + parentWorkspaceId to avoid NULL analytics attribution.
+    // Multi-project workspaces stay stored under _multi in config, but analytics should
+    // still attribute spend to the workspace's first real project path.
+    const ingestWorkspaceAnalytics = (workspaceId: string) => {
+      const workspaceLookup = config.findWorkspace(workspaceId);
+      const sessionDir = path.join(config.sessionsDir, workspaceId);
+      const analyticsProjectPath =
+        workspaceLookup?.attributionProjectPath ?? workspaceLookup?.projectPath;
+      analyticsService.ingestWorkspace(workspaceId, sessionDir, {
+        projectPath: analyticsProjectPath,
+        projectName: analyticsProjectPath ? path.basename(analyticsProjectPath) : undefined,
+        workspaceName: workspaceLookup?.workspaceName,
+        parentWorkspaceId: workspaceLookup?.parentWorkspaceId,
+      });
+    };
+    aiService.on("stream-end", (data: StreamEndEvent) => {
+      sessionTimingService.handleStreamEnd(data);
+      ingestWorkspaceAnalytics(data.workspaceId);
+    });
+    // Billable usage persisted outside StreamManager stream-end requests its
+    // own incremental ingest pass.
+    workspaceService.on("analyticsIngest", (event) => {
+      ingestWorkspaceAnalytics(event.workspaceId);
+    });
+    // Memory consolidation/harvest spend rides the headless-usage sidecar
+    // without any chat activity; ingest promptly so background sweeps reach
+    // dashboard totals instead of stranding until an unrelated stream-end
+    // or app restart.
+    memoryConsolidationService.on("analyticsIngest", (event: { workspaceId: string }) => {
+      ingestWorkspaceAnalytics(event.workspaceId);
+    });
+    // WorkspaceService emits metadata:null after successful remove().
+    // Clear analytics rows immediately so deleted workspaces disappear from stats
+    // without waiting for a future ingest pass.
+    workspaceService.on("metadata", (event) => {
+      if (event.metadata !== null) {
+        return;
+      }
+
+      // Removed sub-agent children archive their transcript into the parent's
+      // session dir before this event fires. Re-ingest the parent (chained after
+      // the clear) so the child's spend is restored from the archive instead of
+      // vanishing from analytics until the parent's next stream-end.
+      let reingestAfterClear:
+        | { workspaceId: string; sessionDir: string; meta: IngestWorkspaceMeta }
+        | undefined;
+      const parentWorkspaceId = event.removedParentWorkspaceId;
+      if (parentWorkspaceId) {
+        const parentLookup = config.findWorkspace(parentWorkspaceId);
+        const parentProjectPath = parentLookup?.attributionProjectPath ?? parentLookup?.projectPath;
+        reingestAfterClear = {
+          workspaceId: parentWorkspaceId,
+          sessionDir: path.join(config.sessionsDir, parentWorkspaceId),
+          meta: {
+            projectPath: parentProjectPath,
+            projectName: parentProjectPath ? path.basename(parentProjectPath) : undefined,
+            workspaceName: parentLookup?.workspaceName,
+            parentWorkspaceId: parentLookup?.parentWorkspaceId,
+          },
+        };
+      }
+
+      analyticsService.clearWorkspace(event.workspaceId, { reingestAfterClear });
+    });
+
+    aiService.on("stream-abort", (data: StreamAbortEvent) => {
+      sessionTimingService.handleStreamAbort(data);
+      // Aborted turns persist their spend before this event fires (same async
+      // chain): normal aborts commit the usage-stamped partial to chat.jsonl
+      // (or the headless sidecar for non-commit-worthy partials); abandoned
+      // aborts (edit/discard) write only the sidecar. Ingest both, or the
+      // interrupted turn's spend stays out of dashboards until the next
+      // stream-end.
+      ingestWorkspaceAnalytics(data.workspaceId);
+    });
+    // Errored turns whose partial would be dropped at commit time route their
+    // usage to the headless sidecar (persistStreamError). The sidecar write
+    // precedes this event in the same async chain, so ingest here keeps the
+    // dashboard current instead of waiting for the next stream or restart.
+    aiService.on("error", (data: ErrorEvent) => {
+      ingestWorkspaceAnalytics(data.workspaceId);
+    });
+  })
+);
+
+// ---------------------------------------------------------------------------
+// Staged composition (the group DAG). Base groups are true siblings: none of
+// their constructors takes another desktop service (audited per constructor;
+// only `CoderOauthService` subscribes to a collaborator — the core
+// ProviderService — in its constructor, and the two token managers start their
+// own unref'd cleanup intervals). OAuth and the workers need base services.
+// ---------------------------------------------------------------------------
+
+const DesktopBase = Layer.mergeAll(
+  MiscDesktopLive,
+  BrowserLive,
+  DesktopBridgeLive,
+  TerminalEditorLive
+);
+const DesktopUpper = Layer.mergeAll(OauthLive, WorkersLive).pipe(Layer.provideMerge(DesktopBase));
+
+/**
+ * Every desktop-only service, wired. Built above the core graph: it needs the
+ * stores, the runtime's `EffectRunner`, the cross-cutting services and every
+ * core tag (`AppLive` in ./app.ts provides them beneath).
+ */
+export const DesktopLive: Layer.Layer<
+  DesktopTags,
+  never,
+  StoreTags | EffectRunnerTag | CrossCuttingTags | CoreTags
+> = DesktopWiringLive.pipe(Layer.provideMerge(DesktopUpper));

--- a/src/node/services/di/tags.ts
+++ b/src/node/services/di/tags.ts
@@ -19,33 +19,71 @@ import type {
   SecretsStore,
   WorkspaceSessionLocator,
 } from "@/node/config";
+import type { AgentPluginInstallService } from "@/node/services/agentPlugins/installService";
+import type { AgentStatusService } from "@/node/services/agentStatusService";
 import type { AIService } from "@/node/services/aiService";
 import type { AnalyticsService } from "@/node/services/analytics/analyticsService";
 import type { BackgroundProcessManager } from "@/node/services/backgroundProcessManager";
+import type { BackupService } from "@/node/services/backup/backupService";
+import type { AgentBrowserSessionDiscoveryService } from "@/node/services/browser/AgentBrowserSessionDiscoveryService";
+import type { BrowserBridgeServer } from "@/node/services/browser/BrowserBridgeServer";
+import type { BrowserBridgeTokenManager } from "@/node/services/browser/BrowserBridgeTokenManager";
+import type { BrowserControlService } from "@/node/services/browser/BrowserControlService";
+import type { BrowserSessionStateHub } from "@/node/services/browser/BrowserSessionStateHub";
+import type { CoderOauthService } from "@/node/services/coderOauthService";
+import type { CoderService } from "@/node/services/coderService";
+import type { CodexOauthService } from "@/node/services/codexOauthService";
+import type { CopilotOauthService } from "@/node/services/copilotOauthService";
+import type { DesktopBridgeServer } from "@/node/services/desktop/DesktopBridgeServer";
+import type { DesktopSessionManager } from "@/node/services/desktop/DesktopSessionManager";
+import type { DesktopTokenManager } from "@/node/services/desktop/DesktopTokenManager";
 import type { DevToolsService } from "@/node/services/devToolsService";
+import type { EditorService } from "@/node/services/editorService";
 import type { ExperimentsService } from "@/node/services/experimentsService";
 import type { ExtensionMetadataService } from "@/node/services/ExtensionMetadataService";
+import type { HeartbeatService } from "@/node/services/heartbeatService";
 import type { HistoryService } from "@/node/services/historyService";
+import type { IdleCompactionService } from "@/node/services/idleCompactionService";
 import type { IdleDispatcher } from "@/node/services/idleDispatcher";
 import type { InitStateManager } from "@/node/services/initStateManager";
+import type { InstructionsService } from "@/node/services/instructionsService";
 import type { MCPConfigService } from "@/node/services/mcpConfigService";
+import type { McpOauthService } from "@/node/services/mcpOauthService";
 import type { MCPServerManager } from "@/node/services/mcpServerManager";
 import type { MemoryConsolidationService } from "@/node/services/memoryConsolidationService";
 import type { MemoryMetaService } from "@/node/services/memoryMeta";
 import type { MemoryService } from "@/node/services/memoryService";
+import type { MenuEventService } from "@/node/services/menuEventService";
+import type { MuxGatewayOauthService } from "@/node/services/muxGatewayOauthService";
+import type { MuxGovernorOauthService } from "@/node/services/muxGovernorOauthService";
 import type { PolicyService } from "@/node/services/policyService";
+import type { ProjectService } from "@/node/services/projectService";
 import type { ProviderService } from "@/node/services/providerService";
+import type { QuickJSRuntimeFactory } from "@/node/services/ptc/quickjsRuntime";
+import type { PTYService } from "@/node/services/ptyService";
+import type { RefineService } from "@/node/services/refinement/refineService";
+import type { ServerAuthService } from "@/node/services/serverAuthService";
+import type { ServerService } from "@/node/services/serverService";
 import type { SessionTimingService } from "@/node/services/sessionTimingService";
 import type { SessionUsageService } from "@/node/services/sessionUsageService";
+import type { SshPromptService } from "@/node/services/sshPromptService";
 import type { StreamManager } from "@/node/services/streamManager";
 import type { TaskService } from "@/node/services/taskService";
 import type { TelemetryService } from "@/node/services/telemetryService";
 import type { TerminalAttentionStore } from "@/node/services/terminalAttentionStore";
+import type { TerminalService } from "@/node/services/terminalService";
+import type { TimelineService } from "@/node/services/timelineService";
+import type { TokenizerService } from "@/node/services/tokenizerService";
 import type { TurnRequestBuilderBindings } from "@/node/services/turnRequestBuilder";
+import type { UpdateService } from "@/node/services/updateService";
+import type { VoiceService } from "@/node/services/voiceService";
+import type { WindowService } from "@/node/services/windowService";
 import type { WorkspaceGoalService } from "@/node/services/workspaceGoalService";
+import type { WorkspaceLifecycleHooks } from "@/node/services/workspaceLifecycleHooks";
 import type { WorkspaceMcpOverridesService } from "@/node/services/workspaceMcpOverridesService";
 import type { WorkspaceService } from "@/node/services/workspaceService";
 import type { WorkspaceTurnManager } from "@/node/services/workspaceTurnManager";
+import type { WorktreeArchiveSnapshotService } from "@/node/services/worktreeArchiveSnapshotService";
 import type { AppFiberScopeTag } from "./appFiberScope";
 import type { EffectRunnerTag } from "./effectRunner";
 import type { CoreOptionsTag } from "./layers/core";
@@ -142,6 +180,107 @@ export class WorkspaceMcpOverrides extends Context.Service<
   WorkspaceMcpOverridesService
 >()("xum/WorkspaceMcpOverrides") {}
 
+// Desktop/server-only services (`DesktopLive` group layers in ./layers/desktop.ts).
+// Browser automation bridge.
+export class BrowserBridgeTokenManagerTag extends Context.Service<
+  BrowserBridgeTokenManagerTag,
+  BrowserBridgeTokenManager
+>()("xum/BrowserBridgeTokenManager") {}
+export class AgentBrowserSessionDiscovery extends Context.Service<
+  AgentBrowserSessionDiscovery,
+  AgentBrowserSessionDiscoveryService
+>()("xum/AgentBrowserSessionDiscovery") {}
+export class BrowserControl extends Context.Service<BrowserControl, BrowserControlService>()(
+  "xum/BrowserControl"
+) {}
+export class BrowserSessionStateHubTag extends Context.Service<
+  BrowserSessionStateHubTag,
+  BrowserSessionStateHub
+>()("xum/BrowserSessionStateHub") {}
+export class BrowserBridgeServerTag extends Context.Service<
+  BrowserBridgeServerTag,
+  BrowserBridgeServer
+>()("xum/BrowserBridgeServer") {}
+// Desktop companion bridge.
+export class DesktopSessionManagerTag extends Context.Service<
+  DesktopSessionManagerTag,
+  DesktopSessionManager
+>()("xum/DesktopSessionManager") {}
+export class DesktopTokenManagerTag extends Context.Service<
+  DesktopTokenManagerTag,
+  DesktopTokenManager
+>()("xum/DesktopTokenManager") {}
+export class DesktopBridgeServerTag extends Context.Service<
+  DesktopBridgeServerTag,
+  DesktopBridgeServer
+>()("xum/DesktopBridgeServer") {}
+// Terminal, editor and token budgeting.
+export class PTY extends Context.Service<PTY, PTYService>()("xum/PTY") {}
+export class Terminal extends Context.Service<Terminal, TerminalService>()("xum/Terminal") {}
+export class Editor extends Context.Service<Editor, EditorService>()("xum/Editor") {}
+export class Tokenizer extends Context.Service<Tokenizer, TokenizerService>()("xum/Tokenizer") {}
+export class Instructions extends Context.Service<Instructions, InstructionsService>()(
+  "xum/Instructions"
+) {}
+// Leaves and the remaining desktop services.
+/** `WindowTag`: the bare name would shadow the DOM `Window` global. */
+export class WindowTag extends Context.Service<WindowTag, WindowService>()("xum/Window") {}
+export class SshPrompt extends Context.Service<SshPrompt, SshPromptService>()("xum/SshPrompt") {}
+export class QuickJSRuntimeFactoryTag extends Context.Service<
+  QuickJSRuntimeFactoryTag,
+  QuickJSRuntimeFactory
+>()("xum/QuickJSRuntimeFactory") {}
+export class Backup extends Context.Service<Backup, BackupService>()("xum/Backup") {}
+export class AgentPluginInstall extends Context.Service<
+  AgentPluginInstall,
+  AgentPluginInstallService
+>()("xum/AgentPluginInstall") {}
+export class Project extends Context.Service<Project, ProjectService>()("xum/Project") {}
+export class Update extends Context.Service<Update, UpdateService>()("xum/Update") {}
+export class Server extends Context.Service<Server, ServerService>()("xum/Server") {}
+export class MenuEvent extends Context.Service<MenuEvent, MenuEventService>()("xum/MenuEvent") {}
+export class Voice extends Context.Service<Voice, VoiceService>()("xum/Voice") {}
+/** The module singleton `coderService`, provided under a tag like every other field. */
+export class Coder extends Context.Service<Coder, CoderService>()("xum/Coder") {}
+export class ServerAuth extends Context.Service<ServerAuth, ServerAuthService>()(
+  "xum/ServerAuth"
+) {}
+export class WorkspaceLifecycleHooksTag extends Context.Service<
+  WorkspaceLifecycleHooksTag,
+  WorkspaceLifecycleHooks
+>()("xum/WorkspaceLifecycleHooks") {}
+export class WorktreeArchiveSnapshot extends Context.Service<
+  WorktreeArchiveSnapshot,
+  WorktreeArchiveSnapshotService
+>()("xum/WorktreeArchiveSnapshot") {}
+// OAuth flows (all need the WindowService for the browser hand-off).
+export class McpOauth extends Context.Service<McpOauth, McpOauthService>()("xum/McpOauth") {}
+export class MuxGatewayOauth extends Context.Service<MuxGatewayOauth, MuxGatewayOauthService>()(
+  "xum/MuxGatewayOauth"
+) {}
+export class MuxGovernorOauth extends Context.Service<MuxGovernorOauth, MuxGovernorOauthService>()(
+  "xum/MuxGovernorOauth"
+) {}
+export class CodexOauth extends Context.Service<CodexOauth, CodexOauthService>()(
+  "xum/CodexOauth"
+) {}
+export class CoderOauth extends Context.Service<CoderOauth, CoderOauthService>()(
+  "xum/CoderOauth"
+) {}
+export class CopilotOauth extends Context.Service<CopilotOauth, CopilotOauthService>()(
+  "xum/CopilotOauth"
+) {}
+// Clock-driven workers and the timeline/refine pair they record into.
+export class IdleCompaction extends Context.Service<IdleCompaction, IdleCompactionService>()(
+  "xum/IdleCompaction"
+) {}
+export class Heartbeat extends Context.Service<Heartbeat, HeartbeatService>()("xum/Heartbeat") {}
+export class Timeline extends Context.Service<Timeline, TimelineService>()("xum/Timeline") {}
+export class Refine extends Context.Service<Refine, RefineService>()("xum/Refine") {}
+export class AgentStatus extends Context.Service<AgentStatus, AgentStatusService>()(
+  "xum/AgentStatus"
+) {}
+
 /** The process's config stores (`ConfigStores`), one tag per store. */
 export type StoreTags =
   | ConfigTag
@@ -203,5 +342,48 @@ export type CrossCuttingTags =
   | DevTools
   | WorkspaceMcpOverrides;
 
+/** The desktop-only services provided by the `DesktopLive` group layers, by group. */
+export type BrowserTags =
+  | BrowserBridgeTokenManagerTag
+  | AgentBrowserSessionDiscovery
+  | BrowserControl
+  | BrowserSessionStateHubTag
+  | BrowserBridgeServerTag;
+export type DesktopBridgeTags =
+  | DesktopSessionManagerTag
+  | DesktopTokenManagerTag
+  | DesktopBridgeServerTag;
+export type TerminalEditorTags = PTY | Terminal | Editor | Tokenizer | Instructions;
+export type MiscDesktopTags =
+  | WindowTag
+  | SshPrompt
+  | QuickJSRuntimeFactoryTag
+  | Backup
+  | AgentPluginInstall
+  | Project
+  | Update
+  | Server
+  | MenuEvent
+  | Voice
+  | Coder
+  | ServerAuth
+  | WorkspaceLifecycleHooksTag
+  | WorktreeArchiveSnapshot;
+export type OauthTags =
+  | McpOauth
+  | MuxGatewayOauth
+  | MuxGovernorOauth
+  | CodexOauth
+  | CoderOauth
+  | CopilotOauth;
+export type WorkerTags = IdleCompaction | Heartbeat | Timeline | Refine | AgentStatus;
+export type DesktopTags =
+  | BrowserTags
+  | DesktopBridgeTags
+  | TerminalEditorTags
+  | MiscDesktopTags
+  | OauthTags
+  | WorkerTags;
+
 /** Every service the desktop/server app graph (`AppLive`) provides. */
-export type AppTags = CoreRootTags | CrossCuttingTags;
+export type AppTags = CoreRootTags | CrossCuttingTags | DesktopTags;

--- a/src/node/services/retryManager.ts
+++ b/src/node/services/retryManager.ts
@@ -67,9 +67,9 @@ export class RetryManager {
     private readonly onStatusChange: (event: RetryStatusEvent) => void,
     /**
      * Runs the retry fiber fork and its interrupt. The global runtime by
-     * default (the streamManager call site keeps it until the runtime seam
-     * reaches StreamManager); a context-bound runner puts the backoff sleep on
-     * the runtime's `Clock` — a `TestClock` in tests.
+     * default (direct construction in tests); AgentSession passes its stream
+     * manager's runner, so the backoff sleep shares the stream's `Clock` — the
+     * app runtime's in production, a `TestClock` in tests.
      */
     private readonly runner: EffectRunner = defaultEffectRunner
   ) {

--- a/src/node/services/serviceContainer.test.ts
+++ b/src/node/services/serviceContainer.test.ts
@@ -6,36 +6,147 @@ import { Context, Duration, Effect, Layer } from "effect";
 import { TestClock } from "effect/testing";
 import { MULTI_PROJECT_CONFIG_KEY } from "@/common/constants/multiProject";
 import { createConfigStores, type Config, type ConfigStores } from "@/node/config";
+import type { ORPCContext } from "@/node/orpc/context";
+import { isInteractiveHostKeyApprovalAvailable } from "@/node/runtime/sshConnectionPool";
 import { AppFiberScopeTag } from "@/node/services/di/appFiberScope";
 import { EffectRunnerTag } from "@/node/services/di/effectRunner";
 import * as appLayers from "@/node/services/di/layers/app";
 import { CoreOptionsTag } from "@/node/services/di/layers/core";
 import {
+  AgentBrowserSessionDiscovery,
+  AgentPluginInstall,
   AI,
   Analytics,
+  Backup,
+  BrowserBridgeServerTag,
+  BrowserBridgeTokenManagerTag,
+  BrowserControl,
+  BrowserSessionStateHubTag,
+  Coder,
+  CoderOauth,
+  CodexOauth,
+  ConfigTag,
+  CopilotOauth,
+  DesktopBridgeServerTag,
+  DesktopSessionManagerTag,
+  DesktopTokenManagerTag,
   DevTools,
+  Editor,
   Experiments,
+  FileLeaseManagerTag,
+  History,
   IdleDispatcherTag,
   InitStateManagerTag,
+  Instructions,
   MCPConfig,
+  McpOauth,
   MCPServerManagerTag,
   Memory,
   MemoryConsolidation,
   MemoryMeta,
+  MenuEvent,
+  MuxGatewayOauth,
+  MuxGovernorOauth,
   Policy,
+  Project,
   Provider,
+  ProvidersConfigStoreTag,
+  QuickJSRuntimeFactoryTag,
+  Refine,
+  SecretsStoreTag,
+  Server,
+  ServerAuth,
+  SessionLocatorTag,
   SessionTiming,
   SessionUsage,
+  SshPrompt,
   StreamManagerTag,
   Task,
   Telemetry,
+  Terminal,
+  Timeline,
+  Tokenizer,
+  TurnRequestBuilderBindingsTag,
+  Update,
+  Voice,
+  WindowTag,
   Workspace,
   WorkspaceGoal,
+  WorkspaceLifecycleHooksTag,
   WorkspaceMcpOverrides,
-  WorkspaceTurnManagerTag,
+  WorktreeArchiveSnapshot,
   type AppTags,
 } from "@/node/services/di/tags";
 import { ServiceContainer } from "./serviceContainer";
+
+/**
+ * Independent field → tag listing for every ORPC context field (the production
+ * mapping lives in the Layer files); `Record<keyof …>` keeps it exhaustive, so
+ * a field added to `ORPCContext` without a tag fails to compile here.
+ */
+const ORPC_FIELD_TAGS: Record<
+  keyof Omit<ORPCContext, "headers" | "effect/context" | "effect/wrap">,
+  Context.Key<AppTags, unknown>
+> = {
+  config: ConfigTag,
+  sessionLocator: SessionLocatorTag,
+  providersConfigStore: ProvidersConfigStoreTag,
+  secretsStore: SecretsStoreTag,
+  fileLeaseManager: FileLeaseManagerTag,
+  aiService: AI,
+  historyService: History,
+  streamManager: StreamManagerTag,
+  initStateManager: InitStateManagerTag,
+  projectService: Project,
+  workspaceService: Workspace,
+  taskService: Task,
+  providerService: Provider,
+  muxGatewayOauthService: MuxGatewayOauth,
+  muxGovernorOauthService: MuxGovernorOauth,
+  codexOauthService: CodexOauth,
+  coderOauthService: CoderOauth,
+  copilotOauthService: CopilotOauth,
+  backupService: Backup,
+  terminalService: Terminal,
+  editorService: Editor,
+  windowService: WindowTag,
+  updateService: Update,
+  tokenizerService: Tokenizer,
+  serverService: Server,
+  menuEventService: MenuEvent,
+  voiceService: Voice,
+  mcpConfigService: MCPConfig,
+  mcpOauthService: McpOauth,
+  workspaceMcpOverridesService: WorkspaceMcpOverrides,
+  mcpServerManager: MCPServerManagerTag,
+  agentPluginInstallService: AgentPluginInstall,
+  sessionTimingService: SessionTiming,
+  timelineService: Timeline,
+  telemetryService: Telemetry,
+  experimentsService: Experiments,
+  memoryService: Memory,
+  memoryMetaService: MemoryMeta,
+  memoryConsolidationService: MemoryConsolidation,
+  refineService: Refine,
+  sessionUsageService: SessionUsage,
+  instructionsService: Instructions,
+  workspaceGoalService: WorkspaceGoal,
+  devToolsService: DevTools,
+  browserSessionDiscoveryService: AgentBrowserSessionDiscovery,
+  browserBridgeTokenManager: BrowserBridgeTokenManagerTag,
+  browserBridgeServer: BrowserBridgeServerTag,
+  browserControlService: BrowserControl,
+  browserSessionStateHub: BrowserSessionStateHubTag,
+  policyService: Policy,
+  coderService: Coder,
+  serverAuthService: ServerAuth,
+  sshPromptService: SshPrompt,
+  analyticsService: Analytics,
+  desktopSessionManager: DesktopSessionManagerTag,
+  desktopTokenManager: DesktopTokenManagerTag,
+  desktopBridgeServer: DesktopBridgeServerTag,
+  workflowRuntimeFactory: QuickJSRuntimeFactoryTag,
+};
 
 describe("ServiceContainer", () => {
   let tempDir: string;
@@ -283,42 +394,155 @@ describe("ServiceContainer", () => {
     services.idleCompactionService.stop();
   });
 
-  it("serves the layer-built core and cross-cutting services through the fields and the Effect context", () => {
+  it("serves every ORPC context field through its tag (one instance each)", () => {
     services = new ServiceContainer(stores);
-    const effectContext = services.toORPCContext()["effect/context"];
+    const orpcContext = services.toORPCContext();
+    const effectContext = orpcContext["effect/context"];
 
-    const fieldTags: Array<[keyof ServiceContainer, Context.Key<AppTags, unknown>]> = [
-      ["aiService", AI],
-      ["streamManager", StreamManagerTag],
-      ["initStateManager", InitStateManagerTag],
-      ["workspaceService", Workspace],
-      ["taskService", Task],
-      ["workspaceTurnManager", WorkspaceTurnManagerTag],
-      ["providerService", Provider],
-      ["mcpConfigService", MCPConfig],
-      ["mcpServerManager", MCPServerManagerTag],
-      ["sessionUsageService", SessionUsage],
-      ["workspaceGoalService", WorkspaceGoal],
-      ["memoryService", Memory],
-      ["memoryMetaService", MemoryMeta],
-      ["memoryConsolidationService", MemoryConsolidation],
-      ["idleDispatcher", IdleDispatcherTag],
-      ["policyService", Policy],
-      ["telemetryService", Telemetry],
-      ["experimentsService", Experiments],
-      ["sessionTimingService", SessionTiming],
-      ["analyticsService", Analytics],
-      ["devToolsService", DevTools],
-      ["workspaceMcpOverridesService", WorkspaceMcpOverrides],
-    ];
-    for (const [field, tag] of fieldTags) {
-      expect(Context.get(effectContext, tag)).toBe(services[field]);
+    for (const [field, tag] of Object.entries(ORPC_FIELD_TAGS) as Array<
+      [keyof typeof ORPC_FIELD_TAGS, Context.Key<AppTags, unknown>]
+    >) {
+      expect(Context.get(effectContext, tag)).toBe(orpcContext[field]);
     }
+    expect(services.runtime.get(IdleDispatcherTag)).toBe(services.idleDispatcher);
+    expect(services.runtime.get(StreamManagerTag).effectRunner).toBe(
+      services.runtime.get(EffectRunnerTag)
+    );
     // The core graph's options are derived from the layer-built cross-cutting
     // instances, so core constructors received the same objects the fields expose.
     const coreOptions = services.runtime.get(CoreOptionsTag);
     expect(coreOptions.policyService).toBe(services.policyService);
     expect(coreOptions.experimentsService).toBe(services.experimentsService);
+  });
+
+  it("wires the desktop services like the constructor did (each line has an observable effect)", () => {
+    services = new ServiceContainer(stores);
+
+    // turnRequestBuilderBindings: the desktop-only collaborators.
+    const bindings = services.runtime.get(TurnRequestBuilderBindingsTag);
+    expect(bindings.analyticsService).toBe(services.analyticsService);
+    expect(bindings.desktopSessionManager).toBe(services.desktopSessionManager);
+    expect(bindings.timelineService).toBe(services.timelineService);
+    expect(bindings.codexOauthService).toBe(services.codexOauthService);
+    expect(bindings.coderOauthService).toBe(services.coderOauthService);
+
+    // Setter-provided collaborators (the former `set*` lines).
+    const workspaceInternals = services.workspaceService as unknown as {
+      terminalService?: unknown;
+      desktopSessionManager?: unknown;
+      refinePassCanceller?: unknown;
+      timelineRecorder?: unknown;
+      worktreeArchiveSnapshotService?: unknown;
+      workspaceLifecycleHooks?: unknown;
+    };
+    expect(workspaceInternals.terminalService).toBe(services.terminalService);
+    expect(workspaceInternals.desktopSessionManager).toBe(services.desktopSessionManager);
+    expect(workspaceInternals.refinePassCanceller).toBe(services.refineService);
+    expect(workspaceInternals.timelineRecorder).toBe(services.timelineService);
+    expect(workspaceInternals.worktreeArchiveSnapshotService).toBe(
+      services.runtime.get(WorktreeArchiveSnapshot)
+    );
+    expect(workspaceInternals.workspaceLifecycleHooks).toBe(
+      services.runtime.get(WorkspaceLifecycleHooksTag)
+    );
+    for (const recorderOwner of [
+      services.taskService,
+      services.heartbeatService,
+      services.workspaceGoalService,
+    ]) {
+      expect((recorderOwner as unknown as { timelineRecorder?: unknown }).timelineRecorder).toBe(
+        services.timelineService
+      );
+    }
+    const projectInternals = services.projectService as unknown as {
+      workspaceService?: unknown;
+      workspaceMetadataRefresher?: unknown;
+      mcpServerManager?: unknown;
+    };
+    expect(projectInternals.workspaceService).toBe(services.workspaceService);
+    expect(projectInternals.workspaceMetadataRefresher).toBe(services.workspaceService);
+    expect(projectInternals.mcpServerManager).toBe(services.mcpServerManager);
+    expect(
+      (services.mcpServerManager as unknown as { mcpOauthService?: unknown }).mcpOauthService
+    ).toBe(services.mcpOauthService);
+    const backupInternals = services.backupService as unknown as {
+      projectRegistrar?: unknown;
+      memoryNotifier?: unknown;
+    };
+    expect(backupInternals.projectRegistrar).toBe(services.projectService);
+    expect(backupInternals.memoryNotifier).toBe(services.memoryService);
+
+    // Idle-compaction outcomes reach the idle compaction service.
+    const recordOutcomeSpy = spyOn(services.idleCompactionService, "recordOutcome");
+    const outcomeListener = (
+      services.workspaceService as unknown as {
+        idleCompactionOutcomeListener?: (workspaceId: string, outcome: unknown) => void;
+      }
+    ).idleCompactionOutcomeListener;
+    outcomeListener?.("ws-1", { success: true });
+    expect(recordOutcomeSpy).toHaveBeenCalledWith("ws-1", { success: true });
+
+    // Global registrations: the SSH connection pools consult this container's
+    // prompt service for interactive host-key approval.
+    const responderSpy = spyOn(services.sshPromptService, "hasInteractiveResponder");
+    responderSpy.mockReturnValue(true);
+    expect(isInteractiveHostKeyApprovalAvailable()).toBe(true);
+    responderSpy.mockReturnValue(false);
+    expect(isInteractiveHostKeyApprovalAvailable()).toBe(false);
+
+    // Timeline subscribed to the workspace service, and the workers' timing
+    // listeners registered: a stream-start reaches the session timing service.
+    const timingSpy = spyOn(services.sessionTimingService, "handleStreamStart").mockImplementation(
+      () => undefined
+    );
+    services.aiService.emit("stream-start", {
+      type: "stream-start",
+      workspaceId: "ws-1",
+      messageId: "m-1",
+      model: "openai:gpt-4o",
+      historySequence: 1,
+      startTime: Date.now(),
+      mode: "exec",
+    });
+    expect(timingSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("tears down in the fixed dispose() and shutdown() order", async () => {
+    const order: string[] = [];
+    const record = (step: string) => () => {
+      order.push(step);
+      return Promise.resolve(undefined);
+    };
+    services = new ServiceContainer(stores);
+    spyOn(services.desktopBridgeServer, "stop").mockImplementation(record("bridge.stop"));
+    spyOn(services.desktopSessionManager, "closeAll").mockImplementation(
+      record("sessions.closeAll")
+    );
+    spyOn(services.browserBridgeServer, "stop").mockImplementation(record("browserBridge.stop"));
+    spyOn(services.analyticsService, "dispose").mockImplementation(record("analytics.dispose"));
+    spyOn(services.timelineService, "flush").mockImplementation(record("timeline.flush"));
+    spyOn(services.telemetryService, "shutdown").mockImplementation(record("telemetry.shutdown"));
+
+    await services.dispose();
+    // §5: bridge before sessions; browser bridge before analytics; timeline flush last.
+    expect(order).toEqual([
+      "bridge.stop",
+      "sessions.closeAll",
+      "browserBridge.stop",
+      "analytics.dispose",
+      "timeline.flush",
+    ]);
+
+    order.length = 0;
+    await services.shutdown();
+    expect(order).toEqual([
+      "bridge.stop",
+      "sessions.closeAll",
+      "browserBridge.stop",
+      "timeline.flush",
+      "analytics.dispose",
+      "telemetry.shutdown",
+    ]);
   });
 
   it("surfaces a throwing layer as a synchronous constructor throw", () => {

--- a/src/node/services/serviceContainer.ts
+++ b/src/node/services/serviceContainer.ts
@@ -1,85 +1,51 @@
-import * as path from "path";
-import { DEFAULT_CODER_ARCHIVE_BEHAVIOR } from "@/common/config/coderArchiveBehavior";
-import { DEFAULT_WORKTREE_ARCHIVE_BEHAVIOR } from "@/common/config/worktreeArchiveBehavior";
 import { log } from "@/node/services/log";
 import type { Config, ConfigStores, WorkspaceSessionLocator } from "@/node/config";
 import type { FileLeaseManager, ProvidersConfigStore, SecretsStore } from "@/node/config";
 import type { CoreServices } from "@/node/services/coreServices";
-import { PTYService } from "@/node/services/ptyService";
 import type { TerminalWindowManager } from "@/desktop/terminalWindowManager";
-import { ProjectService } from "@/node/services/projectService";
-import { MuxGatewayOauthService } from "@/node/services/muxGatewayOauthService";
-import { MuxGovernorOauthService } from "@/node/services/muxGovernorOauthService";
-import { CodexOauthService } from "@/node/services/codexOauthService";
-import { CoderOauthService } from "@/node/services/coderOauthService";
-import { CopilotOauthService } from "@/node/services/copilotOauthService";
-import { TerminalService } from "@/node/services/terminalService";
-import { BackupService } from "@/node/services/backup/backupService";
-import { createBackupGitRepo, createBackupPayloadStore } from "@/node/services/backup/adapters";
-import { EditorService } from "@/node/services/editorService";
-import { WindowService } from "@/node/services/windowService";
-import { UpdateService } from "@/node/services/updateService";
-import { TokenizerService } from "@/node/services/tokenizerService";
-import { InstructionsService } from "@/node/services/instructionsService";
-import { ServerService } from "@/node/services/serverService";
-import { MenuEventService } from "@/node/services/menuEventService";
-import { VoiceService } from "@/node/services/voiceService";
+import type { ProjectService } from "@/node/services/projectService";
+import type { MuxGatewayOauthService } from "@/node/services/muxGatewayOauthService";
+import type { MuxGovernorOauthService } from "@/node/services/muxGovernorOauthService";
+import type { CodexOauthService } from "@/node/services/codexOauthService";
+import type { CoderOauthService } from "@/node/services/coderOauthService";
+import type { CopilotOauthService } from "@/node/services/copilotOauthService";
+import type { TerminalService } from "@/node/services/terminalService";
+import type { BackupService } from "@/node/services/backup/backupService";
+import type { EditorService } from "@/node/services/editorService";
+import type { WindowService } from "@/node/services/windowService";
+import type { UpdateService } from "@/node/services/updateService";
+import type { TokenizerService } from "@/node/services/tokenizerService";
+import type { InstructionsService } from "@/node/services/instructionsService";
+import type { ServerService } from "@/node/services/serverService";
+import type { MenuEventService } from "@/node/services/menuEventService";
+import type { VoiceService } from "@/node/services/voiceService";
 import type { TelemetryService } from "@/node/services/telemetryService";
-import type {
-  ErrorEvent,
-  ReasoningDeltaEvent,
-  StreamAbortEvent,
-  StreamDeltaEvent,
-  StreamEndEvent,
-  StreamStartEvent,
-  ToolCallDeltaEvent,
-  ToolCallEndEvent,
-  ToolCallStartEvent,
-} from "@/common/types/stream";
-import { BrowserBridgeServer } from "@/node/services/browser/BrowserBridgeServer";
-import { AgentBrowserSessionDiscoveryService } from "@/node/services/browser/AgentBrowserSessionDiscoveryService";
-import { BrowserBridgeTokenManager } from "@/node/services/browser/BrowserBridgeTokenManager";
-import { BrowserControlService } from "@/node/services/browser/BrowserControlService";
-import { BrowserSessionStateHub } from "@/node/services/browser/BrowserSessionStateHub";
+import type { BrowserBridgeServer } from "@/node/services/browser/BrowserBridgeServer";
+import type { AgentBrowserSessionDiscoveryService } from "@/node/services/browser/AgentBrowserSessionDiscoveryService";
+import type { BrowserBridgeTokenManager } from "@/node/services/browser/BrowserBridgeTokenManager";
+import type { BrowserControlService } from "@/node/services/browser/BrowserControlService";
+import type { BrowserSessionStateHub } from "@/node/services/browser/BrowserSessionStateHub";
 import type { DevToolsService } from "@/node/services/devToolsService";
 import type { SessionTimingService } from "@/node/services/sessionTimingService";
-import { TimelineService } from "@/node/services/timelineService";
-import type {
-  AnalyticsService,
-  IngestWorkspaceMeta,
-} from "@/node/services/analytics/analyticsService";
+import type { TimelineService } from "@/node/services/timelineService";
+import type { AnalyticsService } from "@/node/services/analytics/analyticsService";
 import type { ExperimentsService } from "@/node/services/experimentsService";
 import type { WorkspaceMcpOverridesService } from "@/node/services/workspaceMcpOverridesService";
-import { AgentPluginInstallService } from "@/node/services/agentPlugins/installService";
-import { EXPERIMENT_IDS } from "@/common/constants/experiments";
-import { McpOauthService } from "@/node/services/mcpOauthService";
-import { HeartbeatService } from "@/node/services/heartbeatService";
-import { AgentStatusService } from "@/node/services/agentStatusService";
-import { IdleCompactionService } from "@/node/services/idleCompactionService";
+import type { AgentPluginInstallService } from "@/node/services/agentPlugins/installService";
+import type { McpOauthService } from "@/node/services/mcpOauthService";
+import type { HeartbeatService } from "@/node/services/heartbeatService";
+import type { AgentStatusService } from "@/node/services/agentStatusService";
+import type { IdleCompactionService } from "@/node/services/idleCompactionService";
 import type { IdleDispatcher } from "@/node/services/idleDispatcher";
-import { coderService, type CoderService } from "@/node/services/coderService";
-import { SshPromptService } from "@/node/services/sshPromptService";
-import { WorkspaceLifecycleHooks } from "@/node/services/workspaceLifecycleHooks";
-import { WorktreeArchiveSnapshotService } from "@/node/services/worktreeArchiveSnapshotService";
-import {
-  createCoderArchiveHook,
-  createCoderUnarchiveHook,
-} from "@/node/runtime/coderLifecycleHooks";
-import { createWorktreeArchiveHook } from "@/node/runtime/worktreeLifecycleHooks";
-import { QuickJSRuntimeFactory } from "@/node/services/ptc/quickjsRuntime";
-import { RefineService } from "@/node/services/refinement/refineService";
-import { setGlobalCoderService } from "@/node/runtime/runtimeFactory";
-import { setSshPromptService } from "@/node/runtime/sshConnectionPool";
-import { setSshPromptService as setSSH2SshPromptService } from "@/node/runtime/SSH2ConnectionPool";
-import {
-  createRuntimeForWorkspace,
-  resolveWorkspaceExecutionPath,
-} from "@/node/runtime/runtimeHelpers";
+import type { CoderService } from "@/node/services/coderService";
+import type { SshPromptService } from "@/node/services/sshPromptService";
+import type { QuickJSRuntimeFactory } from "@/node/services/ptc/quickjsRuntime";
+import type { RefineService } from "@/node/services/refinement/refineService";
 import type { PolicyService } from "@/node/services/policyService";
-import { ServerAuthService } from "@/node/services/serverAuthService";
-import { DesktopBridgeServer } from "@/node/services/desktop/DesktopBridgeServer";
-import { DesktopSessionManager } from "@/node/services/desktop/DesktopSessionManager";
-import { DesktopTokenManager } from "@/node/services/desktop/DesktopTokenManager";
+import type { ServerAuthService } from "@/node/services/serverAuthService";
+import type { DesktopBridgeServer } from "@/node/services/desktop/DesktopBridgeServer";
+import type { DesktopSessionManager } from "@/node/services/desktop/DesktopSessionManager";
+import type { DesktopTokenManager } from "@/node/services/desktop/DesktopTokenManager";
 import type { ORPCContext } from "@/node/orpc/context";
 import type { Scope } from "effect";
 import { AppFiberScopeTag } from "@/node/services/di/appFiberScope";
@@ -89,30 +55,85 @@ import {
   makeAppRuntime,
   type AppRuntime,
 } from "@/node/services/di/appRuntime";
-import { EffectRunnerTag } from "@/node/services/di/effectRunner";
 import { AppLive } from "@/node/services/di/layers/app";
-import { coreServicesFromContext } from "@/node/services/di/layers/core";
 import {
+  AgentBrowserSessionDiscovery,
+  AgentPluginInstall,
+  AgentStatus,
+  AI,
   Analytics,
+  BackgroundProcessManagerTag,
+  Backup,
+  BrowserBridgeServerTag,
+  BrowserBridgeTokenManagerTag,
+  BrowserControl,
+  BrowserSessionStateHubTag,
+  Coder,
+  CoderOauth,
+  CodexOauth,
+  ConfigTag,
+  CopilotOauth,
+  DesktopBridgeServerTag,
+  DesktopSessionManagerTag,
+  DesktopTokenManagerTag,
   DevTools,
+  Editor,
   Experiments,
+  ExtensionMetadata,
+  FileLeaseManagerTag,
+  Heartbeat,
+  History,
+  IdleCompaction,
+  IdleDispatcherTag,
+  InitStateManagerTag,
+  Instructions,
+  MCPConfig,
+  McpOauth,
+  MCPServerManagerTag,
+  Memory,
+  MemoryConsolidation,
+  MemoryMeta,
+  MenuEvent,
+  MuxGatewayOauth,
+  MuxGovernorOauth,
   Policy,
+  Project,
+  Provider,
+  ProvidersConfigStoreTag,
+  QuickJSRuntimeFactoryTag,
+  Refine,
+  SecretsStoreTag,
+  Server,
+  ServerAuth,
+  SessionLocatorTag,
   SessionTiming,
+  SessionUsage,
+  SshPrompt,
+  StreamManagerTag,
+  Task,
   Telemetry,
+  Terminal,
+  Timeline,
+  Tokenizer,
+  Update,
+  Voice,
+  WindowTag,
+  Workspace,
+  WorkspaceGoal,
   WorkspaceMcpOverrides,
+  WorkspaceTurnManagerTag,
   type AppTags,
 } from "@/node/services/di/tags";
 /**
  * ServiceContainer - Central dependency container for all backend services.
  *
- * This class instantiates and wires together all services needed by the ORPC router.
- * Services are accessed via the ORPC context object.
- *
- * Services provided by the Effect Layer graph (`di/layers/app.ts`: the stores,
- * the runtime seams, the cross-cutting services and the whole core graph) are
- * built first by `runtime` and handed to the constructor-wired desktop
- * remainder; the migration moves services into the graph incrementally (see
- * the DI contract in `di/appRuntime.ts`).
+ * Every service is built by the Effect Layer graph (`di/layers/app.ts`: the
+ * stores, the runtime seams, the cross-cutting services, the core graph shared
+ * with the CLI roots, and the desktop group layers with their wiring). The
+ * constructor builds that graph once, eagerly and synchronously, and exposes
+ * the services as plain fields for the ORPC context; startup (`initialize()`)
+ * and the hand-ordered teardown (`dispose()`/`shutdown()`) stay here (DI
+ * contract in `di/appRuntime.ts`).
  */
 export class ServiceContainer {
   public readonly runtime: AppRuntime<AppTags>;
@@ -121,7 +142,7 @@ export class ServiceContainer {
    * Closed early in `dispose()`; no production occupant yet.
    */
   public readonly appFiberScope: Scope.Closeable;
-  public readonly workflowRuntimeFactory = new QuickJSRuntimeFactory();
+  public readonly workflowRuntimeFactory: QuickJSRuntimeFactory;
   public readonly config: Config;
   public readonly sessionLocator: WorkspaceSessionLocator;
   public readonly providersConfigStore: ProvidersConfigStore;
@@ -147,7 +168,7 @@ export class ServiceContainer {
   public readonly refineService: RefineService;
   private readonly extensionMetadata: CoreServices["extensionMetadata"];
   private readonly backgroundProcessManager: CoreServices["backgroundProcessManager"];
-  // Desktop-only services
+  // Desktop-only services (`di/layers/desktop.ts`)
   public readonly projectService: ProjectService;
   public readonly muxGatewayOauthService: MuxGatewayOauthService;
   public readonly muxGovernorOauthService: MuxGovernorOauthService;
@@ -184,8 +205,7 @@ export class ServiceContainer {
   public readonly desktopSessionManager: DesktopSessionManager;
   public readonly desktopTokenManager: DesktopTokenManager;
   public readonly desktopBridgeServer: DesktopBridgeServer;
-  public readonly sshPromptService = new SshPromptService();
-  private readonly ptyService: PTYService;
+  public readonly sshPromptService: SshPromptService;
   public readonly idleCompactionService: IdleCompactionService;
   public readonly idleDispatcher: IdleDispatcher;
   public readonly heartbeatService: HeartbeatService;
@@ -201,421 +221,76 @@ export class ServiceContainer {
   private disposePromise: Promise<void> | null = null;
 
   constructor(stores: ConfigStores) {
-    // Built eagerly and synchronously (a layer body that throws fails the
-    // constructor, like any service constructor) before the constructor-wired
-    // services so layer-provided instances can be passed into them.
+    // Built eagerly and synchronously: a layer body that throws fails the
+    // constructor, like any service constructor did before the graph existed.
     this.runtime = makeAppRuntime(AppLive(stores));
-    this.appFiberScope = this.runtime.get(AppFiberScopeTag);
-    // Clock-driven workers run their lifecycle fibers through the runtime's
-    // context-bound runner (unsupervised; see di/effectRunner.ts).
-    const effectRunner = this.runtime.get(EffectRunnerTag);
-    const config = stores.config;
-    this.config = config;
-    this.sessionLocator = stores.sessionLocator;
-    this.providersConfigStore = stores.providersConfigStore;
-    this.secretsStore = stores.secretsStore;
-    this.fileLeaseManager = stores.fileLeaseManager;
-
-    // Cross-cutting services: layer-built (`CrossCuttingLive`) ahead of the
-    // core graph, whose options derive from them (`CoreOptionsFromDesktopLive`).
-    this.policyService = this.runtime.get(Policy);
-    this.telemetryService = this.runtime.get(Telemetry);
-    this.experimentsService = this.runtime.get(Experiments);
-    this.backupService = new BackupService(config, {
-      gitRepo: createBackupGitRepo({
-        cacheRoot: path.join(config.rootDir, "backup-cache"),
-      }),
-      payload: createBackupPayloadStore({ config }),
-    });
-    this.sessionTimingService = this.runtime.get(SessionTiming);
-    this.analyticsService = this.runtime.get(Analytics);
-    this.devToolsService = this.runtime.get(DevTools);
-    this.browserBridgeTokenManager = new BrowserBridgeTokenManager();
-    this.workspaceMcpOverridesService = this.runtime.get(WorkspaceMcpOverrides);
-
-    // The core graph (shared with the `xum run`/`xum workflow` roots) is built by
-    // `CoreLive`; read it back as the plain object the wiring below uses.
-    const core = coreServicesFromContext(this.runtime.context);
-
-    // Spread core services into class fields
-    this.historyService = core.historyService;
-    this.aiService = core.aiService;
-    this.streamManager = core.streamManager;
-    this.initStateManager = core.initStateManager;
-    core.turnRequestBuilderBindings.analyticsService = this.analyticsService;
-    this.browserSessionDiscoveryService = new AgentBrowserSessionDiscoveryService({
-      resolveWorkspaceCandidatePathsFn: async (workspaceId: string) => {
-        const allWorkspaceMetadata = await config.getAllWorkspaceMetadata();
-        const workspaceMetadata =
-          allWorkspaceMetadata.find((candidate) => candidate.id === workspaceId) ?? null;
-        if (workspaceMetadata == null) {
-          return [];
-        }
-
-        const runtime = createRuntimeForWorkspace(workspaceMetadata);
-        const workspacePath = resolveWorkspaceExecutionPath(workspaceMetadata, runtime);
-        return [workspaceMetadata.projectPath, workspacePath].filter(
-          (candidatePath): candidatePath is string => candidatePath.trim().length > 0
-        );
-      },
-    });
-    this.browserControlService = new BrowserControlService({
-      browserSessionDiscoveryService: this.browserSessionDiscoveryService,
-      resolveSessionEnvFn: () => Promise.resolve(process.env),
-    });
-    this.browserSessionStateHub = new BrowserSessionStateHub({
-      browserControlService: this.browserControlService,
-    });
-    this.browserBridgeServer = new BrowserBridgeServer({
-      browserSessionDiscoveryService: this.browserSessionDiscoveryService,
-      browserBridgeTokenManager: this.browserBridgeTokenManager,
-      browserSessionStateHub: this.browserSessionStateHub,
-    });
-    this.workspaceService = core.workspaceService;
-    this.taskService = core.taskService;
-    this.workspaceTurnManager = core.workspaceTurnManager;
-    this.providerService = core.providerService;
-    this.mcpConfigService = core.mcpConfigService;
-    this.mcpServerManager = core.mcpServerManager;
-    this.sessionUsageService = core.sessionUsageService;
-    this.workspaceGoalService = core.workspaceGoalService;
-    this.memoryService = core.memoryService;
-    this.memoryMetaService = core.memoryMetaService;
-    this.memoryConsolidationService = core.memoryConsolidationService;
-    this.extensionMetadata = core.extensionMetadata;
-    this.backgroundProcessManager = core.backgroundProcessManager;
-
-    // Managed Agent Plugin installer (agent-plugins experiment). Gated on the
-    // backend ExperimentsService exactly like the plugin MCP provider; the
-    // MCP manager dependency lets update/uninstall recycle running plugin
-    // servers whose content changed behind an unchanged command line.
-    this.agentPluginInstallService = new AgentPluginInstallService(config, {
-      isEnabled: () => this.experimentsService.isExperimentEnabled(EXPERIMENT_IDS.AGENT_PLUGINS),
-      mcpServerManager: this.mcpServerManager,
-      workspaceMcpOverridesService: this.workspaceMcpOverridesService,
-    });
-
-    this.projectService = new ProjectService(config, this.sshPromptService, this.secretsStore);
-    this.projectService.setWorkspaceService(this.workspaceService);
-    this.projectService.setWorkspaceMetadataRefresher(this.workspaceService);
-    this.projectService.setMcpServerManager(this.mcpServerManager);
-    // Backup restores register approved project imports through the same create() path the
-    // UI uses; setter injection because BackupService is constructed before ProjectService.
-    this.backupService.setProjectService(this.projectService);
-    // Restored project memory is written directly, so the service announces it through
-    // MemoryService for the memory browser's change subscription.
-    this.backupService.setMemoryNotifier(this.memoryService);
-    this.desktopSessionManager = new DesktopSessionManager({
-      config,
-      experimentsService: this.experimentsService,
-      workspaceService: this.workspaceService,
-    });
-    core.turnRequestBuilderBindings.desktopSessionManager = this.desktopSessionManager;
-    this.desktopTokenManager = new DesktopTokenManager();
-    this.desktopBridgeServer = new DesktopBridgeServer({
-      desktopSessionManager: this.desktopSessionManager,
-      desktopTokenManager: this.desktopTokenManager,
-    });
-
-    // Idle compaction service - auto-compacts workspaces after configured idle period
-    this.idleCompactionService = new IdleCompactionService(
-      config,
-      this.historyService,
-      this.extensionMetadata,
-      (workspaceId) => this.workspaceService.executeIdleCompaction(workspaceId),
-      effectRunner
-    );
-    // Forward terminal idle-compaction outcomes so the loop stops re-attempting a
-    // persistently failing workspace (immediately on model_not_found, otherwise after
-    // two consecutive failures).
-    this.workspaceService.setIdleCompactionOutcomeListener((workspaceId, outcome) =>
-      this.idleCompactionService.recordOutcome(workspaceId, outcome)
-    );
-    // IdleDispatcher + goal continuation bridge are owned by the core graph
-    // so the wiring works for `xum run` too. Share the same dispatcher with
-    // HeartbeatService — its priority ordering ensures an active goal
-    // suppresses background heartbeats.
-    this.idleDispatcher = core.idleDispatcher;
-    this.heartbeatService = new HeartbeatService(
-      config,
-      this.extensionMetadata,
-      this.workspaceService,
-      this.taskService,
-      this.idleDispatcher,
-      effectRunner
-    );
-    this.timelineService = new TimelineService(
-      config,
-      this.historyService,
-      this.experimentsService
-    );
-    // /refine trajectory distillation (RLM r11). Chat emission routes through
-    // WorkspaceService so a live session renders the appended summary row
-    // immediately (the row itself is already durable in chat.jsonl).
-    this.refineService = new RefineService(
-      config,
-      this.memoryService,
-      this.memoryMetaService,
-      this.historyService,
-      this.aiService,
-      this.experimentsService,
-      {
-        timelineService: this.timelineService,
-        sessionUsageService: this.sessionUsageService,
-        emitChatMessage: (workspaceId, message) =>
-          this.workspaceService.emitChatEvent(workspaceId, { ...message, type: "message" }),
-        // r40: refine row publication and apply mutations must not interleave
-        // with a concurrent turn's PREPARING snapshot or split its
-        // user/assistant pair — hold the session's turn-admission block while
-        // they land, failing closed when a turn is active.
-        acquireTurnExclusion: (workspaceId) =>
-          this.workspaceService.acquireIdleTurnExclusion(workspaceId),
-      }
-    );
-    // Removal must be able to abort + drain a running /refine pass before it
-    // deletes the session directory (post-construction wiring: RefineService
-    // is built after WorkspaceService).
-    this.workspaceService.setRefinePassCanceller(this.refineService);
-    this.workspaceService.setTimelineRecorder(this.timelineService);
-    this.taskService.setTimelineRecorder(this.timelineService);
-    this.heartbeatService.setTimelineRecorder(this.timelineService);
-    this.workspaceGoalService.setTimelineRecorder(this.timelineService);
-    core.turnRequestBuilderBindings.timelineService = this.timelineService;
-    this.timelineService.subscribeToWorkspace(this.workspaceService);
-    this.windowService = new WindowService();
-    this.mcpOauthService = new McpOauthService(
-      config,
-      this.mcpConfigService,
-      this.windowService,
-      this.telemetryService
-    );
-    this.mcpServerManager.setMcpOauthService(this.mcpOauthService);
-
-    this.muxGatewayOauthService = new MuxGatewayOauthService(
-      this.providersConfigStore,
-      this.providerService,
-      this.windowService
-    );
-    this.muxGovernorOauthService = new MuxGovernorOauthService(
-      config,
-      this.windowService,
-      this.policyService
-    );
-    this.codexOauthService = new CodexOauthService(
-      this.providersConfigStore,
-      this.providerService,
-      this.windowService
-    );
-    core.turnRequestBuilderBindings.codexOauthService = this.codexOauthService;
-    this.coderOauthService = new CoderOauthService(
-      this.providersConfigStore,
-      this.fileLeaseManager,
-      this.providerService,
-      this.windowService,
-      // Policy-aware: an enforced forcedBaseUrl overrides the deployment URL
-      // for logins, refreshes, and issuer checks.
-      this.policyService
-    );
-    core.turnRequestBuilderBindings.coderOauthService = this.coderOauthService;
-    this.copilotOauthService = new CopilotOauthService(this.providerService, this.windowService);
-    // Terminal services - PTYService is cross-platform
-    this.ptyService = new PTYService();
-    this.terminalService = new TerminalService(config, this.ptyService, this.secretsStore);
-    // Wire terminal service to workspace service for cleanup on removal
-    this.workspaceService.setTerminalService(this.terminalService);
-    this.workspaceService.setDesktopSessionManager(this.desktopSessionManager);
-    // Plugin-override pruning is wired inside the core graph (shared with
-    // headless CLI registration), using this.workspaceMcpOverridesService.
-    // Editor service for opening workspaces in code editors
-    this.editorService = new EditorService(config, this.workspaceService);
-    this.updateService = new UpdateService(this.config);
-    this.tokenizerService = new TokenizerService(
-      this.sessionUsageService,
-      this.aiService,
-      this.providerService
-    );
-    this.instructionsService = new InstructionsService(
-      config,
-      this.aiService,
-      this.tokenizerService
-    );
-    // AgentStatusService depends on tokenizer + window focus state; instantiate
-    // after both are constructed so the small-model status loop can run with
-    // accurate token budgeting and focus-aware cadence.
-    this.agentStatusService = new AgentStatusService(
-      config,
-      this.historyService,
-      this.tokenizerService,
-      this.extensionMetadata,
-      this.workspaceService,
-      this.windowService,
-      this.aiService,
-      // Status generation spends tokens outside StreamManager; give it a cost
-      // telemetry sink so that spend shows up in per-workspace usage, and an
-      // ingest trigger so the headless-usage sidecar reaches dashboard totals
-      // even when the workspace has no further stream activity.
-      {
-        sessionUsageService: this.sessionUsageService,
-        requestAnalyticsIngest: (workspaceId) => {
-          this.workspaceService.emit("analyticsIngest", { workspaceId });
-        },
-      }
-    );
-    this.serverService = new ServerService();
-    this.menuEventService = new MenuEventService();
-    this.voiceService = new VoiceService(
-      config,
-      this.providerService,
-      this.policyService,
-      this.providersConfigStore
-    );
-    this.coderService = coderService;
-
-    this.serverAuthService = new ServerAuthService(config);
-
-    const workspaceLifecycleHooks = new WorkspaceLifecycleHooks();
-    const worktreeArchiveSnapshotService = new WorktreeArchiveSnapshotService(this.config);
-    this.workspaceService.setWorktreeArchiveSnapshotService(worktreeArchiveSnapshotService);
-    const getArchiveBehavior = () =>
-      this.config.loadConfigOrDefault().coderWorkspaceArchiveBehavior ??
-      DEFAULT_CODER_ARCHIVE_BEHAVIOR;
-    workspaceLifecycleHooks.registerBeforeArchive(
-      createCoderArchiveHook({
-        coderService: this.coderService,
-        getArchiveBehavior,
-        // Model-driven archives probe the remote spawn-record layout before stopping a
-        // running Coder workspace: detached jobs surviving an unclean Xum exit live only in
-        // those records, which the host-local crash-orphan scans cannot see.
-        hasUnsettledRemoteBackgroundJobs: async (workspaceMetadata) => {
-          const runtime = createRuntimeForWorkspace(workspaceMetadata);
-          return await this.backgroundProcessManager.hasUnsettledRemoteSpawnRecords(
-            runtime,
-            workspaceMetadata.id
-          );
-        },
-      })
-    );
-    workspaceLifecycleHooks.registerAfterUnarchive(
-      createCoderUnarchiveHook({
-        coderService: this.coderService,
-        getArchiveBehavior,
-      })
-    );
-    const getWorktreeArchiveBehavior = () =>
-      this.config.loadConfigOrDefault().worktreeArchiveBehavior ??
-      DEFAULT_WORKTREE_ARCHIVE_BEHAVIOR;
-    workspaceLifecycleHooks.registerAfterArchive(
-      createWorktreeArchiveHook({ getWorktreeArchiveBehavior })
-    );
-    this.workspaceService.setWorkspaceLifecycleHooks(workspaceLifecycleHooks);
-
-    // Register globally so all createRuntime calls can create CoderSSHRuntime
-    setGlobalCoderService(this.coderService);
-    setSshPromptService(this.sshPromptService);
-    setSSH2SshPromptService(this.sshPromptService);
-
-    // Backend timing stats.
-    this.aiService.on("stream-start", (data: StreamStartEvent) =>
-      this.sessionTimingService.handleStreamStart(data)
-    );
-    this.aiService.on("stream-delta", (data: StreamDeltaEvent) =>
-      this.sessionTimingService.handleStreamDelta(data)
-    );
-    this.aiService.on("reasoning-delta", (data: ReasoningDeltaEvent) =>
-      this.sessionTimingService.handleReasoningDelta(data)
-    );
-    this.aiService.on("tool-call-start", (data: ToolCallStartEvent) =>
-      this.sessionTimingService.handleToolCallStart(data)
-    );
-    this.aiService.on("tool-call-delta", (data: ToolCallDeltaEvent) =>
-      this.sessionTimingService.handleToolCallDelta(data)
-    );
-    this.aiService.on("tool-call-end", (data: ToolCallEndEvent) =>
-      this.sessionTimingService.handleToolCallEnd(data)
-    );
-    // Newly created sub-agent workspaces are ingested here before a full rebuild,
-    // so keep workspaceName + parentWorkspaceId to avoid NULL analytics attribution.
-    // Multi-project workspaces stay stored under _multi in config, but analytics should
-    // still attribute spend to the workspace's first real project path.
-    const ingestWorkspaceAnalytics = (workspaceId: string) => {
-      const workspaceLookup = this.config.findWorkspace(workspaceId);
-      const sessionDir = path.join(this.config.sessionsDir, workspaceId);
-      const analyticsProjectPath =
-        workspaceLookup?.attributionProjectPath ?? workspaceLookup?.projectPath;
-      this.analyticsService.ingestWorkspace(workspaceId, sessionDir, {
-        projectPath: analyticsProjectPath,
-        projectName: analyticsProjectPath ? path.basename(analyticsProjectPath) : undefined,
-        workspaceName: workspaceLookup?.workspaceName,
-        parentWorkspaceId: workspaceLookup?.parentWorkspaceId,
-      });
-    };
-    this.aiService.on("stream-end", (data: StreamEndEvent) => {
-      this.sessionTimingService.handleStreamEnd(data);
-      ingestWorkspaceAnalytics(data.workspaceId);
-    });
-    // Billable usage persisted outside StreamManager stream-end requests its
-    // own incremental ingest pass.
-    this.workspaceService.on("analyticsIngest", (event) => {
-      ingestWorkspaceAnalytics(event.workspaceId);
-    });
-    // Memory consolidation/harvest spend rides the headless-usage sidecar
-    // without any chat activity; ingest promptly so background sweeps reach
-    // dashboard totals instead of stranding until an unrelated stream-end
-    // or app restart.
-    this.memoryConsolidationService.on("analyticsIngest", (event: { workspaceId: string }) => {
-      ingestWorkspaceAnalytics(event.workspaceId);
-    });
-    // WorkspaceService emits metadata:null after successful remove().
-    // Clear analytics rows immediately so deleted workspaces disappear from stats
-    // without waiting for a future ingest pass.
-    this.workspaceService.on("metadata", (event) => {
-      if (event.metadata !== null) {
-        return;
-      }
-
-      // Removed sub-agent children archive their transcript into the parent's
-      // session dir before this event fires. Re-ingest the parent (chained after
-      // the clear) so the child's spend is restored from the archive instead of
-      // vanishing from analytics until the parent's next stream-end.
-      let reingestAfterClear:
-        | { workspaceId: string; sessionDir: string; meta: IngestWorkspaceMeta }
-        | undefined;
-      const parentWorkspaceId = event.removedParentWorkspaceId;
-      if (parentWorkspaceId) {
-        const parentLookup = this.config.findWorkspace(parentWorkspaceId);
-        const parentProjectPath = parentLookup?.attributionProjectPath ?? parentLookup?.projectPath;
-        reingestAfterClear = {
-          workspaceId: parentWorkspaceId,
-          sessionDir: path.join(this.config.sessionsDir, parentWorkspaceId),
-          meta: {
-            projectPath: parentProjectPath,
-            projectName: parentProjectPath ? path.basename(parentProjectPath) : undefined,
-            workspaceName: parentLookup?.workspaceName,
-            parentWorkspaceId: parentLookup?.parentWorkspaceId,
-          },
-        };
-      }
-
-      this.analyticsService.clearWorkspace(event.workspaceId, { reingestAfterClear });
-    });
-
-    this.aiService.on("stream-abort", (data: StreamAbortEvent) => {
-      this.sessionTimingService.handleStreamAbort(data);
-      // Aborted turns persist their spend before this event fires (same async
-      // chain): normal aborts commit the usage-stamped partial to chat.jsonl
-      // (or the headless sidecar for non-commit-worthy partials); abandoned
-      // aborts (edit/discard) write only the sidecar. Ingest both, or the
-      // interrupted turn's spend stays out of dashboards until the next
-      // stream-end.
-      ingestWorkspaceAnalytics(data.workspaceId);
-    });
-    // Errored turns whose partial would be dropped at commit time route their
-    // usage to the headless sidecar (persistStreamError). The sidecar write
-    // precedes this event in the same async chain, so ingest here keeps the
-    // dashboard current instead of waiting for the next stream or restart.
-    this.aiService.on("error", (data: ErrorEvent) => {
-      ingestWorkspaceAnalytics(data.workspaceId);
-    });
+    const get = this.runtime.get;
+    this.appFiberScope = get(AppFiberScopeTag);
+    this.workflowRuntimeFactory = get(QuickJSRuntimeFactoryTag);
+    this.config = get(ConfigTag);
+    this.sessionLocator = get(SessionLocatorTag);
+    this.providersConfigStore = get(ProvidersConfigStoreTag);
+    this.secretsStore = get(SecretsStoreTag);
+    this.fileLeaseManager = get(FileLeaseManagerTag);
+    this.historyService = get(History);
+    this.aiService = get(AI);
+    this.streamManager = get(StreamManagerTag);
+    this.initStateManager = get(InitStateManagerTag);
+    this.workspaceService = get(Workspace);
+    this.taskService = get(Task);
+    this.workspaceTurnManager = get(WorkspaceTurnManagerTag);
+    this.providerService = get(Provider);
+    this.mcpConfigService = get(MCPConfig);
+    this.mcpServerManager = get(MCPServerManagerTag);
+    this.sessionUsageService = get(SessionUsage);
+    this.workspaceGoalService = get(WorkspaceGoal);
+    this.memoryService = get(Memory);
+    this.memoryMetaService = get(MemoryMeta);
+    this.memoryConsolidationService = get(MemoryConsolidation);
+    this.refineService = get(Refine);
+    this.extensionMetadata = get(ExtensionMetadata);
+    this.backgroundProcessManager = get(BackgroundProcessManagerTag);
+    this.projectService = get(Project);
+    this.muxGatewayOauthService = get(MuxGatewayOauth);
+    this.muxGovernorOauthService = get(MuxGovernorOauth);
+    this.codexOauthService = get(CodexOauth);
+    this.coderOauthService = get(CoderOauth);
+    this.copilotOauthService = get(CopilotOauth);
+    this.backupService = get(Backup);
+    this.terminalService = get(Terminal);
+    this.editorService = get(Editor);
+    this.windowService = get(WindowTag);
+    this.updateService = get(Update);
+    this.tokenizerService = get(Tokenizer);
+    this.instructionsService = get(Instructions);
+    this.serverService = get(Server);
+    this.menuEventService = get(MenuEvent);
+    this.voiceService = get(Voice);
+    this.mcpOauthService = get(McpOauth);
+    this.workspaceMcpOverridesService = get(WorkspaceMcpOverrides);
+    this.agentPluginInstallService = get(AgentPluginInstall);
+    this.telemetryService = get(Telemetry);
+    this.sessionTimingService = get(SessionTiming);
+    this.timelineService = get(Timeline);
+    this.devToolsService = get(DevTools);
+    this.browserSessionDiscoveryService = get(AgentBrowserSessionDiscovery);
+    this.browserBridgeTokenManager = get(BrowserBridgeTokenManagerTag);
+    this.browserBridgeServer = get(BrowserBridgeServerTag);
+    this.browserControlService = get(BrowserControl);
+    this.browserSessionStateHub = get(BrowserSessionStateHubTag);
+    this.analyticsService = get(Analytics);
+    this.experimentsService = get(Experiments);
+    this.policyService = get(Policy);
+    this.coderService = get(Coder);
+    this.serverAuthService = get(ServerAuth);
+    this.desktopSessionManager = get(DesktopSessionManagerTag);
+    this.desktopTokenManager = get(DesktopTokenManagerTag);
+    this.desktopBridgeServer = get(DesktopBridgeServerTag);
+    this.sshPromptService = get(SshPrompt);
+    this.idleCompactionService = get(IdleCompaction);
+    this.idleDispatcher = get(IdleDispatcherTag);
+    this.heartbeatService = get(Heartbeat);
+    this.agentStatusService = get(AgentStatus);
   }
 
   async initialize(): Promise<void> {

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -44,6 +44,7 @@ import * as modelStatsModule from "@/common/utils/tokens/modelStats";
 import { SessionUsageService } from "./sessionUsageService";
 import type { HistoryService } from "./historyService";
 import { createTestHistoryService } from "./testHistoryService";
+import { makeTestEffectRunner } from "./di/testEffectRunner";
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { countTokens } from "@/node/utils/main/tokenizer";
 import { shouldRunIntegrationTests, validateApiKeys } from "../../../tests/testUtils";
@@ -1108,6 +1109,49 @@ describe("StreamManager - stream resource scope", () => {
     const writesAtStreamEnd = writePartialSpy.mock.calls.length;
     await new Promise((resolve) => setTimeout(resolve, throttleMs + 200));
     expect(writePartialSpy.mock.calls.length).toBe(writesAtStreamEnd);
+  });
+
+  test("runs the partial-write debounce on the injected runner's clock", async () => {
+    // The debounce fiber must sleep on the injected EffectRunner (the app
+    // runtime's clock in production), not the global runtime: a TestClock
+    // runner fires the flush only when the test clock advances.
+    const testRunner = makeTestEffectRunner();
+    try {
+      const streamManager = new StreamManager(
+        historyService,
+        undefined,
+        undefined,
+        undefined,
+        testRunner.runner
+      );
+      expect(streamManager.effectRunner).toBe(testRunner.runner);
+      const workspaceId = "runner-debounce-workspace";
+      // Inside the throttle window, so the write is debounced rather than immediate.
+      const streamInfo = createStreamInfoForTests({ lastPartialWriteTime: Date.now() });
+      getWorkspaceStreamsForTests(streamManager).set(workspaceId, streamInfo);
+      const schedulePartialWrite = getPrivateMethodForTests<
+        (workspaceId: string, streamInfo: Record<string, unknown>) => Promise<void>
+      >(streamManager, "schedulePartialWrite");
+      const writePartialSpy = spyOn(historyService, "writePartial");
+      const throttleMs: unknown = Reflect.get(streamManager, "PARTIAL_WRITE_THROTTLE_MS");
+      if (typeof throttleMs !== "number") {
+        throw new Error("Expected StreamManager.PARTIAL_WRITE_THROTTLE_MS to be a number");
+      }
+
+      await schedulePartialWrite.call(streamManager, workspaceId, streamInfo);
+      expect(streamInfo.partialWriteFiber).toBeDefined();
+      // Real time passes; the virtual clock has not, so nothing flushes.
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(writePartialSpy).not.toHaveBeenCalled();
+
+      await testRunner.adjust(throttleMs);
+      // The flush's Effect.promise settles on the next macrotask.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(writePartialSpy).toHaveBeenCalledTimes(1);
+      expect(streamInfo.partialWriteFiber).toBeUndefined();
+    } finally {
+      await testRunner.dispose();
+    }
   });
 });
 

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -97,6 +97,7 @@ import {
 } from "@/common/utils/providers/modelEntries";
 import { clampErrorMessage, getErrorMessage } from "@/common/utils/errors";
 import { runLanguageModelCleanup } from "./languageModelCleanup";
+import { defaultEffectRunner, type EffectRunner } from "./di/effectRunner";
 import { shellQuote } from "@/common/utils/shell";
 import { classify429Capacity } from "@/common/utils/errors/classify429Capacity";
 import { extractChunkDeltaText } from "@/common/utils/ai/streamChunks";
@@ -778,6 +779,14 @@ export class StreamManager {
   private readonly sessionUsageService?: SessionUsageService;
   private readonly getProvidersConfig: () => ProvidersConfigMap | null;
   private eventSink: TurnEngineEventSink;
+  /**
+   * Runs the clock-driven lifecycle fibers (partial-write debounce and its
+   * interrupt) and is handed to per-session workers that must share this
+   * stream's clock (`RetryManager`, via `AgentSessionStreamManager`). The app
+   * runtime's context-bound runner in production — a `TestClock` in tests —
+   * and the global runtime wherever nothing is injected (di/effectRunner.ts).
+   */
+  public readonly effectRunner: EffectRunner;
   // Token tracker for live streaming statistics
   private tokenTracker = new StreamingTokenTracker();
   // Track OpenAI previousResponseIds that have been invalidated
@@ -793,12 +802,14 @@ export class StreamManager {
     historyService: HistoryService,
     sessionUsageService?: SessionUsageService,
     getProvidersConfig?: () => ProvidersConfigMap | null,
-    eventSink: TurnEngineEventSink = () => undefined
+    eventSink: TurnEngineEventSink = () => undefined,
+    runner: EffectRunner = defaultEffectRunner
   ) {
     this.historyService = historyService;
     this.sessionUsageService = sessionUsageService;
     this.getProvidersConfig = getProvidersConfig ?? (() => null);
     this.eventSink = eventSink;
+    this.effectRunner = runner;
   }
 
   setEventSink(eventSink: TurnEngineEventSink): void {
@@ -1138,9 +1149,9 @@ export class StreamManager {
     // to the sleep, so the debounce delay is registered before this method
     // returns (same observable ordering as the previous setTimeout call).
     streamInfo.partialWriteFiber = streamInfo.resourceScope
-      ? Effect.runSync(Effect.forkIn(delayedFlush, streamInfo.resourceScope))
+      ? this.effectRunner.runSync(Effect.forkIn(delayedFlush, streamInfo.resourceScope))
       : // Whitebox test fixtures register stream infos without a resource scope.
-        Effect.runFork(delayedFlush);
+        this.effectRunner.runFork(delayedFlush);
   }
 
   /**
@@ -1155,7 +1166,7 @@ export class StreamManager {
       return;
     }
     streamInfo.partialWriteFiber = undefined;
-    Effect.runFork(Fiber.interrupt(fiber));
+    this.effectRunner.runFork(Fiber.interrupt(fiber));
   }
 
   private async awaitPendingPartialWrite(streamInfo: WorkspaceStreamInfo): Promise<void> {


### PR DESCRIPTION
## Summary

Effect migration Phase 11, PR 5 of 6. **The desktop-only tail of the service graph now builds as Effect Layers too**: six `Layer.effectContext` **group layers** (`BrowserLive` · `DesktopBridgeLive` · `TerminalEditorLive` · `MiscDesktopLive` → `OauthLive` · `WorkersLive`) construct the ~40 remaining desktop services with their existing argument lists, `DesktopWiringLive` replays the former `ServiceContainer` constructor's setter / listener / global-registration statements **verbatim and in order** after `CoreLive`, and the `ServiceContainer` constructor shrinks to `makeAppRuntime(AppLive(stores))` plus field assignment from the built context (`toORPCContext()` unchanged in shape; `initialize()`/`dispose()`/`shutdown()` untouched, §5 order fixed). `StreamManager` gains an optional trailing `runner: EffectRunner`: its partial-write debounce forks through it and `AgentSession` hands the same runner to its `RetryManager`, so both sleep on the app runtime's `Clock` (a `TestClock` in tests).

Stacked on PR 1 #4049, PR 2 #4050, PR 3 #4051, PR 4a #4054, PR 4b #4057. Plan: `<details>` at the bottom (§2.1/§2.2, §2.3 invariants, §3 "PR 5", §5, §7).

## Implementation

- **`di/tags.ts`** — 47 new `Context.Service` tags (type-only imports; §2.1 naming; `Tag` suffix where the bare name is not a `*Service` class or would shadow — `WindowTag`, `QuickJSRuntimeFactoryTag`, `DesktopSessionManagerTag`, …), grouped as `BrowserTags | DesktopBridgeTags | TerminalEditorTags | MiscDesktopTags | OauthTags | WorkerTags = DesktopTags`; `AppTags = CoreRootTags | CrossCuttingTags | DesktopTags`.
- **`di/layers/desktop.ts`** — six `Layer.effectContext` group layers (each yields its inputs, constructs several services in the constructor's original order, returns a `Context`; the `R` annotation on each group *is* its declared dependency set); `DesktopWiringLive` (`Layer.effectDiscard`, yields every collaborator first, then the wiring statements); composition below.
- **`di/layers/app.ts`** — `AppLive = DesktopLive ▹ CoreLive ▹ CoreOptionsFromDesktopLive ▹ CrossCuttingLive ▹ MemoryMetaLive ▹ runtimeSeams`. **`core.ts`** — `StreamManagerLive` passes `yield* EffectRunnerTag` (5th ctor arg); `CoreInputTags` gains `EffectRunnerTag`.
- **`serviceContainer.ts`** — constructor = build + 66 `this.x = get(Tag)` lines; service imports type-only; the never-read private `ptyService` field is gone (the PTY lives in the graph under `PTY` for `TerminalService`). `initialize()`, `toORPCContext()`, `shutdown()`, `dispose()` byte-identical.
- **`streamManager.ts`** — `constructor(…, eventSink = () => undefined, runner: EffectRunner = defaultEffectRunner)`, `public readonly effectRunner`; `schedulePartialWrite`'s `runSync(forkIn)`/`runFork` and `interruptPartialWriteFiber`'s `runFork(Fiber.interrupt)` go through it; both `Scope.close` sites stay `Effect.runFork` (async-close precedent). **`agentSession.ts`/`retryManager.ts`** — `AgentSessionStreamManager` gains `readonly effectRunner?: EffectRunner`; `new RetryManager(…, this.streamManager.effectRunner)` (undefined → RetryManager's default, so doubles and the `aiService` fallback are unchanged).
- **Tests** — `serviceContainer.test.ts`: exhaustive `Record<keyof Omit<ORPCContext, "headers" | "effect/context" | "effect/wrap">, Tag>` identity test (a new ORPC field without a tag fails to compile), a desktop-wiring behavioral test (bindings, every `set*` collaborator, idle-compaction outcome forwarding, SSH-prompt global registration observed via `isInteractiveHostKeyApprovalAvailable()`, a timing listener), and a `dispose()`/`shutdown()` order test via spies on the public methods already spied today; the original assertions are unchanged. `streamManager.test.ts`: the debounce fires on the injected runner's `TestClock` (red-checked against the global-runtime fork).

## PR 5 notes

### Group DAG (re-derived from the constructor argument lists)

| Group | Services, in the former constructor's order | Declared requirements (`R`) |
|---|---|---|
| `BrowserLive` | BrowserBridgeTokenManager → AgentBrowserSessionDiscovery → BrowserControl → BrowserSessionStateHub → BrowserBridgeServer | Config |
| `DesktopBridgeLive` | DesktopSessionManager → DesktopTokenManager → DesktopBridgeServer | Config, Experiments, Workspace |
| `TerminalEditorLive` | PTY → Terminal → Editor → Tokenizer → Instructions | Config, SecretsStore, Workspace, SessionUsage, AI, Provider |
| `MiscDesktopLive` | QuickJSRuntimeFactory, SshPrompt, **Window**, Backup, AgentPluginInstall, Project (needs SshPrompt), Update, Server, MenuEvent, Voice, Coder (singleton), ServerAuth, WorkspaceLifecycleHooks, WorktreeArchiveSnapshot | Config, SecretsStore, ProvidersConfigStore, Experiments, Policy, Provider, MCPServerManager, WorkspaceMcpOverrides |
| `OauthLive` | McpOauth → MuxGatewayOauth → MuxGovernorOauth → CodexOauth → CoderOauth → CopilotOauth | Config, ProvidersConfigStore, FileLeaseManager, MCPConfig, Provider, Policy, Telemetry, **Window** |
| `WorkersLive` | IdleCompaction → Heartbeat → Timeline → Refine (needs Timeline) → AgentStatus (needs Tokenizer, Window) | Config, **EffectRunner**, Experiments, History, ExtensionMetadata, Workspace, Task, IdleDispatcher, Memory, MemoryMeta, AI, SessionUsage, **Tokenizer**, **Window** |
| `DesktopWiringLive` | the former constructor's 12 wiring blocks, verbatim, in order — incl. #4043's `backupService.setProjectService/setMemoryNotifier` after the `projectService.set*` lines (rebased) — runs after `CoreLive`, so core listeners still precede desktop ones | Config, CrossCuttingTags, CoreTags, DesktopTags |

```
DesktopBase  = Layer.mergeAll(MiscDesktopLive, BrowserLive, DesktopBridgeLive, TerminalEditorLive)   // true siblings
DesktopUpper = Layer.mergeAll(OauthLive, WorkersLive).pipe(Layer.provideMerge(DesktopBase))          // both need Base
DesktopLive  = DesktopWiringLive.pipe(Layer.provideMerge(DesktopUpper))
AppLive      = DesktopLive ▹ CoreLive ▹ CoreOptionsFromDesktopLive ▹ CrossCuttingLive ▹ MemoryMetaLive ▹ (AppFiberScope ▹ EffectRunner ▹ Stores)
```

"True siblings" was checked constructor by constructor (I6 table): no base-group constructor takes or calls another desktop service, so their relative build order is a don't-care. The two upper groups' edges (`WindowService`, `TokenizerService`) are the only cross-group dependencies and are expressed with `provideMerge`, never with `mergeAll` argument order.

### I6 constructor side-effect audit (38 constructions moved here; full 38-row table with file:line cites in the first PR comment)

| Group | Constructors (args exactly as the former constructor passed them) | Beyond capturing args | Order that matters |
|---|---|---|---|
| Browser | `BrowserBridgeTokenManager()` · `AgentBrowserSessionDiscoveryService({resolveWorkspaceCandidatePathsFn})` · `BrowserControlService({discovery, resolveSessionEnvFn})` · `BrowserSessionStateHub({control})` · `BrowserBridgeServer({discovery, tokenManager, stateHub})` | token manager: own unref'd cleanup `setInterval` (as before); bridge server: unattached `WebSocketServer({noServer})` | intra-group arg order only |
| DesktopBridge | `DesktopSessionManager({config, experimentsService, workspaceService})` · `DesktopTokenManager()` · `DesktopBridgeServer({sessionManager, tokenManager})` | token manager: own unref'd cleanup `setInterval` (as before) | intra-group arg order; core `Workspace` (staging) |
| TerminalEditor | `PTYService()` · `TerminalService(config, pty, secretsStore)` · `EditorService(config, workspaceService)` · `TokenizerService(sessionUsage, ai, provider)` · `InstructionsService(config, ai, tokenizer)` | none (the tokenizer *worker* is created at `workerPool.ts` import time, not by the ctor — see Observations) | intra-group arg order |
| Misc | `QuickJSRuntimeFactory()` · `SshPromptService()` · `WindowService()` · `BackupService(config, {gitRepo, payload})` · `AgentPluginInstallService(config, {isEnabled, mcpServerManager, workspaceMcpOverridesService})` · `ProjectService(config, sshPrompt, secretsStore)` · `UpdateService(config)` · `ServerService()` · `MenuEventService()` · `VoiceService(config, provider, policy, providersStore)` · `coderService` · `ServerAuthService(config)` · `WorkspaceLifecycleHooks()` · `WorktreeArchiveSnapshotService(config)` | `AgentPluginInstallService`: un-awaited startup journal reconcile + module-level discovery gate (as before, from its own args); `UpdateService`: `config.getUpdateChannel()` + un-awaited `initialize()` (no-op outside Electron) | `Project` after `SshPrompt` (same group, in order); `AgentPluginInstall` after core (staging) |
| OAuth | `McpOauthService(config, mcpConfig, window, telemetry)` · `MuxGatewayOauthService(providersStore, provider, window)` · `MuxGovernorOauthService(config, window, policy)` · `CodexOauthService(providersStore, provider, window)` · `CoderOauthService(providersStore, fileLeaseManager, provider, window, policy)` · `CopilotOauthService(provider, window)` | **`CoderOauthService` subscribes `providerService.onConfigChanged`** (`coderOauthService.ts:373`) — a declared *core* dependency; `AIService`'s own subscription (S3) still precedes it because every desktop group builds above `CoreLive`; no other desktop ctor subscribes to `providerService` | after Misc (`WindowService`) via `OauthLive ▹ DesktopBase` |
| Workers | `IdleCompactionService(config, history, extensionMetadata, executeIdleCompaction, runner)` · `HeartbeatService(config, extensionMetadata, workspace, task, idleDispatcher, runner)` · `TimelineService(config, history, experiments)` · `RefineService(config, memory, memoryMeta, history, ai, experiments, {timeline, sessionUsage, emitChatMessage, acquireTurnExclusion})` · `AgentStatusService(config, history, tokenizer, extensionMetadata, workspace, window, ai, {sessionUsage, requestAnalyticsIngest})` | none (scopes/fibers/intervals start in `start()`; `subscribeToWorkspace` is a wiring statement) | `Refine` after `Timeline` (same group); after Misc (`Window`) + TerminalEditor (`Tokenizer`) via `WorkersLive ▹ DesktopBase` |

No moved constructor reads a setter-provided collaborator or registers listeners on `workspaceService`/`aiService`/`taskService`/`memoryConsolidationService`/`mcpServerManager` (only `CoderOauthService` → `providerService`, above). Wiring statements that used to sit *between* constructions now run after all of them; none of the constructors that followed them read the wired state, so the observable order of effects is unchanged.

### Split decision

Raw product diff is +1149 / −517 (8 files), above the plan's ~600-line heuristic; I evaluated a 5a/5b split along group boundaries and kept one PR: the surface is mechanical relocation (~330 wiring + ~250 constructor-call lines moved verbatim, 184 lines of tags — `git diff --color-moved=dimmed-zebra origin/main -- src/node/services/serviceContainer.ts src/node/services/di/layers/desktop.ts` dims them), a mergeable 5a would need a throwaway hybrid constructor, and the wiring move would still land whole in one half.

### Deviations from the plan / observations

- **`RetryManager` site.** The plan places the runner hand-off in `streamManager.ts`; the constructor is in `agentSession.ts` — reached via the optional `AgentSessionStreamManager.effectRunner` field.
- **Tokenizer worker starts ~1 s later in `xum server`/ACP (not desktop).** `workerPool.ts` creates the tokenizer `Worker` at import time; `main` reached it via `serviceContainer.ts`'s early `TokenizerService` import (~0.9 s after spawn, before `effect`/`di/*` loaded), now via `core.ts` → `aiService` → `historyService` → `tokenizer` (~1.9 s). Total startup is unchanged (spawn → `initialize completed` ≈ 2.55 s on both) and the desktop is unaffected (`desktop/main.ts` imports `tokenizer` first), but a SIGTERM *during* the worker's ≈19 s encoding load waits for its current module evaluation on both trees (so a "1 s after init" probe read 0.6 s vs 1.6 s — strace: the gap sits between `exit(0)` and the worker thread's exit, not in `dispose()`, which is 70–120 ms on both). Steady-state shutdown is unchanged (table). Left as is: pre-existing import-time worker creation, unrelated to the composition root; an explicit warm-up call site is a follow-up candidate, not a bug.
- `DesktopWiringLive` is a `Layer.effectDiscard` over an `Effect.gen` body whose only yields are service tags (synchronous); no finalizers, no forks (I5) — same shape as `CoreWiringLive`.

### Pre-review audits (plan §3)

1. **Interruption posture** — moved forks: `StreamManager.schedulePartialWrite` (`runner.runSync(forkIn(…, resourceScope))` / whitebox `runner.runFork`) and `interruptPartialWriteFiber` (`runner.runFork(Fiber.interrupt)`) — unsupervised through the runner exactly as through the global runtime; interrupted by the stream's resource-scope close and by re-arm, unchanged. `RetryManager` forks through the injected runner; cancelled by `cancel()`/`dispose()` as before. No forks in `di/layers/`.
2. **Uninterruptible teardown** — `dispose()`/`shutdown()` bodies byte-identical; the §5 order is now asserted.
3. **No defect escapes** — no new Promise facades; `makeAppRuntime` stays the one throw site (throwing-layer test passes through the deeper graph).
4. **Spy-seam check** — `rg 'spyOn\(' src/node/services/serviceContainer.test.ts tests/ipc tests/ui`: every target is a public method on an instance the container still exposes → intercepted, since each field *is* the context instance (identity test). Arity: only `StreamManager` gained a trailing optional param; `AgentSessionStreamManager` gained an optional readonly field. Typecheck of every test proves it.
5. **Sync-start** — the new debounce test pins that `partialWriteFiber` is armed synchronously and fires on `TestClock.adjust`.
6. **I6** — table above. 7. **I3** — `memoryConsolidationService.ts` not in the diff.

### Re-recorded gate numbers (R7/R8)

Sibling worktrees under one scratch dir with shared `node_modules`, interleaved runs; `origin/main` = `1c81235c1` (4b) vs this branch. Host: 96 cores, CPU PSI `some avg60` ≈ 39–41 %.

| metric | origin/main (4b) | branch (PR 5) | note |
|---|---|---|---|
| `tsgo --noEmit` wall, 3 interleaved pairs (median, min–max) | 12.01 s (11.47–14.04) | 11.94 s (11.82–14.71) | flat |
| `tsgo --extendedDiagnostics` (renderer) | types 1 930 432 · check 10.50 s | types 1 934 836 (+0.23 %) · check 9.43 s | noise |
| `new ServiceContainer(stores)` in-process, 3 runs × 15: **cold** (first) median | 27 ms (24–29) | **35 ms** (35–44) | **+≈8 ms cold** — Layer first-use for 7 more layers + 3 composition nodes (trend 12 → 18 → 23 → 27 → 35 ms across PR 3/4a/4b/main/PR 5; `main`'s 27 includes the imperative desktop constructor) |
| … **warm** median (min) | 1.87 ms (1.11) | 2.18 ms (1.65) | +≈0.3 ms |
| `[startup] AppRuntime built` in `xum server` (10 runs) | 11 ms (core only) | 16 ms (whole graph) | not comparable (main excludes the desktop ctor) |
| spawn → `AppRuntime built` / → `initialize completed` (3 pairs) | 2.35 s / 2.55 s | 2.32 s / 2.55 s | unchanged |
| `ServiceContainer.initialize completed { totalMs }` (10 runs) | 245 (215–336) | 243 (215–279) | unchanged code |
| SIGTERM → exit, steady state (25 s after init; 5 pairs) | 151 ms (134–185), exit 0 ×5 | 169 ms (149–179), exit 0 ×5 | noise; `[shutdown] AppFiberScope closed` → explicit steps → `[shutdown] AppRuntime disposed` in every transcript |

A chained (`provideMerge`-only) composition of the same six groups costs the same (30–42 / 2.1–3.0 ms): the +8 ms is Effect first-use, not sibling concurrency.

### Lessons for PR 6 (TestClock sweep + shutdown hardening + DI contract docs)

- `StreamManager` takes a runner now: the partial-write debounce cases in `streamManager.test.ts` can move to `makeTestEffectRunner()` (5th ctor arg; the new test is the template); `RetryManager` gets its runner from `streamManager.effectRunner`, so `agentSession` harness tests can inject a TestClock through a stream-manager double.
- The tokenizer worker is created at import time (`workerPool.ts`); `[shutdown]` timing probes must wait for its ≈19 s load or they measure its module-evaluation tail — PR 6's per-step `[shutdown]` lines will expose the `AppRuntime disposed` → `process.exit` gap.
- `Record<keyof Omit<ORPCContext, …>, Tag>` is the ORPC exhaustiveness guard (exclude `effect/wrap` with `headers`/`effect/context`). Six group layers + three composition nodes cost +8 ms cold / +0.3 ms warm — record the per-layer first-use cost in the contract doc.

## Validation

- `make static-check` green. `bun test` gate (`streamManager*`, `aiService`, `serviceContainer`, `coreServicesRoot`, `di/*`, `retryManager`, `heartbeat`, `idleCompaction`, `cli/server`, `cli/cli`) 375/375; all 26 `agentSession*` suites 279/279; `bun test src/node/services src/cli src/node/orpc src/node/acp` 7057 pass / 15 fail — the known host baselines (taskGitPatchEngine ×2, WorkspaceTurnManager ×2, agent_skill_delete, BackupRepoCache ×9) + one `attachmentService.completedReports` flake that passes in isolation on both trees.
- `TEST_INTEGRATION=1 bun x jest tests` (tests/ipc + tests/ui): 669 pass / 77 fail / 49 skipped — all environment baselines: provider-backed suites (`403 Forbidden` from the AI bridge / missing xAI key), SSH/Docker rows, four `src/**/__tests__` bun:test files jest picks up, and `terminal.test.ts` (1) · `sendModeDropdown.test.ts` (1) · `reportRelocation.test.ts` (1), which fail identically on **pristine `origin/main`** (re-run in the foreground in the sibling worktree). CI is the lane for the provider suites.
- **Dogfooding** (headless Coder host, `XUM_LOG_LEVEL=debug DEV_SERVER_SANDBOX_ARGS=--clean-projects make dev-server-sandbox`): log order `AppRuntime built { ms: 24 }` → `initialize starting` → six step durations → `initialize completed { totalMs: 233 }`; no `ManagedRuntime disposed`/defect lines. agent-browser: loaded the app (`v0.28.3-nightly.148-28-g909dadd90`), added a scratch git repo as a project, sent "Reply with exactly the single word: pong" → worktree workspace created, model replied `pong`, Stats tab populated (screenshot). **oRPC Effect path:** memory experiment enabled, `memory.save` → `setPinned true` → `list` (`pinned: true`) → `setPinned false` over `/orpc` (all `handlerGen` + runtime `effect/context`), then pinned/unpinned from the Memory tab; `memory-meta.json` flipped `pinned` true → false (screenshot). **Graceful quit:** SIGTERM → `[shutdown] AppFiberScope closed { ms: 1 }` → `AgentStatusService stopped` → `terminateAll()` → `[analytics-worker] Shutting down, closing DuckDB` → `[shutdown] AppRuntime disposed { ms: 7 }` → nodemon `clean exit`, 191 ms, exit 0; plus the 5 steady-state pairs in the table (exit 0 ×10). Not exercised headless: Electron `before-quit` (same `dispose()`; `tests/e2e` in CI).

![pong reply](https://github.com/user-attachments/assets/7fae654e-8c34-496c-9d0d-c7ab4a5e83d2)

![memory pinned](https://github.com/user-attachments/assets/4c33414f-1dc1-4d23-84a8-7e251d1674fe)

https://github.com/user-attachments/assets/0d3e4c76-82d2-4344-80ae-b1dba493ecaf

## Risks

- **Low–medium.** The one behavioral surface is the wiring relocation: every statement is verbatim and in order, the constructors that used to run between wiring lines are audited as not observing them (I6), the `tests/ipc` behavioral gate matches pristine `main`, and the desktop wiring test pins each collaborator edge. `dispose()`/`shutdown()` are unchanged and their order is asserted.
- Startup: +≈8 ms cold construction; `initialize()` unchanged; tokenizer-worker import-order shift in `xum server`/ACP (observation above) — no functional change.

---

<details>
<summary>📋 Implementation Plan</summary>

# Effect migration — Wave 3 / Phase 11: ManagedRuntime + Layer dependency injection

## 0. Summary

Replace the two hand-written composition roots (`createCoreServices` + the `ServiceContainer` constructor) with an **Effect `Layer` graph** built once per process by a **`ManagedRuntime`** ("AppRuntime"), while keeping every service class, constructor signature, Promise facade, private method, and test seam compatible. The runtime becomes (a) the owner of the app-lifetime `Scope`, (b) the provider of `"effect/context"` for oRPC Effect-native handlers, and (c) the source of two runtime seams: an **`EffectRunner`** (context-bound, *unsupervised* runner that lets clock-driven workers run on a `TestClock`) and an **`AppFiberScope`** (a runtime-owned, *supervised* scope whose close is awaited by `dispose()` — the slot the streamManager engine core will occupy later).

Six stacked, independently mergeable PRs. Product PRs keep existing tests unchanged; only the final test-modernization PR edits tests. Net product LoC ≈ **+420** (per-PR estimates below). Service classes are *not* rewritten — Layers are thin adapters around existing constructors; cycle-breaking setter wiring moves into explicit "wiring layers" that replay today's order.

Unlocks (not done here): streamManager ENGINE CORE conversion, `TestClock` for timing suites, app-lifetime scopes.

## 1. Verified current state (evidence)

- **Roots.** `src/node/services/coreServices.ts:103-389` (`createCoreServices`: 25 constructions, 12 `turnRequestBuilderBindings` writes, ~14 setters) and `src/node/services/serviceContainer.ts:161-575` (45 more constructions; `aiService.on(...)`/`workspaceService.on(...)` analytics wiring at 474-574; global registrations `setGlobalCoderService/setSshPromptService` at 469-471). `new ServiceContainer(stores)` is called by `headlessEnvironment.ts:111`, `tests/ipc/setup.ts`, `src/cli/server.ts:132`, `src/node/acp/serverConnection.ts:155`, `src/desktop/main.ts:653`; `src/cli/run.ts:661` and `src/cli/workflow.ts:376` call `createCoreServices` directly. ⇒ two graph roots (App vs Core), five process entry points, all constructing **synchronously**.
- **Startup.** `ServiceContainer.initialize()` (577-642) awaits six `initialize()`s (no try/catch; failure propagates to `main.ts:1255-1265` "Startup Failed" dialog + quit; `server.ts`/ACP log and exit), then sync `start()`s idleCompaction/heartbeat/agentStatus, then two fire-and-forget sweeps. All constructors are synchronous; two have side effects on **declared constructor dependencies** only (`AIService` → `streamManager.setEventSink`, `WorkspaceService` → `backgroundProcessManager.on/aiService.on`).
- **Teardown.** `dispose()` (746-779) is explicit and hand-ordered (`backgroundProcessManager.beginShutdown()` MUST be first — it is a latch protecting persisted monitor records; bridges stop before sessions close; `terminateAll` late; `timelineService.flush()` last). `shutdown()` (718-732) is a *second* sequence fired concurrently by a second `before-quit` listener (`main.ts:1321`). `main.ts:1296-1304` races `dispose()` against 5 s then `app.quit()`; `cli/server.ts:227-268` has a 5 s `process.exit(1)` force timer; `tests/ipc` cleanup calls `dispose()` then `shutdown()`; `headlessEnvironment.dispose` never calls `services.dispose()`.
- **Existing Effect surface.** 25 files import `effect`. Only `Context.Service` tag: `MemoryMeta` (`src/node/orpc/effectContext.ts:21`). `handlerGen` (`@orpc/experimental-effect`) runs `Effect.runPromiseExit` per request and `Effect.provide`s `opts.context["effect/context"]`. `streamBridge.ts` runs streams on the global runtime. Scope-owning workers: `heartbeatService.ts:134-243`, `idleCompactionService.ts:86-122` (`Scope.makeUnsafe` + `Effect.runSync(Scope.close(..))`, valid only because their fibers suspend solely on the clock), `oauthFlowManager.ts:164`, `streamManager.ts:4767/4054` (already `Effect.runFork(Scope.close(..))` — the async-close precedent). `memoryConsolidationService.ts:667-703, 837-860`: check-and-reserve funnels with zero suspensions before `inFlight.set`/`harvestInFlight.set`.
- **effect@4.0.0-rc.112 API (verified in `node_modules/effect/dist`).** `Context.Service<Self, Shape>()("id")` (module `Context`, not `ServiceMap`); `Layer.{succeed,sync,effect,effectContext,effectDiscard,provide,provideMerge,mergeAll,build,buildWithScope}` (no `Layer.scoped`; `Layer.effect` strips `Scope` from R); `ManagedRuntime.make(layer)` → `{ runSync, runSyncExit, runFork, runPromise, runPromiseExit, contextEffect, cachedContext, scope, dispose(), disposeEffect }`; `Effect.{runSyncWith,runForkWith,runPromiseWith,runPromiseExitWith}(context)`; `Effect.context<R>()`; `Effect.serviceOption`; `Scope.{fork,forkUnsafe,close,provide}`; `TestClock` from `effect/testing` (`layer, adjust, setTime, withLive`); `Clock.Clock` is a `Context.Reference` (defaulted; `TestClock.layer()` overrides it).
- **ManagedRuntime internals the design relies on** (`ManagedRuntime.js`): `make` creates `scope = Scope.makeUnsafe("parallel")` and `layerScope = Scope.forkUnsafe(scope, "sequential")`; the first `runX` forks a build fiber over `Layer.buildWithMemoMap` — a **fully synchronous layer graph builds synchronously**, so `runtime.runSync(Effect.context())` succeeds and sets `cachedContext`; afterwards every `runX` is `Effect.run…With(cachedContext)` (no extra async boundary). Fibers started through `runtime.runX` are registered in `scope` (`onFiberStart: Fiber.runIn(scope)`). `dispose()` = `Scope.close(scope)` (interrupt registered fibers in parallel → layer finalizers sequentially in reverse), after which any `runtime.runX` dies with `"ManagedRuntime disposed"`.
- **Layer composition semantics.** `Layer.mergeAll(A, B)` is *not* a dependency resolver: B's requirements are not satisfied by A's outputs; requirements bubble up. Dependencies are satisfied only via `Layer.provide`/`provideMerge` chains. Siblings in `mergeAll` may build concurrently.
- **Test seams that pin signatures** (Explore report): private-method spies (`Config.saveConfig`, `WorkspaceService.retireKernelWorkflowRunReferences/startStartupRecovery/createSession/updateAgentStatus`, `MCPServerManager.startServers`, `AgentPluginInstallService.reconcileJournals`, …); module-level export spies (`agentStatusService.generateWorkspaceStatus`, `sshConnectionPool.verifyHostKeyAgainstPolicyEffect`, …); direct construction in tests (`Config` 44 files, `HistoryService` 22, `MemoryMetaService` 11, `WorkspaceService` 7, `IdleDispatcher` 6, `StreamManager` 4, `ServiceContainer` 3); partial-mock casts (`InitStateManager` 193, `AIService` 158, `TaskService` 149, `ORPCContext` 62). `effectBridge.test.ts:24-30` builds a partial `ORPCContext` via `buildOrpcEffectContext` + `as unknown as ORPCContext`.
- **Timing probes** (TestClock candidates): `heartbeatService.test.ts` 6 real sleeps, `idleCompactionService.test.ts` 2, `retryManager.test.ts` 3 `setSystemTime`, `streamManager.test.ts` 7 (partial-write debounce), `streamBridge.test.ts` 11 (heartbeat ticker), OAuth device-flow suites 14 (non-goal).

## 2. Target architecture

### 2.1 Building blocks (all under `src/node/services/di/`; the *only* directory allowed to import `Layer`/`Context`/`ManagedRuntime`/`TestClock`)

| Module | Contents |
|---|---|
| `tags.ts` | One `Context.Service` tag per service class provided by the graph. Type-only imports of service classes ⇒ no runtime import cycles. Ids `"xum/<Name>"`. Naming: class name minus trailing `Service` (`MemoryMeta`, `Workspace`, `History`); classes without that suffix or colliding with an exported name get a `Tag` suffix (`ConfigTag`, `StreamManagerTag`, `IdleDispatcherTag`). Exports the unions `CoreTags` and `AppTags`. |
| `effectRunner.ts` | `interface EffectRunner { runSync<A,E>(e: Effect<A,E,never>): A; runSyncExit; runFork; runPromise; runPromiseExit }` — a **context-bound, unsupervised** runner whose methods accept only effects with **no service requirements** (`R = never`; defaulted references like `Clock` do not appear in `R`). That makes "not a service locator" type-enforced: a fiber that needs services must take them as explicit constructor dependencies and, if it must be awaited on shutdown, fork into `AppFiberScope`. `defaultEffectRunner` = the global `Effect.runX` (today's exact behavior). `effectRunnerFromContext(ctx)` = `Effect.run…With(ctx)`. `EffectRunnerTag` + `EffectRunnerLive = Layer.effect(EffectRunnerTag, Effect.map(Effect.context<never>(), effectRunnerFromContext))`, placed at the **base** of the graph so the captured context contains only refs (`Clock`, later `Logger`/`Random`) plus stores. Fibers forked through it are owned by the worker's own `Scope` (explicit `start/stop`), **not** by the ManagedRuntime; `runtime.dispose()` does not interrupt them. Services import only this file from `di/`. |
| `appFiberScope.ts` | `AppFiberScopeTag: Scope.Closeable`. `AppFiberScopeLive = Layer.effect(AppFiberScopeTag, Effect.gen(function*(){ const parent = yield* Effect.scope; return yield* Scope.fork(parent, "parallel"); }))` — a child of the runtime's layer scope. Fibers forked into it via `Effect.forkIn(_, appFiberScope)` are interrupted **and awaited** when the scope closes. This is the **supervised** seam for I/O-suspended fibers (engine core, later). `ServiceContainer.dispose()` closes it explicitly and early (§5) so interrupted fibers can still use their dependencies during finalization; `runtime.dispose()` later re-closes it idempotently as a backstop. No production occupant in Phase 11; the seam exists with tests. |
| `appRuntime.ts` | `makeAppRuntime(layer)`: `ManagedRuntime.make(layer)` + **eager synchronous build** (`runtime.runSync(Effect.context<R>())`; `assert(runtime.cachedContext !== undefined)`); a layer body that suspends is a programming error and throws here — exactly where a throwing constructor throws today, so every entry point's existing catch/dialog/log path is preserved. `disposeAppRuntime(runtime, timeoutMs)` and `closeScopeBounded(scope, timeoutMs)` share one shape: `Effect.uninterruptible` teardown shell around `Effect.interruptible(target.pipe(Effect.timeout(timeoutMs)))` where `target` is `runtime.disposeEffect` resp. `Scope.close(scope, Exit.void)` (never a non-cancellable JS Promise wrapper); `Effect.catchTag("TimeoutError", …)` + `Effect.catchDefect` → `log.warn`; run via `Effect.runPromise`; **never rejects**; idempotent (`Scope.close` is idempotent; `disposeEffect` is guarded by a latch). Verify the exact rc `Effect.timeout` error type at implementation time (rc.112: fails with `Cause.TimeoutError`, `_tag: "TimeoutError"`). Module doc comment = the DI contract (§2.3, §5). |
| `layers/stores.ts` | `StoresLive(stores: ConfigStores)` = `Layer.mergeAll` of `Layer.succeed` for `ConfigTag`, `SessionLocatorTag`, `ProvidersConfigStoreTag`, `SecretsStoreTag`, `FileLeaseManagerTag` (true siblings — no inter-dependencies). `StoresFromCoreOptionsLive` reproduces the `opts.x ?? new X(config.rootDir)` defaults of `coreServices.ts:106-112` for the CLI root. |
| `layers/core.ts` | `CoreOptionsTag` (today's `CoreServicesOptions` minus stores — carries the *optional* cross-cutting services exactly as today). **PR 3:** `CoreProjectionLive = Layer.effectContext(...)` wrapping the existing `createCoreServices` body and returning a `Context<CoreTags>` (coarse projection, zero behavior change). **PR 4:** peel into per-service `Layer.effect(Tag, Effect.gen(...))` layers composed in **explicit dependency stages** (`Layer.provideMerge` between stages; `Layer.mergeAll` only for true siblings within a stage — every sibling claim below was checked against the constructor argument lists in `coreServices.ts` and must be re-checked in the PR): S1 History · InitState · Provider · BackgroundProcess · ExtensionMetadata · MemoryMeta · TerminalAttention · IdleDispatcher · WorkspaceMcpOverrides(default) · `TurnRequestBuilderBindingsTag` (`Layer.succeed(_, {})`) → S2a SessionUsage · Goal · Memory → S2b StreamManager (needs SessionUsage) → S3 AIService → S4 Consolidation · MCPConfig → S5 MCPServerManager → S6 Workspace → S7 Task → S8 TurnManager → `CoreWiringLive` (`Layer.effectDiscard`, **`Effect.sync` only — no `acquireRelease`**, replays `coreServices.ts:137-166, 209-210, 258-270, 288-325, 349-352, 360-367` in order). |
| `layers/desktop.ts` | `CrossCuttingLive` (policy, telemetry, experiments, backup, sessionTiming, analytics, devTools, workspaceMcpOverrides, browserBridgeTokenManager), `CoreOptionsFromDesktopLive` (derives `CoreOptionsTag` from those tags + `extensionMetadataPath`), then **group layers** (`Layer.effectContext` returning a `Context` of several tags, constructed in today's order): `BrowserLive`, `DesktopBridgeLive`, `OauthLive`, `WorkersLive` (idleCompaction, heartbeat, agentStatus, timeline, refine), `TerminalEditorLive`, `MiscDesktopLive`; staged with `provideMerge` where one group needs another. `DesktopWiringLive` (`Effect.sync` only) = setters + `aiService.on/workspaceService.on/memoryConsolidationService.on` wiring + global registrations. |
| `layers/app.ts` | `AppLive(stores) = DesktopLive ▹ CoreLive ▹ CoreOptionsFromDesktopLive ▹ CrossCuttingLive ▹ AppFiberScopeLive ▹ EffectRunnerLive ▹ StoresLive(stores)` — read `X ▹ Y` as "X is *provided with* Y, and both stay exposed", i.e. **`X.pipe(Layer.provideMerge(Y))`** (rc.112 signature: `provideMerge(that: provider)(self: consumer)`; the *right-hand* operand is the dependency). Every `▹` keeps all tags visible in the final `Context<AppTags>`. |
| `testEffectRunner.ts` (test helper, sibling of `testHistoryService.ts`) | `makeTestEffectRunner()` → `{ runner, adjust(duration), setTime(ms), dispose }` over one memoised `ManagedRuntime.make(EffectRunnerLive.pipe(Layer.provideMerge(TestClock.layer())))` (the TestClock is the *provider*; the runner captures it), so the worker under test and `TestClock.adjust` share one `TestClock`. |

### 2.2 Composition roots after Phase 11

```mermaid
flowchart TB
  Stores["StoresLive(stores)<br/>Config · SessionLocator · ProvidersConfigStore · SecretsStore · FileLeaseManager"]
  Runner["EffectRunnerLive (unsupervised, ref-bound)<br/>+ AppFiberScopeLive (supervised, closed on dispose)"]
  Cross["CrossCuttingLive (desktop only)<br/>Policy · Telemetry · Experiments · Analytics · SessionTiming · DevTools · WorkspaceMcpOverrides · Backup"]
  Opts["CoreOptionsTag<br/>desktop: derived from CrossCutting · CLI: Layer.succeed(opts)"]
  Core["CoreLive<br/>PR 3: coarse CoreProjectionLive → PR 4: stages S1…S8 + CoreWiringLive"]
  Desk["DesktopLive — group Layers<br/>Browser · DesktopBridge · OAuth · Workers · TerminalEditor · Misc → DesktopWiringLive"]
  RT["AppRuntime = ManagedRuntime.make(AppLive)<br/>eager sync build · Context<AppTags> = oRPC effect/context · dispose() last"]
  Stores --> Runner --> Cross --> Opts --> Core --> Desk --> RT
  CLI["CLI root (xum run / xum workflow)<br/>createCoreServices(opts) = makeAppRuntime(CoreLive ▹ StoresFromCoreOptionsLive ▹ AppFiberScopeLive ▹ EffectRunnerLive ▹ succeed(CoreOptionsTag, opts))"]
  Core -.same Layer definitions.-> CLI
```

`ServiceContainer` keeps its public fields and the synchronous `new ServiceContainer(stores)`: the constructor calls `makeAppRuntime(AppLive(stores))`, stores `this.serviceContext = runtime.runSync(Effect.context<AppTags>())`, and assigns fields via `Context.get(this.serviceContext, Tag)`. `toORPCContext()` returns the same plain fields plus `"effect/context": this.serviceContext`. `initialize()` is untouched. `dispose()` follows §5.

`createCoreServices(opts)` keeps its signature and return shape plus `runtime` and `appFiberScope` fields; `cli/run.ts:1574-1580` and `cli/workflow.ts:275-320` cleanup lists gain `closeScopeBounded(appFiberScope)` before `session.dispose()` and `disposeAppRuntime(runtime)` as the final step (PR 3).

**Staged composition skeleton (PR 4 shape; direction matters):**

```ts
// Each stage depends only on stages defined above it. `provideMerge` keeps both sides exposed.
const S1 = Layer.mergeAll(HistoryLive, InitStateLive, ProviderLive, /* … true siblings only */);
const S2a = Layer.mergeAll(SessionUsageLive, GoalLive, MemoryLive).pipe(Layer.provideMerge(S1));
const S2b = StreamManagerLive.pipe(Layer.provideMerge(S2a));          // StreamManager needs SessionUsage
const S3 = AIServiceLive.pipe(Layer.provideMerge(S2b));
// … S4 … S8 likewise …
export const CoreLive = CoreWiringLive.pipe(Layer.provideMerge(S8));  // wiring runs after every service exists
```

**oRPC typing.** `OrpcEffectServices` (in `effectContext.ts`) becomes `AppTags`, so `ORPCContext["effect/context"]: Context<AppTags>` is satisfied by the runtime context in production. `buildOrpcEffectContext` stays as the narrow test helper it already is (its only caller, `effectBridge.test.ts:24-30`, deliberately builds a partial context and casts it via `unknown`); no production caller remains after PR 1.

### 2.3 Invariants (the "DI contract"; enforced by tests and the `appRuntime.ts` doc comment)

| # | Invariant | Constraint served |
|---|---|---|
| I1 | **Phase 11 compatibility contract, not permanent law:** layer bodies are synchronous (`Layer.succeed`/`Layer.sync`/`Layer.effect` over sync effects; `acquireRelease` with a sync acquire is fine). `makeAppRuntime` asserts the eager build completed. Future async resource acquisition belongs in `initialize()`/startup effects or an explicit async factory root (`ServiceContainer.create()`), never silently inside a layer. | #2 sync-start, #5 startup parity |
| I2 | Services never hold the `ManagedRuntime`. Workers hold an `EffectRunner` (default `defaultEffectRunner`); `EffectRunner.runX` ≡ `Effect.run…With(ctx)` — same sync-start semantics as `Effect.runX`, and still valid after `runtime.dispose()`, so late callbacks cannot hit "ManagedRuntime disposed". Supervision, when needed, is explicit via `AppFiberScope`. | #2, #3 |
| I3 | Per-call pipelines (`Effect.runPromise(this.effects…)` facades) and the `memoryConsolidationService` funnels are untouched. **Audit item:** no DI lookup, runner call, or `await` may be inserted before `inFlight.set` / `harvestInFlight.set`. Only lifecycle forks in workers move to `this.runner.runX`. | #1, #2 |
| I4 | Constructors, facades, private methods, module exports unchanged; new constructor parameters are optional, trailing, defaulting to `defaultEffectRunner`. | #1, #6 |
| I5 | Teardown order stays explicit in `dispose()`/`shutdown()`. Layer bodies and wiring layers register **no finalizers** in Phase 11 (`Effect.sync` only), so `runtime.dispose()` reorders nothing. The one supervised resource (`AppFiberScope`) is closed explicitly at a fixed position in `dispose()` (§5). | #3 |
| I6 | Wiring layers replay today's setter/listener order; a constructor may touch only its *declared* dependencies (built earlier by staging). Per-PR audit: grep each moved constructor for calls on setter-provided collaborators → forbidden. Dependency order is expressed only with `provide`/`provideMerge` stages; never rely on `mergeAll` sibling order. | #6 |
| I7 | No persisted-data changes; DI is in-process only. | #4 |
| I8 | Every process root builds from the same Layer definitions (`CoreLive` shared by App and CLI). Unit harnesses (`createTestHistoryService`, `createTestToolConfig`, `createAgentSessionHarness`, …) intentionally bypass Layers. | #7 |

### 2.4 Decisions and alternatives (product-LoC deltas)

<details>
<summary>D1 — Granularity: coarse core first (PR 3), per-service core stages behind a decision gate (PR 4), group layers for the desktop tail (PR 5)</summary>

Honest framing: the three unlocks (engine-core async scope, TestClock, app-lifetime scope) are delivered by `AppRuntime` + `EffectRunner` + `AppFiberScope` and **do not require per-service layers**. Per-service core layers are *migration leverage*: typed requirement sets for the engine-core work, per-service swap in integration tests, explicit dependency stages instead of implicit ordering.

- **(A) Per-service everywhere** (~70 layers): +~900/−~700. Desktop tail has hand-tuned teardown that must not become finalizers, so per-service there buys uniformity only. Rejected.
- **(B) Recommended:** PR 3 coarse `CoreProjectionLive` (+~120/−~10) delivers the shared root and runtime ownership; PR 4 peels the core into staged per-service layers (+~330/−~290) **only if** PR 3's typecheck/startup budgets hold (gate in §3); desktop tail as ~6 group layers (+~170/−~150). Tags for all services either way (~3 LoC each).
- **(C) Coarse only:** stop after PR 3 + desktop projection (~+200 total). Cheapest; the engine-core phase would then redo dependency declarations. Remains the fallback if PR 4's gate fails.
</details>

<details>
<summary>D2 — Async init stays an explicit `initialize()`; Layers construct only</summary>

Folding `initialize()` into layer construction would make the build asynchronous (breaks I1), change failure semantics (today: fail-fast → dialog/log), and move the six-step order into memoised builds. Deferred; a later phase can turn `initialize()` into `runtime.runPromise(startupEffect)` with per-step `Effect.timeout`.
</details>

<details>
<summary>D3 — Optional cross-cutting services stay optional via `CoreOptionsTag`, not `Effect.serviceOption`</summary>

Core layer bodies read `opts.policyService` etc. exactly as today, so CLI (absent) vs desktop (present) behavior is unchanged and no service gains a new `undefined` branch.
</details>

<details>
<summary>D4 — Two seams instead of one: `EffectRunner` (unsupervised, clock-bound) + `AppFiberScope` (supervised)</summary>

A single "runtime handle" conflates two needs. Workers need *which clock* (TestClock) and must keep sync `stop()`; the engine core needs *who awaits me on shutdown*. Explicit `Clock` injection per worker was rejected (a `provideService(Clock.Clock, …)` at every fork site, and it does not extend to other refs).
</details>

<details>
<summary>D5 — oRPC: `effect/context` = the runtime's `Context`; `handlerGen` unchanged</summary>

`handlerGen` already `Effect.provide`s the context per request; providing ~70 entries instead of one is one Map merge per request. The existing `echoAsync`/`echoEffect` probes record the delta as a **diagnostic** in the PR body (no stable benchmark harness exists to make it a hard gate). `effect/wrap` not needed.
</details>

## 3. Phasing — six stacked PRs

Every PR: `make static-check`; gate suites below; existing tests unchanged (PR 6 is the only PR that edits tests, and only to replace real-timer probes). Before `@codex review`, run the **house pre-review audits**:

1. **Interruption posture** — list every new/moved fiber fork; state what interrupts it and when (unsupervised via `EffectRunner` + worker scope, or supervised via `AppFiberScope`).
2. **Uninterruptible teardown** — teardown effects are `Effect.uninterruptible` end-to-end; bounded waits inside use `Effect.interruptible(Effect.timeout(...))` (house shape from #4038).
3. **No defect escapes** — `disposeAppRuntime`/`closeScopeBounded` and every Promise facade fold defects; `makeAppRuntime` is the one place allowed to throw (constructor semantics).
4. **Spy-seam check** — `rg 'spyOn\(' src/node/services/<touched>.test.ts tests/` per touched class; constructor arity and private-method Promise signatures unchanged (typecheck of tests proves it).
5. **Sync-start check** — a fork through `EffectRunner` runs to its first `sleep` before `runFork` returns (mirrors `heartbeatService.ts:199-202`).
6. **Constructor side-effect audit (I6)** for every constructor moved into a Layer in that PR.
7. **Zero-suspension audit (I3)** whenever `memoryConsolidationService` is in the diff.

### PR 1 — Skeleton: AppRuntime + Stores/MemoryMeta layers + runtime-backed `effect/context` + dispose hook (+~150 LoC)

**Scope**
- `di/tags.ts` (`ConfigTag`, `SessionLocatorTag`, `ProvidersConfigStoreTag`, `SecretsStoreTag`, `FileLeaseManagerTag`, `MemoryMeta` moved from `orpc/effectContext.ts`, which re-exports it; `AppTags` union).
- `di/layers/stores.ts` (`StoresLive`), `di/layers/core.ts` with `MemoryMetaLive = Layer.effect(MemoryMeta, Effect.map(ConfigTag, c => new MemoryMetaService(c.rootDir)))`, `di/layers/app.ts` (`AppLive(stores) = MemoryMetaLive ▹ StoresLive`).
- `di/appRuntime.ts` (`makeAppRuntime`, `disposeAppRuntime`); `APP_RUNTIME_DISPOSE_TIMEOUT_MS` in `src/constants/`.
- `coreServices.ts`: `CoreServicesOptions.memoryMetaService?` (precedent: `workspaceMcpOverridesService?`).
- `serviceContainer.ts`: build runtime first, pass `Context.get(ctx, MemoryMeta)` to `createCoreServices`, `public readonly runtime`, `toORPCContext()["effect/context"] = this.serviceContext`, `dispose()` appends `disposeAppRuntime` behind a `disposed` latch; new `log.debug("[startup] AppRuntime built", { ms })`.
- `orpc/effectContext.ts`: `OrpcEffectServices = AppTags`; `buildOrpcEffectContext` retyped/test-helper doc.
- `headlessEnvironment.dispose` calls `await services.dispose()` before removing the temp dir (the bench harness currently leaks the container; runtime ownership starts here).

**Acceptance**
- `di/appRuntime.test.ts`: (a) sync build sets `cachedContext`; (b) a layer with an async body makes `makeAppRuntime` **throw synchronously** (I1 enforced); (c) probe layers' finalizers run in reverse order on dispose; (d) dispose is idempotent and bounded (hung finalizer → `warn`, resolves at the timeout); (e) `runtime.runFork` after the eager build starts synchronously.
- `serviceContainer.test.ts`: `Context.get(toORPCContext()["effect/context"], MemoryMeta) === services.memoryMetaService`; `dispose()` closes the runtime; `dispose(); shutdown()` (tests/ipc order) is clean; a throwing layer surfaces as a synchronous throw from `new ServiceContainer(stores)` (same shape as today's constructor throw → existing entry-point catch paths).
- `effectBridge.test.ts`, `memoryMeta*.test.ts` unchanged and green; echo-probe overhead recorded in the PR body.
- Gate: `bun test src/node/services/di src/node/services/serviceContainer.test.ts src/node/orpc src/node/services/memoryMeta*` · `make test-integration` · `make static-check`.

**Rollback:** `git revert`; classes untouched.

### PR 2 — Runtime seams: `EffectRunner` + `AppFiberScope`; TestClock on idleCompaction/heartbeat/retryManager (+~140 LoC)

**Scope**
- `di/effectRunner.ts`, `di/appFiberScope.ts`; `AppLive` gains `AppFiberScopeLive ▹ EffectRunnerLive` at the base; `ServiceContainer` exposes `appFiberScope` (used only by `dispose()` in Phase 11) and closes it per §5.
- `IdleCompactionService`, `HeartbeatService`, `RetryManager`: trailing optional `runner: EffectRunner = defaultEffectRunner`; every lifecycle `Effect.runSync/runFork` in `start/stop/schedule/cancel` becomes `this.runner.runX`. Deadline math (`Date.now()`/injected `now`) unchanged. `ServiceContainer` passes `Context.get(ctx, EffectRunnerTag)` to the two workers; `RetryManager` keeps the default until PR 5 (so `streamManager.ts` is untouched here).
- `di/testEffectRunner.ts` helper.

**Acceptance**
- New TestClock tests (existing real-timer tests untouched — they exercise the `defaultEffectRunner` path, which is production behavior wherever no runner is injected): heartbeat `STARTUP_DELAY_MS` → first tick after `adjust`, one tick per `CHECK_INTERVAL_MS`, no ticks after `stop()`; idleCompaction initial delay + cadence; retryManager fires exactly at `delayMs`, `cancel()` before `adjust` never fires.
- Pin runtime facts: `runner.runSync(Scope.close(scope, Exit.void))` completes synchronously for a fiber suspended on a TestClock sleep; `runFork` through the runner reaches its first sleep synchronously; `Effect.context<never>()` inside `EffectRunnerLive` sees the upstream `TestClock` (else the helper provides `Clock.Clock` explicitly — same seam, one line).
- `AppFiberScope` contract tests: (i) an **I/O-suspended** fiber (interruptible `Effect.async` that never resolves, with a cancel path) forked with `Effect.forkIn(_, appFiberScope)` is interrupted **and awaited** by `closeScopeBounded(appFiberScope)` — and this happens *before* the explicit teardown steps in `dispose()` (assert ordering against a spy on `desktopBridgeServer.stop`); (ii) a fiber forked via `EffectRunner` is *not* interrupted by either close (documents the asymmetry); (iii) `disposeAppRuntime` afterwards idempotently re-closes the already-closed child scope (no error, no second finalizer run).
- If `TestClock.adjust` leaves continuations pending, the helper adds `Effect.yieldNow`/`Fiber.await` — decided by tests.
- Gate: `heartbeatService.test.ts`, `idleCompactionService.test.ts`, `retryManager.test.ts`, `serviceContainer.test.ts`, `di/*`, tests/ipc.

**Rollback:** revert restores defaults; no call site depends on the new params.

### PR 3 — Shared core root: coarse `CoreProjectionLive` + `createCoreServices` facade + CLI runtime disposal (+~120 / −~10)

**Scope**
- Tags for the remaining 19 core services; `CoreOptionsTag`; `StoresFromCoreOptionsLive`.
- `CoreProjectionLive = Layer.effectContext(Effect.gen(function*(){ const opts = yield* CoreOptionsTag; const stores = yield* …; const core = buildCoreGraph({ ...opts, ...stores }); return Context.make(History, core.historyService).pipe(Context.add(...)) }))` where `buildCoreGraph` is today's `createCoreServices` body, unchanged, renamed.
- `createCoreServices(opts)` = `makeAppRuntime(CoreProjectionLive ▹ StoresFromCoreOptionsLive ▹ AppFiberScopeLive ▹ EffectRunnerLive ▹ Layer.succeed(CoreOptionsTag, opts))`, returns today's `CoreServices` object read from the context plus `runtime` and `appFiberScope`. `cli/run.ts` and `cli/workflow.ts` cleanup lists append `closeScopeBounded(appFiberScope)` **before** `session.dispose()` and `disposeAppRuntime(runtime)` **after** `backgroundProcessManager.terminateAll()`.
- `ServiceContainer` stops calling `createCoreServices`; `AppLive = CoreProjectionLive ▹ CoreOptionsFromDesktopLive ▹ CrossCuttingLive ▹ …` (cross-cutting services move into `CrossCuttingLive` now because core options derive from them). Desktop constructions otherwise stay in the constructor.

**Acceptance**
- Identity test: every `CoreServices` field `===` `Context.get(ctx, Tag)`; `serviceContainer.test.ts` unchanged and green.
- **Decision gate for PR 4** recorded in the PR body: `make typecheck` wall time, `[startup] AppRuntime built` ms and `initialize` totals vs `origin/main` baseline from the sandbox (§7). Proceed to PR 4 only if typecheck regresses < 10 % and startup within noise; otherwise stop at (C).
- Gate: `bun test src/node/services`, `src/cli/*.test.ts` (run/workflow/server/cli), tests/ipc, `make static-check`.

**Rollback:** revert restores the imperative call; PR 1/2 unaffected.

### PR 4 — Peel the core into staged per-service Layers + `CoreWiringLive` (+~330 / −~290 ⇒ net ≈ +40; split 4a/4b if > ~600 diff lines)

**Scope**
- Stages S1, S2a, S2b, S3…S8 (§2.1 + skeleton in §2.2) as `Layer.effect` adapters with today's argument lists; `CoreWiringLive` (`Effect.sync` only) replays the wiring lines in order; `CoreLive = CoreWiringLive.pipe(Layer.provideMerge(S8))` replaces `CoreProjectionLive`; `buildCoreGraph` deleted.
- Before writing any stage: re-derive the DAG from the constructor argument lists (the plan's stage table was checked once; `StreamManager → SessionUsage` is the kind of edge that turns "siblings" into a stage split) and record it in the PR body.
- 4a (S1–S3: leaves through `AIService`) / 4b (S4–S8 + wiring) if needed — 4a alone is mergeable because the remaining services are built by a shrunken projection layer that reads S1–S3 from the context.

**Acceptance**
- Wiring assertions that are behavioral (a missing wiring line fails them): `turnRequestBuilderBindings` fully populated; goal continuation consumer registered on `idleDispatcher`; `streamManager` MCP manager set; registration probe installed on `extensionMetadata`.
- I6 audit table for all 19 constructors in the PR body; missing-provider = compile error (R must be `never` at `makeAppRuntime`) demonstrated by a type-level test (`// @ts-expect-error`).
- Gate: as PR 3 plus `streamManager*.test.ts`, `aiService.test.ts`, `workspaceService*.test.ts`.

**Rollback:** revert to PR 3's projection.

### PR 5 — `DesktopLive` group layers + `DesktopWiringLive`; thin `ServiceContainer`; `StreamManager` runner param (+~170 / −~150 ⇒ net ≈ +20)

**Scope**
- Tags for the 45 desktop services; six group layers (`Layer.effectContext`, today's construction order inside each; `provideMerge` between groups that depend on each other); `DesktopWiringLive` (`Effect.sync` only) = `serviceContainer.ts:209, 263-265, 271, 288-290, 334-340, 348, 365, 375, 381-382, 434, 438-471, 474-574` in order.
- `ServiceContainer` constructor = `makeAppRuntime(AppLive(stores))` + field assignment from the context. `toORPCContext()` unchanged in shape.
- `StreamManager`: optional trailing `runner: EffectRunner`; `schedulePartialWrite` fork (`streamManager.ts:1141`) and `RetryManager` construction use it; `Scope.close` stays `Effect.runFork` (existing async-close precedent). `WorkersLive` receives `EffectRunnerTag`.

**Acceptance**
- All four existing `serviceContainer.test.ts` assertions unchanged; new identity test over `toORPCContext()` fields vs tags; `dispose()`/`shutdown()` call order asserted via spies on the *public* methods already spied today.
- I6 audit for the 45 constructors.
- Gate: tests/ipc + tests/ui (`make test-integration`), `src/cli/server.test.ts`, `src/cli/cli.test.ts`, `streamManager*.test.ts`, `aiService.test.ts`.

### PR 6 — TestClock adoption sweep + shutdown hardening + contract docs (+~20 LoC product; tests edited)

**Scope**
- Replace real-sleep cadence probes with `makeTestEffectRunner()` in `heartbeatService.test.ts`, `idleCompactionService.test.ts`, `retryManager.test.ts`, and the partial-write debounce cases of `streamManager.test.ts`; keep **one real-timer smoke test per worker** (guards the `defaultEffectRunner` path).
- `cli/server.ts`: `[shutdown]` log lines per step incl. `AppRuntime disposed {ms}`; confirm the whole `dispose()` fits the existing 5 s force-exit budget.
- Finalize the contract doc comment in `di/appRuntime.ts` (I1–I8, §5).

**Acceptance:** converted suites have zero `setTimeout`-based cadence waits (grep in PR body), same assertions; `make test-integration` green; sandbox startup/shutdown evidence (§7).

## 4. TestClock story

- **Mechanism.** `Effect.sleep`, `Schedule.fixed`, `Effect.timeout`, `Clock.currentTimeMillis` read the `Clock` reference from the running fiber's context. Workers that fork through an `EffectRunner` built under `TestClock.layer()` run on the test clock; `await testRunner.adjust("2 minutes")` advances it. `Date.now()`, `setTimeout`, `setInterval` are unaffected — heartbeat deadline math via injected `now`, `AgentStatusService`'s ref'd `setInterval`, and `backgroundProcessManager` stay on real timers/injected timestamps.
- **Benefit now:** `heartbeatService.test.ts` (6), `idleCompactionService.test.ts` (2), `retryManager.test.ts` (3 `setSystemTime` → `adjust`; `Date.now`-based `retryAt` may move to `Clock.currentTimeMillis` only if a test needs both clocks aligned), `streamManager.test.ts` debounce cases (7).
- **Deferred:** `streamBridge.test.ts` ticker (11) — needs a context/runner parameter on `subscriptionIterable`; OAuth device-flow polling and `oauthFlowManager.test.ts` (25) — non-goal.
- **Stays real:** child-process/PTY/WASM/fs-lock waits (`backgroundProcessManager` 72, `quickjsRuntime` 26, lock sleeps in `workspaceService`/`taskService`), end-to-end suites (tests/ipc, e2e).
- **Pinned in PR 2, not assumed:** `adjust` runs due sleeps and their synchronous continuations before resolving (or the helper yields until they do); `Schedule.fixed` anchoring under `TestClock` matches the wall-clock expectations in `heartbeatService.ts:149-155`; sync `Scope.close` of a TestClock-suspended fiber completes synchronously.

## 5. Shutdown protocol

1. **Trigger points unchanged:** `main.ts` `before-quit` (preventDefault → `dispose()` raced with 5 s → `app.quit()`; update-install path fire-and-forget), the second `before-quit` listener's `shutdown()` (unchanged, concurrent), `cli/server.ts` SIGINT/SIGTERM (5 s force exit), ACP `close()`, tests/ipc (`dispose()` then `shutdown()`), headless bench (`dispose()` from PR 1).
2. **`ServiceContainer.dispose()` order:**
   1. `backgroundProcessManager.beginShutdown()` — unchanged, first (latch protecting persisted monitor records).
   2. **`closeScopeBounded(appFiberScope, APP_FIBER_SCOPE_CLOSE_TIMEOUT_MS)`** — interrupts and awaits supervised fibers *while every dependency they might touch during finalization is still alive*. No occupants in Phase 11; the position is fixed now so the engine-core phase does not have to re-derive it.
   3. The existing explicit sequence verbatim (`desktopBridgeServer.stop()` … `terminateAll()` … `timelineService.flush()`).
   4. **`disposeAppRuntime(runtime, APP_RUNTIME_DISPOSE_TIMEOUT_MS)`** — closes the runtime scope (interrupts any fiber started via `runtime.runX` — none long-lived in Phase 11; runs layer finalizers — none in Phase 11 by I5). Hung → `warn` at the timeout; never rejects.
   Budget: 2 s + 2 s inner bounds inside the callers' 5 s outer budgets; the outer race in `main.ts` remains the last line of defense.
   **Rule for future occupants:** anything forked into `AppFiberScope` must tolerate interruption at any suspension point and must not depend on resources torn down in step 1; anything that needs a Layer finalizer must first prove reverse-construction order is compatible with steps 2–3 (I5).
3. **Latches:** `disposed` makes `dispose()` idempotent (two `before-quit` listeners, tests/ipc dispose+shutdown). `shutdown()` never touches the runtime or `AppFiberScope`.
4. **Late callers:** `EffectRunner` handles keep working after runtime dispose (I2), so a stray `tick()`/`scheduleRetry()` after quit cannot defect. The `ManagedRuntime` is referenced only by `ServiceContainer` and the `createCoreServices` return value.
5. **Worker `stop()` stays synchronous** (`runner.runSync(Scope.close)`) because their fibers suspend only on the clock. The engine core will fork into `AppFiberScope` (step 2.2 awaits it) — the reason both seams exist now.
6. **Crash paths:** unchanged — `uncaughtException`/SIGKILL run no finalizers. Finalizers are best-effort; durable state must remain crash-safe without them (AGENTS.md self-healing rule). Nothing in Phase 11 makes a finalizer the sole guardian of durable state.

## 6. Risk register

| # | Risk | L/I | Mitigation |
|---|---|---|---|
| R1 | A layer body suspends → `runSync` throws at startup | M/H | I1 assert + PR 1 test (b); doc comment; review checklist; entry-point catch paths verified in PR 1 |
| R2 | Construction-order side effects differ under staged builds | L/H | I6 audit per moved constructor; explicit `provideMerge` stages; wiring layers replay today's order; tests/ipc as behavioral gate |
| R3 | Double teardown (`shutdown()` ∥ `dispose()`; dispose+shutdown in tests) | M/M | `disposed` latch; runtime/AppFiberScope closed only in `dispose()`; PR 1 test |
| R4 | Late `runtime.runX` after dispose → defect | M/M | I2: services hold `EffectRunner`, never the ManagedRuntime |
| R5 | TestClock semantics differ from assumptions | M/L | PR 2 pins them before any suite converts; per-suite fallback to real timers |
| R6 | effect v4 RC churn (`Context`→`ServiceMap`, Layer renames) | M/M | All `Layer/Context/ManagedRuntime/TestClock` imports confined to `di/`; exact pin |
| R7 | Startup latency regression (splash) | L/M | `AppRuntime built` ms + `initialize` totals vs baseline in sandbox; PR 3 gate |
| R8 | Typecheck slowdown from large requirement unions | L/L | PR 3 gate records `make typecheck` wall time; fallback (C) |
| R9 | Per-request `Effect.provide` of a ~70-entry Context | L/L | echo-probe diagnostic in PR 1/5 bodies |
| R10 | Spy seams / direct-construction tests break | L/H | I4; optional trailing params; audit 4; typecheck of tests |
| R11 | CLI roots forget to dispose runtime/scope | M/L | PR 3 wires both cleanups; `src/cli/*.test.ts` assert the cleanup steps exist |
| R12 | Someone forks long-lived I/O work via `EffectRunner` expecting dispose to await it | M/M | Doc on `EffectRunner` ("unsupervised"); PR 2 asymmetry test; review audit 1 |

**Rollback:** PRs are stacked; revert in reverse order (6→1). Service classes are never modified except for optional trailing params, so any revert restores the previous composition root wholesale with no data or API implications.

## 7. Dogfooding (per PR; evidence attached to the PR body)

**Environment (headless Coder host, no `DISPLAY`):**
```bash
XUM_LOG_LEVEL=debug DEV_SERVER_SANDBOX_ARGS="--clean-projects" make dev-server-sandbox   # background bash task; prints URL + XUM_ROOT
```
- **Startup correctness:** `<XUM_ROOT>/logs/*.log` shows, in order: `Loading services...`, `[startup] AppRuntime built {ms}`, `[startup] ServiceContainer.initialize starting`, six step durations, `[startup] ServiceContainer.initialize completed {totalMs, stepDurationsMs}`. Paste baseline (`origin/main`) vs branch numbers.
- **Startup-never-crash parity (once, locally, not committed):** inject a throwing scratch layer → `xum server` exits non-zero with the existing logged error and **no** unhandled-rejection trace; for desktop, confirm by code path (`loadServices()` rejects → `main.ts:1255` dialog) and via `src/cli/server.test.ts`/ACP tests.
- **UI smoke (agent-browser):** `open <url>` → `snapshot -i` → add a scratch git repo as a project → create a workspace → send one message → `screenshot` the loaded app and the response; `attach_file` both. **Video:** start `agent-browser record` before the flow and stop it with a hard timeout (`timeout 30 agent-browser record stop`); if stopping hangs (known), attach the truncated WebM plus the screenshots and say so.
- **oRPC Effect path:** pin/unpin a memory entry (rides `handlerGen` + runtime `effect/context`); screenshot before/after; grep logs for `ManagedRuntime disposed`/defect lines (expect none).
- **Graceful quit:** record the terminal with `script -q /tmp/<workspace>-shutdown.log` (or `agent-tty` if present), `kill -TERM <pid>` → expect `[shutdown]` lines, `AppRuntime disposed {ms}`, exit 0, no force-exit message; attach the typescript. Exercise the timeout branch once with a scratch hung finalizer → `warn` + timely exit.
- **Electron (best effort):** with `Xvfb`, `make dev` + agent-browser via CDP (electron skill): screenshot splash → main window, quit via menu, confirm exit < 5 s; otherwise state that the Electron path is covered by `tests/e2e` in CI and the shared `dispose()` path exercised by `server.ts`.

**Gate suites per PR** (plus `make static-check` always):

| PR | Must pass |
|---|---|
| 1 | `src/node/services/di/*`, `serviceContainer.test.ts`, `src/node/orpc/*`, `memoryMeta*`, `make test-integration` |
| 2 | + `heartbeatService.test.ts`, `idleCompactionService.test.ts`, `retryManager.test.ts` |
| 3 | + `bun test src/node/services`, `src/cli/*.test.ts`; record PR 4 gate numbers |
| 4 | + `streamManager*.test.ts`, `aiService.test.ts`, `workspaceService*.test.ts` |
| 5 | + tests/ui via `make test-integration`, `src/cli/server.test.ts`, `src/cli/cli.test.ts` |
| 6 | converted suites + full `make test-integration` + sandbox startup/shutdown evidence |

## 8. Non-goals (explicit)

- streamManager ENGINE CORE conversion (first `AppFiberScope` occupant; separate phase).
- `Schema` at persistence boundaries; OAuth refresh/device-flow workers; `AgentStatusService` `setInterval` → Effect.
- `initialize()` as a Layer/startup effect (D2); per-service optional tags (D3); `streamBridge` on the runtime; layer finalizers for existing `dispose()` steps.
- Any change to persisted data, IPC wire shapes, or oRPC handler bodies beyond the `effect/context` source.

## 9. Assumptions stated

- `Effect.context<never>()` inside `EffectRunnerLive` returns the enclosing build context including an upstream `TestClock` entry (PR 2 test; fallback: provide `Clock.Clock` explicitly in the helper).
- `Scope.fork(parent)` inside a `Layer.effect` body yields a child closed by the runtime's layer scope on `dispose()` (PR 2 `AppFiberScope` test).
- Layer bodies never need to observe sibling construction order; all ordering that matters is expressed as `provide`/`provideMerge` stages or wiring-layer statement order.
- `EffectRunner`'s `R = never` constraint is sufficient for every lifecycle fork in the three Phase 11 workers and `StreamManager.schedulePartialWrite` (they only use `Effect.sleep`/`Schedule`/`Effect.sync`/`Effect.tryPromise` — no service tags). Verified by typecheck in PR 2/5.
- The desktop tail's teardown remains explicit unless a later RFC proves reverse-construction order compatible; this plan does not attempt it.

</details>

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$39.39`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=39.39 -->

