### PR TITLE
🤖 release: v0.28.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coder/xum",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "desktopName": "xum.desktop",
   "description": "xum - coding agent multiplexer",
   "author": "Coder",

--- a/packages/mux-compat/package.json
+++ b/packages/mux-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mux",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "description": "Compatibility package forwarding the legacy mux command to @coder/xum",
   "bin": {
     "mux": "bin/mux.js"
@@ -10,7 +10,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@coder/xum": "0.28.3"
+    "@coder/xum": "0.28.4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Version bump for the v0.28.4 patch release. The headline change since v0.28.3 is Gemini 3.8 Flash becoming the default Gemini Flash model (#4060). The release also carries browser Login with Coder on remote Xum servers (#4047), the opt-in project bundle for settings backup (#4043), the connection-indicator slow-response surfacing (#4059), send-queue and terminal-wake fixes (#4053, #4052), and the Effect Phase 11 runtime refactors.

## Implementation

Bumped with `node ./scripts/set-package-version.js 0.28.4` so the root `package.json` and the legacy `packages/mux-compat` forwarding package stay version-locked (the v0.28.3 bump missed the compat package and broke `Test / Unit` on main, fixed in #4048). `src/common/compat/productIdentity.test.ts` passes locally.

After this PR merges, the `v0.28.4` tag will be applied to the squash commit and the GitHub Release published to trigger the desktop/npm/docker pipelines.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `medium` • Cost: `$0.00`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=medium costs=0.00 -->
