### PR TITLE
fix(scripts): budget 8 GiB per ESLint lane in worker_budget

### DIFF
--- a/scripts/lib/worker_budget.js
+++ b/scripts/lib/worker_budget.js
@@ -15,10 +15,11 @@ const DEFAULT_PROC_SELF_CGROUP = "/proc/self/cgroup";
 // caps as absent instead of trusting them.
 const UNLIMITED_BYTES_FLOOR = 2n ** 62n;
 
-// Peak RSS measured per worker in this repo, rounded up for growth: ESLint's --concurrency lanes are
-// worker threads in one process (~2.8GiB per lane), while Jest forks reach ~4.7GiB each.
+// Peak RSS measured per worker in this repo, rounded up for growth. Cold type-aware ESLint runs at
+// --concurrency 4 measured 14.3 and 15.4GiB RSS (3.6 to 3.9GiB per lane); 8GiB per lane keeps one
+// cold lint on a 32GiB cgroup at 2 lanes, leaving room for another workspace. Jest forks: ~4.7GiB.
 const PROFILES = {
-  eslint: { memoryPerWorkerGib: 4, maxWorkers: 4 },
+  eslint: { memoryPerWorkerGib: 8, maxWorkers: 4 },
   jest: { memoryPerWorkerGib: 6, maxWorkers: 4 },
 };
 
@@ -217,6 +218,7 @@ function workerBudgetFor(profileName) {
 }
 
 module.exports = {
+  PROFILES,
   computeWorkers,
   readCgroupUsageBytes,
   resolveMemoryConstraint,

--- a/tests/workerBudget.test.ts
+++ b/tests/workerBudget.test.ts
@@ -190,3 +190,18 @@ describe("worker budget sizing", () => {
     ).toBe(1);
   });
 });
+
+describe("eslint profile", () => {
+  const eslintWorkersAt = (limitGib: number) =>
+    workerBudget.computeWorkers({
+      ...workerBudget.PROFILES.eslint,
+      cpuCount: 8,
+      limitBytes: limitGib * GIB,
+      inUseBytes: 10 * GIB,
+    });
+
+  it("leaves room for a second cold lint on a 32GiB cgroup while large hosts keep 4 lanes", () => {
+    expect(eslintWorkersAt(32)).toBe(2);
+    expect(eslintWorkersAt(64)).toBe(4);
+  });
+});


### PR DESCRIPTION
## Problem

Mux workspaces on this repo start as fresh worktrees with no `.eslintcache`, so `scripts/lint.sh` takes the cold path and `scripts/lib/worker_budget.js` sizes lanes from the cgroup assuming 4 GiB per lane. On a 32 GiB cgroup with ~10 GiB resident (the Mux server alone holds ~4.8 GiB) it granted `--concurrency 4`: usable = 32 - 10 - max(2, 0.15 * 32) = 17.2 GiB, floor(17.2 / 4) = 4.

## Evidence

Measured on the cmux Coder workspace (cgroup `memory.max` 32768 MiB, sampled every 15 s by a cgroup watcher; full snapshots in `~/.local/state/mux-memwatch/alerts.log`):

- 2026-09-03T09:20:30Z: `node_modules/.bin/eslint --concurrency 4` (pid 3996022, worktree codex-review-86de) RSS 14342 MiB; cgroup anon 19879 MiB, `memory.current` 29136 MiB, Coder used (`memory.current` minus `inactive_file`) 24190 MiB. Peak sample 09:21:15Z: `memory.current` 32321 MiB against the 32768 MiB ceiling, Coder used 29643 MiB (90%).
- 2026-09-03T09:49:18Z: second independent cold run (pid 4076862, worktree workspace-wakeup-14xm) RSS 15438 MiB; anon 20972 MiB, Coder used 23293 MiB.
- Coder's "workspace is low on memory" notification fires at 80% of `memory.max` (26214 MiB) using clistat's used = `memory.current` - `inactive_file`, which still counts kernel slab; two overlapping cold lints from different Mux workspaces reached the cgroup ceiling (`memory.events` max counter 73738 reclaim events, no OOM kill).
- Per lane that is 3.6 to 3.9 GiB, versus the 2.8 GiB the old comment documented and the 4 GiB it budgeted.

## Fix

Budget 8 GiB per ESLint lane (`eslint.memoryPerWorkerGib` 4 -> 8, `maxWorkers` unchanged). On the 32 GiB / 10 GiB-resident case this yields 2 lanes (about 7 to 8 GiB) instead of 4 (14 to 15 GiB); a 64 GiB cgroup still gets 4 lanes. Warm-cache runs are unaffected (`lint.sh` already uses concurrency 1 when `.eslintcache` exists).

`PROFILES` is now exported so the existing `tests/workerBudget.test.ts` can guard the real eslint profile instead of a copied constant: 32 GiB limit / 10 GiB in use -> 2 lanes, 64 GiB / 10 GiB -> 4 lanes (`cpuCount` fixed at 8).

## Validation

All lint ran with `MUX_ESLINT_CONCURRENCY=1` so validation did not reproduce the 15 GiB run.

- `bun test ./tests/workerBudget.test.ts`: 14 pass, 0 fail.
- Red-green for the new guard: with `memoryPerWorkerGib` toggled back to 4, `(fail) eslint profile > leaves room for a second cold lint on a 32GiB cgroup while large hosts keep 4 lanes`, `Expected: 2`, `Received: 4` (13 pass, 1 fail). Restored to 8: 14 pass, 0 fail.
- `bun x jest --silent tests/workerBudget.test.ts` (the CI path for `tests/`): 1 suite, 14 passed.
- `bun x prettier --check scripts/lib/worker_budget.js tests/workerBudget.test.ts`: all files use Prettier code style.
- `bun x eslint --concurrency 1 --max-warnings 0 scripts/lib/worker_budget.js`: exit 0 (`tests/` is outside `lint.sh`'s ESLint patterns and has no type-aware project, so the test file is not lintable, as before).
- `make typecheck`: both tsgo runs exited 0.

> Xum (AI agent) opened this PR on behalf of @ibetitsmike.
