### PR TITLE
🤖 fix: drop withdrawn queued wakes from pending work

### DIFF
--- a/src/node/services/agentSession.queueDispatch.test.ts
+++ b/src/node/services/agentSession.queueDispatch.test.ts
@@ -421,6 +421,38 @@ describe("AgentSession queued message tool-call dispatch", () => {
     }
   });
 
+  test.each([
+    ["turn-end", "tool-end"],
+    ["tool-end", "turn-end"],
+  ] as const)(
+    "queueMessage reports the live entry's mode behind a withdrawn %s head",
+    async (withdrawnMode, liveMode) => {
+      const { session, cleanup } = await createAgentSessionHarness({
+        workspaceId: "queue-dispatch-withdrawn-" + withdrawnMode + "-head",
+      });
+      try {
+        const controller = new AbortController();
+        session.queueMessage(
+          "Background monitor wake",
+          { model: TEST_MODEL, agentId: "exec", queueDispatchMode: withdrawnMode },
+          { synthetic: true, agentInitiated: true, cancelSignal: controller.signal }
+        );
+        controller.abort("monitor withdrawn");
+
+        expect(
+          session.queueMessage("follow up", {
+            model: TEST_MODEL,
+            agentId: "exec",
+            queueDispatchMode: liveMode,
+          })
+        ).toBe(liveMode);
+      } finally {
+        session.dispose();
+        await cleanup();
+      }
+    }
+  );
+
   test("waits for every known sibling before stopping after a provider-executed result", async () => {
     const workspaceId = "queue-dispatch-provider-siblings";
     const { session, cleanup, aiEmitter, aiService } = await createAgentSessionHarness({

--- a/src/node/services/agentSession.queueDispatch.test.ts
+++ b/src/node/services/agentSession.queueDispatch.test.ts
@@ -372,6 +372,55 @@ describe("AgentSession queued message tool-call dispatch", () => {
     }
   });
 
+  test("withdrawn tool-end entry neither soft-stops nor hides a later entry's mode", async () => {
+    const workspaceId = "queue-dispatch-withdrawn-head";
+    const queuedSignals: boolean[] = [];
+    const { session, cleanup, aiEmitter, aiService } = await createAgentSessionHarness({
+      workspaceId,
+      backgroundProcessManagerOverrides: {
+        setMessageQueued: mock((_workspaceId: string, queued: boolean) => {
+          queuedSignals.push(queued);
+        }),
+      },
+    });
+    const stopStream = spyOn(aiService, "stopStream").mockResolvedValue(Ok(undefined));
+
+    try {
+      aiEmitter.emit("stream-start", streamStartEvent(workspaceId));
+      const controller = new AbortController();
+      session.queueMessage(
+        "Background monitor wake",
+        { model: TEST_MODEL, agentId: "exec", queueDispatchMode: "tool-end" },
+        { synthetic: true, agentInitiated: true, cancelSignal: controller.signal }
+      );
+      expect(session.hasQueuedMessages("tool-end")).toBe(true);
+
+      controller.abort("monitor withdrawn");
+      expect(session.hasQueuedMessages("tool-end")).toBe(false);
+      expect(session.hasQueuedMessages()).toBe(false);
+
+      aiEmitter.emit("tool-call-end", {
+        ...toolCallEndEvent(workspaceId),
+        toolName: "web_search",
+        providerExecuted: true,
+      });
+      expect(stopStream).not.toHaveBeenCalled();
+
+      session.queueMessage("follow up", {
+        model: TEST_MODEL,
+        agentId: "exec",
+        queueDispatchMode: "turn-end",
+      });
+      expect(session.hasQueuedMessages("tool-end")).toBe(false);
+      expect(session.hasQueuedMessages("turn-end")).toBe(true);
+      expect(queuedSignals).toEqual([true, false]);
+    } finally {
+      stopStream.mockRestore();
+      session.dispose();
+      await cleanup();
+    }
+  });
+
   test("waits for every known sibling before stopping after a provider-executed result", async () => {
     const workspaceId = "queue-dispatch-provider-siblings";
     const { session, cleanup, aiEmitter, aiService } = await createAgentSessionHarness({

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -6526,12 +6526,11 @@ export class AgentSession {
     this.emitQueuedMessageChanged();
     // Signal to bash_output that it should return early to process queued messages
     // only for tool-end dispatches.
-    const effectiveDispatchMode = this.messageQueue.getNextQueueDispatchMode();
     this.backgroundProcessManager.setMessageQueued(
       this.workspaceId,
-      effectiveDispatchMode === "tool-end"
+      this.messageQueue.getNextDispatchableMode() === "tool-end"
     );
-    return effectiveDispatchMode;
+    return this.messageQueue.getNextQueueDispatchMode();
   }
 
   clearQueue(cancelReason = "Queued message cleared before dispatch."): void {
@@ -6557,7 +6556,7 @@ export class AgentSession {
     // user-authored turn-end entry forward to a step boundary.
     this.backgroundProcessManager.setMessageQueued(
       this.workspaceId,
-      !this.messageQueue.isEmpty() && this.messageQueue.getNextQueueDispatchMode() === "tool-end"
+      this.messageQueue.getNextDispatchableMode() === "tool-end"
     );
     return true;
   }
@@ -6594,7 +6593,7 @@ export class AgentSession {
     this.emitQueuedMessageChanged();
     this.backgroundProcessManager.setMessageQueued(
       this.workspaceId,
-      !this.messageQueue.isEmpty() && this.messageQueue.getNextQueueDispatchMode() === "tool-end"
+      this.messageQueue.getNextDispatchableMode() === "tool-end"
     );
     for (const callbacks of removal.callbacks) {
       this.notifyQueuedMessageCleared(callbacks, cancelReason);
@@ -6622,17 +6621,16 @@ export class AgentSession {
     this.emitQueuedMessageChanged();
     this.backgroundProcessManager.setMessageQueued(
       this.workspaceId,
-      !this.messageQueue.isEmpty() && this.messageQueue.getNextQueueDispatchMode() === "tool-end"
+      this.messageQueue.getNextDispatchableMode() === "tool-end"
     );
     this.notifyQueuedMessageCleared(callbacks, cancelReason);
     return true;
   }
 
+  /** Pending work only: withdrawn (aborted) entries still occupy the queue but never start a turn. */
   hasQueuedMessages(dispatchMode?: "tool-end" | "turn-end"): boolean {
-    return (
-      !this.messageQueue.isEmpty() &&
-      (dispatchMode == null || this.messageQueue.getNextQueueDispatchMode() === dispatchMode)
-    );
+    const nextMode = this.messageQueue.getNextDispatchableMode();
+    return nextMode != null && (dispatchMode == null || nextMode === dispatchMode);
   }
 
   /** Queued intra-tree agent peer messages awaiting dispatch (peer-message queue cap input). */
@@ -6801,8 +6799,11 @@ export class AgentSession {
       return false;
     }
 
+    // Physical check: withdrawn entries must still drain so their onCanceled fires.
     const shouldDispatch =
-      abortReason !== "user" && !this.deferQueuedFlushUntilAfterEdit && this.hasQueuedMessages();
+      abortReason !== "user" &&
+      !this.deferQueuedFlushUntilAfterEdit &&
+      !this.messageQueue.isEmpty();
     this.queuedProviderToolEndAbortInFlight = false;
 
     if (!shouldDispatch) {
@@ -6965,12 +6966,10 @@ export class AgentSession {
 
       // Re-arm dispatch signals for the remaining entries so the stream we are
       // about to start drains them at its next tool end (or stream end).
-      if (!this.messageQueue.isEmpty()) {
-        this.backgroundProcessManager.setMessageQueued(
-          this.workspaceId,
-          this.messageQueue.getNextQueueDispatchMode() === "tool-end"
-        );
-      }
+      this.backgroundProcessManager.setMessageQueued(
+        this.workspaceId,
+        this.messageQueue.getNextDispatchableMode() === "tool-end"
+      );
 
       // Set PREPARING synchronously before the async sendMessage to prevent
       // incoming messages from bypassing the queue during the await gap.

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -113,7 +113,7 @@ import {
   createRuntimeContextForWorkspace,
   createRuntimeForWorkspace,
 } from "@/node/runtime/runtimeHelpers";
-import { MessageQueue } from "./messageQueue";
+import { MessageQueue, cancelReasonBeforeAcceptance } from "./messageQueue";
 import type { QueueCutCutter } from "./messageQueue";
 import {
   copyStreamLifecycleSnapshot,
@@ -3170,12 +3170,8 @@ export class AgentSession {
         }
       }
 
-      const reason =
-        typeof cancelSignal.reason === "string"
-          ? cancelSignal.reason
-          : "Queued message canceled before acceptance.";
       cancellationHandled = true;
-      await internal?.onCanceled?.(reason);
+      await internal?.onCanceled?.(cancelReasonBeforeAcceptance(cancelSignal));
       if (internal?.cancelState != null) {
         internal.cancelState.canceledBeforeAcceptance = true;
       }
@@ -6525,12 +6521,16 @@ export class AgentSession {
     }
     this.emitQueuedMessageChanged();
     // Signal to bash_output that it should return early to process queued messages
-    // only for tool-end dispatches.
+    // only for tool-end dispatches. Return the same mode so the caller's foreground
+    // task waits follow the entry that will actually run, not a withdrawn FIFO head.
+    const nextDispatchableMode = this.messageQueue.getNextDispatchableMode();
     this.backgroundProcessManager.setMessageQueued(
       this.workspaceId,
-      this.messageQueue.getNextDispatchableMode() === "tool-end"
+      nextDispatchableMode === "tool-end"
     );
-    return this.messageQueue.getNextQueueDispatchMode();
+    // Undefined only if the entry just added is itself withdrawn; WorkspaceService.sendMessage
+    // refuses those before enqueue, so null keeps its "nothing pending was queued" meaning.
+    return nextDispatchableMode ?? null;
   }
 
   clearQueue(cancelReason = "Queued message cleared before dispatch."): void {

--- a/src/node/services/messageQueue.test.ts
+++ b/src/node/services/messageQueue.test.ts
@@ -488,6 +488,25 @@ describe("MessageQueue", () => {
       expect(queue.getQueueDispatchMode()).toBe("tool-end");
     });
 
+    it("skips withdrawn entries when reporting the next dispatchable mode", () => {
+      const validOptions: SendMessageOptions = { model: "gpt-4", agentId: "exec" };
+      const withdrawn = new AbortController();
+      queue.add(
+        "withdrawn wake",
+        { ...validOptions, queueDispatchMode: "tool-end" },
+        { synthetic: true, agentInitiated: true, cancelSignal: withdrawn.signal }
+      );
+      expect(queue.getNextDispatchableMode()).toBe("tool-end");
+
+      withdrawn.abort();
+      expect(queue.getNextDispatchableMode()).toBeUndefined();
+      expect(queue.isEmpty()).toBe(false);
+
+      queue.add("follow up", { ...validOptions, queueDispatchMode: "turn-end" });
+      expect(queue.getNextDispatchableMode()).toBe("turn-end");
+      expect(queue.getNextQueueDispatchMode()).toBe("tool-end");
+    });
+
     it("should reset mode to tool-end when cleared", () => {
       queue.add("Follow up", {
         model: "gpt-4",

--- a/src/node/services/messageQueue.ts
+++ b/src/node/services/messageQueue.ts
@@ -93,6 +93,13 @@ type GoalInterventionPolicy = NonNullable<SendMessageOptions["goalInterventionPo
 // Derive from the Zod schema (SendMessageOptions) to stay in sync automatically.
 export type QueueDispatchMode = NonNullable<SendMessageOptions["queueDispatchMode"]>;
 
+/** onCanceled text for a send whose cancel signal fired before the turn was accepted. */
+export function cancelReasonBeforeAcceptance(signal: AbortSignal): string {
+  return typeof signal.reason === "string"
+    ? signal.reason
+    : "Queued message canceled before acceptance.";
+}
+
 /**
  * Input poised to take over a session at a queue cut (see
  * AgentSession.getQueueCutCutter). Engaged stages win over the queue head; an

--- a/src/node/services/messageQueue.ts
+++ b/src/node/services/messageQueue.ts
@@ -265,6 +265,15 @@ export class MessageQueue {
   }
 
   /**
+   * Dispatch mode of the first entry whose cancel signal has not fired, or undefined
+   * when none remains. Aborted entries still drain FIFO (as no-ops that fire
+   * onCanceled), but they are not pending work and must not arm a tool-end stop.
+   */
+  getNextDispatchableMode(): QueueDispatchMode | undefined {
+    return this.entries.find((entry) => entry.cancelSignal?.aborted !== true)?.dispatchMode;
+  }
+
+  /**
    * Whether every queued entry continues the exact workspace turn correlation.
    *
    * The caller uses this for a new continuation that has not entered the queue.

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -5601,6 +5601,19 @@ describe("StreamManager - categorizeError", () => {
     expect(categorizeErrorForTests(retryError)).toBe("model_not_found");
   });
 
+  test("classifies OpenAI 404 model_not_found by error code", () => {
+    const apiError = createApiCallErrorForTests({
+      message: "The model `gpt-nonexistent` does not exist or you do not have access to it.",
+      statusCode: 404,
+      responseBody:
+        '{"error":{"message":"The model `gpt-nonexistent` does not exist or you do not have access to it.","type":"invalid_request_error","code":"model_not_found"}}',
+      isRetryable: false,
+      data: { error: { type: "invalid_request_error", code: "model_not_found" } },
+    });
+
+    expect(categorizeErrorForTests(apiError)).toBe("model_not_found");
+  });
+
   const categorizeCases: Array<{ name: string; error: unknown; expected: string }> = [
     {
       name: "classifies Anthropic missing message_stop as stream_truncated",

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -4586,11 +4586,10 @@ export class StreamManager {
         );
       };
 
-      // OpenAI: 400 with error.code === 'model_not_found'
+      // OpenAI: error.code === 'model_not_found'. The status has flipped between 400 and
+      // 404 over time, so key on the code rather than the status.
       const isOpenAIModelError =
-        error.statusCode === 400 &&
-        hasErrorProperty(error.data) &&
-        error.data.error.code === "model_not_found";
+        hasErrorProperty(error.data) && error.data.error.code === "model_not_found";
 
       // Anthropic: 404 with error.type === 'not_found_error'
       const isAnthropicModelError =

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -238,6 +238,7 @@ describe("WorkspaceService bash monitor wake reconciler wiring", () => {
       getMonitorWakeDeliveryState: mock(() => Promise.resolve(undefined)),
       acknowledgeMonitorWake: mock(() => undefined),
       dropRetiredMonitor: mock(() => undefined),
+      setMessageQueued: mock(() => undefined),
     }) as unknown as BackgroundProcessManager;
     const service = createWorkspaceServiceForTest({
       config,
@@ -838,6 +839,100 @@ describe("WorkspaceService bash monitor wake reconciler wiring", () => {
       expect(queuedMode).toBe("tool-end");
       expect(queuedCancelState).toEqual({ canceledBeforeAcceptance: false });
       expect(afterIdle).not.toHaveBeenCalled();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("withdrawing a queued monitor wake removes it and releases its dedupe key", async () => {
+    const { config, service, cleanup } = await createWakeWiringService();
+    const workspaceId = "withdrawn-wake-owner";
+    await config.addWorkspace("/tmp/withdrawn-wake-project", {
+      id: workspaceId,
+      name: workspaceId,
+      projectName: "withdrawn-wake-project",
+      projectPath: "/tmp/withdrawn-wake-project",
+      runtimeConfig: { type: "local" },
+    });
+    const session = service.getOrCreateSession(workspaceId);
+    const queuedModes: Array<"tool-end" | "turn-end" | null> = [];
+    // The real sendMessage queues behind a busy session; mirror only that branch.
+    const sendMessage = mock(
+      (
+        _workspaceId: string,
+        prompt: string,
+        options: SendMessageOptions,
+        internal?: {
+          synthetic?: boolean;
+          agentInitiated?: boolean;
+          queueDedupeKey?: string;
+          removableQueueDedupeKey?: boolean;
+          cancelState?: { canceledBeforeAcceptance: boolean };
+          cancelSignal?: AbortSignal;
+          onCanceled?: (reason: string) => Promise<void> | void;
+        }
+      ) => {
+        queuedModes.push(
+          session.queueMessage(prompt, options, {
+            synthetic: internal?.synthetic,
+            agentInitiated: internal?.agentInitiated,
+            dedupeKey: internal?.queueDedupeKey,
+            removableDedupeKey: internal?.removableQueueDedupeKey,
+            cancelState: internal?.cancelState,
+            cancelSignal: internal?.cancelSignal,
+            onCanceled: internal?.onCanceled,
+          })
+        );
+        return Promise.resolve(Ok(undefined));
+      }
+    );
+    const internal = service as unknown as {
+      aiService: { isStreaming(workspaceId: string): boolean };
+      hasPendingQueuedOrPreparingTurn(workspaceId: string): boolean;
+      isBusyForMessage(workspaceId: string): boolean;
+      getDelegatedTurnContinuationSendOptions(workspaceId: string): Promise<object>;
+      sendMessage: typeof sendMessage;
+      dispatchBashMonitorWake(dispatch: {
+        ownerWorkspaceId: string;
+        prompt: string;
+        muxMetadata: { type: "bash-monitor-wake"; records: [] };
+        dedupeKey: string;
+        cancelSignal: AbortSignal;
+        onAccepted(): Promise<void>;
+        onDeferred(): Promise<void>;
+      }): Promise<"in-flight" | "deferred">;
+    };
+    const dedupeKey = "bash-monitor-wake:" + workspaceId + ":dispatch-1";
+    const onDeferred = mock(() => Promise.resolve());
+    const dispatch = (cancelSignal: AbortSignal) =>
+      internal.dispatchBashMonitorWake({
+        ownerWorkspaceId: workspaceId,
+        prompt: "wake",
+        muxMetadata: { type: "bash-monitor-wake", records: [] },
+        dedupeKey,
+        cancelSignal,
+        onAccepted: () => Promise.resolve(),
+        onDeferred,
+      });
+    try {
+      internal.aiService = { isStreaming: () => true };
+      internal.hasPendingQueuedOrPreparingTurn = () => false;
+      internal.isBusyForMessage = () => true;
+      internal.getDelegatedTurnContinuationSendOptions = () => Promise.resolve({});
+      internal.sendMessage = sendMessage;
+
+      const controller = new AbortController();
+      expect(await dispatch(controller.signal)).toBe("in-flight");
+      expect(session.hasQueuedMessages("tool-end")).toBe(true);
+
+      controller.abort("output already shown");
+      expect(session.hasQueuedMessages()).toBe(false);
+      expect(service.removeQueuedMessagesByDedupeKeyPrefix(workspaceId, dedupeKey)).toEqual(Ok(0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(onDeferred).toHaveBeenCalledTimes(1);
+
+      expect(await dispatch(new AbortController().signal)).toBe("in-flight");
+      expect(queuedModes).toEqual(["tool-end", "tool-end"]);
     } finally {
       await cleanup();
     }

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -931,6 +931,12 @@ describe("WorkspaceService bash monitor wake reconciler wiring", () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
       expect(onDeferred).toHaveBeenCalledTimes(1);
 
+      // Already withdrawn at dispatch: never reaches the send, so nothing can be enqueued.
+      expect(await dispatch(controller.signal)).toBe("deferred");
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+      expect(session.hasQueuedMessages()).toBe(false);
+      expect(onDeferred).toHaveBeenCalledTimes(1);
+
       expect(await dispatch(new AbortController().signal)).toBe("in-flight");
       expect(queuedModes).toEqual(["tool-end", "tool-end"]);
     } finally {
@@ -9169,6 +9175,35 @@ describe("WorkspaceService sendMessage status clearing", () => {
     } else {
       expect(resetAutoResumeCount).not.toHaveBeenCalled();
     }
+  });
+
+  test("refuses to queue a send whose cancel signal already fired", async () => {
+    fakeSession.isBusy.mockReturnValue(true);
+    const controller = new AbortController();
+    controller.abort("monitor withdrawn");
+    const onCanceled = mock(() => undefined);
+    const cancelState = { canceledBeforeAcceptance: false };
+
+    const result = await workspaceService.sendMessage(
+      "test-workspace",
+      "wake",
+      { model: "openai:gpt-4o-mini", agentId: "exec" },
+      {
+        synthetic: true,
+        agentInitiated: true,
+        cancelSignal: controller.signal,
+        cancelState,
+        onCanceled,
+        queueDedupeKey: "bash-monitor-wake:test-workspace:1",
+        removableQueueDedupeKey: true,
+      }
+    );
+
+    expect(result.success).toBe(true);
+    expect(fakeSession.queueMessage).not.toHaveBeenCalled();
+    expect(onCanceled).toHaveBeenCalledTimes(1);
+    expect(onCanceled).toHaveBeenCalledWith("monitor withdrawn");
+    expect(cancelState.canceledBeforeAcceptance).toBe(true);
   });
 
   test("strips stale workspace-turn correlation behind an earlier queued entry", async () => {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -42,6 +42,7 @@ import {
   type StreamErrorRecoveryOutcome,
 } from "@/node/services/agentSession";
 import type { QueueCutCutter } from "@/node/services/messageQueue";
+import { cancelReasonBeforeAcceptance } from "@/node/services/messageQueue";
 import type { HistoryService } from "@/node/services/historyService";
 import type { AIService } from "@/node/services/aiService";
 import type { StreamManager } from "@/node/services/streamManager";
@@ -2531,6 +2532,10 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
         log.debug("Bash monitor wake has no send options; leaving pending", { ownerWorkspaceId });
         return "deferred";
       }
+
+      // Withdrawn while awaiting send options above: the abort listener below would never
+      // fire, and send preflight (which persists AI settings) has nothing left to admit.
+      if (dispatch.cancelSignal.aborted) return "deferred";
 
       let accepted = false;
       // A queued wake can be superseded after dequeue. Share cancellation state so
@@ -10840,6 +10845,18 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       }
 
       if (shouldQueue) {
+        // Mirrors AgentSession's cancelBeforeAcceptance for the queue path: a send withdrawn
+        // during the preflight awaits above must not occupy a queue slot (and hold its dedupe
+        // key) until the stream drains it. Nothing is persisted yet, so only the handshake runs.
+        if (internal?.cancelSignal?.aborted === true) {
+          await getContinuationSendState().onCanceled?.(
+            cancelReasonBeforeAcceptance(internal.cancelSignal)
+          );
+          if (internal.cancelState != null) {
+            internal.cancelState.canceledBeforeAcceptance = true;
+          }
+          return Ok(undefined);
+        }
         // Everything from here to queueMessage is synchronous, so a probe pass here cannot go
         // stale before the entry is enqueued.
         if (internal?.admissionStale?.() === true) {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -2536,6 +2536,19 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       // A queued wake can be superseded after dequeue. Share cancellation state so
       // AgentSession can release PREPARING when cancellation wins before acceptance.
       const cancelState = { canceledBeforeAcceptance: false };
+      // Withdrawal (output already shown, process discarded, history cleared) must
+      // free the queue slot now, not at stream end: a lingering entry keeps the
+      // workspace reported busy and its dedupe key held. The key is unique per
+      // dispatch, so this cannot drop a newer wake's entry.
+      dispatch.cancelSignal.addEventListener(
+        "abort",
+        () => {
+          this.removeQueuedMessagesByDedupeKeyPrefix(ownerWorkspaceId, dispatch.dedupeKey, {
+            cancelReason: "Bash monitor wake withdrawn before dispatch.",
+          });
+        },
+        { once: true }
+      );
       const sendResult = await this.sendMessage(
         ownerWorkspaceId,
         dispatch.prompt,

--- a/tests/ipc/config/modelNotFound.test.ts
+++ b/tests/ipc/config/modelNotFound.test.ts
@@ -50,7 +50,7 @@ describeIntegration("model_not_found error handling", () => {
   );
 
   test.concurrent(
-    "should classify OpenAI 400 model_not_found as model_not_found (not retryable)",
+    "should classify OpenAI model_not_found as model_not_found (not retryable)",
     async () => {
       const { env, workspaceId, cleanup } = await setupWorkspace("openai");
       const collector = createStreamCollector(env.orpc, workspaceId);
@@ -58,7 +58,7 @@ describeIntegration("model_not_found error handling", () => {
       await collector.waitForSubscription();
       try {
         // Send a message with a non-existent model
-        // OpenAI returns 400 with error.code === 'model_not_found'
+        // OpenAI returns 400 or 404 with error.code === 'model_not_found'
         void sendMessageWithModel(
           env,
           workspaceId,


### PR DESCRIPTION
Drops withdrawn queued wakes from pending work calculations so they cannot block dispatch or show false waiting indicators, and fixes the OpenAI `model_not_found` classification that was failing the integration suite on `main`.

## Withdrawn queued wakes

- `agentSession` queue dispatch refuses already-withdrawn wakes at enqueue time and returns the dispatchable mode instead of a fixed one
- `messageQueue` and `workspaceService.hasPendingWork` skip withdrawn entries
- Unit tests cover the withdrawn wake state in each layer

## OpenAI `model_not_found` classification

Unrelated to the wake change, folded in because it was the only red check on this PR (and on the other open PRs today). OpenAI now answers a nonexistent model with HTTP 404 while still setting `error.code === "model_not_found"`; the classifier only accepted that code on a 400, so the stream error surfaced as `api` and stayed retryable. The check now keys on the error code regardless of status. Adds a unit guard for the 404 shape (fails with `api` on the previous code) and updates the live integration test's wording.

## Validation

- `tests/ipc/config/modelNotFound.test.ts` reproduced locally (FAIL, `Received: "api"`) before the fix and passes after it
- `queuedMessages*` and `backgroundBash*` integration suites pass locally

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$27.79`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=27.79 -->

