### PR TITLE
🤖 feat: show "Archiving..." from every archive entry point while the request is in flight

### DIFF
--- a/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
@@ -219,6 +219,7 @@ function useArchiveActions(
   spyOn(WorkspaceContextModule, "useWorkspaceActions").mockImplementation(
     () =>
       ({
+        archivingWorkspaceIds: new Set<string>(),
         selectedWorkspace: null,
         setSelectedWorkspace: () => undefined,
         removeWorkspace: () => Promise.resolve({ success: true }),
@@ -537,6 +538,7 @@ function installProjectSidebarTestDoubles() {
   spyOn(WorkspaceContextModule, "useWorkspaceActions").mockImplementation(
     () =>
       ({
+        archivingWorkspaceIds: new Set<string>(),
         selectedWorkspace: null,
         setSelectedWorkspace: () => undefined,
         preflightArchiveWorkspace: preflightArchiveWorkspaceMock,
@@ -788,6 +790,7 @@ describe("ProjectSidebar scratch chats", () => {
     spyOn(WorkspaceContextModule, "useWorkspaceActions").mockImplementation(
       () =>
         ({
+          archivingWorkspaceIds: new Set<string>(),
           selectedWorkspace: {
             workspaceId: workspace.id,
             projectPath: scratchPath,
@@ -1794,6 +1797,7 @@ describe("ProjectSidebar multi-project completed-subagent toggles", () => {
     spyOn(WorkspaceContextModule, "useWorkspaceActions").mockImplementation(
       () =>
         ({
+          archivingWorkspaceIds: new Set<string>(),
           selectedWorkspace: {
             workspaceId: "done-1",
             projectPath: "/projects/demo-project",
@@ -2624,6 +2628,7 @@ describe("ProjectSidebar project actions menu", () => {
     spyOn(WorkspaceContextModule, "useWorkspaceActions").mockImplementation(
       () =>
         ({
+          archivingWorkspaceIds: new Set<string>(),
           selectedWorkspace: null,
           setSelectedWorkspace: () => undefined,
           preflightArchiveWorkspace: preflightArchiveWorkspaceMock,
@@ -2737,6 +2742,7 @@ describe("ProjectSidebar project actions menu", () => {
     spyOn(WorkspaceContextModule, "useWorkspaceActions").mockImplementation(
       () =>
         ({
+          archivingWorkspaceIds: new Set<string>(),
           selectedWorkspace: null,
           setSelectedWorkspace: () => undefined,
           preflightArchiveWorkspace: () =>
@@ -2773,6 +2779,7 @@ describe("ProjectSidebar project actions menu", () => {
     spyOn(WorkspaceContextModule, "useWorkspaceActions").mockImplementation(
       () =>
         ({
+          archivingWorkspaceIds: new Set<string>(),
           selectedWorkspace: null,
           setSelectedWorkspace: () => undefined,
           preflightArchiveWorkspace: () =>

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
@@ -690,6 +690,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
     setSelectedWorkspace: onSelectWorkspace,
     preflightArchiveWorkspace,
     archiveWorkspace: onArchiveWorkspace,
+    archivingWorkspaceIds,
     removeWorkspace,
     updateWorkspaceTitle: onUpdateTitle,
     setWorkspacePinned,
@@ -915,7 +916,6 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
     }));
   };
 
-  const [archivingWorkspaceIds, setArchivingWorkspaceIds] = useState<Set<string>>(new Set());
   const [removingWorkspaceIds, setRemovingWorkspaceIds] = useState<Set<string>>(new Set());
   const [draftVisibilityByProject, setDraftVisibilityByProject] = useState<
     Record<string, Record<string, boolean>>
@@ -1087,84 +1087,72 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
       buttonElement?: HTMLElement,
       acknowledgedUntrackedPaths?: string[]
     ) => {
-      // Mark workspace as being archived for UI feedback
-      setArchivingWorkspaceIds((prev) => new Set(prev).add(workspaceId));
-
-      try {
-        const result = await onArchiveWorkspace(
+      const result = await onArchiveWorkspace(
+        workspaceId,
+        acknowledgedUntrackedPaths ? { acknowledgedUntrackedPaths } : undefined
+      );
+      if (result.success && result.data?.kind === "confirm-lossy-untracked-files") {
+        const metadata = workspaceStore.getWorkspaceMetadata(workspaceId);
+        const displayTitle = metadata?.title ?? metadata?.name ?? workspaceId;
+        const aggregator = workspaceStore.getAggregator(workspaceId);
+        const hasActiveStreams = aggregator?.hasInterruptibleActiveStream() ?? false;
+        const pendingStreamStartTime = aggregator?.getPendingStreamStartTime();
+        const isStarting = pendingStreamStartTime != null && !hasActiveStreams;
+        const awaitingUserQuestion = aggregator?.hasAwaitingUserQuestion() ?? false;
+        const isStreaming = (hasActiveStreams || isStarting) && !awaitingUserQuestion;
+        setArchiveConfirmation({
           workspaceId,
-          acknowledgedUntrackedPaths ? { acknowledgedUntrackedPaths } : undefined
-        );
-        if (result.success && result.data?.kind === "confirm-lossy-untracked-files") {
-          const metadata = workspaceStore.getWorkspaceMetadata(workspaceId);
-          const displayTitle = metadata?.title ?? metadata?.name ?? workspaceId;
-          const aggregator = workspaceStore.getAggregator(workspaceId);
-          const hasActiveStreams = aggregator?.hasInterruptibleActiveStream() ?? false;
-          const pendingStreamStartTime = aggregator?.getPendingStreamStartTime();
-          const isStarting = pendingStreamStartTime != null && !hasActiveStreams;
-          const awaitingUserQuestion = aggregator?.hasAwaitingUserQuestion() ?? false;
-          const isStreaming = (hasActiveStreams || isStarting) && !awaitingUserQuestion;
-          setArchiveConfirmation({
-            workspaceId,
-            displayTitle,
-            buttonElement,
-            untrackedPaths: result.data.paths,
-            // The retry path already handled any earlier streaming warning. Only surface the
-            // interruption warning again when the archive attempt has not yet been confirmed.
-            isStreaming: acknowledgedUntrackedPaths == null ? isStreaming : false,
-          });
-          return false;
-        }
-        if (!result.success) {
-          if (acknowledgedUntrackedPaths != null) {
-            // Archive may fail if new untracked files appear between confirmation and capture.
-            // Re-run preflight so we can reopen the modal with the latest paths.
-            const preflight = await preflightArchiveWorkspace(workspaceId);
-            if (preflight.success && preflight.data?.kind === "confirm-lossy-untracked-files") {
-              const pathsChanged = didUntrackedPathSetChange(
-                acknowledgedUntrackedPaths,
-                preflight.data.paths
-              );
-              if (pathsChanged) {
-                const metadata = workspaceStore.getWorkspaceMetadata(workspaceId);
-                const displayTitle = metadata?.title ?? metadata?.name ?? workspaceId;
-                setArchiveConfirmation({
-                  workspaceId,
-                  displayTitle,
-                  buttonElement,
-                  untrackedPaths: preflight.data.paths,
-                  isStreaming: (() => {
-                    const aggregator = workspaceStore.getAggregator(workspaceId);
-                    if (!aggregator) return false;
-                    const hasActiveStreams = aggregator.hasInterruptibleActiveStream();
-                    const isStarting =
-                      aggregator.getPendingStreamStartTime() !== null && !hasActiveStreams;
-                    const awaitingUserQuestion = aggregator.hasAwaitingUserQuestion();
-                    return (hasActiveStreams || isStarting) && !awaitingUserQuestion;
-                  })(),
-                });
-                return false;
-              }
+          displayTitle,
+          buttonElement,
+          untrackedPaths: result.data.paths,
+          // The retry path already handled any earlier streaming warning. Only surface the
+          // interruption warning again when the archive attempt has not yet been confirmed.
+          isStreaming: acknowledgedUntrackedPaths == null ? isStreaming : false,
+        });
+        return false;
+      }
+      if (!result.success) {
+        if (acknowledgedUntrackedPaths != null) {
+          // Archive may fail if new untracked files appear between confirmation and capture.
+          // Re-run preflight so we can reopen the modal with the latest paths.
+          const preflight = await preflightArchiveWorkspace(workspaceId);
+          if (preflight.success && preflight.data?.kind === "confirm-lossy-untracked-files") {
+            const pathsChanged = didUntrackedPathSetChange(
+              acknowledgedUntrackedPaths,
+              preflight.data.paths
+            );
+            if (pathsChanged) {
+              const metadata = workspaceStore.getWorkspaceMetadata(workspaceId);
+              const displayTitle = metadata?.title ?? metadata?.name ?? workspaceId;
+              setArchiveConfirmation({
+                workspaceId,
+                displayTitle,
+                buttonElement,
+                untrackedPaths: preflight.data.paths,
+                isStreaming: (() => {
+                  const aggregator = workspaceStore.getAggregator(workspaceId);
+                  if (!aggregator) return false;
+                  const hasActiveStreams = aggregator.hasInterruptibleActiveStream();
+                  const isStarting =
+                    aggregator.getPendingStreamStartTime() !== null && !hasActiveStreams;
+                  const awaitingUserQuestion = aggregator.hasAwaitingUserQuestion();
+                  return (hasActiveStreams || isStarting) && !awaitingUserQuestion;
+                })(),
+              });
+              return false;
             }
           }
-
-          const error = result.error ?? "Failed to archive chat";
-          // Archive failures can be long-lived workflow errors (for example, untracked-file safety
-          // checks) that users should notice near the active workspace content, not pinned beside a
-          // left-sidebar row that may be far from their current focus. Use the shared toast fallback
-          // position so archive errors match other top-right UI error surfaces.
-          workspaceArchiveError.showError(workspaceId, error);
-          return false;
         }
-        return true;
-      } finally {
-        // Clear archiving state
-        setArchivingWorkspaceIds((prev) => {
-          const next = new Set(prev);
-          next.delete(workspaceId);
-          return next;
-        });
+
+        const error = result.error ?? "Failed to archive chat";
+        // Archive failures can be long-lived workflow errors (for example, untracked-file safety
+        // checks) that users should notice near the active workspace content, not pinned beside a
+        // left-sidebar row that may be far from their current focus. Use the shared toast fallback
+        // position so archive errors match other top-right UI error surfaces.
+        workspaceArchiveError.showError(workspaceId, error);
+        return false;
       }
+      return true;
     },
     [onArchiveWorkspace, preflightArchiveWorkspace, workspaceArchiveError, workspaceStore]
   );

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
@@ -1206,6 +1206,8 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
 
   const handleArchiveWorkspace = useCallback(
     async (workspaceId: string, buttonElement?: HTMLElement) => {
+      // The keyboard shortcut bypasses the row's disabled state, so guard here as well.
+      if (archivingWorkspaceIds.has(workspaceId)) return;
       const metadata = workspaceStore.getWorkspaceMetadata(workspaceId);
       const displayTitle = metadata?.title ?? metadata?.name ?? workspaceId;
       const isStreaming = hasActiveStream(workspaceId);
@@ -1238,6 +1240,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
       await performArchiveWorkspace(workspaceId, buttonElement);
     },
     [
+      archivingWorkspaceIds,
       hasActiveStream,
       performArchiveWorkspace,
       preflightArchiveWorkspace,

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.stories.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.stories.tsx
@@ -1,3 +1,5 @@
+import type { ComponentType } from "react";
+import { userEvent, waitFor, within } from "@storybook/test";
 import { PIXEL_DUAL_THEME, appMeta, AppWithMocks, type AppStory } from "@/browser/stories/meta.js";
 import { createGitStatusExecutor } from "@/browser/stories/helpers/git";
 import {
@@ -117,6 +119,73 @@ export const DevcontainerStopped: AppStory = {
 /** Devcontainer with unknown runtime status — no status chip should be visible. */
 export const DevcontainerUnknown: AppStory = {
   render: () => <AppWithMocks setup={() => createDevcontainerClient("unknown")} />,
+};
+
+const PHONE_WIDTH_PX = 390;
+
+function PhoneWidthDecorator(Story: ComponentType) {
+  return (
+    <div style={{ width: PHONE_WIDTH_PX, height: 844, overflow: "hidden" }}>
+      <Story />
+    </div>
+  );
+}
+
+/**
+ * Archive in flight: the header shows "Archiving..." next to the title. Pinned to the phone
+ * viewport because the status is non-shrinking and the truncating title must yield to it
+ * without pushing the right-side controls off-screen.
+ */
+export const ArchivingPhone: AppStory = {
+  globals: {
+    viewport: { value: "mobile1", isRotated: false },
+  },
+  decorators: [PhoneWidthDecorator],
+  parameters: {
+    ...appMeta.parameters,
+    pixel: {
+      matrix: { themes: ["dark", "light"], viewports: ["phone"] },
+    },
+  },
+  render: () => (
+    <AppWithMocks
+      setup={() => {
+        const workspace = createWorkspace({
+          id: "archiving-1",
+          name: "feature/long-branch-name-that-truncates-on-phones",
+          projectName: "mux",
+          createdAt: "2023-11-14T22:13:20.000Z",
+        });
+        const projects = groupWorkspacesByProject([workspace]);
+        selectWorkspace(workspace);
+        expandProjects([...projects.keys()]);
+        collapseRightSidebar();
+        collapseLeftSidebar();
+        const client = createMockORPCClient({ projects, workspaces: [workspace] });
+        // Never settle so the story holds the in-flight state for the snapshot.
+        client.workspace.archive = () => new Promise(() => undefined);
+        return client;
+      }}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByTestId("workspace-more-actions"));
+    await userEvent.click(
+      await waitFor(() => within(document.body).getByRole("button", { name: /Archive chat/ }))
+    );
+
+    await waitFor(() => {
+      const bar = canvas.getByTestId("workspace-menu-bar").getBoundingClientRect();
+      const status = canvas.getByTestId("workspace-archiving-status").getBoundingClientRect();
+      const more = canvas.getByTestId("workspace-more-actions").getBoundingClientRect();
+      if (status.width === 0 || status.right > bar.right + 1 || more.right > bar.right + 1) {
+        throw new Error(
+          `Archiving status or header controls overflow the ${bar.width}px header (status right=${status.right}, more right=${more.right})`
+        );
+      }
+    });
+  },
 };
 
 export const ScratchWorkspace: AppStory = {

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.test.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.test.tsx
@@ -41,6 +41,7 @@ import {
 let WorkspaceMenuBar!: typeof WorkspaceMenuBarComponent;
 
 let workspaceMetadata = new Map<string, FrontendWorkspaceMetadata>();
+let archivingWorkspaceIds = new Set<string>();
 let cleanupDom: (() => void) | null = null;
 const workspaceId = "workspace-1";
 
@@ -150,6 +151,7 @@ function installWorkspaceMenuBarTestDoubles() {
   spyOn(WorkspaceContextModule, "useWorkspaceActions").mockImplementation(
     () =>
       ({
+        archivingWorkspaceIds,
         preflightArchiveWorkspace: preflightArchiveWorkspaceMock,
         archiveWorkspace: archiveWorkspaceMock,
       }) as unknown as ReturnType<typeof WorkspaceContextModule.useWorkspaceActions>
@@ -338,6 +340,7 @@ const defaultProps: ComponentProps<typeof WorkspaceMenuBarComponent> = {
 describe("WorkspaceMenuBar archive confirmations", () => {
   beforeEach(() => {
     workspaceMetadata = new Map();
+    archivingWorkspaceIds = new Set();
     mockTimelineExperimentEnabled = false;
     cleanupDom = installDom();
     installWorkspaceMenuBarTestDoubles();
@@ -407,6 +410,17 @@ describe("WorkspaceMenuBar archive confirmations", () => {
     expect(scratchMenuProps?.onForkChat).toBeNull();
     expect(scratchMenuProps?.onEnterImmersiveReview).toBeNull();
     expect(scratchMenuProps?.onOpenTouchFullscreenReview).toBeNull();
+  });
+
+  it("shows the archiving status only while this workspace has an archive request in flight", () => {
+    archivingWorkspaceIds = new Set(["some-other-workspace"]);
+    const idle = render(<WorkspaceMenuBar {...defaultProps} />);
+    expect(idle.queryByTestId("workspace-archiving-status")).toBeNull();
+    idle.unmount();
+
+    archivingWorkspaceIds = new Set([workspaceId]);
+    const archiving = render(<WorkspaceMenuBar {...defaultProps} />);
+    expect(archiving.getByTestId("workspace-archiving-status")).not.toBeNull();
   });
 
   it("offers fork and immersive review in the More menu for repo-backed workspaces", () => {

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
@@ -41,6 +41,7 @@ import { ConfirmationModal } from "../ConfirmationModal/ConfirmationModal";
 import { PopoverError } from "../PopoverError/PopoverError";
 import { WorkspaceActionsMenuContent } from "../WorkspaceActionsMenuContent/WorkspaceActionsMenuContent";
 import { WorkspaceTerminalIcon } from "../icons/WorkspaceTerminalIcon/WorkspaceTerminalIcon";
+import { ArchiveIcon } from "../icons/ArchiveIcon/ArchiveIcon";
 
 import { SkillIndicator } from "../SkillIndicator/SkillIndicator";
 import { WorkspaceLinks } from "../WorkspaceLinks/WorkspaceLinks";
@@ -98,7 +99,9 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
 }) => {
   const { api } = useAPI();
   const { disableWorkspaceAgents } = useAgent();
-  const { preflightArchiveWorkspace, archiveWorkspace, setWorkspacePinned } = useWorkspaceActions();
+  const { preflightArchiveWorkspace, archiveWorkspace, archivingWorkspaceIds, setWorkspacePinned } =
+    useWorkspaceActions();
+  const isArchiving = archivingWorkspaceIds.has(workspaceId);
   const { workspaceMetadata } = useWorkspaceContext();
   const workspaceHeartbeatsEnabled = useExperimentValue(EXPERIMENT_IDS.WORKSPACE_HEARTBEATS);
   const timelineExperimentEnabled = useExperimentValue(EXPERIMENT_IDS.TIMELINE);
@@ -151,7 +154,6 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
   const [archiveUntrackedPaths, setArchiveUntrackedPaths] = useState<string[] | null>(null);
   // Whether the confirmation includes an active-stream interruption warning.
   const [archiveConfirmIsStreaming, setArchiveConfirmIsStreaming] = useState(false);
-  const [isArchiving, setIsArchiving] = useState(false);
   const archiveError = usePopoverError();
   const forkError = usePopoverError();
   const stopRuntimeError = usePopoverError();
@@ -312,30 +314,25 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
    */
   const executeArchive = useCallback(
     async (anchorEl?: HTMLElement, acknowledgedUntrackedPaths?: string[]) => {
-      setIsArchiving(true);
-      try {
-        const res = await archiveWorkspace(
+      const res = await archiveWorkspace(
+        workspaceId,
+        acknowledgedUntrackedPaths ? { acknowledgedUntrackedPaths } : undefined
+      );
+      if (res.success && res.data?.kind === "confirm-lossy-untracked-files") {
+        setArchiveUntrackedPaths(res.data.paths);
+        // The retry path already handled any earlier streaming warning. Only surface the
+        // interruption warning again when the archive attempt has not yet been confirmed.
+        setArchiveConfirmIsStreaming(acknowledgedUntrackedPaths == null ? isWorking : false);
+        setArchiveConfirmOpen(true);
+        return;
+      }
+      if (!res.success) {
+        const rect = anchorEl?.getBoundingClientRect();
+        archiveError.showError(
           workspaceId,
-          acknowledgedUntrackedPaths ? { acknowledgedUntrackedPaths } : undefined
+          res.error ?? "Failed to archive chat",
+          rect ? { top: rect.top + window.scrollY, left: rect.right + 10 } : undefined
         );
-        if (res.success && res.data?.kind === "confirm-lossy-untracked-files") {
-          setArchiveUntrackedPaths(res.data.paths);
-          // The retry path already handled any earlier streaming warning. Only surface the
-          // interruption warning again when the archive attempt has not yet been confirmed.
-          setArchiveConfirmIsStreaming(acknowledgedUntrackedPaths == null ? isWorking : false);
-          setArchiveConfirmOpen(true);
-          return;
-        }
-        if (!res.success) {
-          const rect = anchorEl?.getBoundingClientRect();
-          archiveError.showError(
-            workspaceId,
-            res.error ?? "Failed to archive chat",
-            rect ? { top: rect.top + window.scrollY, left: rect.right + 10 } : undefined
-          );
-        }
-      } finally {
-        setIsArchiving(false);
       }
     },
     [workspaceId, archiveWorkspace, archiveError, isWorking]
@@ -351,39 +348,30 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
     async (anchorEl?: HTMLElement) => {
       if (isArchiving) return;
 
-      // Set the in-flight guard before the async preflight call so duplicate clicks
-      // during the await are rejected.
-      setIsArchiving(true);
-      try {
-        // Run preflight to check for untracked files that can't be preserved.
-        const preflight = await preflightArchiveWorkspace(workspaceId);
-        if (!preflight.success) {
-          const rect = anchorEl?.getBoundingClientRect();
-          archiveError.showError(
-            workspaceId,
-            preflight.error ?? "Failed to check archive readiness",
-            rect ? { top: rect.top + window.scrollY, left: rect.right + 10 } : undefined
-          );
-          return;
-        }
+      // Run preflight to check for untracked files that can't be preserved.
+      const preflight = await preflightArchiveWorkspace(workspaceId);
+      if (!preflight.success) {
+        const rect = anchorEl?.getBoundingClientRect();
+        archiveError.showError(
+          workspaceId,
+          preflight.error ?? "Failed to check archive readiness",
+          rect ? { top: rect.top + window.scrollY, left: rect.right + 10 } : undefined
+        );
+        return;
+      }
 
-        const preflightData = preflight.data;
-        const untrackedPaths =
-          preflightData?.kind === "confirm-lossy-untracked-files" ? preflightData.paths : null;
-        const streamingNow = isWorking;
+      const preflightData = preflight.data;
+      const untrackedPaths =
+        preflightData?.kind === "confirm-lossy-untracked-files" ? preflightData.paths : null;
+      const streamingNow = isWorking;
 
-        if (untrackedPaths || streamingNow) {
-          // Show a single combined confirmation dialog for all warnings.
-          setArchiveUntrackedPaths(untrackedPaths);
-          setArchiveConfirmIsStreaming(streamingNow);
-          setArchiveConfirmOpen(true);
-        } else {
-          // No warnings — archive immediately. Await so the finally block doesn't
-          // clear isArchiving before the archive call completes.
-          await executeArchive(anchorEl);
-        }
-      } finally {
-        setIsArchiving(false);
+      if (untrackedPaths || streamingNow) {
+        // Show a single combined confirmation dialog for all warnings.
+        setArchiveUntrackedPaths(untrackedPaths);
+        setArchiveConfirmIsStreaming(streamingNow);
+        setArchiveConfirmOpen(true);
+      } else {
+        await executeArchive(anchorEl);
       }
     },
     [workspaceId, preflightArchiveWorkspace, archiveError, isWorking, isArchiving, executeArchive]
@@ -646,6 +634,16 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
             <span className="text-muted">{namedWorkspacePath}</span>
           </PopoverContent>
         </Popover>
+        {isArchiving && (
+          <span
+            role="status"
+            className="text-muted flex shrink-0 items-center gap-1 text-xs whitespace-nowrap"
+            data-testid="workspace-archiving-status"
+          >
+            <ArchiveIcon className="h-3 w-3 shrink-0" />
+            Archiving...
+          </span>
+        )}
       </div>
       <div className={cn("flex items-center gap-2", isDesktop && "titlebar-no-drag")}>
         {/* The footer hides these links at this width, so the header carries them. */}

--- a/src/browser/contexts/ThinkingContext.test.tsx
+++ b/src/browser/contexts/ThinkingContext.test.tsx
@@ -160,6 +160,7 @@ function createWorkspaceContextValue(): WorkspaceContextValue {
     loading: false,
     loaded: true,
     loadError: null,
+    archivingWorkspaceIds: new Set<string>(),
     workspaceDraftPromotionsByProject: {},
     promoteWorkspaceDraft: () => undefined,
     createWorkspace: () =>

--- a/src/browser/contexts/WorkspaceContext.test.tsx
+++ b/src/browser/contexts/WorkspaceContext.test.tsx
@@ -869,6 +869,56 @@ describe("WorkspaceContext", () => {
         t1: "still-open",
       });
     });
+
+    test("marks the workspace as archiving only while preflight or archive is in flight", async () => {
+      const workspaceId = "ws-archive-pending";
+      let settleArchive: (() => void) | undefined;
+      let failPreflight: ((error: Error) => void) | undefined;
+      createMockAPI({
+        workspace: {
+          archive: () =>
+            new Promise((resolve) => {
+              settleArchive = () =>
+                resolve({ success: true as const, data: { kind: "archived" as const } });
+            }),
+          preflightArchive: () =>
+            new Promise((_resolve, reject) => {
+              failPreflight = reject;
+            }),
+        },
+      });
+
+      const ctx = await setup();
+      expect(ctx().archivingWorkspaceIds.has(workspaceId)).toBe(false);
+
+      let archivePromise: Promise<unknown> | undefined;
+      await act(async () => {
+        archivePromise = ctx().archiveWorkspace(workspaceId);
+        await Promise.resolve();
+      });
+      expect(ctx().archivingWorkspaceIds.has(workspaceId)).toBe(true);
+
+      await act(async () => {
+        settleArchive?.();
+        await archivePromise;
+      });
+      expect(ctx().archivingWorkspaceIds.has(workspaceId)).toBe(false);
+
+      // A failed request must clear the indicator too, or the row would read "Archiving..."
+      // forever after a dropped connection.
+      let preflightPromise: Promise<unknown> | undefined;
+      await act(async () => {
+        preflightPromise = ctx().preflightArchiveWorkspace(workspaceId);
+        await Promise.resolve();
+      });
+      expect(ctx().archivingWorkspaceIds.has(workspaceId)).toBe(true);
+
+      await act(async () => {
+        failPreflight?.(new Error("WebSocket closed"));
+        await preflightPromise;
+      });
+      expect(ctx().archivingWorkspaceIds.has(workspaceId)).toBe(false);
+    });
   });
 
   test("treats legacy archive success without data as archived", async () => {
@@ -1853,6 +1903,10 @@ function createMockAPI(options: MockAPIOptions = {}) {
     archive: mock(
       options.workspace?.archive ??
         (() => Promise.resolve({ success: true as const, data: { kind: "archived" as const } }))
+    ),
+    preflightArchive: mock(
+      options.workspace?.preflightArchive ??
+        (() => Promise.resolve({ success: true as const, data: { kind: "ready" as const } }))
     ),
     unarchive: mock(
       options.workspace?.unarchive ??

--- a/src/browser/contexts/WorkspaceContext.test.tsx
+++ b/src/browser/contexts/WorkspaceContext.test.tsx
@@ -919,6 +919,51 @@ describe("WorkspaceContext", () => {
       });
       expect(ctx().archivingWorkspaceIds.has(workspaceId)).toBe(false);
     });
+
+    test("keeps the workspace marked until the last overlapping request settles", async () => {
+      const workspaceId = "ws-archive-overlap";
+      let settleArchive: (() => void) | undefined;
+      let settlePreflight: (() => void) | undefined;
+      createMockAPI({
+        workspace: {
+          archive: () =>
+            new Promise((resolve) => {
+              settleArchive = () =>
+                resolve({ success: true as const, data: { kind: "archived" as const } });
+            }),
+          preflightArchive: () =>
+            new Promise((resolve) => {
+              settlePreflight = () =>
+                resolve({ success: true as const, data: { kind: "ready" as const } });
+            }),
+        },
+      });
+
+      const ctx = await setup();
+
+      // Header-started archive in flight, then the sidebar shortcut fires a preflight.
+      let archivePromise: Promise<unknown> | undefined;
+      let preflightPromise: Promise<unknown> | undefined;
+      await act(async () => {
+        archivePromise = ctx().archiveWorkspace(workspaceId);
+        preflightPromise = ctx().preflightArchiveWorkspace(workspaceId);
+        await Promise.resolve();
+      });
+      expect(ctx().archivingWorkspaceIds.has(workspaceId)).toBe(true);
+
+      // The first request to finish must not clear the indicator while the other is running.
+      await act(async () => {
+        settlePreflight?.();
+        await preflightPromise;
+      });
+      expect(ctx().archivingWorkspaceIds.has(workspaceId)).toBe(true);
+
+      await act(async () => {
+        settleArchive?.();
+        await archivePromise;
+      });
+      expect(ctx().archivingWorkspaceIds.has(workspaceId)).toBe(false);
+    });
   });
 
   test("treats legacy archive success without data as archived", async () => {

--- a/src/browser/contexts/WorkspaceContext.tsx
+++ b/src/browser/contexts/WorkspaceContext.tsx
@@ -555,6 +555,38 @@ interface WorkspaceProviderProps {
 }
 
 /**
+ * Keeps `workspaceId` in the archiving set while `run` is outstanding. Requests for one
+ * workspace can overlap (the sidebar shortcut fires while a header-started archive is still
+ * in flight), so the id is reference-counted and only removed when the last one settles.
+ */
+async function trackArchivingRequest<T>(
+  counts: Map<string, number>,
+  setArchivingWorkspaceIds: React.Dispatch<React.SetStateAction<ReadonlySet<string>>>,
+  workspaceId: string,
+  run: () => Promise<T>
+): Promise<T> {
+  counts.set(workspaceId, (counts.get(workspaceId) ?? 0) + 1);
+  setArchivingWorkspaceIds((prev) =>
+    prev.has(workspaceId) ? prev : new Set(prev).add(workspaceId)
+  );
+  try {
+    return await run();
+  } finally {
+    const remaining = (counts.get(workspaceId) ?? 1) - 1;
+    if (remaining > 0) {
+      counts.set(workspaceId, remaining);
+    } else {
+      counts.delete(workspaceId);
+      setArchivingWorkspaceIds((prev) => {
+        const next = new Set(prev);
+        next.delete(workspaceId);
+        return next;
+      });
+    }
+  }
+}
+
+/**
  * Startup auto-navigation should yield once the user already has meaningful route state.
  * Desktop launch-project is the exception: its first pass may override a restored
  * file:// route when the backend reports explicit startup intent.
@@ -1647,22 +1679,7 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
   const [archivingWorkspaceIds, setArchivingWorkspaceIds] = useState<ReadonlySet<string>>(
     () => new Set()
   );
-
-  const withArchivingIndicator = useCallback(
-    async <T,>(workspaceId: string, run: () => Promise<T>): Promise<T> => {
-      setArchivingWorkspaceIds((prev) => new Set(prev).add(workspaceId));
-      try {
-        return await run();
-      } finally {
-        setArchivingWorkspaceIds((prev) => {
-          const next = new Set(prev);
-          next.delete(workspaceId);
-          return next;
-        });
-      }
-    },
-    []
-  );
+  const archivingRequestCounts = useRef(new Map<string, number>());
 
   const preflightArchiveWorkspace = useCallback(
     async (
@@ -1671,8 +1688,11 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
       if (!api) return { success: false, error: "API not connected" };
 
       try {
-        const result = await withArchivingIndicator(workspaceId, () =>
-          api.workspace.preflightArchive({ workspaceId })
+        const result = await trackArchivingRequest(
+          archivingRequestCounts.current,
+          setArchivingWorkspaceIds,
+          workspaceId,
+          () => api.workspace.preflightArchive({ workspaceId })
         );
         if (result.success) {
           return { success: true, data: result.data };
@@ -1682,7 +1702,7 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
         return { success: false, error: getErrorMessage(error) };
       }
     },
-    [api, withArchivingIndicator]
+    [api]
   );
 
   const archiveWorkspace = useCallback(
@@ -1693,11 +1713,15 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
       if (!api) return { success: false, error: "API not connected" };
 
       try {
-        const result = await withArchivingIndicator(workspaceId, () =>
-          api.workspace.archive({
-            workspaceId,
-            acknowledgedUntrackedPaths: options?.acknowledgedUntrackedPaths,
-          })
+        const result = await trackArchivingRequest(
+          archivingRequestCounts.current,
+          setArchivingWorkspaceIds,
+          workspaceId,
+          () =>
+            api.workspace.archive({
+              workspaceId,
+              acknowledgedUntrackedPaths: options?.acknowledgedUntrackedPaths,
+            })
         );
         if (result.success) {
           // Older mocks/story fixtures may still return `{ success: true }` without the newer
@@ -1739,7 +1763,7 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
         return { success: false, error: errorMessage };
       }
     },
-    [api, withArchivingIndicator]
+    [api]
   );
 
   const unarchiveWorkspace = useCallback(

--- a/src/browser/contexts/WorkspaceContext.tsx
+++ b/src/browser/contexts/WorkspaceContext.tsx
@@ -485,6 +485,13 @@ export interface WorkspaceContext extends WorkspaceMetadataContextValue {
     options?: { acknowledgedUntrackedPaths?: string[] }
   ) => Promise<{ success: boolean; error?: string; data?: ArchiveWorkspaceResult }>;
   unarchiveWorkspace: (workspaceId: string) => Promise<{ success: boolean; error?: string }>;
+  /**
+   * Workspaces with an archive preflight or archive request in flight. Archive can take tens
+   * of seconds server-side (snapshot + worktree removal), so this lives here rather than in
+   * the component that started it: the sidebar row and the menu bar both show "Archiving..."
+   * no matter which one the user clicked.
+   */
+  archivingWorkspaceIds: ReadonlySet<string>;
   refreshWorkspaceMetadata: () => Promise<void>;
   setWorkspaceMetadata: React.Dispatch<
     React.SetStateAction<Map<string, FrontendWorkspaceMetadata>>
@@ -1637,6 +1644,26 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
     [api, setWorkspaceMetadata]
   );
 
+  const [archivingWorkspaceIds, setArchivingWorkspaceIds] = useState<ReadonlySet<string>>(
+    () => new Set()
+  );
+
+  const withArchivingIndicator = useCallback(
+    async <T,>(workspaceId: string, run: () => Promise<T>): Promise<T> => {
+      setArchivingWorkspaceIds((prev) => new Set(prev).add(workspaceId));
+      try {
+        return await run();
+      } finally {
+        setArchivingWorkspaceIds((prev) => {
+          const next = new Set(prev);
+          next.delete(workspaceId);
+          return next;
+        });
+      }
+    },
+    []
+  );
+
   const preflightArchiveWorkspace = useCallback(
     async (
       workspaceId: string
@@ -1644,7 +1671,9 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
       if (!api) return { success: false, error: "API not connected" };
 
       try {
-        const result = await api.workspace.preflightArchive({ workspaceId });
+        const result = await withArchivingIndicator(workspaceId, () =>
+          api.workspace.preflightArchive({ workspaceId })
+        );
         if (result.success) {
           return { success: true, data: result.data };
         }
@@ -1653,7 +1682,7 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
         return { success: false, error: getErrorMessage(error) };
       }
     },
-    [api]
+    [api, withArchivingIndicator]
   );
 
   const archiveWorkspace = useCallback(
@@ -1664,10 +1693,12 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
       if (!api) return { success: false, error: "API not connected" };
 
       try {
-        const result = await api.workspace.archive({
-          workspaceId,
-          acknowledgedUntrackedPaths: options?.acknowledgedUntrackedPaths,
-        });
+        const result = await withArchivingIndicator(workspaceId, () =>
+          api.workspace.archive({
+            workspaceId,
+            acknowledgedUntrackedPaths: options?.acknowledgedUntrackedPaths,
+          })
+        );
         if (result.success) {
           // Older mocks/story fixtures may still return `{ success: true }` without the newer
           // typed archive payload. Treat that legacy success shape as an ordinary archive so
@@ -1708,7 +1739,7 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
         return { success: false, error: errorMessage };
       }
     },
-    [api]
+    [api, withArchivingIndicator]
   );
 
   const unarchiveWorkspace = useCallback(
@@ -2030,6 +2061,7 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
       preflightArchiveWorkspace,
       archiveWorkspace,
       unarchiveWorkspace,
+      archivingWorkspaceIds,
       refreshWorkspaceMetadata,
       setWorkspaceMetadata,
       selectedWorkspace,
@@ -2056,6 +2088,7 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
       preflightArchiveWorkspace,
       archiveWorkspace,
       unarchiveWorkspace,
+      archivingWorkspaceIds,
       refreshWorkspaceMetadata,
       setWorkspaceMetadata,
       selectedWorkspace,

--- a/src/browser/features/RightSidebar/CodeReview/HunkViewer.stories.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/HunkViewer.stories.tsx
@@ -76,6 +76,7 @@ function createStubWorkspaceContextValue(): WorkspaceContextValue {
     loading: false,
     loaded: true,
     loadError: null,
+    archivingWorkspaceIds: new Set<string>(),
     workspaceDraftPromotionsByProject: {},
     promoteWorkspaceDraft: () => undefined,
     createWorkspace: () =>


### PR DESCRIPTION
## Summary

Archiving a workspace can take 15 to 25 seconds server-side, and if you started it from the workspace menu bar there was no feedback at all until the row vanished. The archive-in-progress state now lives in `WorkspaceContext`, so both the sidebar row and the workspace menu bar show an "Archiving..." status from the moment of the click, whichever surface started it.

## Background

The sidebar row already rendered an inline "Archiving..." status, but the set driving it was `ProjectSidebar`'s own `useState`, populated only by the row's archive button. `WorkspaceMenuBar` kept a separate `isArchiving` boolean purely as a re-entrancy guard and rendered nothing for it. Archiving from the header (the common path when the workspace is selected) therefore looked like a hang, and a slow archive was indistinguishable from a broken connection.

Server-side, the time goes to the archive snapshot (`git format-patch` over `merge-base(trunk, HEAD)..HEAD`), which is large when the local trunk is far behind its remote. That is a separate inefficiency and is not changed here; this PR only makes the wait visible.

## Implementation

- `WorkspaceContext` gains `archivingWorkspaceIds: ReadonlySet<string>`. Both `preflightArchiveWorkspace` and `archiveWorkspace` wrap their RPC in a small helper that adds the id before the call and removes it in `finally`, so a rejected request (for example a dropped WebSocket) clears the indicator instead of leaving the row stuck.
- `ProjectSidebar` reads the set from context; its local copy and the surrounding `try/finally` are removed (most of that file's diff is the resulting de-indent; view with whitespace ignored).
- `WorkspaceMenuBar` reads the same set for its re-entrancy guard and renders a `role="status"` "Archiving..." span with the archive icon next to the title. It is `shrink-0` beside the `min-w-0 truncate` title, so it stays visible at phone widths.

The set is placed in the actions context (alongside selection and drafts) rather than the metadata context: the two consumers already subscribe there, and archive is rare enough that two extra context updates per archive are negligible.

## Validation

- New context test drives `archiveWorkspace` and `preflightArchiveWorkspace` against deferred promises and asserts the id is present only while each is outstanding, including the rejection path.
- New menu bar test asserts the status renders only when this workspace's id is in the set.
- Both tests were red-green verified: making the helper a no-op fails the first; replacing the render condition with `false` fails the second.

## Risks

Low. UI-only, no IPC or persistence changes. The sidebar row now also enters its archiving presentation during the preflight call (previously only during the archive call itself), which is the intended behaviour and lasts well under a second.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$21.13`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=21.13 -->
