### PR TITLE
🤖 ci: ignore Codex informational cards in the Codex Comments gate

### DIFF
--- a/scripts/check_codex_comments.sh
+++ b/scripts/check_codex_comments.sh
@@ -85,7 +85,7 @@ compute_codex_sets_from_arrays() {
   # "Argument list too long". printf is a shell builtin, so it has no such limit.
   REGULAR_COMMENTS=$(printf '%s' "$comments_json" | jq -c --arg bot "$BOT_LOGIN_GRAPHQL" '[
     .[]
-    | select(.author.login == $bot and .isMinimized == false and (.body | test("Didn.t find any major issues|usage limits have been reached|create a Codex account") | not))
+    | select(.author.login == $bot and .isMinimized == false and (.body | test("Didn.t find any major issues|usage limits have been reached|create a Codex account|codex-pull-request-review-summary|No security issues were found") | not))
   ]')
 
   UNRESOLVED_THREADS=$(printf '%s' "$threads_json" | jq -c --arg bot "$BOT_LOGIN_GRAPHQL" '[

--- a/scripts/check_codex_comments.sh
+++ b/scripts/check_codex_comments.sh
@@ -85,7 +85,7 @@ compute_codex_sets_from_arrays() {
   # "Argument list too long". printf is a shell builtin, so it has no such limit.
   REGULAR_COMMENTS=$(printf '%s' "$comments_json" | jq -c --arg bot "$BOT_LOGIN_GRAPHQL" '[
     .[]
-    | select(.author.login == $bot and .isMinimized == false and (.body | test("Didn.t find any major issues|usage limits have been reached|create a Codex account|codex-pull-request-review-summary|No security issues were found") | not))
+    | select(.author.login == $bot and .isMinimized == false and (.body | test("Didn.t find any major issues|usage limits have been reached|create a Codex account|^<!-- codex-pull-request-review-summary -->|^Security review completed[.] No security issues were found in this pull request[.]") | not))
   ]')
 
   UNRESOLVED_THREADS=$(printf '%s' "$threads_json" | jq -c --arg bot "$BOT_LOGIN_GRAPHQL" '[


### PR DESCRIPTION
## Summary

Codex now posts two informational comments that carry no findings: a `<!-- codex-pull-request-review-summary -->` status card when a PR opens, and a "Security review completed. No security issues were found in this pull request." card after each review. `scripts/check_codex_comments.sh` (which the `Codex Comments` CI job runs) counted both as unminimized bot comments, so the check failed on every freshly opened PR until someone minimized them by hand. This teaches the script to ignore exactly those two cards.

## Implementation

The exemptions are anchored to the exact card openings (`^<!-- codex-pull-request-review-summary -->` and `^Security review completed. No security issues were found in this pull request.`) so a comment that carries real findings alongside similar prose is still counted.

## Validation

- jq `test()` against the real card bodies from #4058 and #4069 (both excluded) and an adversarial comment that mentions "No security issues were found" after a P1 finding (still counted).
- `./scripts/check_codex_comments.sh 4069` passes with the cards present and unminimized.

<details>
<summary>History</summary>

This PR originally also carried the OpenAI 404 `model_not_found` classification fix; the identical fix landed on main via #4067, so the branch was reduced to the script change.

</details>

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$165.56`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=165.56 -->
