### PR TITLE
🤖 feat: stream engine becomes the AppFiberScope occupant — dispose() aborts and awaits in-flight streams (Wave 4 PR 1)

### DIFF
--- a/src/node/services/coreServicesRoot.test.ts
+++ b/src/node/services/coreServicesRoot.test.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import type { Context } from "effect";
 import { createConfigStores, type ConfigStores } from "@/node/config";
+import { createRuntime } from "@/node/runtime/runtimeFactory";
 import * as agentPluginsMcpConfig from "@/node/services/agentPlugins/mcpConfig";
 import type { CoreServices } from "@/node/services/coreServices";
 import { AppFiberScopeTag } from "@/node/services/di/appFiberScope";
@@ -155,6 +156,96 @@ describe("createCoreServices", () => {
     await disposeAppRuntime(runtime.managed);
     expect(runtime.managed.cachedContext).toBeUndefined();
     // The afterEach pair then exercises the idempotent second close/dispose.
+  });
+
+  it("the CLI cleanup list's appFiberScope.close aborts and awaits an in-flight stream", async () => {
+    // `xum run`/`xum workflow` mirror ServiceContainer.dispose(): the
+    // appFiberScope.close step runs before session.dispose. With the stream
+    // engine as the scope's occupant, that step must abort a live stream as
+    // "system", commit its partial into chat.jsonl and remove partial.json.
+    root = createCoreServices({
+      ...stores,
+      extensionMetadataPath: path.join(tempDir, "extensionMetadata.json"),
+    });
+    const workspaceId = "cli-cleanup-in-flight-stream-workspace";
+    const messageId = "cli-cleanup-in-flight-stream-message";
+    const abortReasons: string[] = [];
+    Reflect.set(root.streamManager, "tokenTracker", {
+      setModel: () => Promise.resolve(undefined),
+      countTokens: () => Promise.resolve(0),
+    });
+    Reflect.set(
+      root.streamManager,
+      "createStreamResult",
+      (_request: unknown, abortController: AbortController) => ({
+        fullStream: (async function* () {
+          yield { type: "text-delta", text: "cli stream text" };
+          await new Promise<void>((resolve) => {
+            if (abortController.signal.aborted) return resolve();
+            abortController.signal.addEventListener("abort", () => resolve(), { once: true });
+          });
+        })(),
+        totalUsage: Promise.resolve(undefined),
+        usage: Promise.resolve(undefined),
+        providerMetadata: Promise.resolve(undefined),
+        steps: Promise.resolve([]),
+      })
+    );
+    Reflect.set(root.streamManager, "createTempDirForStream", () =>
+      Promise.resolve(path.join(tempDir, "stream-tempdir"))
+    );
+    Reflect.set(root.streamManager, "cleanupStreamTempDir", () => undefined);
+    root.aiService.on("stream-abort", (event: { abortReason?: string }) => {
+      abortReasons.push(event.abortReason ?? "");
+    });
+    const appendResult = await root.historyService.appendToHistory(workspaceId, {
+      id: messageId,
+      role: "assistant",
+      metadata: { historySequence: 1, partial: true },
+      parts: [],
+    });
+    expect(appendResult.success).toBe(true);
+    const started = await root.streamManager.startStream({
+      workspaceId,
+      messageId,
+      model: {
+        specificationVersion: "v3",
+        provider: "test",
+        modelId: "cli-cleanup-model",
+        supportedUrls: {},
+        doGenerate: () => Promise.reject(new Error("unused")),
+        doStream: () => Promise.reject(new Error("unused")),
+      },
+      messages: [{ role: "user", content: "hello" }],
+      modelString: "openai:gpt-4.1-mini",
+      historySequence: 1,
+      system: "system",
+      runtime: createRuntime({ type: "local", srcBaseDir: tempDir }),
+      providedRuntimeTempDir: "",
+    });
+    expect(started.success).toBe(true);
+    if (!started.success) throw new Error("expected the stream to start");
+    const deadline = Date.now() + 5_000;
+    while ((await root.historyService.readPartial(workspaceId)) === null) {
+      if (Date.now() > deadline) throw new Error("partial never written");
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+
+    await closeScopeBounded(root.appFiberScope);
+
+    expect(abortReasons).toEqual(["system"]);
+    expect(await started.data.completion).toEqual({ status: "aborted", abortReason: "system" });
+    expect(root.streamManager.isStreaming(workspaceId)).toBe(false);
+    expect(await root.historyService.readPartial(workspaceId)).toBeNull();
+    const history = await root.historyService.getHistoryFromLatestBoundary(workspaceId);
+    expect(history.success).toBe(true);
+    if (!history.success) throw new Error(history.error);
+    const committed = history.data.find((message) => message.id === messageId);
+    expect(
+      committed?.parts.some((part) => part.type === "text" && part.text === "cli stream text")
+    ).toBe(true);
+    // Dependencies are still alive for the remaining CLI cleanup steps.
+    expect(root.runtime.managed.cachedContext).toBeDefined();
   });
 
   it("surfaces a throwing layer body as a synchronous throw", () => {

--- a/src/node/services/di/appFiberScope.test.ts
+++ b/src/node/services/di/appFiberScope.test.ts
@@ -106,6 +106,79 @@ describe("AppFiberScope", () => {
     expect(appFiberScope.state._tag).toBe("Closed");
   });
 
+  it("interrupts a fiber suspended on Effect.promise and awaits its onInterrupt finalizer before the close resolves", async () => {
+    // The stream engine supervisor's shape (streamManager.ts superviseEngine):
+    // a fiber that suspends on a plain Promise and finalizes through another
+    // async Promise. The close must (1) interrupt the suspended wait without
+    // settling the wrapped promise, (2) run the finalizer to completion, and
+    // (3) resolve only afterwards.
+    const { app, appFiberScope } = buildSeams();
+    const steps: string[] = [];
+    let resolveWork!: () => void;
+    const work = new Promise<void>((resolve) => {
+      resolveWork = resolve;
+    });
+    app.managed.runSync(
+      Effect.forkIn(
+        Effect.promise(() => work).pipe(
+          Effect.onInterrupt(() =>
+            Effect.uninterruptible(
+              Effect.promise(async () => {
+                steps.push("finalizer-start");
+                await new Promise<void>((resolve) => setTimeout(resolve, 10));
+                steps.push("finalizer-end");
+              })
+            )
+          )
+        ),
+        appFiberScope,
+        { startImmediately: true }
+      )
+    );
+
+    await closeScopeBounded(appFiberScope);
+
+    expect(steps).toEqual(["finalizer-start", "finalizer-end"]);
+    // The wrapped promise itself is untouched by the interruption (the
+    // occupant's own cancellation transport decides when it settles).
+    let workSettled = false;
+    void work.then(() => {
+      workSettled = true;
+    });
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect(workSettled).toBe(false);
+    resolveWork();
+    await disposeAppRuntime(app.managed);
+  });
+
+  it("a fiber forked with startImmediately into an already-closed scope still runs its onInterrupt finalizer", async () => {
+    // Pins the rc.112 forkIn semantics the supervisor relies on for streams
+    // that start mid-shutdown: the body runs synchronously up to its first
+    // async boundary, the closed scope interrupts it right there, and the
+    // interruption unwinds through onInterrupt — so such a stream is aborted
+    // rather than left running unsupervised.
+    const { app, appFiberScope } = buildSeams();
+    await closeScopeBounded(appFiberScope);
+    expect(appFiberScope.state._tag).toBe("Closed");
+
+    const steps: string[] = [];
+    const fiber = app.managed.runSync(
+      Effect.forkIn(
+        Effect.promise(() => {
+          steps.push("body-started");
+          return new Promise<void>(() => undefined);
+        }).pipe(Effect.onInterrupt(() => Effect.sync(() => steps.push("interrupted")))),
+        appFiberScope,
+        { startImmediately: true }
+      )
+    );
+
+    expect(steps).toEqual(["body-started", "interrupted"]);
+    expect(fiber.pollUnsafe()).toBeDefined();
+    expect(Exit.isFailure(fiber.pollUnsafe()!)).toBe(true);
+    await disposeAppRuntime(app.managed);
+  });
+
   it("closeScopeBounded returns at the timeout when a fiber cannot be interrupted, warning instead of rejecting", async () => {
     const warnSpy = spyOn(log, "warn").mockImplementation(() => undefined);
     try {

--- a/src/node/services/di/appFiberScope.ts
+++ b/src/node/services/di/appFiberScope.ts
@@ -11,13 +11,15 @@
  * later re-closes it idempotently as a backstop.
  *
  * This is the seam for I/O-suspended, long-lived work that shutdown must wait
- * for (the streamManager engine core, in a later phase). It is the counterpart
- * of `EffectRunner` (`./effectRunner.ts`), which is unsupervised: a fiber forked
- * through the runner is interrupted by neither close. Anything forked here must
- * tolerate interruption at any suspension point and must not depend on
- * resources torn down before the close (see the dispose order in
- * `ServiceContainer`). No production occupant yet; the contract is pinned by
- * tests.
+ * for. Its occupant is the stream engine: `StreamManager.superviseEngine`
+ * forks one supervisor fiber per stream into it, whose interruption cancels the
+ * stream (`"system"` abort) and awaits the turn's settlement, so dispose()
+ * commits the partial into chat.jsonl before the bridges stop. It is the
+ * counterpart of `EffectRunner` (`./effectRunner.ts`), which is unsupervised: a
+ * fiber forked through the runner is interrupted by neither close. Anything
+ * forked here must tolerate interruption at any suspension point and must not
+ * depend on resources torn down before the close (see the dispose order in
+ * `ServiceContainer`). The contract is pinned by tests.
  */
 import { Context, Effect, Layer, Scope } from "effect";
 

--- a/src/node/services/di/appRuntime.ts
+++ b/src/node/services/di/appRuntime.ts
@@ -85,11 +85,15 @@
  * - `AppFiberScope` is **supervised**: a child of the runtime's layer scope;
  *   fibers forked into it with `Effect.forkIn` are interrupted *and awaited*
  *   by `closeScopeBounded` early in `dispose()`, while every dependency they
- *   might touch during finalization is still alive. No production occupant in
- *   Phase 11; the first candidate is the streamManager engine core. **Rule for
- *   occupants:** tolerate interruption at any suspension point, do not depend
- *   on resources torn down before step 2 below, and never fork long-lived I/O
- *   work through `EffectRunner` expecting shutdown to await it.
+ *   might touch during finalization is still alive. Occupant: the stream
+ *   engine (`StreamManager.superviseEngine`, Wave 4 PR 1) — one supervisor
+ *   fiber per stream wrapping the already-running processing promise; the
+ *   stream's AbortSignal stays the cancellation transport and interruption
+ *   routes through the user-stop path (`"system"` abort, partial committed,
+ *   `completion` settled) before the close resolves. **Rule for occupants:**
+ *   tolerate interruption at any suspension point, do not depend on resources
+ *   torn down before step 2 below, and never fork long-lived I/O work through
+ *   `EffectRunner` expecting shutdown to await it.
  *
  * ## Shutdown order (`ServiceContainer.dispose()`, one shared teardown behind
  * a latch so concurrent/repeated calls — the desktop's two `before-quit`
@@ -101,7 +105,10 @@
  *    chat session against further dispatch (`workspaceService.beginShutdown()`,
  *    which also disposes the transient chat-recovery sessions housekeeping
  *    scheduled), and only then bounded-join the housekeeping.
- * 2. `closeScopeBounded(appFiberScope, APP_FIBER_SCOPE_CLOSE_TIMEOUT_MS)`.
+ * 2. `closeScopeBounded(appFiberScope, APP_FIBER_SCOPE_CLOSE_TIMEOUT_MS)` —
+ *    aborts (`"system"`) and awaits every in-flight stream; a flowing stream
+ *    settles within one chunk, a wedged provider (no chunks, ignores abort)
+ *    hits the bound, warns, and the process still exits.
  * 3. The explicit sequence verbatim (`desktopBridgeServer.stop()` …
  *    `terminateAll()` … `timelineService.flush()` last), each step timed as a
  *    `[shutdown] <step> {ms}` debug line (`shutdownStep.ts`).
@@ -137,8 +144,10 @@
  * `initialize()` as a Layer/startup effect (would break I1's failure
  * semantics), layer finalizers for the existing `dispose()` steps (I5),
  * `streamBridge` on the runtime, per-service optional tags (optional
- * cross-cutting services stay optional via `CoreOptionsTag`), the streamManager
- * engine core as the first `AppFiberScope` occupant.
+ * cross-cutting services stay optional via `CoreOptionsTag`). The streamManager
+ * engine core became the `AppFiberScope` occupant in Wave 4 PR 1; the
+ * pre-registration stream-start window (`pendingStreamStarts`) stays
+ * unsupervised (nothing durable exists for it yet).
  */
 import assert from "@/common/utils/assert";
 import { Context, Duration, Effect, Exit, Fiber, ManagedRuntime, Scope } from "effect";

--- a/src/node/services/di/appRuntime.ts
+++ b/src/node/services/di/appRuntime.ts
@@ -87,8 +87,9 @@
  *   by `closeScopeBounded` early in `dispose()`, while every dependency they
  *   might touch during finalization is still alive. Occupant: the stream
  *   engine (`StreamManager.superviseEngine`, Wave 4 PR 1) — one supervisor
- *   fiber per stream wrapping the already-running processing promise; the
- *   stream's AbortSignal stays the cancellation transport and interruption
+ *   fiber per stream, forked at registration and living until the turn's
+ *   completion settles; the stream's AbortSignal stays the cancellation
+ *   transport and interruption
  *   routes through the user-stop path (`"system"` abort, partial committed,
  *   `completion` settled) before the close resolves. **Rule for occupants:**
  *   tolerate interruption at any suspension point, do not depend on resources

--- a/src/node/services/di/layers/core.ts
+++ b/src/node/services/di/layers/core.ts
@@ -12,7 +12,7 @@ import {
 import { AIService } from "@/node/services/aiService";
 import { BackgroundProcessManager } from "@/node/services/backgroundProcessManager";
 import type { CoreOptions, CoreServices, CoreServicesOptions } from "@/node/services/coreServices";
-import { AppFiberScopeLive } from "@/node/services/di/appFiberScope";
+import { AppFiberScopeLive, AppFiberScopeTag } from "@/node/services/di/appFiberScope";
 import { EffectRunnerLive, EffectRunnerTag } from "@/node/services/di/effectRunner";
 import {
   AI,
@@ -90,16 +90,18 @@ export class CoreOptionsTag extends Context.Service<CoreOptionsTag, CoreOptions>
 
 /**
  * What the roots must provide beneath `CoreLive`: the stores, the options,
- * the runtime's `EffectRunner` (the base seam in both roots; StreamManager's
- * clock-driven fibers run through it), and the two always-present
- * collaborators the desktop builds elsewhere (`MemoryMetaLive`;
- * `WorkspaceMcpOverrides` from `CrossCuttingLive`). CLI roots supply the
- * defaults (`MemoryMetaLive`, `WorkspaceMcpOverridesDefaultLive`).
+ * the runtime seams (the base of both roots: `EffectRunner`, through which
+ * StreamManager's clock-driven fibers run, and `AppFiberScope`, which
+ * supervises its stream engine), and the two always-present collaborators the
+ * desktop builds elsewhere (`MemoryMetaLive`; `WorkspaceMcpOverrides` from
+ * `CrossCuttingLive`). CLI roots supply the defaults (`MemoryMetaLive`,
+ * `WorkspaceMcpOverridesDefaultLive`).
  */
 export type CoreInputTags =
   | StoreTags
   | CoreOptionsTag
   | EffectRunnerTag
+  | AppFiberScopeTag
   | MemoryMeta
   | WorkspaceMcpOverrides;
 
@@ -233,7 +235,11 @@ export const StreamManagerLive = Layer.effect(
       () => providerService.getConfig(),
       // Default event sink: AIService installs itself as the sink (S3).
       undefined,
-      yield* EffectRunnerTag
+      yield* EffectRunnerTag,
+      // The stream engine is the AppFiberScope's occupant: dispose() closes the
+      // scope before the explicit teardown steps, which aborts and awaits every
+      // in-flight stream (StreamManager.superviseEngine).
+      yield* AppFiberScopeTag
     );
   })
 );

--- a/src/node/services/serviceContainer.test.ts
+++ b/src/node/services/serviceContainer.test.ts
@@ -7,6 +7,7 @@ import { TestClock } from "effect/testing";
 import { MULTI_PROJECT_CONFIG_KEY } from "@/common/constants/multiProject";
 import { createConfigStores, type Config, type ConfigStores } from "@/node/config";
 import type { ORPCContext } from "@/node/orpc/context";
+import { createRuntime } from "@/node/runtime/runtimeFactory";
 import { isInteractiveHostKeyApprovalAvailable } from "@/node/runtime/sshConnectionPool";
 import { AppFiberScopeTag } from "@/node/services/di/appFiberScope";
 import { EffectRunnerTag } from "@/node/services/di/effectRunner";
@@ -443,6 +444,107 @@ describe("ServiceContainer", () => {
     expect(bridgeStopSpy).toHaveBeenCalledTimes(1);
     expect(steps).toEqual(["occupant-cancelled", "occupant-finalized", "bridge-stop"]);
     expect(services.appFiberScope.state._tag).toBe("Closed");
+  });
+
+  it("dispose() aborts and awaits an in-flight stream before desktopBridgeServer.stop()", async () => {
+    // The AppFiberScope occupant end to end: a real stream on the container's
+    // StreamManager (wired with the runtime's scope), its provider stubbed to
+    // flow one delta and then block until the stream's AbortSignal fires.
+    // dispose() must abort it as "system", let AIService commit the partial
+    // into chat.jsonl and delete partial.json, and only then stop the bridge.
+    services = new ServiceContainer(stores);
+    const workspaceId = "dispose-in-flight-stream-workspace";
+    const messageId = "dispose-in-flight-stream-message";
+    const steps: string[] = [];
+    Reflect.set(services.streamManager, "tokenTracker", {
+      setModel: () => Promise.resolve(undefined),
+      countTokens: () => Promise.resolve(0),
+    });
+    Reflect.set(
+      services.streamManager,
+      "createStreamResult",
+      (_request: unknown, abortController: AbortController) => ({
+        fullStream: (async function* () {
+          yield { type: "text-delta", text: "hello from a stream shutdown must not lose" };
+          await new Promise<void>((resolve) => {
+            if (abortController.signal.aborted) return resolve();
+            abortController.signal.addEventListener("abort", () => resolve(), { once: true });
+          });
+        })(),
+        totalUsage: Promise.resolve(undefined),
+        usage: Promise.resolve(undefined),
+        providerMetadata: Promise.resolve(undefined),
+        steps: Promise.resolve([]),
+      })
+    );
+    Reflect.set(services.streamManager, "createTempDirForStream", () =>
+      Promise.resolve(path.join(tempDir, "stream-tempdir"))
+    );
+    Reflect.set(services.streamManager, "cleanupStreamTempDir", () => undefined);
+    services.aiService.on("stream-abort", (event: { abortReason?: string }) => {
+      steps.push(`stream-abort:${event.abortReason}`);
+    });
+    const bridgeStopSpy = spyOn(services.desktopBridgeServer, "stop").mockImplementation(() => {
+      steps.push("bridge-stop");
+      return Promise.resolve(undefined);
+    });
+
+    const appendResult = await services.historyService.appendToHistory(workspaceId, {
+      id: messageId,
+      role: "assistant",
+      metadata: { historySequence: 1, partial: true },
+      parts: [],
+    });
+    expect(appendResult.success).toBe(true);
+    const started = await services.streamManager.startStream({
+      workspaceId,
+      messageId,
+      model: {
+        specificationVersion: "v3",
+        provider: "test",
+        modelId: "dispose-model",
+        supportedUrls: {},
+        doGenerate: () => Promise.reject(new Error("unused")),
+        doStream: () => Promise.reject(new Error("unused")),
+      },
+      messages: [{ role: "user", content: "hello" }],
+      modelString: "openai:gpt-4.1-mini",
+      historySequence: 1,
+      system: "system",
+      runtime: createRuntime({ type: "local", srcBaseDir: tempDir }),
+      providedRuntimeTempDir: "",
+    });
+    expect(started.success).toBe(true);
+    if (!started.success) throw new Error("expected the stream to start");
+    // Wait for the delta to reach partial.json so there is something to commit.
+    const deadline = Date.now() + 5_000;
+    while ((await services.historyService.readPartial(workspaceId)) === null) {
+      if (Date.now() > deadline) throw new Error("partial never written");
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    expect(services.streamManager.isStreaming(workspaceId)).toBe(true);
+
+    await services.dispose();
+
+    expect(bridgeStopSpy).toHaveBeenCalledTimes(1);
+    expect(steps).toEqual(["stream-abort:system", "bridge-stop"]);
+    expect(await started.data.completion).toEqual({ status: "aborted", abortReason: "system" });
+    expect(services.streamManager.isStreaming(workspaceId)).toBe(false);
+    // Durable outcome at the moment the bridge stopped: partial.json gone, the
+    // interrupted assistant message (still flagged partial, as every
+    // interrupted turn is) committed to chat.jsonl with its streamed text —
+    // instead of an empty placeholder row plus an orphan partial.json that only
+    // the next load would reconcile.
+    expect(await services.historyService.readPartial(workspaceId)).toBeNull();
+    const history = await services.historyService.getHistoryFromLatestBoundary(workspaceId);
+    expect(history.success).toBe(true);
+    if (!history.success) throw new Error(history.error);
+    const committed = history.data.find((message) => message.id === messageId);
+    expect(
+      committed?.parts.some(
+        (part) => part.type === "text" && part.text === "hello from a stream shutdown must not lose"
+      )
+    ).toBe(true);
   });
 
   it("shares one teardown across concurrent dispose() calls", async () => {

--- a/src/node/services/serviceContainer.test.ts
+++ b/src/node/services/serviceContainer.test.ts
@@ -482,14 +482,15 @@ describe("ServiceContainer", () => {
     );
     Reflect.set(services.streamManager, "cleanupStreamTempDir", () => undefined);
     services.aiService.on("stream-abort", (event: { abortReason?: string }) => {
-      steps.push(`stream-abort:${event.abortReason}`);
+      steps.push(`stream-abort:${event.abortReason ?? "none"}`);
     });
     const bridgeStopSpy = spyOn(services.desktopBridgeServer, "stop").mockImplementation(() => {
       steps.push("bridge-stop");
       return Promise.resolve(undefined);
     });
 
-    const appendResult = await services.historyService.appendToHistory(workspaceId, {
+    const historyService = services.runtime.get(History);
+    const appendResult = await historyService.appendToHistory(workspaceId, {
       id: messageId,
       role: "assistant",
       metadata: { historySequence: 1, partial: true },
@@ -518,7 +519,7 @@ describe("ServiceContainer", () => {
     if (!started.success) throw new Error("expected the stream to start");
     // Wait for the delta to reach partial.json so there is something to commit.
     const deadline = Date.now() + 5_000;
-    while ((await services.historyService.readPartial(workspaceId)) === null) {
+    while ((await historyService.readPartial(workspaceId)) === null) {
       if (Date.now() > deadline) throw new Error("partial never written");
       await new Promise((resolve) => setTimeout(resolve, 5));
     }
@@ -535,8 +536,8 @@ describe("ServiceContainer", () => {
     // interrupted turn is) committed to chat.jsonl with its streamed text —
     // instead of an empty placeholder row plus an orphan partial.json that only
     // the next load would reconcile.
-    expect(await services.historyService.readPartial(workspaceId)).toBeNull();
-    const history = await services.historyService.getHistoryFromLatestBoundary(workspaceId);
+    expect(await historyService.readPartial(workspaceId)).toBeNull();
+    const history = await historyService.getHistoryFromLatestBoundary(workspaceId);
     expect(history.success).toBe(true);
     if (!history.success) throw new Error(history.error);
     const committed = history.data.find((message) => message.id === messageId);

--- a/src/node/services/serviceContainer.ts
+++ b/src/node/services/serviceContainer.ts
@@ -589,10 +589,13 @@ export class ServiceContainer {
         }
       });
     }
-    // Interrupt and await the runtime's supervised fibers while every dependency
-    // they might touch during finalization is still alive. Fixed here (before
-    // the explicit teardown) so later occupants do not re-derive the position;
-    // bounded and idempotent, and never rejects (di/appRuntime.ts).
+    // Interrupt and await the runtime's supervised fibers — the stream engine's
+    // per-stream supervisors (StreamManager.superviseEngine): every in-flight
+    // stream is aborted as "system" and its partial committed to chat.jsonl —
+    // while every dependency they touch during finalization is still alive.
+    // Fixed here (before the explicit teardown) so clients still receive the
+    // stream-abort over the bridges; bounded and idempotent, and never rejects
+    // (di/appRuntime.ts).
     await closeScopeBounded(this.appFiberScope);
     // Stop the bridge before closing sessions so desktop clients get a clean disconnect.
     await shutdownStep("desktopBridgeServer.stop", () => this.desktopBridgeServer.stop());

--- a/src/node/services/streamManager.chaos.test.ts
+++ b/src/node/services/streamManager.chaos.test.ts
@@ -9,7 +9,9 @@
  * stream afterwards.
  */
 import { describe, test, expect, afterEach, beforeEach } from "bun:test";
+import { Scope } from "effect";
 import { StreamManager, type TurnEngineEvent } from "./streamManager";
+import { closeScopeBounded } from "./di/appRuntime";
 import type { HistoryService } from "./historyService";
 import { createTestHistoryService } from "./testHistoryService";
 import { createRuntime } from "@/node/runtime/runtimeFactory";
@@ -218,6 +220,125 @@ describe("StreamManager chaos", () => {
         }
       }
 
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  }, 120_000);
+
+  test(`with an engine scope closed at a random iteration, every stream settles exactly once (seed=${SEED})`, async () => {
+    // Shutdown variant: the manager is constructed with an engine scope (the
+    // app's AppFiberScope), streams before the close are hostile and settle on
+    // their own, the stream at the close point flows then blocks until its
+    // AbortSignal fires (so the close has something to interrupt) and may race a
+    // user stop, and streams after the close start into a closed scope.
+    // Invariant under all of it: one terminal event per messageId and every
+    // completion promise settles.
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      const rng = mulberry32(SEED);
+      const closeAt = randInt(rng, ITERATIONS);
+      const stopRacesClose = rng() < 0.5;
+      const engineScope = Scope.makeUnsafe("parallel");
+      const events: TurnEngineEvent[] = [];
+      const streamManager = new StreamManager(
+        historyService,
+        undefined,
+        undefined,
+        (event) => {
+          events.push(event);
+        },
+        undefined,
+        engineScope
+      );
+      Reflect.set(streamManager, "tokenTracker", {
+        setModel: () => Promise.resolve(),
+        countTokens: () => Promise.resolve(0),
+      });
+      let nextFullStream: (signal: AbortSignal) => AsyncGenerator<unknown, void, unknown> = () =>
+        randomFullStream(rng);
+      Reflect.set(
+        streamManager,
+        "createStreamResult",
+        (_request: unknown, abortController: AbortController) => ({
+          fullStream: nextFullStream(abortController.signal),
+          totalUsage: Promise.resolve(rng() < 0.7 ? undefined : randomHostileValue(rng)),
+          usage: Promise.resolve(undefined),
+          providerMetadata: Promise.resolve(rng() < 0.8 ? undefined : randomHostileValue(rng)),
+          steps: Promise.resolve([]),
+        })
+      );
+
+      const started: Array<{ messageId: string; completion: Promise<{ status: string }> }> = [];
+      for (let iter = 0; iter < ITERATIONS; iter++) {
+        const workspaceId = `chaos-scope-ws-${iter}`;
+        const messageId = `chaos-scope-msg-${iter}`;
+        const appendResult = await historyService.appendToHistory(workspaceId, {
+          id: messageId,
+          role: "assistant",
+          metadata: { historySequence: 1, partial: true },
+          parts: [],
+        });
+        expect(appendResult.success).toBe(true);
+
+        nextFullStream =
+          iter === closeAt
+            ? (signal) =>
+                (async function* () {
+                  yield { type: "text-delta", text: randomFragmentString(rng) };
+                  await new Promise<void>((resolve) => {
+                    if (signal.aborted) return resolve();
+                    signal.addEventListener("abort", () => resolve(), { once: true });
+                  });
+                })()
+            : () => randomFullStream(rng);
+
+        const result = await streamManager.startStream({
+          workspaceId,
+          messageId,
+          model: createTestLanguageModel(),
+          messages: [{ role: "user", content: "hello" }],
+          modelString: "openai:gpt-4.1-mini",
+          historySequence: 1,
+          system: "system",
+          runtime: LOCAL_TEST_RUNTIME,
+          providedRuntimeTempDir: "",
+        });
+        expect(result.success).toBe(true);
+        if (!result.success) continue;
+        started.push({ messageId, completion: result.data.completion });
+
+        if (iter === closeAt) {
+          await Promise.all([
+            stopRacesClose ? streamManager.stopStream(workspaceId) : Promise.resolve(),
+            closeScopeBounded(engineScope),
+          ]);
+          expect(engineScope.state._tag).toBe("Closed");
+        }
+      }
+
+      const completions = await Promise.race([
+        Promise.all(started.map((entry) => entry.completion)),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("a supervised stream never settled")), 15_000)
+        ),
+      ]);
+      for (const completion of completions) {
+        expect(["completed", "failed", "aborted"]).toContain(completion.status);
+      }
+      // Let the last abort deliveries and finally blocks settle.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      for (const { messageId } of started) {
+        const terminal = events.filter(
+          (event) =>
+            ["stream-end", "error", "stream-abort"].includes(event.type) &&
+            "messageId" in event &&
+            event.messageId === messageId
+        );
+        expect(terminal).toHaveLength(1);
+      }
       expect(unhandled).toEqual([]);
     } finally {
       process.off("unhandledRejection", onUnhandled);

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -1236,8 +1236,9 @@ describe("StreamManager - engine supervision (AppFiberScope occupant)", () => {
    */
   function createSupervisedStreamManagerForTests(
     fullStream: (signal: AbortSignal) => AsyncGenerator<unknown, void, unknown>,
-    engineScope: Scope.Closeable | undefined = Scope.makeUnsafe("parallel")
+    options: { supervised: boolean } = { supervised: true }
   ) {
+    const engineScope = Scope.makeUnsafe("parallel");
     const events: TurnEngineEvent[] = [];
     const streamManager = new StreamManager(
       historyService,
@@ -1247,7 +1248,7 @@ describe("StreamManager - engine supervision (AppFiberScope occupant)", () => {
         events.push(event);
       },
       undefined,
-      engineScope
+      options.supervised ? engineScope : undefined
     );
     Reflect.set(streamManager, "tokenTracker", {
       setModel: () => Promise.resolve(undefined),
@@ -1328,7 +1329,7 @@ describe("StreamManager - engine supervision (AppFiberScope occupant)", () => {
     expect(streamManager.isStreaming(workspaceId)).toBe(true);
 
     // What ServiceContainer.dispose() does at step 2: interrupt + await.
-    await closeScopeBounded(engineScope!);
+    await closeScopeBounded(engineScope);
 
     // The finalizer routed through the user-stop path: the streamed text was
     // flushed (with usage stamping) before the abort was delivered ...
@@ -1360,7 +1361,7 @@ describe("StreamManager - engine supervision (AppFiberScope occupant)", () => {
     // cleanupAbortedStream waits for the loop, which waits on the provider that
     // never returns; the close must still resolve at the bound, and never reject.
     const startedAt = Date.now();
-    await closeScopeBounded(engineScope!, 100);
+    await closeScopeBounded(engineScope, 100);
     expect(Date.now() - startedAt).toBeLessThan(2_000);
   });
 
@@ -1368,7 +1369,7 @@ describe("StreamManager - engine supervision (AppFiberScope occupant)", () => {
     const workspaceId = "supervised-late-start-workspace";
     const { streamManager, events, engineScope } =
       createSupervisedStreamManagerForTests(flowingThenBlockedStream);
-    await closeScopeBounded(engineScope!);
+    await closeScopeBounded(engineScope);
 
     const handle = await startSupervisedStreamForTests(streamManager, workspaceId);
 
@@ -1391,7 +1392,7 @@ describe("StreamManager - engine supervision (AppFiberScope occupant)", () => {
           yield { type: "text-delta", text: "final answer" };
           yield { type: "finish", finishReason: "stop" };
         })(),
-      undefined
+      { supervised: false }
     );
     let stopPromise: Promise<unknown> | undefined;
     const realUpdateHistory = historyService.updateHistory.bind(historyService);
@@ -1441,7 +1442,7 @@ describe("StreamManager - engine supervision (AppFiberScope occupant)", () => {
     // Both cancellers enter cancelStreamSafely in the same tick; the latch is
     // taken synchronously, so the second joins the first's cleanup.
     const stopPromise = streamManager.stopStream(workspaceId, { abortReason: "user" });
-    const closePromise = closeScopeBounded(engineScope!);
+    const closePromise = closeScopeBounded(engineScope);
     await Promise.all([stopPromise, closePromise]);
     await new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -1473,7 +1474,7 @@ describe("StreamManager - engine supervision (AppFiberScope occupant)", () => {
     expect(getWorkspaceStreamsForTests(streamManager).size).toBe(0);
     expect(events.filter((event) => event.type === "stream-end")).toHaveLength(50);
 
-    await closeScopeBounded(engineScope!);
+    await closeScopeBounded(engineScope);
 
     expect(events.filter((event) => event.type === "stream-abort")).toHaveLength(0);
     expect(getWorkspaceStreamsForTests(streamManager).size).toBe(0);

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -45,6 +45,8 @@ import { SessionUsageService } from "./sessionUsageService";
 import type { HistoryService } from "./historyService";
 import { createTestHistoryService } from "./testHistoryService";
 import { makeTestEffectRunner } from "./di/testEffectRunner";
+import { closeScopeBounded } from "./di/appRuntime";
+import { Scope } from "effect";
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { countTokens } from "@/node/utils/main/tokenizer";
 import { shouldRunIntegrationTests, validateApiKeys } from "../../../tests/testUtils";
@@ -1220,6 +1222,261 @@ describe("StreamManager - stream resource scope", () => {
     } finally {
       await testRunner.dispose();
     }
+  });
+});
+
+describe("StreamManager - engine supervision (AppFiberScope occupant)", () => {
+  type StreamAbortEvent = Extract<TurnEngineEvent, { type: "stream-abort" }>;
+
+  /**
+   * A manager whose streams are supervised by `engineScope` (the app runtime's
+   * AppFiberScope in production). `fullStream` receives the stream's own
+   * AbortSignal so scenarios can model a provider that stops on abort — or one
+   * that ignores it.
+   */
+  function createSupervisedStreamManagerForTests(
+    fullStream: (signal: AbortSignal) => AsyncGenerator<unknown, void, unknown>,
+    engineScope: Scope.Closeable | undefined = Scope.makeUnsafe("parallel")
+  ) {
+    const events: TurnEngineEvent[] = [];
+    const streamManager = new StreamManager(
+      historyService,
+      undefined,
+      undefined,
+      (event) => {
+        events.push(event);
+      },
+      undefined,
+      engineScope
+    );
+    Reflect.set(streamManager, "tokenTracker", {
+      setModel: () => Promise.resolve(undefined),
+      countTokens: () => Promise.resolve(0),
+    });
+    Reflect.set(
+      streamManager,
+      "createStreamResult",
+      (_request: unknown, abortController: AbortController) =>
+        createStreamResultForTests(fullStream(abortController.signal))
+    );
+    Reflect.set(streamManager, "createTempDirForStream", () =>
+      Promise.resolve("/tmp/wave4-supervisor-tempdir")
+    );
+    Reflect.set(streamManager, "cleanupStreamTempDir", () => undefined);
+    return { streamManager, events, engineScope };
+  }
+
+  async function startSupervisedStreamForTests(
+    streamManager: StreamManager,
+    workspaceId: string,
+    historySequence = 1
+  ) {
+    const messageId = `${workspaceId}-msg-${historySequence}`;
+    await appendPartialAssistantForTests(workspaceId, messageId, historySequence);
+    const result = await streamManager.startStream(
+      testStartOptions({
+        workspaceId,
+        messageId,
+        model: createTestLanguageModel(),
+        tools: {},
+        historySequence,
+      })
+    );
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      throw new Error("Expected stream to start");
+    }
+    return result.data;
+  }
+
+  /** Yields one delta, then blocks until the stream's AbortSignal fires (a well-behaved provider). */
+  function flowingThenBlockedStream(signal: AbortSignal): AsyncGenerator<unknown, void, unknown> {
+    return (async function* () {
+      yield { type: "text-delta", text: "hello" };
+      await new Promise<void>((resolve) => {
+        if (signal.aborted) return resolve();
+        signal.addEventListener("abort", () => resolve(), { once: true });
+      });
+    })();
+  }
+
+  async function waitForPartialText(workspaceId: string, text: string): Promise<void> {
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline) {
+      const partial = await historyService.readPartial(workspaceId);
+      if (
+        partial?.parts.some((part) => part.type === "text" && part.text.includes(text)) === true
+      ) {
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    throw new Error(`partial for ${workspaceId} never contained ${JSON.stringify(text)}`);
+  }
+
+  function terminalEvents(events: TurnEngineEvent[]): TurnEngineEvent[] {
+    return events.filter((event) => ["stream-end", "stream-abort", "error"].includes(event.type));
+  }
+
+  test("closing the engine scope aborts a flowing stream as 'system', commits its partial and settles it", async () => {
+    const workspaceId = "supervised-flowing-workspace";
+    const { streamManager, events, engineScope } =
+      createSupervisedStreamManagerForTests(flowingThenBlockedStream);
+    const writePartialSpy = spyOn(historyService, "writePartial");
+    const handle = await startSupervisedStreamForTests(streamManager, workspaceId);
+    await waitForPartialText(workspaceId, "hello");
+    expect(streamManager.isStreaming(workspaceId)).toBe(true);
+
+    // What ServiceContainer.dispose() does at step 2: interrupt + await.
+    await closeScopeBounded(engineScope!);
+
+    // The finalizer routed through the user-stop path: the streamed text was
+    // flushed (with usage stamping) before the abort was delivered ...
+    const lastWrite = writePartialSpy.mock.calls.at(-1)?.[1];
+    expect(lastWrite?.parts.some((part) => part.type === "text" && part.text === "hello")).toBe(
+      true
+    );
+    // ... exactly one terminal event, an involuntary backend abort, no stream-end ...
+    const terminal = terminalEvents(events);
+    expect(terminal.map((event) => event.type)).toEqual(["stream-abort"]);
+    expect((terminal[0] as StreamAbortEvent).abortReason).toBe("system");
+    // ... and the turn handle plus the registry were settled before the close resolved.
+    expect(await handle.completion).toEqual({ status: "aborted", abortReason: "system" });
+    expect(getWorkspaceStreamsForTests(streamManager).size).toBe(0);
+    expect(streamManager.isStreaming(workspaceId)).toBe(false);
+  });
+
+  test("a wedged provider (never yields, ignores abort) cannot pin the bounded close", async () => {
+    const workspaceId = "supervised-wedged-workspace";
+    const { streamManager, engineScope } = createSupervisedStreamManagerForTests(() =>
+      (async function* () {
+        await new Promise<never>(() => undefined);
+        yield { type: "text-delta", text: "never" };
+      })()
+    );
+    await startSupervisedStreamForTests(streamManager, workspaceId);
+    expect(streamManager.isStreaming(workspaceId)).toBe(true);
+
+    // cleanupAbortedStream waits for the loop, which waits on the provider that
+    // never returns; the close must still resolve at the bound, and never reject.
+    const startedAt = Date.now();
+    await closeScopeBounded(engineScope!, 100);
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
+  });
+
+  test("a stream started after the engine scope closed is aborted immediately (fail-closed during shutdown)", async () => {
+    const workspaceId = "supervised-late-start-workspace";
+    const { streamManager, events, engineScope } =
+      createSupervisedStreamManagerForTests(flowingThenBlockedStream);
+    await closeScopeBounded(engineScope!);
+
+    const handle = await startSupervisedStreamForTests(streamManager, workspaceId);
+
+    expect(await handle.completion).toEqual({ status: "aborted", abortReason: "system" });
+    expect(terminalEvents(events).map((event) => event.type)).toEqual(["stream-abort"]);
+    expect(getWorkspaceStreamsForTests(streamManager).size).toBe(0);
+  });
+
+  test("a cancel landing after the loop finished but before COMPLETED neither resurrects partial.json nor emits a second terminal event", async () => {
+    // The completion path deletes partial.json, then awaits updateHistory, and
+    // only then flips state to COMPLETED. A cancel (user stop or the shutdown
+    // supervisor) landing inside that window previously re-created partial.json
+    // (pre-abort flush + abort bookkeeping) and emitted stream-abort after
+    // stream-end. No engine scope here: this is the stopStream path itself.
+    const workspaceId = "cancel-after-loop-exit-workspace";
+    const { streamManager, events } = createSupervisedStreamManagerForTests(
+      () =>
+        (async function* () {
+          await Promise.resolve();
+          yield { type: "text-delta", text: "final answer" };
+          yield { type: "finish", finishReason: "stop" };
+        })(),
+      undefined
+    );
+    let stopPromise: Promise<unknown> | undefined;
+    const realUpdateHistory = historyService.updateHistory.bind(historyService);
+    const updateHistorySpy = spyOn(historyService, "updateHistory").mockImplementation(
+      async (targetWorkspaceId, message) => {
+        // partial.json is already gone here; state is still STREAMING.
+        stopPromise ??= streamManager.stopStream(targetWorkspaceId);
+        return realUpdateHistory(targetWorkspaceId, message);
+      }
+    );
+    try {
+      const handle = await startSupervisedStreamForTests(streamManager, workspaceId);
+
+      expect(await handle.completion).toEqual({ status: "completed" });
+      expect(stopPromise).toBeDefined();
+      expect(await stopPromise).toEqual(Ok(undefined));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(terminalEvents(events).map((event) => event.type)).toEqual(["stream-end"]);
+      expect(await historyService.readPartial(workspaceId)).toBeNull();
+      const history = await historyService.getHistoryFromLatestBoundary(workspaceId);
+      expect(history.success).toBe(true);
+      if (!history.success) throw new Error(history.error);
+      const assistantRows = history.data.filter((message) => message.role === "assistant");
+      expect(assistantRows).toHaveLength(1);
+      expect(assistantRows[0].metadata?.partial).not.toBe(true);
+      expect(
+        assistantRows[0].parts.some((part) => part.type === "text" && part.text === "final answer")
+      ).toBe(true);
+      expect(getWorkspaceStreamsForTests(streamManager).size).toBe(0);
+    } finally {
+      updateHistorySpy.mockRestore();
+    }
+  });
+
+  test("stopStream racing the engine-scope close produces exactly one stream-abort and one settle", async () => {
+    const workspaceId = "supervised-stop-vs-close-workspace";
+    const { streamManager, events, engineScope } =
+      createSupervisedStreamManagerForTests(flowingThenBlockedStream);
+    const handle = await startSupervisedStreamForTests(streamManager, workspaceId);
+    await waitForPartialText(workspaceId, "hello");
+    let settleCount = 0;
+    void handle.completion.then(() => {
+      settleCount += 1;
+    });
+
+    // Both cancellers enter cancelStreamSafely in the same tick; the latch is
+    // taken synchronously, so the second joins the first's cleanup.
+    const stopPromise = streamManager.stopStream(workspaceId, { abortReason: "user" });
+    const closePromise = closeScopeBounded(engineScope!);
+    await Promise.all([stopPromise, closePromise]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const aborts = events.filter(
+      (event): event is StreamAbortEvent => event.type === "stream-abort"
+    );
+    expect(aborts).toHaveLength(1);
+    // First canceller's reason wins (the user pressed stop before shutdown reached the stream).
+    expect(aborts[0].abortReason).toBe("user");
+    expect(terminalEvents(events)).toHaveLength(1);
+    expect(settleCount).toBe(1);
+    expect(await handle.completion).toEqual({ status: "aborted", abortReason: "user" });
+    expect(getWorkspaceStreamsForTests(streamManager).size).toBe(0);
+  });
+
+  test("completed streams leave no supervisor residue: closing the scope after 50 completions aborts nothing", async () => {
+    const workspaceId = "supervised-residue-workspace";
+    const { streamManager, events, engineScope } = createSupervisedStreamManagerForTests(() =>
+      (async function* () {
+        await Promise.resolve();
+        yield { type: "text-delta", text: "done" };
+        yield { type: "finish", finishReason: "stop" };
+      })()
+    );
+    for (let i = 1; i <= 50; i++) {
+      const handle = await startSupervisedStreamForTests(streamManager, workspaceId, i);
+      expect(await handle.completion).toEqual({ status: "completed" });
+    }
+    expect(getWorkspaceStreamsForTests(streamManager).size).toBe(0);
+    expect(events.filter((event) => event.type === "stream-end")).toHaveLength(50);
+
+    await closeScopeBounded(engineScope!);
+
+    expect(events.filter((event) => event.type === "stream-abort")).toHaveLength(0);
+    expect(getWorkspaceStreamsForTests(streamManager).size).toBe(0);
   });
 });
 

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -1458,6 +1458,87 @@ describe("StreamManager - engine supervision (AppFiberScope occupant)", () => {
     expect(getWorkspaceStreamsForTests(streamManager).size).toBe(0);
   });
 
+  test("closing the engine scope while the turn-envelope write is pending cancels the STARTING stream inside the close", async () => {
+    // startStream registers the stream, then awaits onStreamConstructed (the
+    // durable turn-envelope write) before launching processing. Supervision
+    // starts at registration, so a shutdown landing inside that await cancels
+    // the STARTING stream through the same hard-interrupt path a user stop
+    // takes there — before closeScopeBounded resolves, not after teardown has
+    // moved on and the envelope write finally returns.
+    const workspaceId = "supervised-starting-window-workspace";
+    const { streamManager, events, engineScope } =
+      createSupervisedStreamManagerForTests(flowingThenBlockedStream);
+    const messageId = `${workspaceId}-msg`;
+    await appendPartialAssistantForTests(workspaceId, messageId, 1);
+    let releaseEnvelope!: () => void;
+    const envelopeWritten = new Promise<void>((resolve) => {
+      releaseEnvelope = resolve;
+    });
+    const startPromise = streamManager.startStream(
+      testStartOptions({
+        workspaceId,
+        messageId,
+        model: createTestLanguageModel(),
+        tools: {},
+        onStreamConstructed: () => envelopeWritten,
+      })
+    );
+    const workspaceStreams = getWorkspaceStreamsForTests(streamManager);
+    const deadline = Date.now() + 5_000;
+    while (!workspaceStreams.has(workspaceId)) {
+      if (Date.now() > deadline) throw new Error("stream never registered");
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+
+    await closeScopeBounded(engineScope);
+
+    // Cancelled inside the close: abort delivered, registry cleared, no
+    // stream-start ever emitted for it.
+    expect(terminalEvents(events).map((event) => event.type)).toEqual(["stream-abort"]);
+    expect((terminalEvents(events)[0] as StreamAbortEvent).abortReason).toBe("system");
+    expect(workspaceStreams.size).toBe(0);
+
+    releaseEnvelope();
+    const result = await startPromise;
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("expected Ok");
+    expect(await result.data.completion).toEqual({ status: "aborted", abortReason: "system" });
+    expect(events.filter((event) => event.type === "stream-start")).toHaveLength(0);
+    expect(terminalEvents(events)).toHaveLength(1);
+    expect(streamManager.isStreaming(workspaceId)).toBe(false);
+  });
+
+  test("a provider whose iterator rejects on abort is still recorded as an abort, not a failure", async () => {
+    // Some transports surface a cancellation as an iterator rejection rather
+    // than a clean close. The canceller owns the terminal bookkeeping, so the
+    // loop must not record that rejection as a provider failure — otherwise the
+    // lost-race guard would suppress the stream-abort and the partial commit.
+    const workspaceId = "abort-as-rejection-workspace";
+    const { streamManager, events } = createSupervisedStreamManagerForTests(
+      (signal) =>
+        (async function* () {
+          yield { type: "text-delta", text: "hello" };
+          await new Promise<void>((resolve) => {
+            if (signal.aborted) return resolve();
+            signal.addEventListener("abort", () => resolve(), { once: true });
+          });
+          throw new Error("connection reset after abort");
+        })(),
+      { supervised: false }
+    );
+    const handle = await startSupervisedStreamForTests(streamManager, workspaceId);
+    await waitForPartialText(workspaceId, "hello");
+
+    expect(await streamManager.stopStream(workspaceId, { abortReason: "user" })).toEqual(
+      Ok(undefined)
+    );
+
+    expect(await handle.completion).toEqual({ status: "aborted", abortReason: "user" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(terminalEvents(events).map((event) => event.type)).toEqual(["stream-abort"]);
+    expect(getWorkspaceStreamsForTests(streamManager).size).toBe(0);
+  });
+
   test("completed streams leave no supervisor residue: closing the scope after 50 completions aborts nothing", async () => {
     const workspaceId = "supervised-residue-workspace";
     const { streamManager, events, engineScope } = createSupervisedStreamManagerForTests(() =>

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -697,6 +697,13 @@ interface WorkspaceStreamInfo {
   partialWritePromise?: Promise<void>;
   // Track background processing promise for guaranteed cleanup
   processingPromise: Promise<void>;
+  // Latched by the first cancelStreamSafely call (synchronously, before its
+  // first await) so concurrent cancellers — a user stop racing shutdown's
+  // engine supervisor — join one cleanup: exactly one stream-abort, one settle.
+  cancelPromise?: Promise<void>;
+  // Supervisor fiber in the app's AppFiberScope (superviseEngine); set only when
+  // the manager was constructed with an engine scope.
+  engineFiber?: Fiber.Fiber<void>;
   // Soft-interrupt state: when pending, stream will end at next block boundary
   softInterrupt:
     | { pending: false }
@@ -787,6 +794,18 @@ export class StreamManager {
    * and the global runtime wherever nothing is injected (di/effectRunner.ts).
    */
   public readonly effectRunner: EffectRunner;
+  /**
+   * Supervised scope for the stream engine (the app runtime's `AppFiberScope`,
+   * di/appFiberScope.ts). When set, every started stream is wrapped in a
+   * supervisor fiber forked here (`superviseEngine`), so
+   * `ServiceContainer.dispose()`/the CLI cleanup lists interrupt **and await**
+   * in-flight streams — aborted as `"system"`, partial flushed and committed —
+   * before the bridges and sessions are torn down. `undefined` (direct
+   * construction in tests, `aiService.ts` compat path) keeps streams
+   * unsupervised: they die with the process and are recovered from
+   * partial.json on next load.
+   */
+  private readonly engineScope?: Scope.Closeable;
   // Token tracker for live streaming statistics
   private tokenTracker = new StreamingTokenTracker();
   // Track OpenAI previousResponseIds that have been invalidated
@@ -803,13 +822,15 @@ export class StreamManager {
     sessionUsageService?: SessionUsageService,
     getProvidersConfig?: () => ProvidersConfigMap | null,
     eventSink: TurnEngineEventSink = () => undefined,
-    runner: EffectRunner = defaultEffectRunner
+    runner: EffectRunner = defaultEffectRunner,
+    engineScope?: Scope.Closeable
   ) {
     this.historyService = historyService;
     this.sessionUsageService = sessionUsageService;
     this.getProvidersConfig = getProvidersConfig ?? (() => null);
     this.eventSink = eventSink;
     this.effectRunner = runner;
+    this.engineScope = engineScope;
   }
 
   setEventSink(eventSink: TurnEngineEventSink): void {
@@ -1783,20 +1804,31 @@ export class StreamManager {
       return;
     }
 
-    try {
-      streamInfo.state = StreamState.STOPPING;
-      // Flush any pending partial write immediately (preserves work on interruption)
-      await this.flushPartialWrite(workspaceId, streamInfo);
-
-      streamInfo.abortController.abort();
-
-      // Unlike checkSoftCancelStream, await cleanup (blocking)
-      await this.cleanupAbortedStream(workspaceId, streamInfo, abortReason, abandonPartial);
-    } catch (error) {
-      log.error("Error during stream cancellation:", error);
-      // Force cleanup even if cancellation fails
-      this.workspaceStreams.delete(workspaceId);
+    // Idempotent for concurrent cancellers (a user stop racing the shutdown
+    // supervisor's "system" cancel): the latch is checked and assigned here,
+    // synchronously, with no suspension before it — an await ahead of this
+    // point would let both callers reach cleanupAbortedStream and emit two
+    // stream-aborts. Later callers join the first cancel (its abortReason wins).
+    if (streamInfo.cancelPromise) {
+      return streamInfo.cancelPromise;
     }
+    streamInfo.cancelPromise = (async () => {
+      try {
+        streamInfo.state = StreamState.STOPPING;
+        // Flush any pending partial write immediately (preserves work on interruption)
+        await this.flushPartialWrite(workspaceId, streamInfo);
+
+        streamInfo.abortController.abort();
+
+        // Unlike checkSoftCancelStream, await cleanup (blocking)
+        await this.cleanupAbortedStream(workspaceId, streamInfo, abortReason, abandonPartial);
+      } catch (error) {
+        log.error("Error during stream cancellation:", error);
+        // Force cleanup even if cancellation fails
+        this.workspaceStreams.delete(workspaceId);
+      }
+    })();
+    return streamInfo.cancelPromise;
   }
 
   // Checks if a soft interrupt is necessary, and performs one if so
@@ -1815,9 +1847,18 @@ export class StreamManager {
       streamInfo.abortController.abort();
 
       // Return back to the stream loop so we can wait for it to finish before
-      // sending the stream abort event.
+      // sending the stream abort event. Not awaited: cleanupAbortedStream waits
+      // for processingPromise, i.e. for the loop this runs inside of.
+      // Shares cancelStreamSafely's latch: a hard cancel that lands during the
+      // flush above already owns the abort bookkeeping (keep its promise), and a
+      // hard cancel arriving later joins this one — one stream-abort either way.
       const { abandonPartial, abortReason } = streamInfo.softInterrupt;
-      void this.cleanupAbortedStream(workspaceId, streamInfo, abortReason, abandonPartial);
+      streamInfo.cancelPromise ??= this.cleanupAbortedStream(
+        workspaceId,
+        streamInfo,
+        abortReason,
+        abandonPartial
+      );
     } catch (error) {
       log.error("Error during stream cancellation:", error);
       // Force cleanup even if cancellation fails
@@ -1835,6 +1876,16 @@ export class StreamManager {
     // This prevents race conditions where the old stream is still running
     // while a new stream starts (e.g., old stream writing to partial.json)
     await streamInfo.processingPromise;
+
+    // The cancel lost the race: the loop had already left the fullStream and
+    // finished as completed/failed (terminalCompletion set, stream-end/error
+    // emitted, completion settled by processStreamWithCleanup's finally).
+    // Re-running the abort bookkeeping here would resurrect partial.json after
+    // deletePartial and emit a second terminal event (stream-abort after
+    // stream-end), which the renderer reads as "still partial".
+    if (streamInfo.terminalCompletion !== undefined) {
+      return;
+    }
 
     // For aborts, use our tracked cumulativeUsage directly instead of AI SDK's totalUsage.
     // cumulativeUsage is updated on each finish-step event (before tool execution),
@@ -4880,6 +4931,8 @@ export class StreamManager {
         ).catch((error) => {
           log.error("Unexpected error in stream processing:", error);
         });
+        // After the assignment: the supervisor wraps the already-started promise.
+        this.superviseEngine(typedWorkspaceId, streamInfo);
 
         return Ok(handle);
       } finally {
@@ -4898,6 +4951,64 @@ export class StreamManager {
       // Convert to strongly-typed error
       return Err(this.convertToSendMessageError(error));
     }
+  }
+
+  /**
+   * Make the engine scope (`AppFiberScope`) supervise this stream: one fiber
+   * per stream that waits on the already-running `processingPromise` and, when
+   * interrupted by the scope closing during shutdown, cancels the stream through
+   * the user-stop path (`cancelStreamSafely`, abort reason `"system"`) and waits
+   * for the turn to settle — i.e. for the partial to be flushed with usage,
+   * `stream-abort` delivered (AIService commits the partial into chat.jsonl and
+   * deletes partial.json) and `completion` resolved. `closeScopeBounded`
+   * awaits that finalizer, so dispose() proceeds to tear down bridges and
+   * sessions only once every in-flight stream is durably settled.
+   *
+   * The fiber is the ownership unit only; the stream's AbortSignal stays the
+   * sole cancellation transport (the loop, the AI SDK, soft interrupts and
+   * `stopStream` all key off it), so interruption meets the stream at exactly
+   * one point — this finalizer. A stream that completes on its own resolves the
+   * promise and the fiber exits, which removes its finalizer from the scope
+   * (no per-stream residue). A stream started after the scope closed is
+   * interrupted synchronously by `forkIn` and thus aborted right away (pinned in
+   * appFiberScope.test.ts); the pre-registration window (`pendingStreamStarts`)
+   * is not supervised — nothing durable exists for it yet and `stopStream`
+   * already aborts pending controllers.
+   */
+  private superviseEngine(workspaceId: WorkspaceId, streamInfo: WorkspaceStreamInfo): void {
+    if (this.engineScope === undefined) {
+      return;
+    }
+    assert(streamInfo.engineFiber === undefined, "stream engine already supervised");
+    // Zero-arity thunk on purpose: Effect.promise allocates an internal
+    // AbortController only when the thunk declares a `signal` parameter; the
+    // stream's own controller must stay the only signal in play.
+    const supervisor = Effect.promise(() => streamInfo.processingPromise).pipe(
+      Effect.onInterrupt(() =>
+        // Finalizers already run uninterruptibly; explicit per house doctrine so
+        // the cancel → settle sequence is visibly atomic under a second interrupt.
+        Effect.uninterruptible(
+          Effect.promise(async () => {
+            await this.cancelStreamSafely(workspaceId, streamInfo, "system");
+            // Abort delivery (partial commit, downstream stream-abort listeners)
+            // settles the completion asynchronously after cancelStreamSafely
+            // returns; shutdown must not proceed until it has.
+            await streamInfo.completionController.promise;
+          })
+        )
+      ),
+      Effect.catchDefect((defect) =>
+        Effect.sync(() => {
+          log.warn("[stream] engine supervisor defect", { workspaceId, error: defect });
+        })
+      )
+    );
+    // startImmediately: the fiber reaches its (only) suspension point — the
+    // promise wait — before forkIn registers it with the scope, so a scope that
+    // is already closed interrupts it right here, synchronously.
+    streamInfo.engineFiber = this.effectRunner.runSync(
+      Effect.forkIn(supervisor, this.engineScope, { startImmediately: true })
+    );
   }
 
   /**

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -5050,7 +5050,8 @@ export class StreamManager {
         Effect.sync(() => {
           log.warn("[stream] engine supervisor defect", { workspaceId, error: defect });
         })
-      )
+      ),
+      Effect.asVoid
     );
     // startImmediately: the fiber reaches its (only) suspension point — the
     // promise wait — before forkIn registers it with the scope, so a scope that

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -1820,7 +1820,8 @@ export class StreamManager {
     // supervisor's "system" cancel): the latch is checked and assigned here,
     // synchronously, with no suspension before it — an await ahead of this
     // point would let both callers reach cleanupAbortedStream and emit two
-    // stream-aborts. Later callers join the first cancel (its abortReason wins).
+    // stream-aborts. Later callers join the first cancel; its abortReason and
+    // abandonPartial are the ones delivered.
     if (streamInfo.cancelPromise) {
       return streamInfo.cancelPromise;
     }

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -701,6 +701,12 @@ interface WorkspaceStreamInfo {
   // first await) so concurrent cancellers — a user stop racing shutdown's
   // engine supervisor — join one cleanup: exactly one stream-abort, one settle.
   cancelPromise?: Promise<void>;
+  // Set by the completion path right before it deletes partial.json and writes
+  // the final message to chat.jsonl. From then on no partial may be written for
+  // this stream: a cancel landing between deletePartial and COMPLETED (the
+  // state flips late, see processStreamWithCleanup) would otherwise resurrect
+  // partial.json through its pre-abort flush.
+  partialRetired?: boolean;
   // Supervisor fiber in the app's AppFiberScope (superviseEngine); set only when
   // the manager was constructed with an engine scope.
   engineFiber?: Fiber.Fiber<void>;
@@ -1209,6 +1215,12 @@ export class StreamManager {
 
     // Cancel any scheduled debounce flush — we're writing now
     this.interruptPartialWriteFiber(streamInfo);
+
+    // The final message owns chat.jsonl now; re-creating partial.json here (a
+    // cancel racing the completion path) would be committed over it on next load.
+    if (streamInfo.partialRetired) {
+      return;
+    }
 
     // Start new write and track the promise
     streamInfo.partialWritePromise = (async () => {
@@ -4028,7 +4040,10 @@ export class StreamManager {
               };
 
               // CRITICAL: Delete partial.json before updating chat.jsonl
-              // On successful completion, partial.json becomes stale and must be removed
+              // On successful completion, partial.json becomes stale and must be removed.
+              // Retire partial writes first: a cancel (user stop, shutdown) landing
+              // between here and COMPLETED must not flush partial.json back to disk.
+              streamInfo.partialRetired = true;
               const deleteResult = await this.historyService.deletePartial(workspaceId as string);
               if (!deleteResult.success) {
                 workspaceLog.warn("Failed to delete partial on stream end", {

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -5005,11 +5005,18 @@ export class StreamManager {
         // the cancel → settle sequence is visibly atomic under a second interrupt.
         Effect.uninterruptible(
           Effect.promise(async () => {
+            const startedAt = performance.now();
             await this.cancelStreamSafely(workspaceId, streamInfo, "system");
             // Abort delivery (partial commit, downstream stream-abort listeners)
             // settles the completion asynchronously after cancelStreamSafely
             // returns; shutdown must not proceed until it has.
             await streamInfo.completionController.promise;
+            // Per-stream cost inside the AppFiberScope close (shutdownStep style).
+            log.debug("[shutdown] streamManager.abortStream", {
+              workspaceId,
+              messageId: streamInfo.messageId,
+              ms: Math.round(performance.now() - startedAt),
+            });
           })
         )
       ),

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -4092,6 +4092,21 @@ export class StreamManager {
           }
           break;
         } catch (error) {
+          // A cancellation may surface as an iterator rejection instead of a
+          // clean close (provider/transport dependent). The canceller that
+          // aborted the signal owns the terminal bookkeeping (cleanupAbortedStream
+          // after processingPromise resolves: stream-abort, partial commit,
+          // settle), so recording this as a provider failure would turn a user
+          // stop or a shutdown abort into an error event and — via the
+          // lost-race guard in cleanupAbortedStream — suppress the abort. Take
+          // the same exit as the clean-close abort path instead.
+          if (streamInfo.abortController.signal.aborted) {
+            workspaceLog.debug("Stream iterator rejected after abort; treating as cancellation", {
+              error: getErrorMessage(error),
+            });
+            await this.flushPartialWrite(workspaceId, streamInfo);
+            break;
+          }
           let handledError: unknown = error;
           let retried = false;
           try {
@@ -4915,6 +4930,11 @@ export class StreamManager {
 
         streamInfo.unlinkAbortSignal = unlinkAbortSignal;
         streamRegistered = true;
+        // Supervise from registration on: a shutdown landing during the envelope
+        // write below must find this STARTING stream and cancel it inside the
+        // scope close (the hard-interrupt path documented after the await),
+        // not after teardown has moved past the bridges.
+        this.superviseEngine(typedWorkspaceId, streamInfo);
 
         // Stream constructed + registered: durable request-describing side
         // effects (turn envelope) may be recorded now.
@@ -4947,8 +4967,6 @@ export class StreamManager {
         ).catch((error) => {
           log.error("Unexpected error in stream processing:", error);
         });
-        // After the assignment: the supervisor wraps the already-started promise.
-        this.superviseEngine(typedWorkspaceId, streamInfo);
 
         return Ok(handle);
       } finally {
@@ -4964,6 +4982,10 @@ export class StreamManager {
     } catch (error) {
       // Guaranteed cleanup on any failure
       this.workspaceStreams.delete(typedWorkspaceId);
+      // No handle is handed out on this path, so the completion is observed only
+      // by a supervisor forked at registration: settle it so that fiber exits
+      // instead of cancelling this never-started stream at shutdown.
+      completionController.settle({ status: "aborted", abortReason: "startup" });
       // Convert to strongly-typed error
       return Err(this.convertToSendMessageError(error));
     }
@@ -4971,19 +4993,23 @@ export class StreamManager {
 
   /**
    * Make the engine scope (`AppFiberScope`) supervise this stream: one fiber
-   * per stream that waits on the already-running `processingPromise` and, when
-   * interrupted by the scope closing during shutdown, cancels the stream through
-   * the user-stop path (`cancelStreamSafely`, abort reason `"system"`) and waits
-   * for the turn to settle — i.e. for the partial to be flushed with usage,
-   * `stream-abort` delivered (AIService commits the partial into chat.jsonl and
-   * deletes partial.json) and `completion` resolved. `closeScopeBounded`
-   * awaits that finalizer, so dispose() proceeds to tear down bridges and
-   * sessions only once every in-flight stream is durably settled.
+   * per stream that lives exactly as long as the turn is unsettled (it waits on
+   * `completionController.promise`) and, when interrupted by the scope closing
+   * during shutdown, cancels the stream through the user-stop path
+   * (`cancelStreamSafely`, abort reason `"system"`) and waits for the turn to
+   * settle — i.e. for the partial to be flushed with usage, `stream-abort`
+   * delivered (AIService commits the partial into chat.jsonl and deletes
+   * partial.json) and `completion` resolved. `closeScopeBounded` awaits that
+   * finalizer, so dispose() proceeds to tear down bridges and sessions only once
+   * every in-flight stream is durably settled. Supervision starts at
+   * registration (before the awaited turn-envelope write), so a STARTING stream
+   * is covered too: cancelling it takes the same hard-interrupt path a user stop
+   * takes during that write.
    *
    * The fiber is the ownership unit only; the stream's AbortSignal stays the
    * sole cancellation transport (the loop, the AI SDK, soft interrupts and
    * `stopStream` all key off it), so interruption meets the stream at exactly
-   * one point — this finalizer. A stream that completes on its own resolves the
+   * one point — this finalizer. A turn that settles on its own resolves the
    * promise and the fiber exits, which removes its finalizer from the scope
    * (no per-stream residue). A stream started after the scope closed is
    * interrupted synchronously by `forkIn` and thus aborted right away (pinned in
@@ -4999,7 +5025,7 @@ export class StreamManager {
     // Zero-arity thunk on purpose: Effect.promise allocates an internal
     // AbortController only when the thunk declares a `signal` parameter; the
     // stream's own controller must stay the only signal in play.
-    const supervisor = Effect.promise(() => streamInfo.processingPromise).pipe(
+    const supervisor = Effect.promise(() => streamInfo.completionController.promise).pipe(
       Effect.onInterrupt(() =>
         // Finalizers already run uninterruptibly; explicit per house doctrine so
         // the cancel → settle sequence is visibly atomic under a second interrupt.


### PR DESCRIPTION
## Summary

`StreamManager` becomes the first (and intended) occupant of `AppFiberScope`: every started stream is wrapped in one supervisor fiber, so `ServiceContainer.dispose()` (desktop, `xum server`, ACP) and the CLI cleanup lists now **abort and await in-flight streams** — partial flushed with usage, `stream-abort` (`abortReason: "system"`) delivered, the interrupted assistant message committed into `chat.jsonl`, `partial.json` removed — *before* the bridges and sessions are torn down. The same PR closes the two adjacent cancel races the shutdown path would have widened (Wave 4 plan D3): a cancel landing after the stream loop finished no longer resurrects `partial.json` or emits a second terminal event, and concurrent cancellers (user stop racing dispose) join one cleanup.

## Background

Until now `dispose()` had no `streamManager` step: an in-flight stream died with the process and was reconciled from `partial.json` (≤ 500 ms stale) on the *next* load, leaving an empty assistant placeholder row in `chat.jsonl` until then. `AppFiberScope` (Phase 11) was built for exactly this and had no occupant. This is PR 1 of the Effect migration Wave 4 plan (appended below): D1 — the fiber is the ownership/supervision unit, the `AbortSignal` stays the cancellation transport; D2 — supervisor topology; D3 — adjacent cancel races; D4 — the 2 s close bound stays (outer budgets are 5 s).

## Implementation

- **`StreamManager.superviseEngine`** (D2): after `streamInfo.processingPromise` is assigned (byte-identical) it forks `Effect.promise(() => processingPromise)` (zero-arity thunk → rc.112 allocates no internal AbortController) into `engineScope` with `{ startImmediately: true }`. `onInterrupt` → `Effect.uninterruptible(Effect.promise(async () => { await cancelStreamSafely(ws, info, "system"); await info.completionController.promise; }))`; `catchDefect` → `log.warn`. A stream that finishes on its own exits the fiber, which removes its scope finalizer (no residue). A stream started after the scope closed is interrupted synchronously by `forkIn` and aborted right away (fail-closed during shutdown, pinned in `appFiberScope.test.ts`). The pre-registration window (`pendingStreamStarts`) stays unsupervised (documented).
- **`engineScope?: Scope.Closeable`** is a trailing optional 6th constructor parameter, wired from `AppFiberScopeTag` in `StreamManagerLive` (`di/layers/core.ts`; `AppFiberScopeTag` added to `CoreInputTags` — both roots already provide it via `runtimeSeams`). Default `undefined` = today's behavior for every direct construction (tests, `aiService.ts` compat path).
- **D3(a)** `cleanupAbortedStream`: after `await processingPromise`, return if `terminalCompletion !== undefined` (completed/failed while the cancel was in flight). **Plus** a `partialRetired` marker set in the completion path right before `deletePartial`: `flushPartialWrite` becomes a no-op afterwards, because the *pre-abort flush* in `cancelStreamSafely` (not only the abort bookkeeping) re-created `partial.json` when the cancel landed between `deletePartial` and `COMPLETED`.
- **D3(b)** `cancelStreamSafely`: per-stream `cancelPromise` latch, checked and assigned synchronously at entry (after the existing `COMPLETED` early return, before the first `await`). `checkSoftCancelStream` shares the latch (`??=`) so a soft interrupt racing a hard cancel/dispose also yields exactly one `stream-abort`.
- Docs: `appRuntime.ts` contract ("Deliberately not done" updated; step 2 now says what it aborts), `appFiberScope.ts`, `serviceContainer.ts` step comment. New `[shutdown] streamManager.abortStream { workspaceId, messageId, ms }` debug line per supervised stream (shutdownStep style).

Net product change: 5 files, +196/−42 (≈ 70 non-comment lines added).

## PR 1 notes

### Pre-work findings

1. **`processStreamWithCleanup` never rejects** — body is `try { … } catch { await handleStreamFailure } finally { … }`; a throw from `handleStreamFailure`/`finally` *could* still reject, but `startStream` assigns `processingPromise = processStreamWithCleanup(...).catch(log.error)`, so the promise the supervisor wraps never rejects. `catchDefect` stays as belt-and-braces.
2. **Probe test** (`appFiberScope.test.ts`, +2 cases): `closeScopeBounded` interrupts a fiber suspended on `Effect.promise` **without settling the wrapped promise**, runs the async `onInterrupt` finalizer to completion, and resolves only afterwards (`["finalizer-start", "finalizer-end"]`).
3. **Abort observers after the finalizer** — the finalizer resolves only after `completionController.promise`, i.e. after `cleanupAbortedStream` (`writePartial` with usage) → `emitStreamAbort` → AIService sink (`readPartial` → `commitPartial` → `deletePartial` → `emit("stream-abort")` to agentSession/taskService/analytics listeners) → `.finally(settle)`. The only work left after it is the EventEmitter listeners' own async continuations (turn-phase transitions, task-handle settlement) — the same as today's `system` aborts from `taskService`. Durable order `writePartial → commitPartial → deletePartial` holds; a force-exit between any two steps leaves either `partial.json` (recovered by `agentSession.init`'s `commitPartial`) or an already-committed row whose `historySequence` update-or-append is idempotent. **No OFF-RAMP condition fired.**
4. **Measured `[shutdown] AppFiberScope closed { ms }`** (`xum server`, SIGTERM, `XUM_LOG_LEVEL=debug`, `script -f`): idle **1 ms**; one flowing Sonnet 5 stream **56 ms**; two flowing streams **95 ms** (per-stream `abortStream` 91 / 94 ms, parallel); wedged provider (scratch env-gated `fullStream` that never yields and ignores abort, not committed) **2050 ms** with the `teardown timed out` warning, `AppRuntime disposed` 5 ms (idempotent re-close), process exit **2.10 s** after SIGTERM — inside the 5 s force-exit. Baseline `main`: 1 ms (nothing supervised).
5. **Closed-scope `forkIn` pinned** (`appFiberScope.test.ts`): `startImmediately: true` into an already-closed scope runs the body to its first async boundary and then the `onInterrupt` finalizer synchronously (`["body-started", "interrupted"]`, fiber exit is a failure). `streamManager.test.ts` pins the product consequence (late start → `{ status: "aborted", abortReason: "system" }`, one `stream-abort`, registry empty).

### Deviations from the plan (all additive)

- The supervisor finalizer also awaits `completionController.promise` (plan: `cancelStreamSafely` only). `cancelStreamSafely` returns *before* abort delivery — the `stream-abort` sink is where AIService commits the partial — so without this the close would resolve with `partial.json` still present and the commit racing `desktopBridgeServer.stop()`. This is what makes STOP criterion #1 ("`partial.json` absent immediately after exit") true.
- `partialRetired` (see D3(a) above): the plan's guard alone left the pre-abort flush as a resurrection path; the D3(a) test was red against the guard-only variant on exactly that assertion.
- `checkSoftCancelStream` joins the latch: dispose during a pending soft interrupt (queued-message preemption at tool-end) is the same double-cleanup shape D3(b) fixes for hard cancels.
- `[shutdown] streamManager.abortStream` debug line — there was no log line for the abort at all, so the transcript could not show the plan's `stream-abort → AppFiberScope closed → desktopBridgeServer.stop` order; it now does.
- Plan §7 (5) `xum run` Ctrl-C transcript: `xum run` installs **no** SIGINT handler (only `cli/server.ts` does), so Ctrl-C is Node's default immediate termination (exit 130) and the cleanup list — including `appFiberScope.close` — runs only on normal completion. The CLI-root path is pinned by the new `coreServicesRoot.test.ts` case instead; adding a signal handler to `xum run` is out of scope.

### Dogfooding evidence (transcripts + before/after in the first comment)

| Scenario (`xum server`, SIGTERM 3 s after first text) | `AppFiberScope closed` | `partial.json` right after exit | last `chat.jsonl` row |
|---|---|---|---|
| `main` @ 3c06630a7 (baseline) | 1 ms | **present** (1065 chars of text) | empty assistant placeholder (0 chars) |
| this branch, 1 stream | 56 ms | **absent** | assistant row, `partial: true`, 1172 chars |
| this branch, 2 streams | 95 ms | absent | assistant rows committed (933 chars for the new one) |
| this branch, wedged provider | 2050 ms (warn) | n/a (no text produced) | exit 2.10 s after SIGTERM |

Restart UX (screenshot below, branch): the persisted interrupted text is shown above the `INTERRUPTED` barrier; the workspace then **auto-resumed the turn on startup** (agentSession startup auto-retry — `"system"` aborts do not suppress it). Verified the baseline does the same after it commits the partial on load (`[STREAM MESSAGE]` right after startup on `main`), so the only behavioral difference is *when* the partial is committed (at shutdown vs. next load). Not exercised headless: Electron `before-quit` (same `dispose()`; CI e2e).

![Recovered interrupted message after SIGTERM mid-stream, then startup auto-resume](https://github.com/user-attachments/assets/6a7050a8-de45-46ce-b854-9845de6692d3)

### Lessons for PR 3 (`initialize()` as a startup effect)

- Effect v4 `runPromise`/facades reject with the raw error, so error identity is free — but any `Effect.promise` thunk wrapping an `await`ed step must be `async` and the whole pipeline needs `catchDefect` if the facade must never reject.
- Bounded waits inside `dispose()` are cheap (`disposeAppRuntime` after a timed-out scope close took 5 ms because `Scope.close` is idempotent); a startup timeout should equally *not* try to unwind the abandoned step — parity with the existing "throwing step" path is the whole design.
- `[startup] <step> { ms }` lines are already the right measurement surface; this run's cold start showed `taskService.initialize` 114 ms and `workspaceService.initialize` 83 ms, so a 60 s per-step bound is ≥ 500× the slowest observed step.
- Keep the `xum run` parity caveat in mind: the CLI roots have no signal handling, so any "dispose on failed initialize()" work only applies where a dispose path exists (`cli/server.ts` is the one PR 3 adds).

## Validation

- New behavioral tests: `streamManager.test.ts` (6: flowing close, wedged bound, late start, D3(a), D3(b) race, 50-stream residue), `streamManager.chaos.test.ts` (1 new fuzz variant, existing cases untouched; also ran 7 extra seeds locally), `serviceContainer.test.ts` (dispose aborts + awaits a real stream before `desktopBridgeServer.stop()`, checks `partial.json`/`chat.jsonl`), `coreServicesRoot.test.ts` (same via `closeScopeBounded(appFiberScope)`), `appFiberScope.test.ts` (2 probes).
- Red checks: the D3(a) test fails without the two guards (2 terminal events) and the D3(b) test fails without the latch (2 `stream-abort`s).
- Gate suites green: `streamManager.test.ts`, `streamManager.chaos.test.ts`, `streamManager.modelOnlyNotifications.test.ts`, `aiService.test.ts`, `agentSession.disposeRace.test.ts`, `agentSession.sinceReplayContract.test.ts`, `serviceContainer.test.ts`, `coreServicesRoot.test.ts`, `di/*.test.ts`, `taskService.test.ts`, `workspaceService.test.ts` (one unrelated `FakeAIService` metadata test flaked once in a combined run, green isolated and on rerun), `turnRequestBuilder.test.ts`; `make static-check`.
- Pre-review audits: interruption posture (the supervisor's only suspension is the promise; finalizer uninterruptible end-to-end), no defect escapes (`catchDefect`; async thunks), spy seams unchanged (`processStreamWithCleanup`, `createStreamResult`, `createStreamAtomically`, `startStream`; constructor arity trailing-optional; `Reflect.set/get` targets valid), sync-start (`processingPromise` assigned before the fork; `runSync(forkIn)` synchronous), no constructor side effects, zero-suspension latch.

## Risks

- **Shutdown path** (desktop/`xum server`/ACP): a flowing stream now costs one chunk (~50–100 ms) at dispose; a wedged provider costs the existing 2 s bound and a warning — identical outcome to today's process exit. Rollback: revert the one `core.ts` wiring line (`engineScope` undefined → today's behavior); the D3 guards are independent bug fixes.
- **Cancel semantics**: with the latch, the *first* canceller's `abortReason`/`abandonPartial` win; a discard racing a system cancel by a few ms keeps the partial instead of dropping it (previously both cleanups ran and emitted two aborts).
- **Streams started mid-shutdown** are aborted as `"system"` (fail-closed): the caller sees a normal `Ok(handle)` whose completion settles `aborted`, and the turn is recovered on next load exactly like any other `system` abort.

---

<details>
<summary>📋 Implementation Plan</summary>

# Effect migration — Wave 4: finish the concurrency/lifecycle core

Bounded wave: **4 PRs (PR 4 optional), explicit STOP criterion, explicit OFF-RAMPs.** Plan only; nothing here is implemented.

> **Review status:** Independently reviewed (adversarial Reviewer sub-agent, advisor unavailable): APPROVE WITH REQUIRED EDITS — both edits applied; verified claims: Effect.promise 0-arity thunk allocates no AbortController (internal/effect.js:741–776); closed-scope forkIn+startImmediately runs onInterrupt (2237–2274, 391–409); forkIn observer removes the scope finalizer on exit (2270–2271); Effect.timeoutOrElse exists (Effect.d.ts:7833); 0 line drift at b87f62729; 11 settleWorkspaceTurn callers confirmed; 'aborted' ∈ NON_RETRYABLE_STREAM_ERRORS. Line references are to `main` @ `b87f62729`.

## 0. Thesis check (coordinator's judgment vs. evidence)

**Thesis:** Effect's payoff in this app is structured concurrency + interruption-safe lifecycles in the orchestration core (still Promise + AbortController).

**Verdict: holds for the stream engine; only half-holds for turn handles.**

- Stream engine — **holds.** `ServiceContainer.dispose()` never stops or awaits in-flight streams (`serviceContainer.ts:478–537` has no `streamManager` step); an in-flight stream dies with the process and is recovered on next load from `partial.json` (≤ 500 ms stale, `PARTIAL_WRITE_THROTTLE_MS`, `streamManager.ts:776`). `AppFiberScope` exists precisely for this and has no occupant. A supervised per-stream fiber is the right tool.
- Turn handles — **half-holds.** The 7× "superseded by an uncorrelated workspace stream-end" false-settle is a *correlation-predicate* bug (`interruptWorkspaceTurnFromUncorrelatedStreamEnd`, `workspaceTurnManager.ts:4220–4307`: any uncorrelated stream-end after the prompt index settles the handle `interrupted`), not a Promise-vs-fiber structure bug. Turn handles are **persisted records** (`taskHandleStore.upsertWorkspaceTurn`) spanning **multiple streams** (tool-call continuations are deferred via `hasSameTurnContinuation`, `:4491`) and surviving restarts; a fiber/Deferred can only model the in-process waiter and would not fix correlation. Open PR **#3949** fixes the predicate in Promise idiom and is Codex-green. Wave 4's turn-handle PR therefore becomes **"codify the settlement invariant + prove the class is gone"**, not "fiberize handles" (D5 below).

Corrected baseline numbers (measured this workspace): 46/470 `src/node` non-test files import `effect` (coordinator said 35); 113 direct `Effect.run*` sites outside `di/` in 16 files; 226 `Effect.gen`; 9 `TaggedError` classes; effect `4.0.0-rc.112`, `@orpc/*` `1.14.11`; **effect v4 is not GA** (rc line still current).

## 1. Verified current state (evidence the design rests on)

<details>
<summary>Stream engine (streamManager.ts)</summary>

- `startStream` (`:4723–4901`): per-workspace mutex → `new AbortController()` + `linkAbortSignal` (`:4771–4772`) → `resourceScope = Scope.makeUnsafe()` (`:4777`) → temp-dir `Effect.acquireRelease` (`:4802–4824`) → `createStreamAtomically` → `streamText` (`:2244`, `abortSignal: abortController.signal` `:2250`) → registered in `workspaceStreams` (`:2463`) → **`streamInfo.processingPromise = this.processStreamWithCleanup(...)` fire-and-forget (`:4876–4882`)** → returns `Ok({ messageId, completion })`.
- `processStreamWithCleanup` (`:3331–4089`, plain async): `while(true)` retry loop; `for await (part of fullStream)` (`:3358–3837`) with abort check at loop head (`:3361`); post-loop `if (!signal.aborted)` gate (`:3849`) → completion path (`deletePartial` `:3981`, `updateHistory` `:3989`, `recordSessionUsage` `:4001`, `state = COMPLETED` `:4017`, emit `stream-end` `:4023`, `terminalCompletion` `:4024`); error path → `handleStreamFailure` (`:4094–4112`) → `persistStreamError` writes error partial; `finally` (`:4052–4088`): release MCP lease, `Effect.runFork(Scope.close(resourceScope))` (`:4064–4066`), unlink abort, `workspaceStreams.delete`, `eventSpine.emit("stream.end")`, `completionController.settle`.
- Cancellation: `stopStream` (`:5043–5111`) → `cancelStreamSafely` (`:1766–1800`): `if (state === COMPLETED) { await processingPromise; return }` → `state = STOPPING` → `flushPartialWrite` → `abortController.abort()` → `cleanupAbortedStream` (`:1828–1951`): `await processingPromise` → usage → `writePartial` (`:1876–1910`) → `emitStreamAbort` → `settle({status:"aborted"})`. **No completed-guard after the await** (verified `:1838–1951`): a cancel landing between `:3849` and `:4017` re-writes `partial.json` after `deletePartial` and emits `stream-abort` after `stream-end` (pre-existing window; dispose() will widen its exposure). `cancelStreamSafely` is also not idempotent for concurrent callers (only `COMPLETED` is checked).
- AIService on `stream-abort` (`aiService.ts:355–377`): `abandonPartial ? deletePartial : commitPartial → deletePartial` (fire-and-forget listener).
- Crash recovery: `HistoryService.commitPartial` (`historyService.ts:1963–2061`) — strips error metadata, `hasCommitWorthyParts`, stale-epoch check, update-or-append by `historySequence`, delete partial; invoked from `agentSession.init` (`:5002`), `aiService.streamMessage` (`:886`), stream-abort (`:364`), `duplicateWorkspace`.
- `StreamAbortReason = "user" | "startup" | "system"` (`src/common/orpc/schemas/stream.ts:295`).
- Pinned seams: chaos test `Reflect.set(streamManager, "tokenTracker" | "createStreamResult")` (`streamManager.chaos.test.ts:130–134, 238–242`); `streamManager.test.ts` `Reflect.set` on `processStreamWithCleanup` (`:2787`), `createStreamAtomically` (`:2783`), `createTempDirForStream`, `cleanupStreamTempDir`, `Reflect.get` on `workspaceStreams`, `schedulePartialWrite`, …; `modelOnlyNotifications.test.ts` calls `processStreamWithCleanup` directly (`:93, :187`); `aiService.test.ts` spies `startStream`, `generateStreamToken`, `createTempDirForStream`, `isResponseIdLost`. Constructor: `(historyService, sessionUsageService?, getProvidersConfig?, eventSink = noop, runner = defaultEffectRunner)` (`:801–813`); `effectRunner` used at `:1152, :1154, :1169` only.
- Every stream event carries `workspaceId` + `messageId`; `stream-end`/`stream-abort`/`error` carry `metadata.muxMetadata` when the prompt had it.
</details>

<details>
<summary>DI / shutdown / startup</summary>

- `AppFiberScopeLive` is in `CoreLive`'s `runtimeSeams` (`di/layers/core.ts:644`), so both roots have it; `StreamManagerLive` (`core.ts:226–238`, stage S2b) already yields `EffectRunnerTag`. CLI cleanup lists include `appFiberScope.close` (`cli/run.ts:1579`, `cli/workflow.ts:286`).
- Bounds: `APP_FIBER_SCOPE_CLOSE_TIMEOUT_MS = 2000`, `APP_RUNTIME_DISPOSE_TIMEOUT_MS = 2000`; outer budgets are **5000 ms** on both desktop (`desktop/main.ts:1297` `Promise.race` vs `setTimeout(5000)`) and `xum server` (`cli/server.ts:236–243` force-exit). **The scope bound cannot grow** without changing outer budgets.
- rc.112 semantics verified in `node_modules/effect/dist/internal/effect.js:2264`: `forkIn` registers a scope finalizer and **removes it when the fiber completes** (no leak), and **interrupts immediately if the scope is already closed** (streams starting mid-shutdown fail closed). `Effect.promise(evaluate: (signal) => PromiseLike)`, `Effect.onInterrupt`, `Effect.forkIn(_, scope, { startImmediately? })`, `Stream.toAsyncIterableWith(context)`, `Stream.provideContext` all exist.
- `ServiceContainer.initialize()` (`serviceContainer.ts:297–362`): six awaited `initialize()`s wrapped in `recordStep` (durations only, no catch, no timeout) + three sync `start()`s + two fire-and-forget sweeps. Failure handling: desktop `Startup Failed` dialog + `app.quit()` (`desktop/main.ts:1249–1265`); `cli/server.ts:136` uncontained; ACP `serverConnection.ts:205–216` dispose + rethrow; `tests/ipc/setup.ts:85` no catch. No outer timeout anywhere.
- `streamBridge.subscriptionIterable` (`orpc/streamBridge.ts:176`) → `Stream.toAsyncIterable(...)` on the global runtime, 19 call sites in `routerSubscriptions.ts`; heartbeat via `Effect.sleep` in `forkScoped` (`:145–152`). `streamBridge.test.ts` has 11 real-time waits, but only **3 are clock-bound** (`:207` 1 ms initial delay, `:241` heartbeat 10 ms, `:255` 10 ms laziness); 8 are `waitFor(listenerCount…)` readiness polls that TestClock cannot replace.
</details>

<details>
<summary>Turn handles + open PRs</summary>

- Handle record `{ handleId "wst_…", ownerWorkspaceId, workspaceId, turnId, messageId, status, attentionPolicy, disposableWorkspace }`; prompt carries `muxMetadata: { type:"workspace-turn-task", taskHandleId, ownerWorkspaceId, turnId }` (`workspaceTurnManager.ts:1420`). `TaskService` forwards `aiService` `stream-end`/`stream-abort`/`error` to `finalizeWorkspaceTurnFromStreamEnd` (`:4442–4544`): correlated branch matches `record.workspaceId && record.turnId` (`:4472`); **uncorrelated branch** (`metadata == null`, not `agentId === "compact"`) → `interruptWorkspaceTurnFromUncorrelatedStreamEnd` → settles `interrupted` whenever `streamEndIndex >= promptIndex` (`:4293–4305`). Producers of such uncorrelated ends: bash-monitor wake continuations, child terminal-attention deliveries, heartbeat, peer messages, parent auto-resume.
- Cascade: disposable child → `cleanupDisposableWorkspaceTurn` → `workspaceService.remove(…, true)` kills its background processes; persistent child → parent sees `interrupted` → `task_stop` → `backgroundProcessManager.stopMonitor(…, "canceled")`. This is the observed "monitors died afterwards".
- Settlement chokepoint: `settleWorkspaceTurn(params)` (`:2085`), **11 callers**, guarded by `workspaceTurnSettlementLocks.withLock(handleId)`; waiters in `pendingWorkspaceTurnWaitersByHandleId` with `setTimeout` timeouts (`:2425–2496`).
- **#3949** "preserve turns across synthetic wake ends" (coadler): rewrites the uncorrelated branch — walks history from the turn anchor to the stream-end and settles *only if a manual child input intervened* (`isManualChildWorkspaceInput`); otherwise ignores the end. Touches `:281–295, :4217–4355` + tests (+286/−31). Codex: "Didn't find any major issues" + clean security on `f9baa2fc9`. `mergeable: MERGEABLE`, but `Test / Unit` and `Codex Comments` red, 19 commits behind main.
- **#3915** "correlate workspace-turn liveness" (coadler): creation reservations + `getWorkspaceTurnLiveness`/`getWorkspaceTurnRuntimeActivity` (identity-matches the active stream's `muxMetadata` against the record) for staleness/capacity. Touches `:442–486, :1298, :2573, :3761, :3800–4064` (+494/−60). `BLOCKED`, latest Codex review has open findings, `Test / Unit` red, 19 behind.
- Together they are the identity-correlated model the coordinator wants: #3915 = identity-correlated *liveness*, #3949 = identity-gated *settlement*.
</details>

## 2. Design decisions

**D1 — Fibers WRAP the AbortController; they do not replace it.**
The AI SDK is cancelled only via `AbortSignal`; the `for await` loop, soft-interrupt at step boundaries, retry/fallback re-creation of `streamResult`, and ~30 abort touchpoints (#4032) all key off the signal. Converting the 750-line loop to `Stream.fromAsyncIterable` + fiber interruption would touch hundreds of `WorkspaceStreamInfo` transitions and break the `processStreamWithCleanup`/`createStreamResult` spy seams. Instead: **the fiber is the ownership/supervision unit; the signal stays the cancellation transport.** The dual-cancellation glue #4032 feared is confined to **one** point — the supervisor's `onInterrupt` — which routes through the existing user-stop path (`cancelStreamSafely`), so shutdown ≡ "user pressed stop" semantically (partial flushed with usage, `stream-abort` emitted, `completion` settles `aborted`, AIService commits the partial).

**D2 — Supervisor topology: one supervisor fiber per stream in `AppFiberScope`, wrapping the already-started `processingPromise`.**
`streamInfo.processingPromise = this.processStreamWithCleanup(...)` stays byte-identical (sync-start preserved; `Reflect.set(processStreamWithCleanup)` seam preserved; `cleanupAbortedStream`'s `await processingPromise` unchanged). Immediately after it:

```ts
// startStream, after processingPromise is assigned (unsupervised path unchanged when no scope)
this.superviseEngine(typedWorkspaceId, streamInfo);

private superviseEngine(workspaceId: WorkspaceId, streamInfo: WorkspaceStreamInfo): void {
  if (this.engineScope === undefined) return;               // direct construction / CLI tests: today's behavior
  assert(streamInfo.engineFiber === undefined, "engine already supervised");
  // Zero-arity thunk on purpose: rc.112 allocates an internal AbortController only
  // when `evaluate.length !== 0`; the stream's own controller stays the sole signal.
  const supervisor = Effect.promise(() => streamInfo.processingPromise).pipe(
    Effect.onInterrupt(() =>
      Effect.uninterruptible(   // explicit, per house doctrine (finalizers are already uninterruptible)
        Effect.promise(async () => this.cancelStreamSafely(workspaceId, streamInfo, "system"))
      )
    ),
    Effect.catchDefect((d) => Effect.sync(() => log.warn("[stream] engine supervisor defect", { workspaceId, error: d })))
  );
  streamInfo.engineFiber = this.effectRunner.runSync(
    Effect.forkIn(supervisor, this.engineScope, { startImmediately: true })
  );
}
```
- `Effect.promise` is interruptible while suspended (`internal/effect.js:741–801`, Async op); `onInterrupt` = `onErrorFilter(causeFilterInterruptors, …)` (`:1762`); `forkIn` registers `fiberInterrupt(fiber)` as the scope finalizer (`:2264–2275`), `fiberInterrupt` awaits the fiber (`:635–642`), and parallel `scopeClose` awaits all finalizers via `fiberAwaitAll` (`:1590–1601`) → `closeScopeBounded` at dispose step 2 gives "interrupt **and** await" while `historyService`/`sessionUsage`/`eventSink → AIService → bridge servers` are still alive (bridges stop in step 3, so clients receive `stream-abort`).
- Normal completion: fiber exits → `forkIn`'s observer removes the scope finalizer (verified) → no per-stream residue.
- Stream started after step 2: `forkIn` on a closed scope calls `fiber.interruptUnsafe` synchronously and returns the fiber (`:2272–2274`, `runSync` does not defect). With `startImmediately: true`, `forkUnsafe` runs `child.evaluate` synchronously (`:2233–2247`) up to the `Effect.promise` Async op (`:772–801`), so the fiber is suspended (`_running=false`) when the interrupt lands and `interruptUnsafe` (`:391–409`) unwinds the stack through the `onInterrupt` handler → the stream is aborted as `system` (fail-closed during shutdown). Verified in rc.112 internals (`effect.js:2233–2247, 391–409`); **pin with a test** ("stream started after scope close is aborted") so an RC bump cannot silently change it.
- `"system"` is semantically exact: `"user"`/`"startup"` suppress next-startup recovery (`retryEligibility.ts:114–118, 284–287`), `"system"` marks an involuntary backend interruption (as `taskService.ts:8100, 8223` use it). **No in-session retry loop is possible:** the `stream-abort` handler (`agentSession.ts:6010`) routes `{ type: "aborted" }` to `retryManager.handleStreamFailure`, and `"aborted"` is in `NON_RETRYABLE_STREAM_ERRORS` (`retryEligibility.ts:49–59, 106`) → `retryManager.ts:99–104` abandons immediately, never schedules a fiber. Dogfooding still checks the *restart* UX (the recovered partial is shown as interrupted; note whether any next-startup recovery re-sends — same class as today's `system` aborts from `taskService`).
- `engineScope` arrives as an **optional 6th constructor parameter** (`engineScope?: Scope.Closeable`), wired from `AppFiberScopeTag` in `StreamManagerLive` (`core.ts:226`). Default `undefined` keeps every direct-construction test and `aiService.ts:174` path identical (I4). `AppFiberScopeLive` already sits beneath S2b in `runtimeSeams`, so no staging change (I6).
- Abort reason: reuse **`"system"`** — no wire/schema change; UI copy for `system` already exists.
- Pending-start window (`pendingStreamStarts`, before registration) is **not** supervised: nothing is persisted for it yet, and `stopStream` already aborts pending controllers. Documented, not fixed.

**D3 — Fix the two adjacent cancel races in the same PR (closely-related bugs, not deferrals).**
(a) `cleanupAbortedStream`: after `await processingPromise`, if `streamInfo.terminalCompletion !== undefined` (completed/failed while the cancel was in flight) → return without abort bookkeeping (prevents `partial.json` resurrection after `deletePartial` and a `stream-abort` after `stream-end`). (b) `cancelStreamSafely` (`:1766`): latch a per-stream `cancelPromise` so concurrent cancellers (user stop racing dispose) join one cleanup → exactly one `stream-abort`, one `settle`. **Zero-suspension requirement:** the latch must be checked and assigned **synchronously at function entry, before any `await`** (the current first await is `flushPartialWrite` at `:1789`) — otherwise racing callers can both enter `cleanupAbortedStream`. Shape:

```ts
if (streamInfo.cancelPromise) return streamInfo.cancelPromise;
streamInfo.cancelPromise = (async () => { /* existing body, unchanged */ })();
return streamInfo.cancelPromise;
```
Both are ≤ 10 LoC and get behavioral tests.

**D4 — Shutdown bound stays 2 s; the finalizer must be fast or abandoned.**
Outer budgets are 5 s; 2 s + 2 s already consume 4 s. A flowing stream aborts within one chunk; a wedged provider (no chunks, ignores abort) hits the existing `boundedTeardown` timeout: warning, continue, process exit — identical to today's outcome. Dogfooding measures the actual `[shutdown] AppFiberScope closed { ms }` with a live stream.

**D5 — Turn handles: codify the settlement invariant; do not fiberize.**
Invariant: *a workspace-turn handle settles terminally only by (i) a stream terminal event whose `muxMetadata` correlates `{taskHandleId, ownerWorkspaceId, turnId}` to the record; (ii) an explicit interrupt (`task_stop`/`interruptWorkspaceTurn`); (iii) manual supersession — a manual child input after the turn anchor; (iv) stale-liveness reconciliation.* An uncorrelated stream-end is **never** terminal by itself. #3949 makes (iii) the only uncorrelated outcome; #3915 implements (iv) by identity. Wave 4 adds a `cause` discriminant to `settleWorkspaceTurn` (the single chokepoint) with a runtime assertion, plus the regression harness. Rationale for not converting waiters to `Deferred`/fibers: no behavioral gain, 4.9k-line file, and the coordinator's "settle only on the owning stream's termination" is over-specified — a turn owns *several* streams.

**D6 — Startup: `initialize()` stays a Promise facade over a runtime-run startup effect; timeout ⇒ same failure path as a thrown step.**
Each step is `Effect.tryPromise({ try: async () => step(), catch: identity }).pipe(Effect.timeoutOrElse({ duration: STARTUP_STEP_TIMEOUT_MS, orElse: () => Effect.fail(new StartupStepTimeoutError(name, ms)) }))` (`timeoutOrElse` exists in rc.112, `Effect.d.ts:7833`; chosen over `timeout` + `catchTag` because the step's error channel is `unknown`, which `catchTag` cannot narrow). No `forkDetach` needed: a Promise step keeps running on its own when the waiting fiber times out (not inside an uninterruptible region, so the timeout interrupts the wait directly). `StartupStepTimeoutError extends Error` with `name = "StartupStepTimeoutError"` set in the constructor and message `"<step> exceeded <ms> ms"` (so the desktop dialog's error formatting shows both the class and the step name) → desktop shows it in the existing `Startup Failed` dialog; CLI/ACP/tests paths unchanged. Step **errors keep their identity** (v4 `runPromise` rejects with the raw failure). Downgrading any step to best-effort is a **policy change, out of scope** (audit of the six implementations: extensionMetadata/telemetry/experiments are local fs, <50 ms; policy has its own 10 s fetch timeout; workspaceService bounds its sync internally; only `taskService.initialize` — config scan + `editConfig` + recovery `sendMessage`s — is potentially unbounded). The three `start()`s stay sync (`Effect.sync`), the two fire-and-forget sweeps stay outside the effect. `stepDurationsMs` is preserved.
**Abandon-and-quit safety:** an abandoned `taskService.initialize` may be mid-`editConfig` when the root exits. Parity requirement for PR 3: after a rejected `initialize()`, every root runs the bounded `dispose()` before exiting. Verified: desktop already does — `services` is assigned before the await (`main.ts:653–656`), the catch calls `app.quit()`, and the `before-quit` listener (`:1271–1305`, guard `if (isDisposing || !services) return`) races `services.dispose()` against 5 s; ACP does (`serverConnection.ts:205–216`); **`cli/server.ts` does not** (`:133–136` awaited at top level, `main().catch` at `:282` only logs) → PR 3 adds a bounded `dispose()` there (≤ 10 LoC, same 5 s budget).

**D7 — streamBridge: thread the runtime context, not a runner.** `subscriptionIterable` gains `context?: Context.Context<never>` → `Stream.toAsyncIterableWith(context)`; `routerSubscriptions` passes the handler's `"effect/context"`. Production behavior identical; heartbeat sleeps on the runtime `Clock`; tests can run the 3 clock-bound waits on `TestClock`. Honest scope: the 8 readiness polls stay.

## 3. PRs (ordered by value ÷ risk; each independently mergeable)

### PR 1 — StreamManager engine core becomes the first `AppFiberScope` occupant
**Value:** high (the only remaining shutdown data-integrity gap; the reason `AppFiberScope` exists). **Risk:** medium → low with D1/D2. **Net product LoC ≈ +55** (`superviseEngine` ~25, ctor param/field ~5, `engineFiber` field ~2, D3 guards ~12, `core.ts` wiring ~2, doc updates in `appRuntime.ts`/`appFiberScope.ts` "occupant" text ~10).

Files: `src/node/services/streamManager.ts`, `src/node/services/di/layers/core.ts`, `src/node/services/di/appRuntime.ts` + `appFiberScope.ts` (docs), tests below.

Pre-work (before writing product code; each yields a note in the PR body):
1. Confirm `processStreamWithCleanup` never rejects (try/catch/finally shape `:3331–4089`); else the supervisor must fold rejections (it already `catchDefect`s).
2. Confirm `Effect.promise` interruption + `onInterrupt` await ordering under `Scope.close` in a 20-line probe test (pattern of `appFiberScope.test.ts:27–47`).
3. Enumerate abort observers that run *after* the finalizer resolves (AIService `stream-abort` listener → `commitPartial`; agentSession completion continuations) and confirm the durable order (`writePartial` → commit → `deletePartial`) makes a mid-flight `process.exit` recoverable on next load (it is: partial survives until commit completes).
4. Measure: `[shutdown] AppFiberScope closed { ms }` with a live stream in the sandbox (D4).
5. Pin (same probe test): a fiber forked with `startImmediately: true` into an already-closed scope still runs its `onInterrupt` finalizer (reviewer-verified in rc.112 internals; the test guards RC bumps).

Acceptance (behavioral tests only):
- `streamManager.test.ts` (new cases; existing cases untouched): with `engineScope = Scope.makeUnsafe("parallel")` and a fake `createStreamResult` whose `fullStream` yields one `text-delta` then blocks until its `AbortSignal` fires — `closeScopeBounded(engineScope)` resolves; `writePartial` was called with the streamed text; exactly one `stream-abort` (`abortReason: "system"`) and zero `stream-end`; `completion` settles `{status:"aborted"}`; `workspaceStreams` is empty.
- Wedged provider (fullStream never yields, ignores abort): `closeScopeBounded` resolves within the bound, never rejects, warns once (assert the returned promise resolves and no throw; do **not** assert log text).
- No-scope construction: identical event sequence to today (guards existing suites; no new assertions needed beyond the unchanged suites passing).
- D3(a): cancel issued after the loop exits but before `COMPLETED` → history has exactly one final message, `partial.json` absent, event order `stream-end` only.
- D3(b): `stopStream` + `closeScopeBounded` racing on one stream → exactly one `stream-abort`, one settle.
- Fiber residue: after 50 completed streams, `closeScopeBounded(engineScope)` emits zero `stream-abort` and completes in the same tick class as an empty scope (assert no aborts and `workspaceStreams.size === 0`).
- `streamManager.chaos.test.ts` — existing cases byte-identical; **one new fuzz variant** constructs with an engine scope and closes it at a random iteration: every stream settles **exactly once** (count terminal events per `messageId` ≤ 1, all `completion` promises settle).
- `serviceContainer.test.ts`: "dispose() aborts and awaits an in-flight stream before `desktopBridgeServer.stop()`" (extend the ordering harness at `:295–323`); `coreServicesRoot.test.ts`: `xum run` cleanup list does the same via `appFiberScope.close`.

Gate suites: `streamManager.test.ts`, `streamManager.chaos.test.ts`, `streamManager.modelOnlyNotifications.test.ts`, `aiService.test.ts`, `agentSession.disposeRace.test.ts`, `agentSession.sinceReplayContract.test.ts`, `serviceContainer.test.ts`, `coreServicesRoot.test.ts`, `di/*.test.ts`, `taskService.test.ts`, `workspaceService.test.ts`, `turnRequestBuilder.test.ts`; `make static-check`.

House pre-review audits: interruption posture (supervisor's only suspension is the promise; finalizer uninterruptible end-to-end incl. `cancelStreamSafely` → `cleanupAbortedStream`); no defect escapes (`catchDefect` on the supervisor; `Effect.promise` thunks `async`); spy-seam check (`processStreamWithCleanup`, `createStreamResult`, `createStreamAtomically`, `startStream` signatures unchanged; constructor arity unchanged, trailing optional); sync-start (`processingPromise` assigned before fork; `runSync(forkIn)` completes synchronously); no constructor side-effects added; zero-suspension check on D3(b) latch (`cancelPromise` checked-and-assigned synchronously at `cancelStreamSafely` entry, before the first `await` at `:1789`; review the diff for any inserted `await`/lookup ahead of the assignment).

Rollback: revert the `core.ts` wiring line → `engineScope` undefined → today's behavior; D3 guards can stay (independent bug fixes).

### PR 2 — Turn-settlement invariant + false-settle regression harness (gated on #3949)
**Value:** high (7× production race). **Risk:** low. **Net product LoC ≈ +40** (`WorkspaceTurnSettlementCause` union + `cause` on `settleWorkspaceTurn` params + assert ~10; 11 call sites × 1–3 lines).

Relationship to open PRs — explicit:
- **#3949 is the fix and a hard prerequisite.** PR 2 rebases on it, changes none of its logic (`interruptWorkspaceTurnFromUncorrelatedStreamEnd`, `isWorkspaceTurnAnchorForRecord`, `isManualChildWorkspaceInput`), and adds the invariant + proof on top. If #3949 has not merged when PRs 1/3 are done: **do not fork a competing fix**; report to the coordinator, offer the regression test file to #3949's author as a review artifact, and hold PR 2 (it is not on any other PR's critical path).
- **#3915 is a soft prerequisite.** Its diff (`:3800–4064` incl. `settleStaleWorkspaceTurn`, a `settleWorkspaceTurn` caller) overlaps PR 2's one-line-per-caller change. Prefer landing after it; if PR 2 must go first, the conflict is a one-line `cause:` addition per caller. PR 2 never edits liveness/reservation code.
- Wave 4 does not otherwise touch `workspaceTurnManager.ts`.

Design: `type WorkspaceTurnSettlementCause` enumerated from the 11 callers (audited at `main` @ `b87f62729`): `:1373` creation validation failure; `:1476` pre-stream interrupt during launch; `:1500`/`:1518` pre-stream send failure; `:3834`/`:3863` stale-liveness recovery / restart timeout (`settleStaleWorkspaceTurn` — #3915's region); `:4301` **uncorrelated-stream-end manual supersession** (the only uncorrelated settle in the codebase; the path #3949 rewrites); `:4529` correlated terminal; `:4571` stream-abort; `:4675` deferred stream error; `:4736` terminal stream error. `settleWorkspaceTurn` asserts `params.cause` is a member and, for `manual-supersession`, that the superseding input's `messageId` is supplied — turning D5 into an exhaustive `Record<Cause, …>` check rather than prose, so a future "settle on uncorrelated end" cannot be added without naming (and justifying) a cause.

Acceptance:
- New `workspaceTurnManager.uncorrelatedStreamEnd.test.ts` (real `WorkspaceTurnManager` + `TaskHandleStore` + fake `aiService` emitter, following the existing suite's harness): (1) create turn → correlated `stream-start` → **synthetic wake stream** on the same child ends uncorrelated after the anchor → handle stays `running`, waiter unresolved, no disposable cleanup, no terminal attention → correlated `stream-end` → `completed`. (2) same with `finishReason:"tool-calls"` continuation in between. (3) manual child input between anchor and end → `interrupted` with `cause: manual-supersession`. (4) explicit `interruptWorkspaceTurn` → `interrupted`, `cause: explicit-interrupt`. Case (1) is the **scripted reproduction**: it must **fail on the pre-#3949 merge-base** (run the file from a sibling worktree at `git merge-base origin/main <#3949 head>`; record the failing assertion in the PR body) and pass after.
- Existing 113 `workspaceTurnManager.test.ts` cases and `taskService.test.ts` turn cases unchanged.

Gate suites: `workspaceTurnManager.test.ts`, `taskService.test.ts`, `taskHandleStore.test.ts`, `tools/task*.test.ts`; `make static-check`.

Audits: spy-seam (`getWorkspaceTurn`, `listAllWorkspaceTurns`, `enqueueTerminalAttention`, `deliverPersistentChildWorkspaceTurnResult` untouched); settlement lock held across the assert; no new suspension inside `withLock`.

Rollback: revert; the test file stays valid against #3949 alone (drop the `cause` assertions).

### PR 3 — `ServiceContainer.initialize()` as a runtime-run startup effect with per-step timeouts
**Value:** medium (a hung `taskService.initialize()` currently pins the splash screen forever; deterministic TestClock tests of startup). **Risk:** low–medium. **Net product LoC ≈ +80** (step table ~20, timed-step helper ~15, `StartupStepTimeoutError` ~8, constant ~3, facade ~10, root dispose-on-failure parity ≤ 10, doc update ~10).

Files: `serviceContainer.ts`, `src/constants/terminationTimeouts.ts` (keep with the termination constants so the budget doc stays in one place), `cli/server.ts` (dispose in the startup catch if missing), `di/appRuntime.ts` doc ("Deliberately not done" → remove the initialize() line; add startup contract).

Design (D6): `initialize(): Promise<void>` → `this.runtime.managed.runPromise(this.startupEffect())`. `startupEffect = Effect.gen` over an ordered `readonly steps: ReadonlyArray<{ name, run: () => Promise<void> }>` (assert names unique); each step: `recordStep` timing kept, `Effect.tryPromise({ try: async () => run(), catch: identity }).pipe(Effect.timeoutOrElse({ duration: STARTUP_STEP_TIMEOUT_MS, orElse: () => Effect.fail(new StartupStepTimeoutError(name, STARTUP_STEP_TIMEOUT_MS)) }))`. Then `Effect.sync` for the three `start()`s; the sweeps remain after `runPromise`. Constant `STARTUP_STEP_TIMEOUT_MS` — pre-work measures `[startup] <step> { ms }` across sandbox cold starts and picks ≥ 10× the slowest observed (propose 60 s; must be generous — a false timeout turns a slow-but-fine start into a crash). Roots dispose after a rejected `initialize()` (D6 abandon-and-quit safety).

Acceptance (all in `serviceContainer.test.ts`, TestClock via the existing `AppLive` spy at `:355–395`):
- A step that never resolves → `initialize()` rejects with `StartupStepTimeoutError` naming the step after exactly `TestClock.adjust(STARTUP_STEP_TIMEOUT_MS)`; later steps did not run.
- A rejecting step → `initialize()` rejects with **the same error object** (identity), later steps did not run (parity with today).
- Happy path → `stepDurationsMs` has all six keys; `start()`s called once each; second `initialize()` call behavior unchanged from today (verify whether re-entry is guarded today; preserve).
- `tests/ipc` harness and ACP entry still pass unchanged.

Gate suites: `serviceContainer.test.ts`, `coreServicesRoot.test.ts`, `di/*.test.ts`, `src/node/acp/*.test.ts`, `TEST_INTEGRATION=1 bun x jest tests/ipc` (smoke subset); `make static-check`.

Audits: I1 untouched (no layer body changes); I2 (only the composition root touches the runtime); error identity preserved (no wrapping); abandoned-step safety — every root runs bounded `dispose()` after a rejected `initialize()` (D6; `cli/server.ts` gains it in this PR); no sweep moved into the effect; the six-step order and `[startup] <step>` names unchanged.

Rollback: revert; constant removal.

### PR 4 (optional — cut if budget is exhausted) — `streamBridge` on the runtime context
**Value:** low (closes the last documented "global runtime" exception; enables TestClock for the heartbeat). **Risk:** low. **Net product LoC ≈ +30** (`context?` option + `toAsyncIterableWith` ~8; 19 call sites × 1 line via one shared helper in `routerSubscriptions.ts` ~3).

Acceptance: the 3 clock-bound waits (`:207, :241, :255`) run on `TestClock`; the heartbeat test asserts N heartbeats after `TestClock.adjust(N × interval)` with zero real time; existing behavioral assertions unchanged; `tests/ipc` subscription tests pass. Do not rewrite the 8 readiness polls.

Gate suites: `streamBridge.test.ts`, `routerSubscriptions*.test.ts`, `orpc/*.test.ts`, `TEST_INTEGRATION=1 bun x jest tests/ipc` (subscription subset); `make static-check`.

Audits: `Stream.toAsyncIterableWith` preserves double-close safety (pin with the existing test); `Cause.Done` typing unchanged; no `Scope`/`MemoMap`/`Scheduler` captured (pass the oRPC `effect/context`, which the DI layer already strips per `EffectRunnerLive`); `context` stays optional so direct callers/tests without a runtime keep today's global-runtime path.

Rollback: revert; the optional `context` default (`Context.empty()`) is exactly today's `toAsyncIterable`, so a partial revert of call sites is also safe.

### Execution order and size
Net product LoC for the wave ≈ **+205** (PR 1 ≈ +55, PR 2 ≈ +40, PR 3 ≈ +80, PR 4 ≈ +30); tests ≈ +600–800. PR 1 starts immediately. PR 2 starts the moment #3949 merges (parallel with PR 1/3 — disjoint files). PR 3 after PR 1 merges (both touch `appRuntime.ts` docs; PR 3 also touches `serviceContainer.ts`). PR 4 last, only if PRs 1–3 landed and no OFF-RAMP fired. Each PR: Codex dual review, `Codex Comments` minimization, merge queue; commit WIP early (`/tmp` wipes).

## 4. STOP criterion (measurable) and OFF-RAMPs

Wave 4 is **done** — and the Effect migration line **stops** without a new RFC — when all hold:
1. **dispose() awaits in-flight streams:** `serviceContainer.test.ts` ordering test + `coreServicesRoot.test.ts` pass on main; a sandbox `script -f` transcript of `xum server` receiving SIGTERM mid-stream shows `stream-abort` → `[shutdown] AppFiberScope closed { ms }` → `[shutdown] desktopBridgeServer.stop`, and immediately after exit `partial.json` is absent while `chat.jsonl` contains the interrupted assistant message (baseline on `main`: `partial.json` present, message absent until next load). `{ ms }` < 2000 in the flowing-stream case.
2. **False-settle class eliminated:** the scripted reproduction fails on the pre-#3949 merge-base and passes on main after PR 2; `settleWorkspaceTurn` rejects any settlement without an enumerated cause; the coordinator's own Mux sessions show zero "superseded by an uncorrelated workspace stream-end" in the two weeks after PR 2 (soft signal, logged in the wave summary).
3. **Startup:** timeout and error-identity tests pass under TestClock; `[startup]` per-step lines unchanged in the sandbox transcript; a throwaway build with the constant set to 1 ms shows `Startup failed: StartupStepTimeoutError: <step> exceeded 1 ms` and a clean exit.
4. **No new lifecycle flakes:** 0 failures attributable to the touched suites across **N = 20** consecutive *completed* `Test / Unit` runs on `main` after the last Wave 4 merge — query `gh run list --workflow pr.yml --branch main --limit 60 --json databaseId,status,conclusion,event,headSha` (note: `gh run list --json` serializes these fields in **lowercase**, e.g. `{"status":"completed","conclusion":"success"}`, unlike `statusCheckRollup`), keep `status === "completed"` (pending runs have an empty `conclusion`, not null), take the newest 20, and for any run with `conclusion !== "success"` (case-insensitive normalization acceptable) inspect the failing job's log for the touched suite names (job `timeout`/`cancelled` from the 15-min budget is not a flake); plus green merge-queue runs for each PR. Any attributable flake → fix or revert before declaring done.

**OFF-RAMP (PR 1):** fires if pre-work 1–3 shows (a) routing shutdown through `cancelStreamSafely` cannot preserve crash-recovery semantics without changing `cleanupAbortedStream`'s contract beyond D3, (b) the chaos variant exposes a double-settle not closable by D3(b), or (c) the finalizer cannot fit the 2 s bound for flowing streams. Then: stop PR 1, keep `AppFiberScope` unoccupied, update `appRuntime.ts` "Deliberately not done" with the concrete blocker and the measured evidence, land D3 alone as a bug-fix PR. PRs 2–4 are independent and proceed.
**OFF-RAMP (PR 3):** if error identity or the `tests/ipc`/ACP paths cannot be preserved, keep `initialize()` as is and record why.
**OFF-RAMP (PR 2):** #3949 not merged → hold (see PR 2).

## 5. Risk register

| Risk | Likelihood | Mitigation |
|---|---|---|
| Crash-recovery regression: double commit / partial resurrection when shutdown-abort races completion | medium (window widens with dispose()) | D3(a) guard + test; `commitPartial`'s `historySequence` update-or-append is idempotent (`historyService.ts:2036–2041`) |
| Provider abort emits an `error` chunk → error path instead of abort path | low | identical to today's user-stop path (parity); chaos variant covers hostile streams |
| Wedged provider pins the 2 s bound → warning every shutdown | low | `boundedTeardown` already bounds; transcript measures; no budget change possible (5 s outer) |
| AIService `stream-abort` listener (`commitPartial`) still in flight when `process.exit` runs | low | durable order writePartial → commit → deletePartial; next-load recovery; PR 1 transcript checks `partial.json` is already gone when `cli/server.ts` logs its final cleanup line before `process.exit(0)` (`:252–266`) |
| Chaos-test seams (`createStreamResult`, `tokenTracker`) | none if scope-less construction stays default | new variant added, old cases untouched |
| Collision with #3915/#3949 | medium | PR 2 gated; no edits to their regions; one-line `cause:` conflicts only |
| RC churn (rc.113+ renames `forkIn`/`onInterrupt`/`toAsyncIterableWith`) | low | all Effect imports already in `streamManager.ts`/`streamBridge.ts`; pins fixed; GA upgrade is a separate lockstep PR (§6) |
| Startup false timeout on slow hosts | medium if constant too small | measure first; ≥ 10× slowest observed; generous default (60 s) |
| Sync-start assumptions in tests that `Reflect.set(processStreamWithCleanup)` | low | promise assigned before fork; forkIn `runSync` synchronous |
| `shutdown()` (desktop second `before-quit` listener) still does not await streams | accepted | contract says `shutdown()` never touches the runtime; desktop's dispose race is the covered path |
| Streams starting during shutdown | covered | `forkIn` on closed scope interrupts immediately → `system` abort (`startImmediately` semantics verified in rc.112; pinned by test) |
| `system` abort triggers an in-session RetryManager retry during shutdown | **unreachable** (verified) | `"aborted"` ∈ `NON_RETRYABLE_STREAM_ERRORS` → `retryManager.ts:99–104` abandons; no fiber scheduled |
| PR 3: abandoned `taskService.initialize` mid-`editConfig` when the root exits after a timeout | low | desktop/ACP already dispose on startup failure; PR 3 adds the missing `cli/server.ts` dispose; config writes are lock/journal-protected |
| `startImmediately`/`onInterrupt` semantics differ in a later RC | low | pinned by the probe test in `appFiberScope.test.ts` style; RC bumps are a separate lockstep PR |

## 6. Standing item — effect v4 GA + `@orpc/experimental-effect` lockstep (analysis only)

v4 is **not GA** (rc.112 is current; v3 `3.x` remains the stable line). No PR this wave. When GA ships: one lockstep PR bumping `effect` + all `@orpc/*` (`1.14.11` today; check the GA-compatible `@orpc/experimental-effect`), canary gates = `di/*.test.ts`, `streamBridge.test.ts`, `streamManager.test.ts`, `serviceContainer.test.ts`, `TEST_INTEGRATION=1 bun x jest tests/ipc`, `make static-check`. The `Context → ServiceMap` rename risk is firewalled: `Context.Service` tags, `Context.omit/get`, `Layer`, `ManagedRuntime`, `TestClock` live only under `di/` + `orpc/effectContext.ts`; `streamManager.ts`/`streamBridge.ts` use `Effect`/`Scope`/`Fiber`/`Exit`/`Stream`/`Queue`/`Cause` only. PR 4 adds one `Context.Context<never>` type reference to `streamBridge.ts` — keep it as a type-only import so a rename is a one-line fix.

## 7. Dogfooding (per PR; evidence attached to the PR with `gh … --attach`)

Common setup: `make dev-server-sandbox DEV_SERVER_SANDBOX_ARGS="--clean-projects"` (or `xum server` on a temp `XUM_ROOT`) with `XUM_LOG_LEVEL=debug`, run under `script -f ~/wave4-scratch/<pr>-<scenario>.log`; scratch under `$HOME/wave4-scratch/` (never `/tmp`). Drive the UI with `agent-browser` (`open` → `snapshot -i` → click the explicit "Send message" ref; re-snapshot after typing). Screenshots are primary evidence; record WebM and finalize with `ffmpeg -c copy`.

- **PR 1:** (1) start a long stream (prompt that streams ~30 s), wait 3–5 s, `kill -TERM <server pid>`; transcript must show the order in STOP #1 and `[shutdown] AppFiberScope closed { ms }`; (2) `ls <XUM_ROOT>/sessions/<ws>/partial.json` (absent) + `tail -n 1 chat.jsonl` (interrupted assistant message); (3) restart, open the workspace in agent-browser, screenshot the persisted interrupted message; (4) same scenario on `main` for the baseline diff; (5) `xum run` Ctrl-C mid-stream transcript (CLI root parity); (6) quality gate between phases: gate suites green before the sandbox run, sandbox evidence before requesting review.
- **PR 2:** primary evidence is the regression file run on both the merge-base worktree (failing output) and the branch (passing). Secondary: sandbox parent workspace delegates via `task` kind=workspace to a child that arms a background bash monitor firing within ~10 s and keeps working ~60 s; screenshot the parent's task result (baseline `main`: `interrupted … uncorrelated workspace stream-end`; after: `completed`) and the child's log lines.
- **PR 3:** `xum server` cold start transcript with `[startup] <step> { ms }` for the six steps (parity); throwaway worktree build with `STARTUP_STEP_TIMEOUT_MS = 1` → transcript of `Startup failed: StartupStepTimeoutError …` and exit code (do not ship); desktop dialog cannot be shown headless — cite the unchanged `desktop/main.ts:1249–1265` catch.
- **PR 4:** agent-browser session left idle 60 s with the connection indicator visible (heartbeats keep it green) + screenshot; `streamBridge.test.ts` on TestClock.

## 8. Non-goals (restated; out of this wave)

Typed-error propagation sweep / removing the ~113 facades; converting services to `yield*`-based Effect services; PubSub for the internal EventEmitter bus; Schema at persistence boundaries; Effect observability; converting sync read paths, AI-SDK per-request callbacks, cross-process lock interiors, or deterministic try-lock funnels; replacing `AbortController` as the SDK cancellation transport; converting the `fullStream` loop to `Stream`; fiberizing turn-handle waiters; downgrading startup steps to best-effort; changing outer quit budgets; supervising the pre-registration stream-start window; `shutdown()` semantics; the effect GA bump (standing analysis only).

</details>

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$34.90`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=34.90 -->
