### PR TITLE
🤖 feat: initializeCore() becomes a runtime-run startup effect with per-step timeouts (Wave 4 PR 3)

### DIFF
--- a/src/cli/server.ts
+++ b/src/cli/server.ts
@@ -12,6 +12,8 @@ import { initializeXumHomeTransition } from "@/node/compat/xumTransition";
 import { ServerLockfile } from "@/node/services/serverLockfile";
 import { log } from "@/node/services/log";
 import { shutdownStep } from "@/node/services/shutdownStep";
+import { raceWithAbortAndTimeout } from "@/node/utils/concurrency/withTimeout";
+import { SERVICE_TEARDOWN_BUDGET_MS } from "@/constants/terminationTimeouts";
 import type { BrowserWindow } from "electron";
 import { Command } from "commander";
 import { validateProjectPath } from "@/node/utils/pathUtils";
@@ -48,6 +50,10 @@ process.on("beforeExit", (code) => {
 
 // Track the launch project path for initial navigation
 let launchProjectPath: string | null = null;
+
+// Set as soon as the container exists so a startup that fails afterwards (main() rejecting) still
+// runs the bounded teardown before the process exits.
+let constructedServices: ServiceContainer | undefined;
 
 // Minimal BrowserWindow stub for services that expect one
 // eslint-disable-next-line local/no-chained-type-assertions -- grandfathered when the rule was introduced; fix the underlying type instead of copying this pattern
@@ -131,6 +137,7 @@ async function main(): Promise<void> {
   const stores = createConfigStores();
   const config = stores.config;
   const serviceContainer = new ServiceContainer(stores);
+  constructedServices = serviceContainer;
   // Headless server has no interactive host-key dialog
   setOpenSSHHostKeyPolicyMode("headless-fallback");
   // Core init (including agent-task recovery, which must finish before any client can act on
@@ -247,11 +254,11 @@ async function main(): Promise<void> {
     const forceExitTimer = setTimeout(() => {
       appendServerCrashLogSync({
         event: "Server cleanup timed out",
-        context: { timeoutMs: 5000 },
+        context: { timeoutMs: SERVICE_TEARDOWN_BUDGET_MS },
       });
       console.log("Cleanup timed out, forcing exit...");
       process.exit(1);
-    }, 5000);
+    }, SERVICE_TEARDOWN_BUDGET_MS);
 
     try {
       // Close all PTY sessions first
@@ -290,12 +297,28 @@ async function main(): Promise<void> {
   process.on("SIGTERM", () => void cleanup());
 }
 
-void main().catch((error) => {
+void main().catch(async (error: unknown) => {
   appendServerCrashLogSync({
     event: "Failed to initialize server",
     detail: error,
   });
   console.error("Failed to initialize server:", error);
+  if (constructedServices) {
+    // Parity with the desktop before-quit race and the ACP root: a startup step that failed — or
+    // timed out and is still running as a plain promise (StartupStepTimeoutError) — must not leave
+    // half-started services behind. Bounded like the SIGTERM cleanup; the process exits either way.
+    const teardown = await raceWithAbortAndTimeout(
+      constructedServices.dispose().catch((disposeError: unknown) => {
+        log.error("[shutdown] dispose after failed startup failed", { error: disposeError });
+      }),
+      { timeoutMs: SERVICE_TEARDOWN_BUDGET_MS }
+    );
+    if (teardown.kind === "timeout") {
+      log.warn("[shutdown] dispose after failed startup timed out; exiting", {
+        timeoutMs: SERVICE_TEARDOWN_BUDGET_MS,
+      });
+    }
+  }
   process.exit(1);
 });
 

--- a/src/constants/terminationTimeouts.ts
+++ b/src/constants/terminationTimeouts.ts
@@ -32,6 +32,14 @@ export const APP_FIBER_SCOPE_CLOSE_TIMEOUT_MS = 2 * 1000;
 export const STARTUP_HOUSEKEEPING_JOIN_TIMEOUT_MS = 500;
 
 /**
+ * Outer budget the `xum server` and ACP roots give the whole
+ * `ServiceContainer.dispose()` — the SIGTERM cleanup and the dispose after a
+ * failed startup; `desktop/main.ts` races its before-quit dispose against the
+ * same 5 s. The bounded steps above are sized to fit inside it.
+ */
+export const SERVICE_TEARDOWN_BUDGET_MS = 5 * 1000;
+
+/**
  * Bounds each hard startup step of `ServiceContainer.initializeCore()` on the app
  * runtime's clock. A step that has not settled by then fails startup with a
  * `StartupStepTimeoutError` through the same exit path as a throwing step

--- a/src/constants/terminationTimeouts.ts
+++ b/src/constants/terminationTimeouts.ts
@@ -30,3 +30,17 @@ export const APP_FIBER_SCOPE_CLOSE_TIMEOUT_MS = 2 * 1000;
  * inside the same 5 s quit budgets.
  */
 export const STARTUP_HOUSEKEEPING_JOIN_TIMEOUT_MS = 500;
+
+/**
+ * Bounds each hard startup step of `ServiceContainer.initializeCore()` on the app
+ * runtime's clock. A step that has not settled by then fails startup with a
+ * `StartupStepTimeoutError` through the same exit path as a throwing step
+ * (desktop "Startup Failed" dialog, `xum server`/ACP log-and-exit after the
+ * bounded `dispose()`), instead of pinning the splash screen or the listener
+ * bind forever. Deliberately generous — a false timeout turns a slow-but-fine
+ * start into a crash: sandbox cold starts measured ≤ 60 ms for the slowest core
+ * step (`taskService.recoverInterruptedTasks`, which scales with the number of
+ * active agent tasks, not with deployment size), so this is ≥ 1000× the observed
+ * maximum and still above the policy service's own 10 s fetch timeout.
+ */
+export const STARTUP_STEP_TIMEOUT_MS = 60 * 1000;

--- a/src/node/acp/serverConnection.ts
+++ b/src/node/acp/serverConnection.ts
@@ -5,11 +5,13 @@ import { RPCLink as WebSocketRPCLink } from "@orpc/client/websocket";
 import type { RouterClient } from "@orpc/server";
 import WebSocket from "ws";
 import { getXumHome } from "@/common/constants/paths";
+import { SERVICE_TEARDOWN_BUDGET_MS } from "@/constants/terminationTimeouts";
 import { createConfigStores } from "@/node/config";
 import type { AppRouter } from "@/node/orpc/router";
 import { createOrpcServer } from "@/node/orpc/server";
 import { ServiceContainer } from "@/node/services/serviceContainer";
 import { ServerLockfile } from "@/node/services/serverLockfile";
+import { raceWithAbortAndTimeout } from "@/node/utils/concurrency/withTimeout";
 
 interface ConnectViaWebSocketResult {
   client: ORPCClient;
@@ -154,12 +156,10 @@ async function connectToInProcessServer(requestedAuthToken?: string): Promise<Se
   const stores = createConfigStores();
   const serviceContainer = new ServiceContainer(stores);
 
-  let initialized = false;
   let inProcessServer: InProcessOrpcServer | undefined;
 
   try {
     await serviceContainer.initialize();
-    initialized = true;
 
     const context = serviceContainer.toORPCContext();
     inProcessServer = await createOrpcServer({
@@ -207,9 +207,16 @@ async function connectToInProcessServer(requestedAuthToken?: string): Promise<Se
       await inProcessServer.close().catch(() => undefined);
     }
 
-    if (initialized) {
-      await serviceContainer.dispose().catch(() => undefined);
-    }
+    // Also after a rejected initialize(): a startup step that failed — or timed out and is still
+    // running as a plain promise (StartupStepTimeoutError) — must not leave half-started services
+    // behind, and the stdio adapter must still exit if a teardown step hangs. dispose() is safe
+    // on a container that never finished initializing.
+    await raceWithAbortAndTimeout(
+      serviceContainer.dispose().catch(() => undefined),
+      {
+        timeoutMs: SERVICE_TEARDOWN_BUDGET_MS,
+      }
+    );
 
     throw error;
   }

--- a/src/node/services/di/appRuntime.ts
+++ b/src/node/services/di/appRuntime.ts
@@ -96,6 +96,32 @@
  *   torn down before step 2 below, and never fork long-lived I/O work through
  *   `EffectRunner` expecting shutdown to await it.
  *
+ * ## Startup (`ServiceContainer.initializeCore()`, Wave 4 PR 3)
+ *
+ * The hard startup steps (`startupCoreSteps`: the initializations request
+ * handling depends on, then agent-task recovery) run as one startup effect on
+ * the runtime — `runtime.managed.runPromise(startupCoreEffect())`, a
+ * root fiber on the built context, not a layer (I1 keeps layer bodies
+ * synchronous, so asynchronous acquisition lives here). Each step is a Promise
+ * thunk in `Effect.tryPromise` with an identity catch, bounded by
+ * `Effect.timeoutOrElse(STARTUP_STEP_TIMEOUT_MS)` on the runtime's `Clock`
+ * (tests inject a `TestClock` beneath the graph and drive the bound
+ * deterministically). Contract: step names/order are the `stepDurationsMs`
+ * keys of the completion log; the first failure or timeout rejects the facade
+ * with the step's own error (identity — v4 `runPromise` rejects with the raw
+ * failure) or a `StartupStepTimeoutError`, later steps do not run, and a
+ * timed-out step keeps running as a plain promise (the timeout interrupts only
+ * the wait; nothing observes the step's result afterwards). Every root
+ * therefore runs the bounded `dispose()` before exiting on a rejected startup
+ * (desktop before-quit race, `cli/server.ts` `main().catch`, ACP
+ * `connectToInProcessServer` catch) so an abandoned step's work is cut off by
+ * the same latches as a quit. Disposing the runtime does not interrupt an
+ * in-flight startup fiber (root fibers are not scope children), matching the
+ * promise chain it replaced. `runStartupHousekeeping()` stays a Promise
+ * pipeline on purpose: its steps are already cancellable through the dispose
+ * abort signal and non-fatal by policy, so a per-step timeout there would be a
+ * policy change, not a lifecycle fix.
+ *
  * ## Shutdown order (`ServiceContainer.dispose()`, one shared teardown behind
  * a latch so concurrent/repeated calls — the desktop's two `before-quit`
  * listeners, tests' dispose-then-shutdown — await the same sequence)
@@ -142,12 +168,13 @@
  *
  * ## Deliberately not done in Phase 11
  *
- * `initialize()` as a Layer/startup effect (would break I1's failure
- * semantics), layer finalizers for the existing `dispose()` steps (I5),
- * `streamBridge` on the runtime, per-service optional tags (optional
- * cross-cutting services stay optional via `CoreOptionsTag`). The streamManager
- * engine core became the `AppFiberScope` occupant in Wave 4 PR 1; the
- * pre-registration stream-start window (`pendingStreamStarts`) stays
+ * Startup as a Layer (would break I1's failure semantics; it became a
+ * runtime-run effect instead, see "Startup"), layer finalizers for the existing
+ * `dispose()` steps (I5), `streamBridge` on the runtime, per-service optional
+ * tags (optional cross-cutting services stay optional via `CoreOptionsTag`),
+ * per-step timeouts for `runStartupHousekeeping()` (policy, see "Startup"). The
+ * streamManager engine core became the `AppFiberScope` occupant in Wave 4 PR 1;
+ * the pre-registration stream-start window (`pendingStreamStarts`) stays
  * unsupervised (nothing durable exists for it yet).
  */
 import assert from "@/common/utils/assert";

--- a/src/node/services/serviceContainer.test.ts
+++ b/src/node/services/serviceContainer.test.ts
@@ -362,6 +362,14 @@ describe("ServiceContainer", () => {
     };
   }
 
+  /** The rejection reason of `promise` as-is (identity assertions), or a marker if it resolved. */
+  function rejectionOf(promise: Promise<unknown>): Promise<unknown> {
+    return promise.then(
+      () => "<resolved>",
+      (reason: unknown) => reason
+    );
+  }
+
   it("initializeCore times out a hung step on the runtime clock and skips the later steps", async () => {
     // TestClock beneath the real graph: the per-step bound must sleep on the runtime's clock
     // (the effect runs through the ManagedRuntime, not a global Effect.runPromise).
@@ -449,7 +457,7 @@ describe("ServiceContainer", () => {
     const recoverTasks = spyOn(services.taskService, "recoverInterruptedTasks");
 
     // Identity, not a wrapped copy: roots log/print the object they receive.
-    await expect(services.initializeCore()).rejects.toBe(boom);
+    expect(await rejectionOf(services.initializeCore())).toBe(boom);
     expect(experimentsInitialize).not.toHaveBeenCalled();
     expect(recoverTasks).not.toHaveBeenCalled();
   });
@@ -462,7 +470,7 @@ describe("ServiceContainer", () => {
     });
     const recoverTasks = spyOn(services.taskService, "recoverInterruptedTasks");
 
-    await expect(services.initializeCore()).rejects.toBe(boom);
+    expect(await rejectionOf(services.initializeCore())).toBe(boom);
     expect(recoverTasks).not.toHaveBeenCalled();
   });
 
@@ -486,7 +494,9 @@ describe("ServiceContainer", () => {
 
     // A disposed ManagedRuntime would otherwise reject with a bare "ManagedRuntime disposed"
     // defect string from inside the first step.
-    await expect(services.initializeCore()).rejects.toThrow("after dispose()");
+    const rejection = await rejectionOf(services.initializeCore());
+    expect(rejection).toBeInstanceOf(Error);
+    expect((rejection as Error).message).toContain("after dispose()");
     expect(recoverTasks).not.toHaveBeenCalled();
   });
 

--- a/src/node/services/serviceContainer.test.ts
+++ b/src/node/services/serviceContainer.test.ts
@@ -13,6 +13,7 @@ import { AppFiberScopeTag } from "@/node/services/di/appFiberScope";
 import { EffectRunnerTag } from "@/node/services/di/effectRunner";
 import * as appLayers from "@/node/services/di/layers/app";
 import { CoreOptionsTag } from "@/node/services/di/layers/core";
+import { STARTUP_STEP_TIMEOUT_MS } from "@/constants/terminationTimeouts";
 import {
   AgentBrowserSessionDiscovery,
   AgentPluginInstall,
@@ -78,7 +79,7 @@ import {
   WorktreeArchiveSnapshot,
   type AppTags,
 } from "@/node/services/di/tags";
-import { ServiceContainer } from "./serviceContainer";
+import { ServiceContainer, StartupStepTimeoutError } from "./serviceContainer";
 
 /**
  * Independent field → tag listing for every ORPC context field (the production
@@ -343,6 +344,150 @@ describe("ServiceContainer", () => {
     expect(idleCompactionStart).toHaveBeenCalledTimes(1);
     expect(heartbeatStart).toHaveBeenCalledTimes(1);
     expect(agentStatusStart).toHaveBeenCalledTimes(1);
+  });
+
+  const CORE_STEP_NAMES = [
+    "extensionMetadata.initialize",
+    "telemetryService.initialize",
+    "policyService.initialize",
+    "experimentsService.initialize",
+    "taskService.recoverInterruptedTasks",
+  ];
+
+  /** The container's private startup bookkeeping, read for assertions only. */
+  function startupInternals(container: ServiceContainer) {
+    return container as unknown as {
+      extensionMetadata: { initialize: () => Promise<void> };
+      startupStepDurationsMs: Record<string, number>;
+    };
+  }
+
+  it("initializeCore times out a hung step on the runtime clock and skips the later steps", async () => {
+    // TestClock beneath the real graph: the per-step bound must sleep on the runtime's clock
+    // (the effect runs through the ManagedRuntime, not a global Effect.runPromise).
+    const realAppLive = appLayers.AppLive;
+    const appLiveSpy = spyOn(appLayers, "AppLive").mockImplementation((appStores) =>
+      realAppLive(appStores).pipe(Layer.provideMerge(TestClock.layer()))
+    );
+    try {
+      services = new ServiceContainer(stores);
+    } finally {
+      appLiveSpy.mockRestore();
+    }
+    const runtime = services.runtime.managed;
+    spyOn(startupInternals(services).extensionMetadata, "initialize").mockResolvedValue(undefined);
+    spyOn(services.telemetryService, "initialize").mockResolvedValue(undefined);
+    let policyCalled: (() => void) | undefined;
+    const policyCalledPromise = new Promise<void>((resolve) => {
+      policyCalled = resolve;
+    });
+    let rejectAbandonedStep: ((error: unknown) => void) | undefined;
+    spyOn(services.policyService, "initialize").mockImplementation(() => {
+      policyCalled?.();
+      return new Promise<void>((_resolve, reject) => {
+        rejectAbandonedStep = reject;
+      });
+    });
+    const experimentsInitialize = spyOn(services.experimentsService, "initialize");
+    const recoverTasks = spyOn(services.taskService, "recoverInterruptedTasks");
+
+    let outcome: { settled: boolean; error?: unknown } = { settled: false };
+    const core = services.initializeCore().then(
+      () => {
+        outcome = { settled: true };
+      },
+      (error: unknown) => {
+        outcome = { settled: true, error };
+      }
+    );
+    await policyCalledPromise;
+
+    // One millisecond short of the budget the wait is still pending...
+    await runtime.runPromise(TestClock.adjust(Duration.millis(STARTUP_STEP_TIMEOUT_MS - 1)));
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect(outcome.settled).toBe(false);
+    // ...and exactly at the budget the step is abandoned.
+    await runtime.runPromise(TestClock.adjust(Duration.millis(1)));
+    await core;
+    expect(outcome.error).toBeInstanceOf(StartupStepTimeoutError);
+    const timeoutError = outcome.error as StartupStepTimeoutError;
+    expect(timeoutError.step).toBe("policyService.initialize");
+    expect(timeoutError.timeoutMs).toBe(STARTUP_STEP_TIMEOUT_MS);
+    // The roots' default Error formatting (dialog / log line) names the class and the step.
+    expect(String(timeoutError)).toMatch(/^StartupStepTimeoutError: policyService\.initialize /);
+    expect(experimentsInitialize).not.toHaveBeenCalled();
+    expect(recoverTasks).not.toHaveBeenCalled();
+    const durations = startupInternals(services).startupStepDurationsMs;
+    expect(Object.keys(durations)).toEqual(CORE_STEP_NAMES.slice(0, 3));
+    const durationsAtTimeout = { ...durations };
+
+    // The abandoned step keeps running as a plain promise: its late rejection is neither
+    // unhandled nor a late side effect on the container.
+    const unhandled: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandledRejection);
+    try {
+      rejectAbandonedStep?.(new Error("late policy failure"));
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+    expect(unhandled).toEqual([]);
+    expect(durations).toEqual(durationsAtTimeout);
+    expect(experimentsInitialize).not.toHaveBeenCalled();
+    expect(recoverTasks).not.toHaveBeenCalled();
+  });
+
+  it("initializeCore rejects with the failing step's own error and skips the later steps", async () => {
+    services = new ServiceContainer(stores);
+    const boom = new Error("policy endpoint unreachable");
+    spyOn(services.policyService, "initialize").mockImplementation(() => Promise.reject(boom));
+    const experimentsInitialize = spyOn(services.experimentsService, "initialize");
+    const recoverTasks = spyOn(services.taskService, "recoverInterruptedTasks");
+
+    // Identity, not a wrapped copy: roots log/print the object they receive.
+    await expect(services.initializeCore()).rejects.toBe(boom);
+    expect(experimentsInitialize).not.toHaveBeenCalled();
+    expect(recoverTasks).not.toHaveBeenCalled();
+  });
+
+  it("initializeCore rejects with a synchronously thrown step error", async () => {
+    services = new ServiceContainer(stores);
+    const boom = new Error("policy store corrupt");
+    spyOn(services.policyService, "initialize").mockImplementation(() => {
+      throw boom;
+    });
+    const recoverTasks = spyOn(services.taskService, "recoverInterruptedTasks");
+
+    await expect(services.initializeCore()).rejects.toBe(boom);
+    expect(recoverTasks).not.toHaveBeenCalled();
+  });
+
+  it("initializeCore records the five core steps and re-runs them when called again", async () => {
+    services = new ServiceContainer(stores);
+    const recoverTasks = spyOn(services.taskService, "recoverInterruptedTasks").mockResolvedValue(
+      undefined
+    );
+
+    await services.initializeCore();
+    expect(Object.keys(startupInternals(services).startupStepDurationsMs)).toEqual(CORE_STEP_NAMES);
+    // Not re-entrancy guarded (parity with the plain promise chain it replaced).
+    await services.initializeCore();
+    expect(recoverTasks).toHaveBeenCalledTimes(2);
+  });
+
+  it("initializeCore after dispose() fails fast without running a step", async () => {
+    services = new ServiceContainer(stores);
+    const recoverTasks = spyOn(services.taskService, "recoverInterruptedTasks");
+    await services.dispose();
+
+    // A disposed ManagedRuntime would otherwise reject with a bare "ManagedRuntime disposed"
+    // defect string from inside the first step.
+    await expect(services.initializeCore()).rejects.toThrow("after dispose()");
+    expect(recoverTasks).not.toHaveBeenCalled();
   });
 
   it("exposes desktopSessionManager in the ORPC context", () => {

--- a/src/node/services/serviceContainer.ts
+++ b/src/node/services/serviceContainer.ts
@@ -1,8 +1,12 @@
+import assert from "@/common/utils/assert";
 import { log } from "@/node/services/log";
 import type { Config, ConfigStores, WorkspaceSessionLocator } from "@/node/config";
 import type { FileLeaseManager, ProvidersConfigStore, SecretsStore } from "@/node/config";
 import { SLOW_STARTUP_WARN_THRESHOLD_MS } from "@/constants/startup";
-import { STARTUP_HOUSEKEEPING_JOIN_TIMEOUT_MS } from "@/constants/terminationTimeouts";
+import {
+  STARTUP_HOUSEKEEPING_JOIN_TIMEOUT_MS,
+  STARTUP_STEP_TIMEOUT_MS,
+} from "@/constants/terminationTimeouts";
 import type { CoreServices } from "@/node/services/coreServices";
 import type { TerminalWindowManager } from "@/desktop/terminalWindowManager";
 import type { ProjectService } from "@/node/services/projectService";
@@ -49,6 +53,7 @@ import type { DesktopBridgeServer } from "@/node/services/desktop/DesktopBridgeS
 import type { DesktopSessionManager } from "@/node/services/desktop/DesktopSessionManager";
 import type { DesktopTokenManager } from "@/node/services/desktop/DesktopTokenManager";
 import type { ORPCContext } from "@/node/orpc/context";
+import { Duration, Effect } from "effect";
 import type { Scope } from "effect";
 import { AppFiberScopeTag } from "@/node/services/di/appFiberScope";
 import {
@@ -128,6 +133,31 @@ import {
   WorkspaceTurnManagerTag,
   type AppTags,
 } from "@/node/services/di/tags";
+
+/**
+ * A hard startup step of `ServiceContainer.initializeCore()` did not settle
+ * within `STARTUP_STEP_TIMEOUT_MS`. Rejects `initializeCore()` like any other
+ * step failure, so the roots' existing startup-failure paths apply unchanged;
+ * `name` is set explicitly so their default `Error` formatting (desktop
+ * "Startup Failed" dialog, `Failed to initialize server:` line) shows the
+ * class together with the step.
+ */
+export class StartupStepTimeoutError extends Error {
+  constructor(
+    readonly step: string,
+    readonly timeoutMs: number
+  ) {
+    super(`${step} exceeded ${timeoutMs} ms`);
+    this.name = "StartupStepTimeoutError";
+  }
+}
+
+interface StartupStep {
+  /** `stepDurationsMs` key of the startup completion log and `StartupStepTimeoutError.step`. */
+  readonly name: string;
+  readonly run: () => Promise<void>;
+}
+
 /**
  * ServiceContainer - Central dependency container for all backend services.
  *
@@ -306,6 +336,10 @@ export class ServiceContainer {
     this.idleDispatcher = get(IdleDispatcherTag);
     this.heartbeatService = get(Heartbeat);
     this.agentStatusService = get(AgentStatus);
+    assert(
+      new Set(this.startupCoreSteps.map((step) => step.name)).size === this.startupCoreSteps.length,
+      "startupCoreSteps names must be unique (they key stepDurationsMs)"
+    );
   }
 
   async initialize(): Promise<void> {
@@ -323,35 +357,83 @@ export class ServiceContainer {
   }
 
   /**
-   * Everything request handling depends on, plus agent-task restart recovery. The server entry
-   * point awaits this before binding its listener: task recovery must finish before any client
-   * can stop, resume, or send to a task (see TaskService.recoverInterruptedTasks), and it is
-   * bounded by the number of active tasks rather than by deployment size. The per-workspace
+   * The hard startup steps, in order: everything request handling depends on, plus agent-task
+   * restart recovery. All five are mandatory — a failure stops startup — and every name is a
+   * `stepDurationsMs` key of the `[startup] ServiceContainer.initialize completed` line (and the
+   * `step` of a `StartupStepTimeoutError`), so names and order are an observability contract.
+   * Downgrading a step to best-effort is runStartupHousekeeping()'s policy, not a change here.
+   */
+  private readonly startupCoreSteps: ReadonlyArray<StartupStep> = [
+    { name: "extensionMetadata.initialize", run: () => this.extensionMetadata.initialize() },
+    { name: "telemetryService.initialize", run: () => this.telemetryService.initialize() },
+    // Startup gating
+    { name: "policyService.initialize", run: () => this.policyService.initialize() },
+    { name: "experimentsService.initialize", run: () => this.experimentsService.initialize() },
+    {
+      name: "taskService.recoverInterruptedTasks",
+      run: () => this.taskService.recoverInterruptedTasks(),
+    },
+  ];
+
+  /**
+   * Runs `startupCoreSteps` on the app runtime (startup contract in di/appRuntime.ts). The
+   * server entry point awaits this before binding its listener: task recovery must finish before
+   * any client can stop, resume, or send to a task (see TaskService.recoverInterruptedTasks), and
+   * it is bounded by the number of active tasks rather than by deployment size. The per-workspace
    * housekeeping lives in runStartupHousekeeping().
+   *
+   * Rejects with the failing step's own error (identity preserved — a synchronous throw included)
+   * or with a `StartupStepTimeoutError` once a step exceeds `STARTUP_STEP_TIMEOUT_MS` on the
+   * runtime clock; later steps do not run. A timed-out step keeps running as a plain promise
+   * (nothing here observes its result afterwards), which is why every root runs the bounded
+   * `dispose()` before exiting on a rejected startup. Not re-entrancy guarded: a second call
+   * re-runs the steps, as the plain promise chain did.
    */
   async initializeCore(): Promise<void> {
-    this.startupStartedAt = Date.now();
+    assert(this.disposePromise === null, "ServiceContainer.initializeCore() after dispose()");
+    await this.runtime.managed.runPromise(this.startupCoreEffect());
+  }
 
-    log.info("[startup] ServiceContainer.initialize starting");
+  private startupCoreEffect(): Effect.Effect<void, unknown> {
+    const self = this;
+    return Effect.gen(function* () {
+      self.startupStartedAt = Date.now();
+      log.info("[startup] ServiceContainer.initialize starting");
+      for (const step of self.startupCoreSteps) {
+        yield* self.timedStartupStep(step);
+      }
+    });
+  }
 
-    await this.recordStartupStep("extensionMetadata.initialize", () =>
-      this.extensionMetadata.initialize()
-    );
-    // Initialize telemetry service
-    await this.recordStartupStep("telemetryService.initialize", () =>
-      this.telemetryService.initialize()
-    );
-
-    // Initialize policy service (startup gating)
-    await this.recordStartupStep("policyService.initialize", () => this.policyService.initialize());
-
-    await this.recordStartupStep("experimentsService.initialize", () =>
-      this.experimentsService.initialize()
-    );
-
-    await this.recordStartupStep("taskService.recoverInterruptedTasks", () =>
-      this.taskService.recoverInterruptedTasks()
-    );
+  /**
+   * One startup step as an effect. `tryPromise` with an identity catch keeps the rejection
+   * reason as the failure; the `async` thunk turns a synchronous throw into the same path.
+   * `timeoutOrElse` (not `timeout` + `catchTag`: the error channel is `unknown`, which
+   * `catchTag` cannot narrow) races the wait against the runtime clock and interrupts only the
+   * wait — the zero-arity thunk gets no AbortSignal, so the promise keeps running and its
+   * eventual settlement is a no-op on the exited fiber (`tryPromise` keeps a rejection handler
+   * attached, so a late rejection is never unhandled). The duration is recorded when the wait
+   * ends — settled, failed, or abandoned at the timeout — never by the abandoned step later.
+   */
+  private timedStartupStep(step: StartupStep): Effect.Effect<void, unknown> {
+    return Effect.suspend(() => {
+      const stepStartedAt = Date.now();
+      return Effect.tryPromise({
+        try: async () => step.run(),
+        catch: (error: unknown) => error,
+      }).pipe(
+        Effect.timeoutOrElse({
+          duration: Duration.millis(STARTUP_STEP_TIMEOUT_MS),
+          orElse: () =>
+            Effect.fail(new StartupStepTimeoutError(step.name, STARTUP_STEP_TIMEOUT_MS)),
+        }),
+        Effect.ensuring(
+          Effect.sync(() => {
+            this.startupStepDurationsMs[step.name] = Date.now() - stepStartedAt;
+          })
+        )
+      );
+    });
   }
 
   /**

--- a/src/node/services/serviceContainer.ts
+++ b/src/node/services/serviceContainer.ts
@@ -425,6 +425,13 @@ export class ServiceContainer {
       }).pipe(
         Effect.timeoutOrElse({
           duration: Duration.millis(STARTUP_STEP_TIMEOUT_MS),
+          // Fatal on purpose — the same exit path a throwing step already takes on every root
+          // (desktop "Startup Failed" dialog, server/ACP log-and-exit). These are the hard steps
+          // request handling depends on (#4058): continuing past a timed-out step would, e.g., let
+          // the server accept task operations while task recovery is still running. The
+          // "startup must never crash the app" rule governs the best-effort work in
+          // runStartupHousekeeping(), which stays non-fatal; this bound only turns an indefinite
+          // hang (splash pinned, listener never bound, no dispose) into the existing failure path.
           orElse: () =>
             Effect.fail(new StartupStepTimeoutError(step.name, STARTUP_STEP_TIMEOUT_MS)),
         }),

--- a/src/node/services/serviceContainer.ts
+++ b/src/node/services/serviceContainer.ts
@@ -363,7 +363,7 @@ export class ServiceContainer {
    * `step` of a `StartupStepTimeoutError`), so names and order are an observability contract.
    * Downgrading a step to best-effort is runStartupHousekeeping()'s policy, not a change here.
    */
-  private readonly startupCoreSteps: ReadonlyArray<StartupStep> = [
+  private readonly startupCoreSteps: readonly StartupStep[] = [
     { name: "extensionMetadata.initialize", run: () => this.extensionMetadata.initialize() },
     { name: "telemetryService.initialize", run: () => this.telemetryService.initialize() },
     // Startup gating
@@ -395,6 +395,7 @@ export class ServiceContainer {
   }
 
   private startupCoreEffect(): Effect.Effect<void, unknown> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
     const self = this;
     return Effect.gen(function* () {
       self.startupStartedAt = Date.now();


### PR DESCRIPTION
## Summary

Wave 4 PR 3 (plan §2 D6 / §3 "PR 3"): `ServiceContainer.initializeCore()` is now a Promise facade over a **startup effect run on the app runtime** — one `Effect.gen` over an ordered table of the five hard startup steps, each `Effect.tryPromise` (identity catch) bounded by `Effect.timeoutOrElse(STARTUP_STEP_TIMEOUT_MS)` on the runtime's `Clock`. A hung step no longer pins the splash screen / listener bind forever: after 60 s it fails startup with a `StartupStepTimeoutError` (`"<step> exceeded <ms> ms"`, `step`/`timeoutMs` fields) through the roots' **unchanged** failure paths. Step errors keep their identity; later steps do not run; the five step names/order and the `[startup] ServiceContainer.initialize completed { stepDurationsMs }` payload are unchanged. Every process root now runs the bounded `dispose()` before exiting on a rejected startup (D6 abandon-and-quit safety): `cli/server.ts` gains it, and the ACP root's existing catch **did not** dispose after a rejected `initialize()` (`if (initialized)` guard — the plan's claim that it did was wrong), so it does now.

## Background

- Plan: `~/.xum/plans/mux/effect-wave4-lifecycle-core-plan.md` (collapsed below); PR 1 = #4070; the plan predates #4058, which split `initialize()` into `initializeCore()` (hard steps, gate the server listener) + `runStartupHousekeeping()` (best-effort, abort-signal cancellable). This PR targets `initializeCore()` only.
- `runStartupHousekeeping()` is deliberately untouched: its steps are already cancellable through the dispose abort signal and non-fatal by policy, so per-step timeouts there would be a policy change the plan forbids (recorded in the `appRuntime.ts` startup contract).

## Implementation

- `serviceContainer.ts`: `startupCoreSteps: readonly StartupStep[]` (names asserted unique in the constructor — they key `stepDurationsMs`); `initializeCore()` = `assert(not disposed)` + `runtime.managed.runPromise(startupCoreEffect())`; `timedStartupStep` = `Effect.suspend` → `tryPromise({ try: async () => run(), catch: identity })` → `timeoutOrElse` → `Effect.ensuring` (duration recorded when the *wait* ends — settled, failed, or abandoned — never by the abandoned step later). `timeoutOrElse` rather than `timeout` + `catchTag` because the error channel is `unknown`. No `forkDetach`: the zero-arity thunk gets no AbortSignal, so the step promise keeps running; its late settlement is a no-op on the exited fiber and `tryPromise` keeps a rejection handler attached (pinned by test).
- `StartupStepTimeoutError extends Error` with `name` set in the constructor, so the desktop `Startup Failed` dialog and `Failed to initialize server:` print class + step without formatting changes.
- `src/constants/terminationTimeouts.ts`: `STARTUP_STEP_TIMEOUT_MS = 60 s` (evidence below) and `SERVICE_TEARDOWN_BUDGET_MS = 5 s` (the outer teardown budget `cli/server.ts` already used as a literal, now shared with the ACP root).
- `cli/server.ts`: `main().catch` runs `dispose()` bounded by the same 5 s budget as the SIGTERM cleanup when the container was constructed, then exits 1. `acp/serverConnection.ts`: the catch disposes unconditionally (bounded). `desktop/main.ts` unchanged — the catch at `:1249–1265` quits and the `before-quit` listener (`:1271–1305`) races `dispose()` against 5 s.
- `appRuntime.ts`: new "Startup" contract section; "Deliberately not done" no longer lists `initialize()`.
- Decisions pinned by tests: re-entry is **not** guarded (parity with the promise chain); `initializeCore()` after `dispose()` fails fast with an assertion instead of the disposed runtime's bare `"ManagedRuntime disposed"` string defect.

## Validation

- `serviceContainer.test.ts` (+5): TestClock timeout — rejects with `StartupStepTimeoutError` naming the step **exactly** at `TestClock.adjust(STARTUP_STEP_TIMEOUT_MS)` (still pending at −1 ms), later steps not called, the abandoned step's late rejection is not unhandled and changes nothing on the container; error identity (`toBe`) for a rejecting and for a synchronously throwing step with later steps skipped; happy path records the five keys in order and a second call re-runs the steps; after `dispose()` fails fast without running a step. **Red check** against the old promise chain: the timeout test (hangs → 5 s test timeout) and the after-dispose test fail; the identity/sync/re-run tests are parity pins (green on both, by design).
- Gates: `serviceContainer.test.ts` (23), `di/*.test.ts` + `coreServicesRoot.test.ts` + `acp/*.test.ts` (55), `TEST_INTEGRATION=1 bun x jest tests/ipc/{doubleRegister,windowTitle,savedQueries,acp.sessionMethods,acp.disconnectCleanup}` (32), `bun test src/cli/` (185), `make static-check`.
- Dogfooding (first comment, with screenshots): 3 + 3 `xum server` cold starts on `main` vs branch — same ten `stepDurationsMs` keys in the same order, slowest core step `taskService.recoverInterruptedTasks` 49–61 ms; a throwaway build with the constant forced to 1 ms on `xum server` and `xum acp` shows `Failed to initialize server: StartupStepTimeoutError: extensionMetadata.initialize exceeded 1 ms`, the full bounded `[shutdown]` dispose sequence (28 ms / 36 ms), exit code 1.
- `cli/server.ts` has no unit seam for `main().catch` (`server.test.ts` exercises `createOrpcServer`); the throwaway transcript is the evidence for that path.

## Risks

- False timeout on a pathologically slow host turns a slow-but-fine start into a crash — bounded at 60 s, ≥ 1000× the measured maximum and above the policy service's own 10 s fetch timeout; the only potentially unbounded step, `taskService.recoverInterruptedTasks`, scales with active agent tasks, not deployment size.
- An abandoned step (e.g. mid-`editConfig`) keeps running until the process exits; the bounded `dispose()` applies the same latches as a quit (`beginShutdown`s) and config writes are lock/journal protected — identical exposure to a SIGTERM mid-startup today.
- Disposing the runtime concurrently with an in-flight `initializeCore()` does not interrupt the startup fiber (root fibers are not scope children) — same as the promise chain it replaces; documented, not changed.

OFF-RAMP did not fire: error identity, `tests/ipc` and the ACP path are preserved.

---

<details>
<summary>📋 Implementation Plan (Wave 4 — effect-wave4-lifecycle-core-plan.md)</summary>

# Effect migration — Wave 4: finish the concurrency/lifecycle core

Bounded wave: **4 PRs (PR 4 optional), explicit STOP criterion, explicit OFF-RAMPs.** Plan only; nothing here is implemented.

> **Review status:** Independently reviewed (adversarial Reviewer sub-agent, advisor unavailable): APPROVE WITH REQUIRED EDITS — both edits applied; verified claims: Effect.promise 0-arity thunk allocates no AbortController (internal/effect.js:741–776); closed-scope forkIn+startImmediately runs onInterrupt (2237–2274, 391–409); forkIn observer removes the scope finalizer on exit (2270–2271); Effect.timeoutOrElse exists (Effect.d.ts:7833); 0 line drift at b87f62729; 11 settleWorkspaceTurn callers confirmed; 'aborted' ∈ NON_RETRYABLE_STREAM_ERRORS. Line references are to `main` @ `b87f62729`.

## 0. Thesis check (coordinator's judgment vs. evidence)

**Thesis:** Effect's payoff in this app is structured concurrency + interruption-safe lifecycles in the orchestration core (still Promise + AbortController).

**Verdict: holds for the stream engine; only half-holds for turn handles.**

- Stream engine — **holds.** `ServiceContainer.dispose()` never stops or awaits in-flight streams (`serviceContainer.ts:478–537` has no `streamManager` step); an in-flight stream dies with the process and is recovered on next load from `partial.json` (≤ 500 ms stale, `PARTIAL_WRITE_THROTTLE_MS`, `streamManager.ts:776`). `AppFiberScope` exists precisely for this and has no occupant. A supervised per-stream fiber is the right tool.
- Turn handles — **half-holds.** The 7× "superseded by an uncorrelated workspace stream-end" false-settle is a *correlation-predicate* bug (`interruptWorkspaceTurnFromUncorrelatedStreamEnd`, `workspaceTurnManager.ts:4220–4307`: any uncorrelated stream-end after the prompt index settles the handle `interrupted`), not a Promise-vs-fiber structure bug. Turn handles are **persisted records** (`taskHandleStore.upsertWorkspaceTurn`) spanning **multiple streams** (tool-call continuations are deferred via `hasSameTurnContinuation`, `:4491`) and surviving restarts; a fiber/Deferred can only model the in-process waiter and would not fix correlation. Open PR **#3949** fixes the predicate in Promise idiom and is Codex-green. Wave 4's turn-handle PR therefore becomes **"codify the settlement invariant + prove the class is gone"**, not "fiberize handles" (D5 below).

Corrected baseline numbers (measured this workspace): 46/470 `src/node` non-test files import `effect` (coordinator said 35); 113 direct `Effect.run*` sites outside `di/` in 16 files; 226 `Effect.gen`; 9 `TaggedError` classes; effect `4.0.0-rc.112`, `@orpc/*` `1.14.11`; **effect v4 is not GA** (rc line still current).

## 1. Verified current state (evidence the design rests on)

<details>
<summary>Stream engine (streamManager.ts)</summary>

- `startStream` (`:4723–4901`): per-workspace mutex → `new AbortController()` + `linkAbortSignal` (`:4771–4772`) → `resourceScope = Scope.makeUnsafe()` (`:4777`) → temp-dir `Effect.acquireRelease` (`:4802–4824`) → `createStreamAtomically` → `streamText` (`:2244`, `abortSignal: abortController.signal` `:2250`) → registered in `workspaceStreams` (`:2463`) → **`streamInfo.processingPromise = this.processStreamWithCleanup(...)` fire-and-forget (`:4876–4882`)** → returns `Ok({ messageId, completion })`.
- `processStreamWithCleanup` (`:3331–4089`, plain async): `while(true)` retry loop; `for await (part of fullStream)` (`:3358–3837`) with abort check at loop head (`:3361`); post-loop `if (!signal.aborted)` gate (`:3849`) → completion path (`deletePartial` `:3981`, `updateHistory` `:3989`, `recordSessionUsage` `:4001`, `state = COMPLETED` `:4017`, emit `stream-end` `:4023`, `terminalCompletion` `:4024`); error path → `handleStreamFailure` (`:4094–4112`) → `persistStreamError` writes error partial; `finally` (`:4052–4088`): release MCP lease, `Effect.runFork(Scope.close(resourceScope))` (`:4064–4066`), unlink abort, `workspaceStreams.delete`, `eventSpine.emit("stream.end")`, `completionController.settle`.
- Cancellation: `stopStream` (`:5043–5111`) → `cancelStreamSafely` (`:1766–1800`): `if (state === COMPLETED) { await processingPromise; return }` → `state = STOPPING` → `flushPartialWrite` → `abortController.abort()` → `cleanupAbortedStream` (`:1828–1951`): `await processingPromise` → usage → `writePartial` (`:1876–1910`) → `emitStreamAbort` → `settle({status:"aborted"})`. **No completed-guard after the await** (verified `:1838–1951`): a cancel landing between `:3849` and `:4017` re-writes `partial.json` after `deletePartial` and emits `stream-abort` after `stream-end` (pre-existing window; dispose() will widen its exposure). `cancelStreamSafely` is also not idempotent for concurrent callers (only `COMPLETED` is checked).
- AIService on `stream-abort` (`aiService.ts:355–377`): `abandonPartial ? deletePartial : commitPartial → deletePartial` (fire-and-forget listener).
- Crash recovery: `HistoryService.commitPartial` (`historyService.ts:1963–2061`) — strips error metadata, `hasCommitWorthyParts`, stale-epoch check, update-or-append by `historySequence`, delete partial; invoked from `agentSession.init` (`:5002`), `aiService.streamMessage` (`:886`), stream-abort (`:364`), `duplicateWorkspace`.
- `StreamAbortReason = "user" | "startup" | "system"` (`src/common/orpc/schemas/stream.ts:295`).
- Pinned seams: chaos test `Reflect.set(streamManager, "tokenTracker" | "createStreamResult")` (`streamManager.chaos.test.ts:130–134, 238–242`); `streamManager.test.ts` `Reflect.set` on `processStreamWithCleanup` (`:2787`), `createStreamAtomically` (`:2783`), `createTempDirForStream`, `cleanupStreamTempDir`, `Reflect.get` on `workspaceStreams`, `schedulePartialWrite`, …; `modelOnlyNotifications.test.ts` calls `processStreamWithCleanup` directly (`:93, :187`); `aiService.test.ts` spies `startStream`, `generateStreamToken`, `createTempDirForStream`, `isResponseIdLost`. Constructor: `(historyService, sessionUsageService?, getProvidersConfig?, eventSink = noop, runner = defaultEffectRunner)` (`:801–813`); `effectRunner` used at `:1152, :1154, :1169` only.
- Every stream event carries `workspaceId` + `messageId`; `stream-end`/`stream-abort`/`error` carry `metadata.muxMetadata` when the prompt had it.
</details>

<details>
<summary>DI / shutdown / startup</summary>

- `AppFiberScopeLive` is in `CoreLive`'s `runtimeSeams` (`di/layers/core.ts:644`), so both roots have it; `StreamManagerLive` (`core.ts:226–238`, stage S2b) already yields `EffectRunnerTag`. CLI cleanup lists include `appFiberScope.close` (`cli/run.ts:1579`, `cli/workflow.ts:286`).
- Bounds: `APP_FIBER_SCOPE_CLOSE_TIMEOUT_MS = 2000`, `APP_RUNTIME_DISPOSE_TIMEOUT_MS = 2000`; outer budgets are **5000 ms** on both desktop (`desktop/main.ts:1297` `Promise.race` vs `setTimeout(5000)`) and `xum server` (`cli/server.ts:236–243` force-exit). **The scope bound cannot grow** without changing outer budgets.
- rc.112 semantics verified in `node_modules/effect/dist/internal/effect.js:2264`: `forkIn` registers a scope finalizer and **removes it when the fiber completes** (no leak), and **interrupts immediately if the scope is already closed** (streams starting mid-shutdown fail closed). `Effect.promise(evaluate: (signal) => PromiseLike)`, `Effect.onInterrupt`, `Effect.forkIn(_, scope, { startImmediately? })`, `Stream.toAsyncIterableWith(context)`, `Stream.provideContext` all exist.
- `ServiceContainer.initialize()` (`serviceContainer.ts:297–362`): six awaited `initialize()`s wrapped in `recordStep` (durations only, no catch, no timeout) + three sync `start()`s + two fire-and-forget sweeps. Failure handling: desktop `Startup Failed` dialog + `app.quit()` (`desktop/main.ts:1249–1265`); `cli/server.ts:136` uncontained; ACP `serverConnection.ts:205–216` dispose + rethrow; `tests/ipc/setup.ts:85` no catch. No outer timeout anywhere.
- `streamBridge.subscriptionIterable` (`orpc/streamBridge.ts:176`) → `Stream.toAsyncIterable(...)` on the global runtime, 19 call sites in `routerSubscriptions.ts`; heartbeat via `Effect.sleep` in `forkScoped` (`:145–152`). `streamBridge.test.ts` has 11 real-time waits, but only **3 are clock-bound** (`:207` 1 ms initial delay, `:241` heartbeat 10 ms, `:255` 10 ms laziness); 8 are `waitFor(listenerCount…)` readiness polls that TestClock cannot replace.
</details>

<details>
<summary>Turn handles + open PRs</summary>

- Handle record `{ handleId "wst_…", ownerWorkspaceId, workspaceId, turnId, messageId, status, attentionPolicy, disposableWorkspace }`; prompt carries `muxMetadata: { type:"workspace-turn-task", taskHandleId, ownerWorkspaceId, turnId }` (`workspaceTurnManager.ts:1420`). `TaskService` forwards `aiService` `stream-end`/`stream-abort`/`error` to `finalizeWorkspaceTurnFromStreamEnd` (`:4442–4544`): correlated branch matches `record.workspaceId && record.turnId` (`:4472`); **uncorrelated branch** (`metadata == null`, not `agentId === "compact"`) → `interruptWorkspaceTurnFromUncorrelatedStreamEnd` → settles `interrupted` whenever `streamEndIndex >= promptIndex` (`:4293–4305`). Producers of such uncorrelated ends: bash-monitor wake continuations, child terminal-attention deliveries, heartbeat, peer messages, parent auto-resume.
- Cascade: disposable child → `cleanupDisposableWorkspaceTurn` → `workspaceService.remove(…, true)` kills its background processes; persistent child → parent sees `interrupted` → `task_stop` → `backgroundProcessManager.stopMonitor(…, "canceled")`. This is the observed "monitors died afterwards".
- Settlement chokepoint: `settleWorkspaceTurn(params)` (`:2085`), **11 callers**, guarded by `workspaceTurnSettlementLocks.withLock(handleId)`; waiters in `pendingWorkspaceTurnWaitersByHandleId` with `setTimeout` timeouts (`:2425–2496`).
- **#3949** "preserve turns across synthetic wake ends" (coadler): rewrites the uncorrelated branch — walks history from the turn anchor to the stream-end and settles *only if a manual child input intervened* (`isManualChildWorkspaceInput`); otherwise ignores the end. Touches `:281–295, :4217–4355` + tests (+286/−31). Codex: "Didn't find any major issues" + clean security on `f9baa2fc9`. `mergeable: MERGEABLE`, but `Test / Unit` and `Codex Comments` red, 19 commits behind main.
- **#3915** "correlate workspace-turn liveness" (coadler): creation reservations + `getWorkspaceTurnLiveness`/`getWorkspaceTurnRuntimeActivity` (identity-matches the active stream's `muxMetadata` against the record) for staleness/capacity. Touches `:442–486, :1298, :2573, :3761, :3800–4064` (+494/−60). `BLOCKED`, latest Codex review has open findings, `Test / Unit` red, 19 behind.
- Together they are the identity-correlated model the coordinator wants: #3915 = identity-correlated *liveness*, #3949 = identity-gated *settlement*.
</details>

## 2. Design decisions

**D1 — Fibers WRAP the AbortController; they do not replace it.**
The AI SDK is cancelled only via `AbortSignal`; the `for await` loop, soft-interrupt at step boundaries, retry/fallback re-creation of `streamResult`, and ~30 abort touchpoints (#4032) all key off the signal. Converting the 750-line loop to `Stream.fromAsyncIterable` + fiber interruption would touch hundreds of `WorkspaceStreamInfo` transitions and break the `processStreamWithCleanup`/`createStreamResult` spy seams. Instead: **the fiber is the ownership/supervision unit; the signal stays the cancellation transport.** The dual-cancellation glue #4032 feared is confined to **one** point — the supervisor's `onInterrupt` — which routes through the existing user-stop path (`cancelStreamSafely`), so shutdown ≡ "user pressed stop" semantically (partial flushed with usage, `stream-abort` emitted, `completion` settles `aborted`, AIService commits the partial).

**D2 — Supervisor topology: one supervisor fiber per stream in `AppFiberScope`, wrapping the already-started `processingPromise`.**
`streamInfo.processingPromise = this.processStreamWithCleanup(...)` stays byte-identical (sync-start preserved; `Reflect.set(processStreamWithCleanup)` seam preserved; `cleanupAbortedStream`'s `await processingPromise` unchanged). Immediately after it:

```ts
// startStream, after processingPromise is assigned (unsupervised path unchanged when no scope)
this.superviseEngine(typedWorkspaceId, streamInfo);

private superviseEngine(workspaceId: WorkspaceId, streamInfo: WorkspaceStreamInfo): void {
  if (this.engineScope === undefined) return;               // direct construction / CLI tests: today's behavior
  assert(streamInfo.engineFiber === undefined, "engine already supervised");
  // Zero-arity thunk on purpose: rc.112 allocates an internal AbortController only
  // when `evaluate.length !== 0`; the stream's own controller stays the sole signal.
  const supervisor = Effect.promise(() => streamInfo.processingPromise).pipe(
    Effect.onInterrupt(() =>
      Effect.uninterruptible(   // explicit, per house doctrine (finalizers are already uninterruptible)
        Effect.promise(async () => this.cancelStreamSafely(workspaceId, streamInfo, "system"))
      )
    ),
    Effect.catchDefect((d) => Effect.sync(() => log.warn("[stream] engine supervisor defect", { workspaceId, error: d })))
  );
  streamInfo.engineFiber = this.effectRunner.runSync(
    Effect.forkIn(supervisor, this.engineScope, { startImmediately: true })
  );
}
```
- `Effect.promise` is interruptible while suspended (`internal/effect.js:741–801`, Async op); `onInterrupt` = `onErrorFilter(causeFilterInterruptors, …)` (`:1762`); `forkIn` registers `fiberInterrupt(fiber)` as the scope finalizer (`:2264–2275`), `fiberInterrupt` awaits the fiber (`:635–642`), and parallel `scopeClose` awaits all finalizers via `fiberAwaitAll` (`:1590–1601`) → `closeScopeBounded` at dispose step 2 gives "interrupt **and** await" while `historyService`/`sessionUsage`/`eventSink → AIService → bridge servers` are still alive (bridges stop in step 3, so clients receive `stream-abort`).
- Normal completion: fiber exits → `forkIn`'s observer removes the scope finalizer (verified) → no per-stream residue.
- Stream started after step 2: `forkIn` on a closed scope calls `fiber.interruptUnsafe` synchronously and returns the fiber (`:2272–2274`, `runSync` does not defect). With `startImmediately: true`, `forkUnsafe` runs `child.evaluate` synchronously (`:2233–2247`) up to the `Effect.promise` Async op (`:772–801`), so the fiber is suspended (`_running=false`) when the interrupt lands and `interruptUnsafe` (`:391–409`) unwinds the stack through the `onInterrupt` handler → the stream is aborted as `system` (fail-closed during shutdown). Verified in rc.112 internals (`effect.js:2233–2247, 391–409`); **pin with a test** ("stream started after scope close is aborted") so an RC bump cannot silently change it.
- `"system"` is semantically exact: `"user"`/`"startup"` suppress next-startup recovery (`retryEligibility.ts:114–118, 284–287`), `"system"` marks an involuntary backend interruption (as `taskService.ts:8100, 8223` use it). **No in-session retry loop is possible:** the `stream-abort` handler (`agentSession.ts:6010`) routes `{ type: "aborted" }` to `retryManager.handleStreamFailure`, and `"aborted"` is in `NON_RETRYABLE_STREAM_ERRORS` (`retryEligibility.ts:49–59, 106`) → `retryManager.ts:99–104` abandons immediately, never schedules a fiber. Dogfooding still checks the *restart* UX (the recovered partial is shown as interrupted; note whether any next-startup recovery re-sends — same class as today's `system` aborts from `taskService`).
- `engineScope` arrives as an **optional 6th constructor parameter** (`engineScope?: Scope.Closeable`), wired from `AppFiberScopeTag` in `StreamManagerLive` (`core.ts:226`). Default `undefined` keeps every direct-construction test and `aiService.ts:174` path identical (I4). `AppFiberScopeLive` already sits beneath S2b in `runtimeSeams`, so no staging change (I6).
- Abort reason: reuse **`"system"`** — no wire/schema change; UI copy for `system` already exists.
- Pending-start window (`pendingStreamStarts`, before registration) is **not** supervised: nothing is persisted for it yet, and `stopStream` already aborts pending controllers. Documented, not fixed.

**D3 — Fix the two adjacent cancel races in the same PR (closely-related bugs, not deferrals).**
(a) `cleanupAbortedStream`: after `await processingPromise`, if `streamInfo.terminalCompletion !== undefined` (completed/failed while the cancel was in flight) → return without abort bookkeeping (prevents `partial.json` resurrection after `deletePartial` and a `stream-abort` after `stream-end`). (b) `cancelStreamSafely` (`:1766`): latch a per-stream `cancelPromise` so concurrent cancellers (user stop racing dispose) join one cleanup → exactly one `stream-abort`, one `settle`. **Zero-suspension requirement:** the latch must be checked and assigned **synchronously at function entry, before any `await`** (the current first await is `flushPartialWrite` at `:1789`) — otherwise racing callers can both enter `cleanupAbortedStream`. Shape:

```ts
if (streamInfo.cancelPromise) return streamInfo.cancelPromise;
streamInfo.cancelPromise = (async () => { /* existing body, unchanged */ })();
return streamInfo.cancelPromise;
```
Both are ≤ 10 LoC and get behavioral tests.

**D4 — Shutdown bound stays 2 s; the finalizer must be fast or abandoned.**
Outer budgets are 5 s; 2 s + 2 s already consume 4 s. A flowing stream aborts within one chunk; a wedged provider (no chunks, ignores abort) hits the existing `boundedTeardown` timeout: warning, continue, process exit — identical to today's outcome. Dogfooding measures the actual `[shutdown] AppFiberScope closed { ms }` with a live stream.

**D5 — Turn handles: codify the settlement invariant; do not fiberize.**
Invariant: *a workspace-turn handle settles terminally only by (i) a stream terminal event whose `muxMetadata` correlates `{taskHandleId, ownerWorkspaceId, turnId}` to the record; (ii) an explicit interrupt (`task_stop`/`interruptWorkspaceTurn`); (iii) manual supersession — a manual child input after the turn anchor; (iv) stale-liveness reconciliation.* An uncorrelated stream-end is **never** terminal by itself. #3949 makes (iii) the only uncorrelated outcome; #3915 implements (iv) by identity. Wave 4 adds a `cause` discriminant to `settleWorkspaceTurn` (the single chokepoint) with a runtime assertion, plus the regression harness. Rationale for not converting waiters to `Deferred`/fibers: no behavioral gain, 4.9k-line file, and the coordinator's "settle only on the owning stream's termination" is over-specified — a turn owns *several* streams.

**D6 — Startup: `initialize()` stays a Promise facade over a runtime-run startup effect; timeout ⇒ same failure path as a thrown step.**
Each step is `Effect.tryPromise({ try: async () => step(), catch: identity }).pipe(Effect.timeoutOrElse({ duration: STARTUP_STEP_TIMEOUT_MS, orElse: () => Effect.fail(new StartupStepTimeoutError(name, ms)) }))` (`timeoutOrElse` exists in rc.112, `Effect.d.ts:7833`; chosen over `timeout` + `catchTag` because the step's error channel is `unknown`, which `catchTag` cannot narrow). No `forkDetach` needed: a Promise step keeps running on its own when the waiting fiber times out (not inside an uninterruptible region, so the timeout interrupts the wait directly). `StartupStepTimeoutError extends Error` with `name = "StartupStepTimeoutError"` set in the constructor and message `"<step> exceeded <ms> ms"` (so the desktop dialog's error formatting shows both the class and the step name) → desktop shows it in the existing `Startup Failed` dialog; CLI/ACP/tests paths unchanged. Step **errors keep their identity** (v4 `runPromise` rejects with the raw failure). Downgrading any step to best-effort is a **policy change, out of scope** (audit of the six implementations: extensionMetadata/telemetry/experiments are local fs, <50 ms; policy has its own 10 s fetch timeout; workspaceService bounds its sync internally; only `taskService.initialize` — config scan + `editConfig` + recovery `sendMessage`s — is potentially unbounded). The three `start()`s stay sync (`Effect.sync`), the two fire-and-forget sweeps stay outside the effect. `stepDurationsMs` is preserved.
**Abandon-and-quit safety:** an abandoned `taskService.initialize` may be mid-`editConfig` when the root exits. Parity requirement for PR 3: after a rejected `initialize()`, every root runs the bounded `dispose()` before exiting. Verified: desktop already does — `services` is assigned before the await (`main.ts:653–656`), the catch calls `app.quit()`, and the `before-quit` listener (`:1271–1305`, guard `if (isDisposing || !services) return`) races `services.dispose()` against 5 s; ACP does (`serverConnection.ts:205–216`); **`cli/server.ts` does not** (`:133–136` awaited at top level, `main().catch` at `:282` only logs) → PR 3 adds a bounded `dispose()` there (≤ 10 LoC, same 5 s budget).

**D7 — streamBridge: thread the runtime context, not a runner.** `subscriptionIterable` gains `context?: Context.Context<never>` → `Stream.toAsyncIterableWith(context)`; `routerSubscriptions` passes the handler's `"effect/context"`. Production behavior identical; heartbeat sleeps on the runtime `Clock`; tests can run the 3 clock-bound waits on `TestClock`. Honest scope: the 8 readiness polls stay.

## 3. PRs (ordered by value ÷ risk; each independently mergeable)

### PR 1 — StreamManager engine core becomes the first `AppFiberScope` occupant
**Value:** high (the only remaining shutdown data-integrity gap; the reason `AppFiberScope` exists). **Risk:** medium → low with D1/D2. **Net product LoC ≈ +55** (`superviseEngine` ~25, ctor param/field ~5, `engineFiber` field ~2, D3 guards ~12, `core.ts` wiring ~2, doc updates in `appRuntime.ts`/`appFiberScope.ts` "occupant" text ~10).

Files: `src/node/services/streamManager.ts`, `src/node/services/di/layers/core.ts`, `src/node/services/di/appRuntime.ts` + `appFiberScope.ts` (docs), tests below.

Pre-work (before writing product code; each yields a note in the PR body):
1. Confirm `processStreamWithCleanup` never rejects (try/catch/finally shape `:3331–4089`); else the supervisor must fold rejections (it already `catchDefect`s).
2. Confirm `Effect.promise` interruption + `onInterrupt` await ordering under `Scope.close` in a 20-line probe test (pattern of `appFiberScope.test.ts:27–47`).
3. Enumerate abort observers that run *after* the finalizer resolves (AIService `stream-abort` listener → `commitPartial`; agentSession completion continuations) and confirm the durable order (`writePartial` → commit → `deletePartial`) makes a mid-flight `process.exit` recoverable on next load (it is: partial survives until commit completes).
4. Measure: `[shutdown] AppFiberScope closed { ms }` with a live stream in the sandbox (D4).
5. Pin (same probe test): a fiber forked with `startImmediately: true` into an already-closed scope still runs its `onInterrupt` finalizer (reviewer-verified in rc.112 internals; the test guards RC bumps).

Acceptance (behavioral tests only):
- `streamManager.test.ts` (new cases; existing cases untouched): with `engineScope = Scope.makeUnsafe("parallel")` and a fake `createStreamResult` whose `fullStream` yields one `text-delta` then blocks until its `AbortSignal` fires — `closeScopeBounded(engineScope)` resolves; `writePartial` was called with the streamed text; exactly one `stream-abort` (`abortReason: "system"`) and zero `stream-end`; `completion` settles `{status:"aborted"}`; `workspaceStreams` is empty.
- Wedged provider (fullStream never yields, ignores abort): `closeScopeBounded` resolves within the bound, never rejects, warns once (assert the returned promise resolves and no throw; do **not** assert log text).
- No-scope construction: identical event sequence to today (guards existing suites; no new assertions needed beyond the unchanged suites passing).
- D3(a): cancel issued after the loop exits but before `COMPLETED` → history has exactly one final message, `partial.json` absent, event order `stream-end` only.
- D3(b): `stopStream` + `closeScopeBounded` racing on one stream → exactly one `stream-abort`, one settle.
- Fiber residue: after 50 completed streams, `closeScopeBounded(engineScope)` emits zero `stream-abort` and completes in the same tick class as an empty scope (assert no aborts and `workspaceStreams.size === 0`).
- `streamManager.chaos.test.ts` — existing cases byte-identical; **one new fuzz variant** constructs with an engine scope and closes it at a random iteration: every stream settles **exactly once** (count terminal events per `messageId` ≤ 1, all `completion` promises settle).
- `serviceContainer.test.ts`: "dispose() aborts and awaits an in-flight stream before `desktopBridgeServer.stop()`" (extend the ordering harness at `:295–323`); `coreServicesRoot.test.ts`: `xum run` cleanup list does the same via `appFiberScope.close`.

Gate suites: `streamManager.test.ts`, `streamManager.chaos.test.ts`, `streamManager.modelOnlyNotifications.test.ts`, `aiService.test.ts`, `agentSession.disposeRace.test.ts`, `agentSession.sinceReplayContract.test.ts`, `serviceContainer.test.ts`, `coreServicesRoot.test.ts`, `di/*.test.ts`, `taskService.test.ts`, `workspaceService.test.ts`, `turnRequestBuilder.test.ts`; `make static-check`.

House pre-review audits: interruption posture (supervisor's only suspension is the promise; finalizer uninterruptible end-to-end incl. `cancelStreamSafely` → `cleanupAbortedStream`); no defect escapes (`catchDefect` on the supervisor; `Effect.promise` thunks `async`); spy-seam check (`processStreamWithCleanup`, `createStreamResult`, `createStreamAtomically`, `startStream` signatures unchanged; constructor arity unchanged, trailing optional); sync-start (`processingPromise` assigned before fork; `runSync(forkIn)` completes synchronously); no constructor side-effects added; zero-suspension check on D3(b) latch (`cancelPromise` checked-and-assigned synchronously at `cancelStreamSafely` entry, before the first `await` at `:1789`; review the diff for any inserted `await`/lookup ahead of the assignment).

Rollback: revert the `core.ts` wiring line → `engineScope` undefined → today's behavior; D3 guards can stay (independent bug fixes).

### PR 2 — Turn-settlement invariant + false-settle regression harness (gated on #3949)
**Value:** high (7× production race). **Risk:** low. **Net product LoC ≈ +40** (`WorkspaceTurnSettlementCause` union + `cause` on `settleWorkspaceTurn` params + assert ~10; 11 call sites × 1–3 lines).

Relationship to open PRs — explicit:
- **#3949 is the fix and a hard prerequisite.** PR 2 rebases on it, changes none of its logic (`interruptWorkspaceTurnFromUncorrelatedStreamEnd`, `isWorkspaceTurnAnchorForRecord`, `isManualChildWorkspaceInput`), and adds the invariant + proof on top. If #3949 has not merged when PRs 1/3 are done: **do not fork a competing fix**; report to the coordinator, offer the regression test file to #3949's author as a review artifact, and hold PR 2 (it is not on any other PR's critical path).
- **#3915 is a soft prerequisite.** Its diff (`:3800–4064` incl. `settleStaleWorkspaceTurn`, a `settleWorkspaceTurn` caller) overlaps PR 2's one-line-per-caller change. Prefer landing after it; if PR 2 must go first, the conflict is a one-line `cause:` addition per caller. PR 2 never edits liveness/reservation code.
- Wave 4 does not otherwise touch `workspaceTurnManager.ts`.

Design: `type WorkspaceTurnSettlementCause` enumerated from the 11 callers (audited at `main` @ `b87f62729`): `:1373` creation validation failure; `:1476` pre-stream interrupt during launch; `:1500`/`:1518` pre-stream send failure; `:3834`/`:3863` stale-liveness recovery / restart timeout (`settleStaleWorkspaceTurn` — #3915's region); `:4301` **uncorrelated-stream-end manual supersession** (the only uncorrelated settle in the codebase; the path #3949 rewrites); `:4529` correlated terminal; `:4571` stream-abort; `:4675` deferred stream error; `:4736` terminal stream error. `settleWorkspaceTurn` asserts `params.cause` is a member and, for `manual-supersession`, that the superseding input's `messageId` is supplied — turning D5 into an exhaustive `Record<Cause, …>` check rather than prose, so a future "settle on uncorrelated end" cannot be added without naming (and justifying) a cause.

Acceptance:
- New `workspaceTurnManager.uncorrelatedStreamEnd.test.ts` (real `WorkspaceTurnManager` + `TaskHandleStore` + fake `aiService` emitter, following the existing suite's harness): (1) create turn → correlated `stream-start` → **synthetic wake stream** on the same child ends uncorrelated after the anchor → handle stays `running`, waiter unresolved, no disposable cleanup, no terminal attention → correlated `stream-end` → `completed`. (2) same with `finishReason:"tool-calls"` continuation in between. (3) manual child input between anchor and end → `interrupted` with `cause: manual-supersession`. (4) explicit `interruptWorkspaceTurn` → `interrupted`, `cause: explicit-interrupt`. Case (1) is the **scripted reproduction**: it must **fail on the pre-#3949 merge-base** (run the file from a sibling worktree at `git merge-base origin/main <#3949 head>`; record the failing assertion in the PR body) and pass after.
- Existing 113 `workspaceTurnManager.test.ts` cases and `taskService.test.ts` turn cases unchanged.

Gate suites: `workspaceTurnManager.test.ts`, `taskService.test.ts`, `taskHandleStore.test.ts`, `tools/task*.test.ts`; `make static-check`.

Audits: spy-seam (`getWorkspaceTurn`, `listAllWorkspaceTurns`, `enqueueTerminalAttention`, `deliverPersistentChildWorkspaceTurnResult` untouched); settlement lock held across the assert; no new suspension inside `withLock`.

Rollback: revert; the test file stays valid against #3949 alone (drop the `cause` assertions).

### PR 3 — `ServiceContainer.initialize()` as a runtime-run startup effect with per-step timeouts
**Value:** medium (a hung `taskService.initialize()` currently pins the splash screen forever; deterministic TestClock tests of startup). **Risk:** low–medium. **Net product LoC ≈ +80** (step table ~20, timed-step helper ~15, `StartupStepTimeoutError` ~8, constant ~3, facade ~10, root dispose-on-failure parity ≤ 10, doc update ~10).

Files: `serviceContainer.ts`, `src/constants/terminationTimeouts.ts` (keep with the termination constants so the budget doc stays in one place), `cli/server.ts` (dispose in the startup catch if missing), `di/appRuntime.ts` doc ("Deliberately not done" → remove the initialize() line; add startup contract).

Design (D6): `initialize(): Promise<void>` → `this.runtime.managed.runPromise(this.startupEffect())`. `startupEffect = Effect.gen` over an ordered `readonly steps: ReadonlyArray<{ name, run: () => Promise<void> }>` (assert names unique); each step: `recordStep` timing kept, `Effect.tryPromise({ try: async () => run(), catch: identity }).pipe(Effect.timeoutOrElse({ duration: STARTUP_STEP_TIMEOUT_MS, orElse: () => Effect.fail(new StartupStepTimeoutError(name, STARTUP_STEP_TIMEOUT_MS)) }))`. Then `Effect.sync` for the three `start()`s; the sweeps remain after `runPromise`. Constant `STARTUP_STEP_TIMEOUT_MS` — pre-work measures `[startup] <step> { ms }` across sandbox cold starts and picks ≥ 10× the slowest observed (propose 60 s; must be generous — a false timeout turns a slow-but-fine start into a crash). Roots dispose after a rejected `initialize()` (D6 abandon-and-quit safety).

Acceptance (all in `serviceContainer.test.ts`, TestClock via the existing `AppLive` spy at `:355–395`):
- A step that never resolves → `initialize()` rejects with `StartupStepTimeoutError` naming the step after exactly `TestClock.adjust(STARTUP_STEP_TIMEOUT_MS)`; later steps did not run.
- A rejecting step → `initialize()` rejects with **the same error object** (identity), later steps did not run (parity with today).
- Happy path → `stepDurationsMs` has all six keys; `start()`s called once each; second `initialize()` call behavior unchanged from today (verify whether re-entry is guarded today; preserve).
- `tests/ipc` harness and ACP entry still pass unchanged.

Gate suites: `serviceContainer.test.ts`, `coreServicesRoot.test.ts`, `di/*.test.ts`, `src/node/acp/*.test.ts`, `TEST_INTEGRATION=1 bun x jest tests/ipc` (smoke subset); `make static-check`.

Audits: I1 untouched (no layer body changes); I2 (only the composition root touches the runtime); error identity preserved (no wrapping); abandoned-step safety — every root runs bounded `dispose()` after a rejected `initialize()` (D6; `cli/server.ts` gains it in this PR); no sweep moved into the effect; the six-step order and `[startup] <step>` names unchanged.

Rollback: revert; constant removal.

### PR 4 (optional — cut if budget is exhausted) — `streamBridge` on the runtime context
**Value:** low (closes the last documented "global runtime" exception; enables TestClock for the heartbeat). **Risk:** low. **Net product LoC ≈ +30** (`context?` option + `toAsyncIterableWith` ~8; 19 call sites × 1 line via one shared helper in `routerSubscriptions.ts` ~3).

Acceptance: the 3 clock-bound waits (`:207, :241, :255`) run on `TestClock`; the heartbeat test asserts N heartbeats after `TestClock.adjust(N × interval)` with zero real time; existing behavioral assertions unchanged; `tests/ipc` subscription tests pass. Do not rewrite the 8 readiness polls.

Gate suites: `streamBridge.test.ts`, `routerSubscriptions*.test.ts`, `orpc/*.test.ts`, `TEST_INTEGRATION=1 bun x jest tests/ipc` (subscription subset); `make static-check`.

Audits: `Stream.toAsyncIterableWith` preserves double-close safety (pin with the existing test); `Cause.Done` typing unchanged; no `Scope`/`MemoMap`/`Scheduler` captured (pass the oRPC `effect/context`, which the DI layer already strips per `EffectRunnerLive`); `context` stays optional so direct callers/tests without a runtime keep today's global-runtime path.

Rollback: revert; the optional `context` default (`Context.empty()`) is exactly today's `toAsyncIterable`, so a partial revert of call sites is also safe.

### Execution order and size
Net product LoC for the wave ≈ **+205** (PR 1 ≈ +55, PR 2 ≈ +40, PR 3 ≈ +80, PR 4 ≈ +30); tests ≈ +600–800. PR 1 starts immediately. PR 2 starts the moment #3949 merges (parallel with PR 1/3 — disjoint files). PR 3 after PR 1 merges (both touch `appRuntime.ts` docs; PR 3 also touches `serviceContainer.ts`). PR 4 last, only if PRs 1–3 landed and no OFF-RAMP fired. Each PR: Codex dual review, `Codex Comments` minimization, merge queue; commit WIP early (`/tmp` wipes).

## 4. STOP criterion (measurable) and OFF-RAMPs

Wave 4 is **done** — and the Effect migration line **stops** without a new RFC — when all hold:
1. **dispose() awaits in-flight streams:** `serviceContainer.test.ts` ordering test + `coreServicesRoot.test.ts` pass on main; a sandbox `script -f` transcript of `xum server` receiving SIGTERM mid-stream shows `stream-abort` → `[shutdown] AppFiberScope closed { ms }` → `[shutdown] desktopBridgeServer.stop`, and immediately after exit `partial.json` is absent while `chat.jsonl` contains the interrupted assistant message (baseline on `main`: `partial.json` present, message absent until next load). `{ ms }` < 2000 in the flowing-stream case.
2. **False-settle class eliminated:** the scripted reproduction fails on the pre-#3949 merge-base and passes on main after PR 2; `settleWorkspaceTurn` rejects any settlement without an enumerated cause; the coordinator's own Mux sessions show zero "superseded by an uncorrelated workspace stream-end" in the two weeks after PR 2 (soft signal, logged in the wave summary).
3. **Startup:** timeout and error-identity tests pass under TestClock; `[startup]` per-step lines unchanged in the sandbox transcript; a throwaway build with the constant set to 1 ms shows `Startup failed: StartupStepTimeoutError: <step> exceeded 1 ms` and a clean exit.
4. **No new lifecycle flakes:** 0 failures attributable to the touched suites across **N = 20** consecutive *completed* `Test / Unit` runs on `main` after the last Wave 4 merge — query `gh run list --workflow pr.yml --branch main --limit 60 --json databaseId,status,conclusion,event,headSha` (note: `gh run list --json` serializes these fields in **lowercase**, e.g. `{"status":"completed","conclusion":"success"}`, unlike `statusCheckRollup`), keep `status === "completed"` (pending runs have an empty `conclusion`, not null), take the newest 20, and for any run with `conclusion !== "success"` (case-insensitive normalization acceptable) inspect the failing job's log for the touched suite names (job `timeout`/`cancelled` from the 15-min budget is not a flake); plus green merge-queue runs for each PR. Any attributable flake → fix or revert before declaring done.

**OFF-RAMP (PR 1):** fires if pre-work 1–3 shows (a) routing shutdown through `cancelStreamSafely` cannot preserve crash-recovery semantics without changing `cleanupAbortedStream`'s contract beyond D3, (b) the chaos variant exposes a double-settle not closable by D3(b), or (c) the finalizer cannot fit the 2 s bound for flowing streams. Then: stop PR 1, keep `AppFiberScope` unoccupied, update `appRuntime.ts` "Deliberately not done" with the concrete blocker and the measured evidence, land D3 alone as a bug-fix PR. PRs 2–4 are independent and proceed.
**OFF-RAMP (PR 3):** if error identity or the `tests/ipc`/ACP paths cannot be preserved, keep `initialize()` as is and record why.
**OFF-RAMP (PR 2):** #3949 not merged → hold (see PR 2).

## 5. Risk register

| Risk | Likelihood | Mitigation |
|---|---|---|
| Crash-recovery regression: double commit / partial resurrection when shutdown-abort races completion | medium (window widens with dispose()) | D3(a) guard + test; `commitPartial`'s `historySequence` update-or-append is idempotent (`historyService.ts:2036–2041`) |
| Provider abort emits an `error` chunk → error path instead of abort path | low | identical to today's user-stop path (parity); chaos variant covers hostile streams |
| Wedged provider pins the 2 s bound → warning every shutdown | low | `boundedTeardown` already bounds; transcript measures; no budget change possible (5 s outer) |
| AIService `stream-abort` listener (`commitPartial`) still in flight when `process.exit` runs | low | durable order writePartial → commit → deletePartial; next-load recovery; PR 1 transcript checks `partial.json` is already gone when `cli/server.ts` logs its final cleanup line before `process.exit(0)` (`:252–266`) |
| Chaos-test seams (`createStreamResult`, `tokenTracker`) | none if scope-less construction stays default | new variant added, old cases untouched |
| Collision with #3915/#3949 | medium | PR 2 gated; no edits to their regions; one-line `cause:` conflicts only |
| RC churn (rc.113+ renames `forkIn`/`onInterrupt`/`toAsyncIterableWith`) | low | all Effect imports already in `streamManager.ts`/`streamBridge.ts`; pins fixed; GA upgrade is a separate lockstep PR (§6) |
| Startup false timeout on slow hosts | medium if constant too small | measure first; ≥ 10× slowest observed; generous default (60 s) |
| Sync-start assumptions in tests that `Reflect.set(processStreamWithCleanup)` | low | promise assigned before fork; forkIn `runSync` synchronous |
| `shutdown()` (desktop second `before-quit` listener) still does not await streams | accepted | contract says `shutdown()` never touches the runtime; desktop's dispose race is the covered path |
| Streams starting during shutdown | covered | `forkIn` on closed scope interrupts immediately → `system` abort (`startImmediately` semantics verified in rc.112; pinned by test) |
| `system` abort triggers an in-session RetryManager retry during shutdown | **unreachable** (verified) | `"aborted"` ∈ `NON_RETRYABLE_STREAM_ERRORS` → `retryManager.ts:99–104` abandons; no fiber scheduled |
| PR 3: abandoned `taskService.initialize` mid-`editConfig` when the root exits after a timeout | low | desktop/ACP already dispose on startup failure; PR 3 adds the missing `cli/server.ts` dispose; config writes are lock/journal-protected |
| `startImmediately`/`onInterrupt` semantics differ in a later RC | low | pinned by the probe test in `appFiberScope.test.ts` style; RC bumps are a separate lockstep PR |

## 6. Standing item — effect v4 GA + `@orpc/experimental-effect` lockstep (analysis only)

v4 is **not GA** (rc.112 is current; v3 `3.x` remains the stable line). No PR this wave. When GA ships: one lockstep PR bumping `effect` + all `@orpc/*` (`1.14.11` today; check the GA-compatible `@orpc/experimental-effect`), canary gates = `di/*.test.ts`, `streamBridge.test.ts`, `streamManager.test.ts`, `serviceContainer.test.ts`, `TEST_INTEGRATION=1 bun x jest tests/ipc`, `make static-check`. The `Context → ServiceMap` rename risk is firewalled: `Context.Service` tags, `Context.omit/get`, `Layer`, `ManagedRuntime`, `TestClock` live only under `di/` + `orpc/effectContext.ts`; `streamManager.ts`/`streamBridge.ts` use `Effect`/`Scope`/`Fiber`/`Exit`/`Stream`/`Queue`/`Cause` only. PR 4 adds one `Context.Context<never>` type reference to `streamBridge.ts` — keep it as a type-only import so a rename is a one-line fix.

## 7. Dogfooding (per PR; evidence attached to the PR with `gh … --attach`)

Common setup: `make dev-server-sandbox DEV_SERVER_SANDBOX_ARGS="--clean-projects"` (or `xum server` on a temp `XUM_ROOT`) with `XUM_LOG_LEVEL=debug`, run under `script -f ~/wave4-scratch/<pr>-<scenario>.log`; scratch under `$HOME/wave4-scratch/` (never `/tmp`). Drive the UI with `agent-browser` (`open` → `snapshot -i` → click the explicit "Send message" ref; re-snapshot after typing). Screenshots are primary evidence; record WebM and finalize with `ffmpeg -c copy`.

- **PR 1:** (1) start a long stream (prompt that streams ~30 s), wait 3–5 s, `kill -TERM <server pid>`; transcript must show the order in STOP #1 and `[shutdown] AppFiberScope closed { ms }`; (2) `ls <XUM_ROOT>/sessions/<ws>/partial.json` (absent) + `tail -n 1 chat.jsonl` (interrupted assistant message); (3) restart, open the workspace in agent-browser, screenshot the persisted interrupted message; (4) same scenario on `main` for the baseline diff; (5) `xum run` Ctrl-C mid-stream transcript (CLI root parity); (6) quality gate between phases: gate suites green before the sandbox run, sandbox evidence before requesting review.
- **PR 2:** primary evidence is the regression file run on both the merge-base worktree (failing output) and the branch (passing). Secondary: sandbox parent workspace delegates via `task` kind=workspace to a child that arms a background bash monitor firing within ~10 s and keeps working ~60 s; screenshot the parent's task result (baseline `main`: `interrupted … uncorrelated workspace stream-end`; after: `completed`) and the child's log lines.
- **PR 3:** `xum server` cold start transcript with `[startup] <step> { ms }` for the six steps (parity); throwaway worktree build with `STARTUP_STEP_TIMEOUT_MS = 1` → transcript of `Startup failed: StartupStepTimeoutError …` and exit code (do not ship); desktop dialog cannot be shown headless — cite the unchanged `desktop/main.ts:1249–1265` catch.
- **PR 4:** agent-browser session left idle 60 s with the connection indicator visible (heartbeats keep it green) + screenshot; `streamBridge.test.ts` on TestClock.

## 8. Non-goals (restated; out of this wave)

Typed-error propagation sweep / removing the ~113 facades; converting services to `yield*`-based Effect services; PubSub for the internal EventEmitter bus; Schema at persistence boundaries; Effect observability; converting sync read paths, AI-SDK per-request callbacks, cross-process lock interiors, or deterministic try-lock funnels; replacing `AbortController` as the SDK cancellation transport; converting the `fullStream` loop to `Stream`; fiberizing turn-handle waiters; downgrading startup steps to best-effort; changing outer quit budgets; supervising the pre-registration stream-start window; `shutdown()` semantics; the effect GA bump (standing analysis only).


</details>

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$13.39`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=13.39 -->
