### PR TITLE
🤖 fix: improve outgoing agent communication cards

### DIFF
--- a/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
@@ -959,6 +959,7 @@ describe("ProjectSidebar flat chat list", () => {
         ({
           selectedWorkspace: null,
           setSelectedWorkspace: () => undefined,
+          archivingWorkspaceIds: new Set<string>(),
           preflightArchiveWorkspace: () =>
             Promise.resolve({ success: true, data: { kind: "ready" } }),
           archiveWorkspace: () => Promise.resolve({ success: true, data: { kind: "archived" } }),
@@ -1010,6 +1011,7 @@ describe("ProjectSidebar flat chat list", () => {
         ({
           selectedWorkspace: null,
           setSelectedWorkspace: () => undefined,
+          archivingWorkspaceIds: new Set<string>(),
           preflightArchiveWorkspace: () =>
             Promise.resolve({ success: true, data: { kind: "ready" } }),
           archiveWorkspace: () => Promise.resolve({ success: true, data: { kind: "archived" } }),
@@ -1100,6 +1102,7 @@ describe("ProjectSidebar flat chat list", () => {
         ({
           selectedWorkspace: null,
           setSelectedWorkspace: () => undefined,
+          archivingWorkspaceIds: new Set<string>(),
           preflightArchiveWorkspace: () =>
             Promise.resolve({ success: true, data: { kind: "ready" } }),
           archiveWorkspace: () => Promise.resolve({ success: true, data: { kind: "archived" } }),
@@ -1280,6 +1283,7 @@ describe("ProjectSidebar flat chat list", () => {
         ({
           selectedWorkspace: null,
           setSelectedWorkspace: () => undefined,
+          archivingWorkspaceIds: new Set<string>(),
           preflightArchiveWorkspace: () =>
             Promise.resolve({ success: true, data: { kind: "ready" } }),
           archiveWorkspace: () => Promise.resolve({ success: true, data: { kind: "archived" } }),
@@ -1335,6 +1339,7 @@ describe("ProjectSidebar flat chat list", () => {
         ({
           selectedWorkspace: null,
           setSelectedWorkspace: () => undefined,
+          archivingWorkspaceIds: new Set<string>(),
           preflightArchiveWorkspace: () =>
             Promise.resolve({ success: true, data: { kind: "ready" } }),
           archiveWorkspace: () => Promise.resolve({ success: true, data: { kind: "archived" } }),

--- a/src/browser/features/Messages/MessageRenderer.stories.tsx
+++ b/src/browser/features/Messages/MessageRenderer.stories.tsx
@@ -212,10 +212,10 @@ The report inherited transcript-sized markdown styles instead of compact task ch
                     title: "Agent update",
                     reportMarkdown: `## Agent update
 
-The same compact report typography applies to incremental agent findings.
+Incremental findings read as outgoing communication, separate from compact task details.
 
-- Body and inline \`code\` remain aligned with tool chrome.
-- Headings retain a modest hierarchy.`,
+- Body and inline \`code\` stay legible alongside transcript messages.
+- Headings retain a clear hierarchy.`,
                   },
                   { success: true }
                 ),
@@ -238,7 +238,7 @@ The same compact report typography applies to incremental agent findings.
 
     const agentReportCard = await waitFor(() => {
       const card = canvasElement.querySelector<HTMLElement>(
-        '[data-component="AgentReportToolCall"]'
+        '[data-component="AgentCommunicationCard"]'
       );
       if (!card) throw new Error("Agent report card not rendered");
       return card;
@@ -287,20 +287,21 @@ The same compact report typography applies to incremental agent findings.
     });
 
     await waitFor(() => {
-      const report = agentReportCard.querySelector<HTMLElement>(".compact-report-markdown");
+      const report = agentReportCard.querySelector<HTMLElement>(".markdown-content");
       const heading = report?.querySelector<HTMLElement>("h2");
       const code = report?.querySelector<HTMLElement>("code");
       if (!report || !heading || !code) {
         throw new Error("Expanded agent report markdown not rendered");
       }
-      if (Number.parseFloat(getComputedStyle(report).fontSize) > 11) {
-        throw new Error("Agent report body text is larger than compact tool chrome");
+      const bodyFontSize = Number.parseFloat(getComputedStyle(report).fontSize);
+      if (bodyFontSize < 14) {
+        throw new Error("Agent report body text is smaller than transcript prose");
       }
-      if (Number.parseFloat(getComputedStyle(heading).fontSize) > 13) {
-        throw new Error("Agent report heading is too large for compact tool chrome");
+      if (Number.parseFloat(getComputedStyle(heading).fontSize) <= bodyFontSize) {
+        throw new Error("Agent report heading has lost its hierarchy");
       }
-      if (Number.parseFloat(getComputedStyle(code).fontSize) > 11) {
-        throw new Error("Agent report inline code is larger than compact tool chrome");
+      if (Number.parseFloat(getComputedStyle(code).fontSize) < 12) {
+        throw new Error("Agent report inline code is too small to read");
       }
       if (agentReportCard.scrollWidth > agentReportCard.clientWidth) {
         throw new Error(

--- a/src/browser/features/Tools/AgentReportToolCall.test.tsx
+++ b/src/browser/features/Tools/AgentReportToolCall.test.tsx
@@ -192,4 +192,69 @@ describe("AgentReportToolCall", () => {
     expect(view.getByRole("alert").textContent).toBe("Blocked by project hook");
     expect(view.getByRole("status").className).toContain("text-danger");
   });
+
+  test.each([null, undefined, { type: "json", value: null }].map((result) => ({ result })))(
+    "does not claim delivery for a missing completed result: %j",
+    ({ result }) => {
+      const view = render(
+        <TooltipProvider>
+          <AgentReportToolCall
+            args={{ reportMarkdown: "Findings" }}
+            result={result}
+            status="completed"
+          />
+        </TooltipProvider>
+      );
+      expect(view.getByRole("status").className).not.toContain("text-success");
+      expect(view.getByRole("status").textContent).toBe("Result unavailable");
+    }
+  );
+
+  test.each([
+    { status: "pending", label: "Pending" },
+    { status: "executing", label: "Sending…" },
+    { status: "failed", label: "Not sent" },
+    { status: "interrupted", label: "Interrupted" },
+  ] as const)("preserves lifecycle status without a result: $status", ({ status, label }) => {
+    const view = render(
+      <TooltipProvider>
+        <AgentReportToolCall args={{ reportMarkdown: "Findings" }} result={null} status={status} />
+      </TooltipProvider>
+    );
+    expect(view.getByRole("status").textContent).toBe(label);
+  });
+
+  test("accepts SDK-wrapped results with inner and outer hook metadata", () => {
+    const view = render(
+      <TooltipProvider>
+        <AgentReportToolCall
+          args={{ reportMarkdown: "Findings" }}
+          status="completed"
+          result={Object.freeze({
+            type: "json",
+            value: Object.freeze({ ...{ success: true }, hook_output: "Inner hook" }),
+            hook_output: "Outer hook",
+            hook_path: ".xum/tool_post",
+          })}
+        />
+      </TooltipProvider>
+    );
+    expect(view.getByRole("status").className).toContain("text-success");
+  });
+
+  test("shows SDK-wrapped blocking errors", () => {
+    const view = render(
+      <TooltipProvider>
+        <AgentReportToolCall
+          args={{ reportMarkdown: "Findings" }}
+          status="completed"
+          result={{
+            type: "json",
+            value: { error: "Wrapped blocking error" },
+          }}
+        />
+      </TooltipProvider>
+    );
+    expect(view.getByRole("alert").textContent).toBe("Wrapped blocking error");
+  });
 });

--- a/src/browser/features/Tools/AgentReportToolCall.test.tsx
+++ b/src/browser/features/Tools/AgentReportToolCall.test.tsx
@@ -129,4 +129,31 @@ describe("AgentReportToolCall", () => {
     expect(view.queryByText("Draft report")).toBeNull();
     expect(view.getByText("Accepted report")).toBeTruthy();
   });
+
+  test.each(["", "   "])("keeps the report toggle named for a blank title: %j", (title) => {
+    const view = render(
+      <TooltipProvider>
+        <AgentReportToolCall args={{ title, reportMarkdown: "Findings" }} status="completed" />
+      </TooltipProvider>
+    );
+    expect(view.getByRole("button", { name: /\S/ })).toBeTruthy();
+  });
+
+  test.each(
+    ["legacy output", 42, true, [], { success: false, message: "Missing errors" }].map(
+      (result) => ({ result })
+    )
+  )("keeps malformed persisted report results renderable: %j", ({ result }) => {
+    const view = render(
+      <TooltipProvider>
+        <AgentReportToolCall
+          args={{ reportMarkdown: "Preserved findings" }}
+          result={result}
+          status="completed"
+        />
+      </TooltipProvider>
+    );
+    expect(view.getByText("Preserved findings")).toBeTruthy();
+    expect(view.getByRole("status").className).not.toContain("text-success");
+  });
 });

--- a/src/browser/features/Tools/AgentReportToolCall.test.tsx
+++ b/src/browser/features/Tools/AgentReportToolCall.test.tsx
@@ -156,4 +156,40 @@ describe("AgentReportToolCall", () => {
     expect(view.getByText("Preserved findings")).toBeTruthy();
     expect(view.getByRole("status").className).not.toContain("text-success");
   });
+
+  test("accepts report results decorated by post hooks without mutating hook output", () => {
+    const result = Object.freeze({
+      success: true,
+      report: { reportMarkdown: "Submitted findings" },
+      hook_output: "Formatter completed",
+      hook_duration_ms: 20,
+      hook_path: ".xum/tool_post",
+      ui_only: {},
+    });
+    const view = render(
+      <TooltipProvider>
+        <AgentReportToolCall
+          args={{ reportMarkdownPath: "report.md" }}
+          result={result}
+          status="completed"
+        />
+      </TooltipProvider>
+    );
+    expect(view.getByText("Submitted findings")).toBeTruthy();
+    expect(view.getByRole("status").className).toContain("text-success");
+  });
+
+  test("shows bare pre-hook blocking errors", () => {
+    const view = render(
+      <TooltipProvider>
+        <AgentReportToolCall
+          args={{ reportMarkdown: "Draft" }}
+          result={{ error: "Blocked by project hook" }}
+          status="completed"
+        />
+      </TooltipProvider>
+    );
+    expect(view.getByRole("alert").textContent).toBe("Blocked by project hook");
+    expect(view.getByRole("status").className).toContain("text-danger");
+  });
 });

--- a/src/browser/features/Tools/AgentReportToolCall.test.tsx
+++ b/src/browser/features/Tools/AgentReportToolCall.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { GlobalWindow } from "happy-dom";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 
 import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
 import { AgentReportToolCall } from "./AgentReportToolCall";
@@ -76,5 +76,57 @@ describe("AgentReportToolCall", () => {
     );
 
     expect(view.getByText(/Report file: report\.md/)).toBeTruthy();
+  });
+
+  test("collapses the body while retaining the title, then reopens it", () => {
+    const view = render(
+      <TooltipProvider>
+        <AgentReportToolCall
+          args={{ title: "Recovery audit", reportMarkdown: "Summary\n\nDetailed findings" }}
+          result={{ success: true }}
+          status="completed"
+        />
+      </TooltipProvider>
+    );
+    const toggle = view.getByRole("button", { name: "Recovery audit" });
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(view.queryByText("Detailed findings")).toBeNull();
+    fireEvent.click(toggle);
+    expect(view.getByText(/Detailed findings/)).toBeTruthy();
+  });
+
+  test("keeps validation failures visible when collapsed instead of claiming delivery", () => {
+    const view = render(
+      <TooltipProvider>
+        <AgentReportToolCall
+          args={{ title: "Audit", reportMarkdown: "Draft" }}
+          result={{
+            success: false,
+            message: "Report rejected",
+            errors: [{ path: "reportMarkdown", message: "Report exceeds limit" }],
+          }}
+          status="completed"
+        />
+      </TooltipProvider>
+    );
+    fireEvent.click(view.getByRole("button", { name: "Audit" }));
+    expect(view.getByRole("alert").textContent).toContain("Report exceeds limit");
+    expect(view.getByRole("status").className).toContain("text-danger");
+  });
+
+  test("prefers the submitted report over the draft arguments", () => {
+    const view = render(
+      <TooltipProvider>
+        <AgentReportToolCall
+          args={{ reportMarkdown: "Draft report" }}
+          result={{ success: true, report: { reportMarkdown: "Accepted report" } }}
+          status="completed"
+        />
+      </TooltipProvider>
+    );
+    expect(view.queryByText("Draft report")).toBeNull();
+    expect(view.getByText("Accepted report")).toBeTruthy();
   });
 });

--- a/src/browser/features/Tools/AgentReportToolCall.tsx
+++ b/src/browser/features/Tools/AgentReportToolCall.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import type { AgentReportToolArgs, AgentReportToolResult } from "@/common/types/tools";
+import { AgentReportToolResultSchema } from "@/common/utils/tools/toolDefinitions";
 
 import { ErrorBox } from "./Shared/ToolPrimitives";
 import { AgentCommunicationCard } from "./Shared/AgentCommunicationCard";
@@ -17,7 +18,7 @@ type AgentReportRenderableArgs = AgentReportToolArgs | LegacyAgentReportFileArgs
 
 interface AgentReportToolCallProps {
   args: AgentReportRenderableArgs;
-  result?: AgentReportToolResult;
+  result?: unknown;
   status?: ToolStatus;
 }
 
@@ -35,15 +36,25 @@ function getSubmittedReportMarkdown(
 }
 
 export const AgentReportToolCall: React.FC<AgentReportToolCallProps> = (props) => {
-  const reportMarkdown = getSubmittedReportMarkdown(props.args, props.result);
-  const failedResult = props.result?.success === false ? props.result : null;
+  // Persisted results bypass input-schema validation and may be malformed.
+  const parsed = AgentReportToolResultSchema.safeParse(props.result);
+  const result = isToolErrorResult(props.result)
+    ? props.result
+    : parsed.success
+      ? parsed.data
+      : undefined;
+  const invalidResult = props.result != null && result == null;
+  const reportMarkdown = getSubmittedReportMarkdown(props.args, result);
+  const failedResult = result?.success === false ? result : null;
+  const title = props.args.title?.trim() ?? "";
 
   return (
     <AgentCommunicationCard
       toolName="agent_report"
-      title={props.args.title ?? "Agent update"}
+      title={title.length > 0 ? title : "Agent update"}
       destination="To parent"
-      status={failedResult ? "failed" : (props.status ?? "pending")}
+      status={failedResult || invalidResult ? "failed" : (props.status ?? "pending")}
+      statusLabel={invalidResult ? "Result unavailable" : undefined}
       preview={reportMarkdown}
       initiallyExpanded
       error={

--- a/src/browser/features/Tools/AgentReportToolCall.tsx
+++ b/src/browser/features/Tools/AgentReportToolCall.tsx
@@ -5,7 +5,11 @@ import { AgentReportToolResultSchema } from "@/common/utils/tools/toolDefinition
 
 import { ErrorBox } from "./Shared/ToolPrimitives";
 import { AgentCommunicationCard } from "./Shared/AgentCommunicationCard";
-import { isToolErrorResult, type ToolStatus } from "./Shared/toolUtils";
+import {
+  isToolErrorResult,
+  normalizeToolResultForRendering,
+  type ToolStatus,
+} from "./Shared/toolUtils";
 import { MarkdownRenderer } from "../Messages/MarkdownRenderer";
 
 interface LegacyAgentReportFileArgs {
@@ -37,9 +41,10 @@ function getSubmittedReportMarkdown(
 
 export const AgentReportToolCall: React.FC<AgentReportToolCallProps> = (props) => {
   // Persisted results bypass input-schema validation and may be malformed.
-  const parsed = AgentReportToolResultSchema.safeParse(props.result);
-  const result = isToolErrorResult(props.result)
-    ? props.result
+  const normalizedResult = normalizeToolResultForRendering(props.result);
+  const parsed = AgentReportToolResultSchema.safeParse(normalizedResult);
+  const result = isToolErrorResult(normalizedResult)
+    ? normalizedResult
     : parsed.success
       ? parsed.data
       : undefined;

--- a/src/browser/features/Tools/AgentReportToolCall.tsx
+++ b/src/browser/features/Tools/AgentReportToolCall.tsx
@@ -2,22 +2,9 @@ import React from "react";
 
 import type { AgentReportToolArgs, AgentReportToolResult } from "@/common/types/tools";
 
-import {
-  ToolContainer,
-  ToolHeader,
-  ExpandIcon,
-  ToolName,
-  StatusIndicator,
-  ToolDetails,
-  ToolIcon,
-  ErrorBox,
-} from "./Shared/ToolPrimitives";
-import {
-  useToolExpansion,
-  getStatusDisplay,
-  isToolErrorResult,
-  type ToolStatus,
-} from "./Shared/toolUtils";
+import { ErrorBox } from "./Shared/ToolPrimitives";
+import { AgentCommunicationCard } from "./Shared/AgentCommunicationCard";
+import { isToolErrorResult, type ToolStatus } from "./Shared/toolUtils";
 import { MarkdownRenderer } from "../Messages/MarkdownRenderer";
 
 interface LegacyAgentReportFileArgs {
@@ -47,42 +34,38 @@ function getSubmittedReportMarkdown(
   return `Report file: ${args.reportMarkdownPath ?? "report.md"}`;
 }
 
-export const AgentReportToolCall: React.FC<AgentReportToolCallProps> = ({
-  args,
-  result,
-  status = "pending",
-}) => {
-  // Default to expanded so incremental findings are visible when they wake the parent.
-  const { expanded, toggleExpanded } = useToolExpansion(true);
-
-  const errorResult = isToolErrorResult(result) ? result : null;
-
-  const title = args.title ?? "Agent update";
-  const reportMarkdown = getSubmittedReportMarkdown(args, result);
-
-  // Show a small preview when collapsed so the card still has some useful context.
-  const firstLine = reportMarkdown.trim().split("\n")[0] ?? "";
-  const preview = firstLine.length > 80 ? firstLine.slice(0, 80).trim() + "…" : firstLine;
+export const AgentReportToolCall: React.FC<AgentReportToolCallProps> = (props) => {
+  const reportMarkdown = getSubmittedReportMarkdown(props.args, props.result);
+  const failedResult = props.result?.success === false ? props.result : null;
 
   return (
-    <ToolContainer expanded={expanded} data-component="AgentReportToolCall">
-      <ToolHeader onClick={toggleExpanded}>
-        <ExpandIcon expanded={expanded}>▶</ExpandIcon>
-        <ToolIcon toolName="agent_report" />
-        <ToolName className="min-w-0 flex-1 truncate">{title}</ToolName>
-        <StatusIndicator status={status}>{getStatusDisplay(status)}</StatusIndicator>
-      </ToolHeader>
-
-      {expanded && (
-        <ToolDetails>
-          <MarkdownRenderer content={reportMarkdown} className="compact-report-markdown" />
-          {errorResult && <ErrorBox className="mt-2">{errorResult.error}</ErrorBox>}
-        </ToolDetails>
-      )}
-
-      {!expanded && preview && (
-        <div className="text-muted mt-1 truncate text-[10px]">{preview}</div>
-      )}
-    </ToolContainer>
+    <AgentCommunicationCard
+      toolName="agent_report"
+      title={props.args.title ?? "Agent update"}
+      destination="To parent"
+      status={failedResult ? "failed" : (props.status ?? "pending")}
+      preview={reportMarkdown}
+      initiallyExpanded
+      error={
+        failedResult && (
+          <ErrorBox className="mt-2" role="alert">
+            {isToolErrorResult(failedResult) ? (
+              failedResult.error
+            ) : (
+              <>
+                {failedResult.message}
+                {failedResult.errors.map((error, index) => (
+                  <div key={index}>
+                    {error.path}: {error.message}
+                  </div>
+                ))}
+              </>
+            )}
+          </ErrorBox>
+        )
+      }
+    >
+      <MarkdownRenderer content={reportMarkdown} className="text-sm leading-relaxed" />
+    </AgentCommunicationCard>
   );
 };

--- a/src/browser/features/Tools/AgentReportToolCall.tsx
+++ b/src/browser/features/Tools/AgentReportToolCall.tsx
@@ -48,7 +48,7 @@ export const AgentReportToolCall: React.FC<AgentReportToolCallProps> = (props) =
     : parsed.success
       ? parsed.data
       : undefined;
-  const invalidResult = props.result != null && result == null;
+  const invalidResult = (props.result != null || props.status === "completed") && result == null;
   const reportMarkdown = getSubmittedReportMarkdown(props.args, result);
   const failedResult = result?.success === false ? result : null;
   const title = props.args.title?.trim() ?? "";

--- a/src/browser/features/Tools/Shared/AgentCommunicationCard.tsx
+++ b/src/browser/features/Tools/Shared/AgentCommunicationCard.tsx
@@ -1,0 +1,93 @@
+import type { ReactNode } from "react";
+import { ChevronRight, CircleAlert, CircleCheck, Clock3 } from "lucide-react";
+import { cn } from "@/common/lib/utils";
+import { ToolChrome, ToolContainer, ToolDetails, ToolIcon } from "./ToolPrimitives";
+import { useToolExpansion, type ToolStatus } from "./toolUtils";
+
+interface AgentCommunicationCardProps {
+  toolName: "agent_report" | "task_send_message";
+  title: string;
+  destination: ReactNode;
+  status: ToolStatus;
+  statusLabel?: string;
+  preview: string;
+  initiallyExpanded: boolean;
+  children: ReactNode;
+  error?: ReactNode;
+}
+
+const DELIVERY_LABELS: Record<ToolStatus, string> = {
+  pending: "Pending",
+  executing: "Sending…",
+  completed: "Sent",
+  failed: "Not sent",
+  interrupted: "Interrupted",
+  backgrounded: "Queued",
+  redacted: "Redacted",
+};
+
+/** Outgoing agent communication should read like the received report, not a command log. */
+export function AgentCommunicationCard(props: AgentCommunicationCardProps) {
+  const { expanded, toggleExpanded } = useToolExpansion(props.initiallyExpanded);
+  const StatusIcon =
+    props.status === "completed"
+      ? CircleCheck
+      : props.status === "failed" || props.status === "interrupted"
+        ? CircleAlert
+        : Clock3;
+
+  return (
+    <ToolContainer
+      expanded={expanded}
+      className="font-primary rounded-lg border border-[var(--color-user-border)] bg-[var(--color-user-surface)] py-3 text-sm"
+      data-component="AgentCommunicationCard"
+    >
+      <ToolChrome>
+        <button
+          type="button"
+          aria-expanded={expanded}
+          onClick={toggleExpanded}
+          data-scroll-intent="ignore"
+          className="focus-visible:ring-ring flex w-full min-w-0 cursor-pointer items-start gap-2.5 rounded-sm text-left focus-visible:ring-2 focus-visible:outline-none"
+        >
+          <ToolIcon toolName={props.toolName} className="text-muted mt-0.5 [&_svg]:size-4" />
+          <span className="min-w-0 flex-1 truncate text-sm leading-snug font-medium text-[var(--color-user-text)]">
+            {props.title}
+          </span>
+          <ChevronRight
+            aria-hidden="true"
+            className={cn("text-muted mt-0.5 size-4 shrink-0", expanded && "rotate-90")}
+          />
+        </button>
+        <div className="text-muted mt-0.5 ml-6.5 flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs leading-snug">
+          <span className="min-w-0 truncate">{props.destination}</span>
+          <span aria-hidden="true">·</span>
+          <span
+            role="status"
+            className={cn(
+              "inline-flex items-center gap-1",
+              props.status === "completed" && "text-success",
+              props.status === "failed" && "text-danger",
+              props.status === "interrupted" && "text-interrupted",
+              (props.status === "executing" || props.status === "backgrounded") &&
+                "text-backgrounded"
+            )}
+          >
+            <StatusIcon aria-hidden="true" className="size-3 shrink-0" />
+            {props.statusLabel ?? DELIVERY_LABELS[props.status]}
+          </span>
+        </div>
+      </ToolChrome>
+      {expanded ? (
+        <ToolDetails className="mt-3 border-0 pt-0 text-sm leading-[1.6] [overflow-wrap:anywhere]">
+          {props.children}
+        </ToolDetails>
+      ) : (
+        <ToolChrome className="text-muted mt-2 truncate text-xs">
+          {props.preview.trim().split("\n")[0]}
+        </ToolChrome>
+      )}
+      {props.error}
+    </ToolContainer>
+  );
+}

--- a/src/browser/features/Tools/Shared/toolUtils.tsx
+++ b/src/browser/features/Tools/Shared/toolUtils.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { AlertTriangle, Check, CircleDot, EyeOff, X } from "lucide-react";
 import type { ToolErrorResult } from "@/common/types/tools";
+import { isPlainObject } from "@/common/utils/isPlainObject";
 import {
   useStickyExpand,
   type UseStickyExpandOptions,
@@ -163,6 +164,21 @@ export function unwrapResult(result: unknown): unknown {
     return (result as { value: unknown }).value;
   }
   return result;
+}
+
+/** Preserve wrapper compatibility before strict result validation without mutating hook/UI output. */
+export function normalizeToolResultForRendering(result: unknown): unknown {
+  if (!isPlainObject(result)) return result;
+  const core = { ...result };
+  delete core.hook_output;
+  delete core.hook_duration_ms;
+  delete core.hook_path;
+  delete core.ui_only;
+  // Blocking pre-hooks return a bare error instead of the tool's result schema.
+  if (typeof core.error === "string" && !("success" in core) && !("status" in core)) {
+    return { success: false, error: core.error };
+  }
+  return core;
 }
 
 /**

--- a/src/browser/features/Tools/Shared/toolUtils.tsx
+++ b/src/browser/features/Tools/Shared/toolUtils.tsx
@@ -168,8 +168,9 @@ export function unwrapResult(result: unknown): unknown {
 
 /** Preserve wrapper compatibility before strict result validation without mutating hook/UI output. */
 export function normalizeToolResultForRendering(result: unknown): unknown {
-  if (!isPlainObject(result)) return result;
-  const core = { ...result };
+  const unwrapped = unwrapResult(result);
+  if (!isPlainObject(unwrapped)) return unwrapped;
+  const core = { ...unwrapped };
   delete core.hook_output;
   delete core.hook_duration_ms;
   delete core.hook_path;

--- a/src/browser/features/Tools/TaskToolCall.test.tsx
+++ b/src/browser/features/Tools/TaskToolCall.test.tsx
@@ -906,6 +906,70 @@ describe("TaskSendMessageToolCall", () => {
     expect(view.getByRole("alert").textContent).toBe("Blocked by project hook");
     expect(view.getByRole("status").className).toContain("text-danger");
   });
+
+  test.each([null, undefined, { type: "json", value: null }].map((result) => ({ result })))(
+    "does not claim delivery for a missing completed result: %j",
+    ({ result }) => {
+      const view = render(
+        <TooltipProvider>
+          <TaskSendMessageToolCall args={taskSendMessageArgs} result={result} status="completed" />
+        </TooltipProvider>
+      );
+      expect(view.getByRole("status").className).not.toContain("text-success");
+      expect(view.getByRole("status").textContent).toBe("Result unavailable");
+    }
+  );
+
+  test.each([
+    { status: "pending", label: "Pending" },
+    { status: "executing", label: "Sending…" },
+    { status: "failed", label: "Not sent" },
+    { status: "interrupted", label: "Interrupted" },
+  ] as const)("preserves lifecycle status without a result: $status", ({ status, label }) => {
+    const view = render(
+      <TooltipProvider>
+        <TaskSendMessageToolCall args={taskSendMessageArgs} result={null} status={status} />
+      </TooltipProvider>
+    );
+    expect(view.getByRole("status").textContent).toBe(label);
+  });
+
+  test("accepts SDK-wrapped results with inner and outer hook metadata", () => {
+    const view = render(
+      <TooltipProvider>
+        <TaskSendMessageToolCall
+          args={taskSendMessageArgs}
+          status="completed"
+          result={Object.freeze({
+            type: "json",
+            value: Object.freeze({
+              ...{ status: "accepted", taskId: "child-task" },
+              hook_output: "Inner hook",
+            }),
+            hook_output: "Outer hook",
+            hook_path: ".xum/tool_post",
+          })}
+        />
+      </TooltipProvider>
+    );
+    expect(view.getByRole("status").className).toContain("text-success");
+  });
+
+  test("shows SDK-wrapped blocking errors", () => {
+    const view = render(
+      <TooltipProvider>
+        <TaskSendMessageToolCall
+          args={taskSendMessageArgs}
+          status="completed"
+          result={{
+            type: "json",
+            value: { error: "Wrapped blocking error" },
+          }}
+        />
+      </TooltipProvider>
+    );
+    expect(view.getByRole("alert").textContent).toBe("Wrapped blocking error");
+  });
 });
 
 const taskTerminateArgs = { task_ids: ["wfr_x"] };

--- a/src/browser/features/Tools/TaskToolCall.test.tsx
+++ b/src/browser/features/Tools/TaskToolCall.test.tsx
@@ -825,6 +825,45 @@ describe("TaskSendMessageToolCall", () => {
       workspaceContextMock = null;
     }
   });
+
+  test.each(
+    [
+      "legacy output",
+      42,
+      true,
+      [],
+      { status: "refused", reason: {} },
+      { status: "constructor" },
+    ].map((result) => ({ result }))
+  )("keeps malformed persisted message results renderable: %j", ({ result }) => {
+    const view = render(
+      <TooltipProvider>
+        <TaskSendMessageToolCall args={taskSendMessageArgs} result={result} status="completed" />
+      </TooltipProvider>
+    );
+    expect(view.getByRole("status").className).not.toContain("text-success");
+    fireEvent.click(view.getByRole("button", { name: "Message to agent" }));
+    expect(view.getByText(taskSendMessageArgs.message)).toBeTruthy();
+  });
+
+  test("does not render unvalidated fields carried beside a transport error", () => {
+    const view = render(
+      <TooltipProvider>
+        <TaskSendMessageToolCall
+          args={taskSendMessageArgs}
+          status="failed"
+          result={{
+            success: false,
+            error: "Connection lost",
+            status: "refused",
+            reason: {},
+            targetRelation: {},
+          }}
+        />
+      </TooltipProvider>
+    );
+    expect(view.getByRole("alert").textContent).toBe("Connection lost");
+  });
 });
 
 const taskTerminateArgs = { task_ids: ["wfr_x"] };

--- a/src/browser/features/Tools/TaskToolCall.test.tsx
+++ b/src/browser/features/Tools/TaskToolCall.test.tsx
@@ -750,10 +750,80 @@ describe("TaskSendMessageToolCall", () => {
       </TooltipProvider>
     );
 
-    expect(view.getByText("queued")).toBeDefined();
-    fireEvent.click(view.getByText("task_send_message"));
+    expect(view.getByRole("status").textContent).toBe("Queued");
+    fireEvent.click(view.getByRole("button", { name: "Message to agent" }));
     expect(view.getByText("child-task")).toBeDefined();
     expect(view.getByText("Use the corrected API shape.")).toBeDefined();
+  });
+
+  test.each([
+    { status: "accepted", taskId: "child-task", targetRelation: "ancestor" },
+    { status: "reactivated", taskId: "child-task" },
+    { status: "queued", taskId: "child-task", targetRelation: "sibling" },
+    { status: "not_found", taskId: "child-task" },
+    { status: "invalid_scope", taskId: "child-task" },
+    { status: "not_active", taskId: "child-task", taskStatus: "reported", error: "Inactive peer" },
+    { status: "error", taskId: "child-task", error: "Delivery failed" },
+    { status: "refused", taskId: "child-task", reason: "Message already queued" },
+    { status: "rate_limited", taskId: "child-task", retryAfterMs: 1200 },
+  ] as const)("uses the delivery outcome instead of generic tool completion: $status", (result) => {
+    const view = render(
+      <TooltipProvider>
+        <TaskSendMessageToolCall args={taskSendMessageArgs} status="completed" result={result} />
+      </TooltipProvider>
+    );
+    const status = view.getByRole("status");
+    const sent = result.status === "accepted" || result.status === "reactivated";
+    expect(status.className.includes("text-success")).toBe(sent);
+    expect(status.className.includes("text-danger")).toBe(!sent && result.status !== "queued");
+    if (result.error != null) expect(view.getByRole("alert").textContent).toBe(result.error);
+    if (result.reason != null) expect(view.getByRole("alert").textContent).toBe(result.reason);
+    if (result.targetRelation != null)
+      expect(view.getByText(`To ${result.targetRelation}`)).toBeTruthy();
+    if (result.retryAfterMs != null) expect(view.getByText("Retry in 2s")).toBeTruthy();
+  });
+
+  test("shows transport failures even while collapsed", () => {
+    const view = render(
+      <TooltipProvider>
+        <TaskSendMessageToolCall
+          args={taskSendMessageArgs}
+          status="failed"
+          result={{ success: false, error: "Connection lost" }}
+        />
+      </TooltipProvider>
+    );
+    expect(view.getByRole("alert").textContent).toBe("Connection lost");
+    expect(
+      view.getByRole("button", { name: "Message to agent" }).getAttribute("aria-expanded")
+    ).toBe("false");
+  });
+
+  test("opens the recipient workspace without toggling the message", () => {
+    const workspace = createWorkspaceMetadata({ id: "child-task", title: "Reviewer" });
+    const select = mock(() => undefined);
+    workspaceContextMock = {
+      workspaceMetadata: new Map([[workspace.id, workspace]]),
+      setSelectedWorkspace: select,
+    };
+    try {
+      const view = render(
+        <TooltipProvider>
+          <TaskSendMessageToolCall
+            args={taskSendMessageArgs}
+            status="completed"
+            result={{ status: "reactivated", taskId: "child-task" }}
+          />
+        </TooltipProvider>
+      );
+      fireEvent.click(view.getByRole("button", { name: "child-task" }));
+      expect(select).toHaveBeenCalledWith(workspace);
+      expect(
+        view.getByRole("button", { name: "Message to Reviewer" }).getAttribute("aria-expanded")
+      ).toBe("false");
+    } finally {
+      workspaceContextMock = null;
+    }
   });
 });
 

--- a/src/browser/features/Tools/TaskToolCall.test.tsx
+++ b/src/browser/features/Tools/TaskToolCall.test.tsx
@@ -864,6 +864,48 @@ describe("TaskSendMessageToolCall", () => {
     );
     expect(view.getByRole("alert").textContent).toBe("Connection lost");
   });
+
+  test.each(["accepted", "queued", "reactivated"] as const)(
+    "preserves hooked delivery outcome: %s",
+    (status) => {
+      const view = render(
+        <TooltipProvider>
+          <TaskSendMessageToolCall
+            args={taskSendMessageArgs}
+            status="completed"
+            result={Object.freeze({
+              status,
+              taskId: "child-task",
+              hook_output: "Post hook finished",
+              hook_duration_ms: 20,
+              hook_path: ".xum/tool_post",
+            })}
+          />
+        </TooltipProvider>
+      );
+      expect(view.getByRole("status").className).toContain(
+        status === "queued" ? "text-backgrounded" : "text-success"
+      );
+    }
+  );
+
+  test("shows bare pre-hook errors alongside their metadata", () => {
+    const view = render(
+      <TooltipProvider>
+        <TaskSendMessageToolCall
+          args={taskSendMessageArgs}
+          status="completed"
+          result={{
+            error: "Blocked by project hook",
+            hook_output: "Policy refused",
+            hook_path: ".xum/tool_pre",
+          }}
+        />
+      </TooltipProvider>
+    );
+    expect(view.getByRole("alert").textContent).toBe("Blocked by project hook");
+    expect(view.getByRole("status").className).toContain("text-danger");
+  });
 });
 
 const taskTerminateArgs = { task_ids: ["wfr_x"] };

--- a/src/browser/features/Tools/TaskToolCall.tsx
+++ b/src/browser/features/Tools/TaskToolCall.tsx
@@ -15,6 +15,7 @@ import {
   useToolExpansion,
   getStatusDisplay,
   isToolErrorResult,
+  normalizeToolResultForRendering,
   type ToolStatus,
 } from "./Shared/toolUtils";
 import { AgentCommunicationCard } from "./Shared/AgentCommunicationCard";
@@ -1734,9 +1735,10 @@ export const TaskSendMessageToolCall: React.FC<TaskSendMessageToolCallProps> = (
     props.args.task_id
   );
   // Persisted output is unknown even when the tool arguments have passed validation.
-  const parsed = TaskSendMessageToolResultSchema.safeParse(props.result);
+  const normalizedResult = normalizeToolResultForRendering(props.result);
+  const parsed = TaskSendMessageToolResultSchema.safeParse(normalizedResult);
   const result = parsed.success ? parsed.data : undefined;
-  const toolError = isToolErrorResult(props.result) ? props.result : undefined;
+  const toolError = isToolErrorResult(normalizedResult) ? normalizedResult : undefined;
   const invalidResult = props.result != null && result == null && toolError == null;
   // A finished tool call can still mean delivery was refused or queued, not sent.
   const delivery = result ? MESSAGE_DELIVERY[result.status] : undefined;

--- a/src/browser/features/Tools/TaskToolCall.tsx
+++ b/src/browser/features/Tools/TaskToolCall.tsx
@@ -17,6 +17,7 @@ import {
   isToolErrorResult,
   type ToolStatus,
 } from "./Shared/toolUtils";
+import { AgentCommunicationCard } from "./Shared/AgentCommunicationCard";
 import { MarkdownRenderer } from "../Messages/MarkdownRenderer";
 import { useOptionalMessageListContext } from "../Messages/MessageListContext";
 import { useStickyExpand } from "../Messages/useStickyExpand";
@@ -1706,53 +1707,77 @@ const TaskListItem: React.FC<{
 
 interface TaskSendMessageToolCallProps {
   args: TaskSendMessageToolArgs;
-  result?: TaskSendMessageToolSuccessResult;
+  result?: TaskSendMessageToolSuccessResult | ToolErrorResult;
   status?: ToolStatus;
 }
 
+const MESSAGE_DELIVERY: Record<
+  TaskSendMessageToolSuccessResult["status"],
+  { status: ToolStatus; label: string }
+> = {
+  accepted: { status: "completed", label: "Accepted" },
+  queued: { status: "backgrounded", label: "Queued" },
+  reactivated: { status: "completed", label: "Sent · Agent reactivated" },
+  not_found: { status: "failed", label: "Target not found" },
+  invalid_scope: { status: "failed", label: "Invalid target" },
+  not_active: { status: "failed", label: "Agent inactive" },
+  error: { status: "failed", label: "Not sent" },
+  refused: { status: "failed", label: "Refused" },
+  rate_limited: { status: "failed", label: "Rate limited" },
+};
+
 export const TaskSendMessageToolCall: React.FC<TaskSendMessageToolCallProps> = (props) => {
-  const { expanded, toggleExpanded } = useToolExpansion(false);
-  const status = props.status ?? "pending";
-  const summary = props.result?.status ?? "sending";
+  const workspaceContext = useOptionalWorkspaceContext();
+  const workspace = findWorkspaceForTaskTarget(
+    workspaceContext?.workspaceMetadata,
+    props.args.task_id
+  );
+  const result = props.result;
+  const toolError = isToolErrorResult(result);
+  // A finished tool call can still mean delivery was refused or queued, not sent.
+  const delivery = result && !toolError ? MESSAGE_DELIVERY[result.status] : undefined;
+  const relation = result && "targetRelation" in result ? result.targetRelation : undefined;
+  const error = result && "error" in result ? result.error : undefined;
 
   return (
-    <ToolContainer expanded={expanded}>
-      <ToolHeader onClick={toggleExpanded}>
-        <ExpandIcon expanded={expanded}>▶</ExpandIcon>
-        <TaskIcon toolName="task_send_message" />
-        <ToolName>task_send_message</ToolName>
-        <span className="text-muted text-[10px]">{summary}</span>
-        <StatusIndicator status={status}>{getStatusDisplay(status)}</StatusIndicator>
-      </ToolHeader>
-
-      {expanded && (
-        <ToolDetails>
-          <div className="task-surface mt-1 space-y-2 rounded-md p-3">
-            <div className="flex items-center gap-2">
-              <TaskId id={props.args.task_id} />
-              {props.result && <TaskStatusBadge status={props.result.status} />}
-              {props.result && "targetRelation" in props.result && props.result.targetRelation && (
-                <span className="text-muted text-[10px]">to {props.result.targetRelation}</span>
-              )}
-            </div>
-            <div className="text-foreground bg-code-bg max-h-[140px] overflow-y-auto rounded-sm p-2 text-[11px] break-words whitespace-pre-wrap">
-              {props.args.message}
-            </div>
-            {props.result && "error" in props.result && props.result.error && (
-              <div className="text-danger text-[11px]">{props.result.error}</div>
-            )}
-            {props.result?.status === "refused" && (
-              <div className="text-danger text-[11px]">{props.result.reason}</div>
-            )}
-            {props.result?.status === "rate_limited" && props.result.retryAfterMs != null && (
-              <div className="text-warning text-[11px]">
-                Retry in {Math.ceil(props.result.retryAfterMs / 1000)}s
+    <AgentCommunicationCard
+      toolName="task_send_message"
+      title={workspace ? `Message to ${workspace.title ?? workspace.name}` : "Message to agent"}
+      destination={
+        <>
+          To {relation && `${relation} `}
+          <TaskId id={props.args.task_id} className="text-xs opacity-100" />
+        </>
+      }
+      status={toolError ? "failed" : (delivery?.status ?? props.status ?? "pending")}
+      statusLabel={delivery?.label}
+      preview={props.args.message}
+      initiallyExpanded={false}
+      error={
+        <>
+          {error && (
+            <ErrorBox className="mt-2" role="alert">
+              {error}
+            </ErrorBox>
+          )}
+          {result && "status" in result && result.status === "refused" && (
+            <ErrorBox className="mt-2" role="alert">
+              {result.reason}
+            </ErrorBox>
+          )}
+          {result &&
+            "status" in result &&
+            result.status === "rate_limited" &&
+            result.retryAfterMs != null && (
+              <div className="text-warning mt-2 text-xs">
+                Retry in {Math.ceil(result.retryAfterMs / 1000)}s
               </div>
             )}
-          </div>
-        </ToolDetails>
-      )}
-    </ToolContainer>
+        </>
+      }
+    >
+      <div className="whitespace-pre-wrap">{props.args.message}</div>
+    </AgentCommunicationCard>
   );
 };
 

--- a/src/browser/features/Tools/TaskToolCall.tsx
+++ b/src/browser/features/Tools/TaskToolCall.tsx
@@ -18,6 +18,7 @@ import {
   type ToolStatus,
 } from "./Shared/toolUtils";
 import { AgentCommunicationCard } from "./Shared/AgentCommunicationCard";
+import { TaskSendMessageToolResultSchema } from "@/common/utils/tools/toolDefinitions";
 import { MarkdownRenderer } from "../Messages/MarkdownRenderer";
 import { useOptionalMessageListContext } from "../Messages/MessageListContext";
 import { useStickyExpand } from "../Messages/useStickyExpand";
@@ -1707,7 +1708,7 @@ const TaskListItem: React.FC<{
 
 interface TaskSendMessageToolCallProps {
   args: TaskSendMessageToolArgs;
-  result?: TaskSendMessageToolSuccessResult | ToolErrorResult;
+  result?: unknown;
   status?: ToolStatus;
 }
 
@@ -1732,12 +1733,15 @@ export const TaskSendMessageToolCall: React.FC<TaskSendMessageToolCallProps> = (
     workspaceContext?.workspaceMetadata,
     props.args.task_id
   );
-  const result = props.result;
-  const toolError = isToolErrorResult(result);
+  // Persisted output is unknown even when the tool arguments have passed validation.
+  const parsed = TaskSendMessageToolResultSchema.safeParse(props.result);
+  const result = parsed.success ? parsed.data : undefined;
+  const toolError = isToolErrorResult(props.result) ? props.result : undefined;
+  const invalidResult = props.result != null && result == null && toolError == null;
   // A finished tool call can still mean delivery was refused or queued, not sent.
-  const delivery = result && !toolError ? MESSAGE_DELIVERY[result.status] : undefined;
+  const delivery = result ? MESSAGE_DELIVERY[result.status] : undefined;
   const relation = result && "targetRelation" in result ? result.targetRelation : undefined;
-  const error = result && "error" in result ? result.error : undefined;
+  const error = toolError?.error ?? (result && "error" in result ? result.error : undefined);
 
   return (
     <AgentCommunicationCard
@@ -1749,8 +1753,10 @@ export const TaskSendMessageToolCall: React.FC<TaskSendMessageToolCallProps> = (
           <TaskId id={props.args.task_id} className="text-xs opacity-100" />
         </>
       }
-      status={toolError ? "failed" : (delivery?.status ?? props.status ?? "pending")}
-      statusLabel={delivery?.label}
+      status={
+        toolError || invalidResult ? "failed" : (delivery?.status ?? props.status ?? "pending")
+      }
+      statusLabel={invalidResult ? "Result unavailable" : delivery?.label}
       preview={props.args.message}
       initiallyExpanded={false}
       error={
@@ -1760,23 +1766,27 @@ export const TaskSendMessageToolCall: React.FC<TaskSendMessageToolCallProps> = (
               {error}
             </ErrorBox>
           )}
-          {result && "status" in result && result.status === "refused" && (
+          {result?.status === "refused" && (
             <ErrorBox className="mt-2" role="alert">
               {result.reason}
             </ErrorBox>
           )}
-          {result &&
-            "status" in result &&
-            result.status === "rate_limited" &&
-            result.retryAfterMs != null && (
-              <div className="text-warning mt-2 text-xs">
-                Retry in {Math.ceil(result.retryAfterMs / 1000)}s
-              </div>
-            )}
+          {result?.status === "rate_limited" && result.retryAfterMs != null && (
+            <div className="text-warning mt-2 text-xs">
+              Retry in {Math.ceil(result.retryAfterMs / 1000)}s
+            </div>
+          )}
         </>
       }
     >
-      <div className="whitespace-pre-wrap">{props.args.message}</div>
+      <div
+        role="region"
+        aria-label="Message content"
+        tabIndex={0}
+        className="focus-visible:ring-ring max-h-[40vh] overflow-y-auto rounded-sm whitespace-pre-wrap focus-visible:ring-2 focus-visible:outline-none"
+      >
+        {props.args.message}
+      </div>
     </AgentCommunicationCard>
   );
 };

--- a/src/browser/features/Tools/TaskToolCall.tsx
+++ b/src/browser/features/Tools/TaskToolCall.tsx
@@ -1739,7 +1739,8 @@ export const TaskSendMessageToolCall: React.FC<TaskSendMessageToolCallProps> = (
   const parsed = TaskSendMessageToolResultSchema.safeParse(normalizedResult);
   const result = parsed.success ? parsed.data : undefined;
   const toolError = isToolErrorResult(normalizedResult) ? normalizedResult : undefined;
-  const invalidResult = props.result != null && result == null && toolError == null;
+  const invalidResult =
+    (props.result != null || props.status === "completed") && result == null && toolError == null;
   // A finished tool call can still mean delivery was refused or queued, not sent.
   const delivery = result ? MESSAGE_DELIVERY[result.status] : undefined;
   const relation = result && "targetRelation" in result ? result.targetRelation : undefined;

--- a/src/browser/stories/App.agentCommunication.stories.tsx
+++ b/src/browser/stories/App.agentCommunication.stories.tsx
@@ -1,0 +1,138 @@
+import { expect, userEvent, within } from "@storybook/test";
+import { getAutoExpandPrefsKey } from "@/common/constants/storage";
+import { updatePersistedState } from "@/browser/hooks/usePersistedState";
+import { appMeta, AppWithMocks, type AppStory } from "./meta.js";
+import { setupSimpleChatStory } from "./helpers/chatSetup";
+import { PhoneSubagentReportDecorator } from "./helpers/subagentReportStory";
+import { collapseLeftSidebar, collapseRightSidebar } from "./helpers/uiState";
+import { createAssistantMessage } from "./mocks/messages";
+import { createWorkspace, STABLE_TIMESTAMP } from "./mocks/workspaces";
+
+const WORKSPACE_ID = "ws-agent-communication";
+const REPORT_TITLE = "Preserving active-pointer crash recovery";
+const REPORT =
+  "One final generation-guard audit caught an edge not covered by existing tests: startup’s authoritative newer-handle selection must be allowed to replace a stale **active** child pointer, not only terminal pointers.\n\nI’m adding a compare-with-snapshotted previous execution ID permission only for startup reconciliation, plus a test for the old running status.";
+const MESSAGE =
+  "Focused follow-up before finalizing: verify the native canvas clipping behavior and the parent popup-blocked failure path.\n\nCheck handshake ordering in src/browser/features/Tools/SubagentTranscriptDialog.tsx and keep the change scoped to the existing behavior.";
+
+function setupCommunicationStory(failed = false) {
+  // Separate transcript stores so switching stories cannot retain a successful delivery.
+  const workspaceId = failed ? `${WORKSPACE_ID}-failed` : WORKSPACE_ID;
+  collapseLeftSidebar();
+  collapseRightSidebar();
+  updatePersistedState(getAutoExpandPrefsKey(workspaceId), {});
+  return setupSimpleChatStory({
+    workspaceId,
+    workspaceName: "agent-communication",
+    projectName: "mux",
+    messages: [
+      createAssistantMessage("outgoing-updates", "", {
+        historySequence: 1,
+        timestamp: STABLE_TIMESTAMP,
+        toolCalls: [
+          {
+            type: "dynamic-tool",
+            toolCallId: "outgoing-report",
+            toolName: "agent_report",
+            state: "output-available",
+            input: { title: REPORT_TITLE, reportMarkdown: REPORT },
+            output: failed
+              ? { success: false, error: "The parent workspace is unavailable." }
+              : { success: true },
+          },
+          {
+            type: "dynamic-tool",
+            toolCallId: "outgoing-message",
+            toolName: "task_send_message",
+            state: "output-available",
+            input: { task_id: "b3947e259a", message: MESSAGE },
+            output: failed
+              ? {
+                  status: "refused",
+                  taskId: "b3947e259a",
+                  reason: "This message is already queued.",
+                }
+              : { status: "reactivated", taskId: "b3947e259a" },
+          },
+        ],
+      }),
+    ],
+    additionalWorkspaces: [
+      createWorkspace({
+        id: "b3947e259a",
+        name: "reviewer",
+        title: "Reviewer",
+        projectName: "mux",
+        parentWorkspaceId: workspaceId,
+        taskStatus: "running",
+      }),
+    ],
+  });
+}
+
+export default {
+  ...appMeta,
+  title: "App/AgentCommunication",
+};
+
+export const Outgoing: AppStory = {
+  render: () => <AppWithMocks setup={setupCommunicationStory} />,
+  parameters: {
+    ...appMeta.parameters,
+    pixel: { matrix: { themes: ["dark", "light"], viewports: ["laptop"] } },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = await canvas.findByRole("button", { name: "Message to Reviewer" });
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await userEvent.click(toggle);
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+    // Prove keyboard collapse/expand as well as pointer interaction.
+    toggle.focus();
+    await userEvent.keyboard("{Enter}");
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await userEvent.keyboard(" ");
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+    );
+  },
+};
+
+export const Phone: AppStory = {
+  ...Outgoing,
+  // Pin both the manager/Pixel viewport and the test-runner's otherwise desktop-width canvas.
+  globals: { viewport: { value: "mobile1", isRotated: false } },
+  decorators: [PhoneSubagentReportDecorator],
+  parameters: {
+    ...appMeta.parameters,
+    pixel: { matrix: { themes: ["dark", "light"], viewports: ["phone"] } },
+  },
+  play: async (context) => {
+    await Outgoing.play?.(context);
+    const cards = context.canvasElement.querySelectorAll(
+      '[data-component="AgentCommunicationCard"]'
+    );
+    await expect(cards.length).toBe(2);
+    for (const card of cards) {
+      await expect(card.clientWidth).toBeLessThan(390);
+      await expect(card.scrollWidth).toBeLessThanOrEqual(card.clientWidth);
+    }
+  },
+};
+
+export const DeliveryFailures: AppStory = {
+  render: () => <AppWithMocks setup={() => setupCommunicationStory(true)} />,
+  parameters: {
+    ...appMeta.parameters,
+    pixel: { matrix: { themes: ["dark", "light"], viewports: ["laptop"] } },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findAllByRole("alert")).toHaveLength(2);
+    const toggle = canvas.getByRole("button", { name: REPORT_TITLE });
+    await userEvent.click(toggle);
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await expect(canvas.getAllByRole("alert")).toHaveLength(2);
+  },
+};

--- a/src/browser/stories/App.agentCommunication.stories.tsx
+++ b/src/browser/stories/App.agentCommunication.stories.tsx
@@ -1,4 +1,4 @@
-import { expect, userEvent, within } from "@storybook/test";
+import { expect, userEvent, waitFor, within } from "@storybook/test";
 import { getAutoExpandPrefsKey } from "@/common/constants/storage";
 import { updatePersistedState } from "@/browser/hooks/usePersistedState";
 import { appMeta, AppWithMocks, type AppStory } from "./meta.js";
@@ -15,9 +15,9 @@ const REPORT =
 const MESSAGE =
   "Focused follow-up before finalizing: verify the native canvas clipping behavior and the parent popup-blocked failure path.\n\nCheck handshake ordering in src/browser/features/Tools/SubagentTranscriptDialog.tsx and keep the change scoped to the existing behavior.";
 
-function setupCommunicationStory(failed = false) {
+function setupCommunicationStory(failed = false, longMessage = false) {
   // Separate transcript stores so switching stories cannot retain a successful delivery.
-  const workspaceId = failed ? `${WORKSPACE_ID}-failed` : WORKSPACE_ID;
+  const workspaceId = `${WORKSPACE_ID}-${failed ? "failed" : longMessage ? "long" : "sent"}`;
   collapseLeftSidebar();
   collapseRightSidebar();
   updatePersistedState(getAutoExpandPrefsKey(workspaceId), {});
@@ -45,7 +45,14 @@ function setupCommunicationStory(failed = false) {
             toolCallId: "outgoing-message",
             toolName: "task_send_message",
             state: "output-available",
-            input: { task_id: "b3947e259a", message: MESSAGE },
+            input: {
+              task_id: "b3947e259a",
+              message: longMessage
+                ? Array.from({ length: 200 }, (_, index) => `Check ${index + 1}: ${MESSAGE}`).join(
+                    "\n\n"
+                  )
+                : MESSAGE,
+            },
             output: failed
               ? {
                   status: "refused",
@@ -135,4 +142,27 @@ export const DeliveryFailures: AppStory = {
     await expect(toggle).toHaveAttribute("aria-expanded", "false");
     await expect(canvas.getAllByRole("alert")).toHaveLength(2);
   },
+};
+
+export const LongMessage: AppStory = {
+  ...Outgoing,
+  render: () => <AppWithMocks setup={() => setupCommunicationStory(false, true)} />,
+  play: async (context) => {
+    await Outgoing.play?.(context);
+    const content = within(context.canvasElement).getByRole("region", { name: "Message content" });
+    await expect(content.scrollHeight).toBeGreaterThan(content.clientHeight);
+    await expect(content.clientHeight).toBeLessThanOrEqual(window.innerHeight * 0.4 + 1);
+    content.focus();
+    await expect(content).toHaveFocus();
+    content.scrollTo({ top: content.scrollHeight });
+    await waitFor(() => expect(content.scrollTop).toBeGreaterThan(0));
+    await expect(content.scrollWidth).toBeLessThanOrEqual(content.clientWidth);
+  },
+};
+
+export const LongMessagePhone: AppStory = {
+  ...LongMessage,
+  globals: Phone.globals,
+  decorators: Phone.decorators,
+  parameters: Phone.parameters,
 };

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -13733,7 +13733,6 @@ describe("WorkspaceService reorderPinned across projects", () => {
 
     const mockConfig: Partial<Config> = {
       srcDir: "/tmp/src",
-      getSessionDir: mock(() => "/tmp/test/sessions"),
       findWorkspace: mock((id: string) => {
         const found = findEntry(id);
         if (!found) return null;


### PR DESCRIPTION
## Summary

Make outgoing `agent_report` and `task_send_message` entries feel like agent communication rather than command output, matching the readable incoming-report treatment.

- Share a single card with clear titles, recipient metadata, consistent transcript typography, and keyboard-accessible expand/collapse.
- Preserve report Markdown, legacy file-backed reports, hook-decorated results and blocking errors, sticky expansion preferences, and task-ID navigation/copy behavior.
- Show delivery outcomes instead of generic tool completion: queued, reactivated, refused, rate-limited, and failed sends remain distinguishable. Errors stay visible when collapsed.
- Validate malformed/missing persisted results, unwrap SDK JSON containers, supply accessible fallback titles, and keep long guidance in a bounded, keyboard-scrollable region.
- Add full-app desktop/phone, long-message, and failure-state stories plus regression tests.

The branch also fixes existing main-branch validation failures: removes an obsolete `getSessionDir` mock from a `Partial<Config>` fixture and supplies the missing archive-state set in five flat-sidebar fixtures. These are test-data-only corrections; no production workspace/sidebar behavior changes.

## Validation

- `make static-check` passed (including both TypeScript projects).
- 86 targeted report/task/tool-dispatch tests passed.
- Four cross-project pin tests and all 49 sidebar tests passed for the corrected fixtures.
- The workflow CLI case that hit a Bun process crash in CI passed when rerun locally.
- 15 Storybook tests passed across the affected transcript and communication stories.
- Dogfooded via the Storybook manager in dark/light themes and at 375px phone width: no horizontal overflow; pointer, Enter/Space toggles, recipient navigation, and collapsed failure alerts verified.
- Independent final code review found no blocking issues.

## Visual evidence

### Desktop
![Outgoing report and message cards](https://github.com/user-attachments/assets/17c83cdc-47d0-4460-83db-585559846f46)

<details>
<summary>Phone layout and interaction recording</summary>

![Outgoing communication at phone width](https://github.com/user-attachments/assets/ec35d50e-8985-4201-9199-4bab6451acfc)

https://github.com/user-attachments/assets/27bde839-97d6-4692-b19f-de03da8a0040

</details>

<details>
<summary>Long-message scrolling after review fixes</summary>

![Bounded long-message region at phone width](https://github.com/user-attachments/assets/a2869a1c-95d4-4194-b50f-0c24cf7c649f)

https://github.com/user-attachments/assets/fd75103e-c9f3-4ab1-822a-e25a6402e3e9

</details>

## Risk

Presentation-only changes to the two outgoing tools; backend delivery is unchanged. Legacy report fallback, all message delivery outcomes, and navigation behavior have regression coverage.

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `coder:openai/gpt-6-astra` • Thinking: `high` • Cost: `$21.44`_

<!-- mux-attribution: model=coder:openai/gpt-6-astra thinking=high costs=21.44 -->




