### PR TITLE
🤖 fix: separate General settings groups with thin dividers

### DIFF
--- a/src/browser/features/Settings/Sections/GeneralSection.tsx
+++ b/src/browser/features/Settings/Sections/GeneralSection.tsx
@@ -604,7 +604,7 @@ export function GeneralSection() {
         </div>
       </div>
 
-      <div>
+      <div className="border-border-light border-t pt-6">
         <h3 className="text-foreground mb-4 text-sm font-medium">Sidebar</h3>
         <div className="space-y-4">
           <div className="flex items-center justify-between gap-4">
@@ -653,7 +653,7 @@ export function GeneralSection() {
         </div>
       </div>
 
-      <div>
+      <div className="border-border-light border-t pt-6">
         <h3 className="text-foreground mb-4 text-sm font-medium">Transcript</h3>
         <div className="space-y-4">
           <div className="flex items-center justify-between gap-4">
@@ -724,7 +724,7 @@ export function GeneralSection() {
         </div>
       </div>
 
-      <div>
+      <div className="border-border-light border-t pt-6">
         <h3 className="text-foreground mb-4 text-sm font-medium">Terminal</h3>
         <div className="space-y-4">
           <div className="flex items-center justify-between gap-4">
@@ -872,7 +872,7 @@ export function GeneralSection() {
         </div>
       </div>
 
-      <div>
+      <div className="border-border-light border-t pt-6">
         <h3 className="text-foreground mb-4 text-sm font-medium">Archiving</h3>
         <div className="space-y-4">
           <div className="flex items-center justify-between gap-4">
@@ -933,7 +933,7 @@ export function GeneralSection() {
         </div>
       </div>
 
-      <div>
+      <div className="border-border-light border-t pt-6">
         <h3 className="text-foreground mb-4 text-sm font-medium">Editor & debugging</h3>
         <div className="space-y-4">
           <div className="flex items-center justify-between">
@@ -1014,7 +1014,7 @@ export function GeneralSection() {
         </div>
       </div>
 
-      <div>
+      <div className="border-border-light border-t pt-6">
         <h3 className="text-foreground mb-4 text-sm font-medium">Projects</h3>
         <div className="space-y-4">
           <div className="flex items-center justify-between gap-4">


### PR DESCRIPTION
## Summary

Settings > General groups its controls under headings (Appearance, Sidebar, Transcript, Terminal, Archiving, Editor & debugging, Projects), but only whitespace separated the groups, so the boundary between one group's last row and the next heading was hard to see. This adds a thin horizontal rule between the groups.

## Implementation

Each group wrapper after the first gets `border-border-light border-t pt-6`: a 1px rule in the theme border color (the same token `divide-border-light` uses elsewhere in Settings), with the existing `space-y-6` gap above the line and `pt-6` below it so the heading is not glued to the rule. No rule above Appearance. Six className edits in `GeneralSection.tsx`, no new components or CSS.

## Validation

- Storybook `GeneralSection` story at 1100px and 390px: computed styles show `0px` border on the Appearance wrapper and `1px rgb(38,38,38)` + `24px` padding-top on the other six; no horizontal overflow.
- Remote dogfood UAT (Coder Agents) on this exact commit: six dividers with even spacing in dark and light themes at desktop and 390px, placement holds when the Terminal group grows/shrinks (Terminal Badge on/off), other tabs unchanged.
- UAT also surfaced a pre-existing issue, not touched here: at 390px the Terminal Font input (fixed `w-80`) overflows the settings column; reproduced on the base commit.

> Note: the first CI run inherited two failures from a then-red `main` (#3994's stale `getSessionDir` mock and five `ProjectSidebar flat chat list` renders missing `archivingWorkspaceIds`); #4077 fixed both on `main`, which is merged in here.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$19.46`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=19.46 -->
