### PR TITLE
🤖 feat: show compact expandable workflow stages

### DIFF
--- a/src/browser/features/RightSidebar/Workflows/WorkflowLongText.tsx
+++ b/src/browser/features/RightSidebar/Workflows/WorkflowLongText.tsx
@@ -7,6 +7,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogTrigger,
 } from "@/browser/components/Dialog/Dialog";
 import { MarkdownRenderer } from "@/browser/features/Messages/MarkdownRenderer";
 import { cn } from "@/common/lib/utils";
@@ -35,7 +36,6 @@ interface WorkflowLongTextProps {
  */
 export const WorkflowLongText: React.FC<WorkflowLongTextProps> = (props) => {
   const [expanded, setExpanded] = React.useState(false);
-  const [dialogOpen, setDialogOpen] = React.useState(false);
   const { preview, truncated, totalChars } = getWorkflowTextPreview(props.text, props.charLimit);
 
   const fullContent = props.markdown ? (
@@ -49,29 +49,34 @@ export const WorkflowLongText: React.FC<WorkflowLongTextProps> = (props) => {
   }
 
   return (
-    <div className={cn("flex min-w-0 flex-col gap-1", props.className)}>
-      {expanded ? fullContent : <span className="break-words whitespace-pre-wrap">{preview}…</span>}
-      <div className="flex items-center gap-1">
-        <button
-          type="button"
-          className={CONTROL_BUTTON_CLASS}
-          onClick={() => setExpanded((value) => !value)}
-          aria-expanded={expanded}
-          aria-label={expanded ? `Show less of ${props.title}` : `Show more of ${props.title}`}
-        >
-          {expanded ? "Show less" : `Show more (${formatCompactCount(totalChars)} chars)`}
-        </button>
-        <button
-          type="button"
-          className={CONTROL_BUTTON_CLASS}
-          onClick={() => setDialogOpen(true)}
-          aria-haspopup="dialog"
-          aria-label={`Open ${props.title} in full view`}
-        >
-          <Maximize2 className="h-2.5 w-2.5" /> Full view
-        </button>
-      </div>
-      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+    <Dialog>
+      <div className={cn("flex min-w-0 flex-col gap-1", props.className)}>
+        {expanded ? (
+          fullContent
+        ) : (
+          <span className="break-words whitespace-pre-wrap">{preview}…</span>
+        )}
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            className={CONTROL_BUTTON_CLASS}
+            onClick={() => setExpanded((value) => !value)}
+            aria-expanded={expanded}
+            aria-label={expanded ? `Show less of ${props.title}` : `Show more of ${props.title}`}
+          >
+            {expanded ? "Show less" : `Show more (${formatCompactCount(totalChars)} chars)`}
+          </button>
+          {/* A registered trigger restores keyboard focus when the full view closes. */}
+          <DialogTrigger asChild>
+            <button
+              type="button"
+              className={CONTROL_BUTTON_CLASS}
+              aria-label={`Open ${props.title} in full view`}
+            >
+              <Maximize2 className="h-2.5 w-2.5" /> Full view
+            </button>
+          </DialogTrigger>
+        </div>
         <DialogContent
           className="flex max-h-[85vh] flex-col gap-3 overflow-hidden"
           maxWidth="56rem"
@@ -84,7 +89,7 @@ export const WorkflowLongText: React.FC<WorkflowLongTextProps> = (props) => {
           </DialogHeader>
           <div className="min-h-0 flex-1 overflow-y-auto text-[12.5px]">{fullContent}</div>
         </DialogContent>
-      </Dialog>
-    </div>
+      </div>
+    </Dialog>
   );
 };

--- a/src/browser/features/RightSidebar/Workflows/WorkflowRunHeader.test.tsx
+++ b/src/browser/features/RightSidebar/Workflows/WorkflowRunHeader.test.tsx
@@ -1,7 +1,11 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render, within } from "@testing-library/react";
 
+import { APIContext } from "@/browser/contexts/API";
 import type { WorkflowRunRecord } from "@/common/types/workflow";
-import { getWorkflowRunRerunScriptPath } from "./WorkflowRunHeader";
+import { installDom } from "../../../../../tests/ui/dom";
+import { getWorkflowRunRerunScriptPath, WorkflowRunHeader } from "./WorkflowRunHeader";
+import { projectWorkflowRun } from "./projectWorkflowRun";
 
 function makeRun(workflow: WorkflowRunRecord["workflow"]): WorkflowRunRecord {
   return {
@@ -18,6 +22,129 @@ function makeRun(workflow: WorkflowRunRecord["workflow"]): WorkflowRunRecord {
     steps: [],
   };
 }
+
+describe("WorkflowRunHeader planned stages", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installDom();
+  });
+
+  afterEach(() => {
+    cleanup();
+    cleanupDom?.();
+    cleanupDom = null;
+  });
+
+  function renderHeader(overrides: Partial<WorkflowRunRecord>) {
+    const run = {
+      ...makeRun({
+        name: "staged-workflow",
+        description: "Staged workflow",
+        scope: "project",
+        executable: true,
+      }),
+      ...overrides,
+    };
+    return render(
+      <APIContext.Provider
+        value={{
+          status: "connecting",
+          api: null,
+          error: null,
+          authenticate: () => undefined,
+          retry: () => undefined,
+        }}
+      >
+        <WorkflowRunHeader workspaceId={run.workspaceId} run={run} view={projectWorkflowRun(run)} />
+      </APIContext.Provider>
+    );
+  }
+
+  test.each(["unstarted", "first-phase", "terminal"])(
+    "starts compact and retains all stage details independently of execution: %s",
+    (state) => {
+      const stages = [
+        { name: "foundation", role: "Architect", brief: "Establish the baseline" },
+        { name: "implementation", role: "Builder", brief: "Implement the change" },
+        { name: "verification", role: "Reviewer", brief: "Check the result" },
+      ];
+      const { getByRole, container } = renderHeader({
+        args: { contract: "Preserve existing behavior", stages },
+        status: state === "terminal" ? "completed" : "running",
+        events:
+          state === "unstarted"
+            ? []
+            : [{ sequence: 1, type: "phase", at: "2026-05-29T00:00:00.000Z", name: "foundation" }],
+      });
+      const disclosure = container.querySelector("details");
+      expect(disclosure).not.toBeNull();
+      expect(disclosure!.open).toBe(false);
+      const summary = disclosure!.querySelector("summary")!;
+      stages.forEach((stage) => {
+        expect(summary.textContent).toContain(stage.name);
+        expect(summary.textContent).not.toContain(stage.role);
+        expect(summary.textContent).not.toContain(stage.brief);
+      });
+      // Native disclosure interaction and CSS visibility are verified in Storybook/browser checks.
+      disclosure!.open = true;
+      const list = getByRole("list", { name: "Planned stages" });
+      expect(disclosure!.contains(list)).toBe(true);
+      expect(list.tagName).toBe("OL");
+      const items = within(list).getAllByRole("listitem");
+      expect(items).toHaveLength(stages.length);
+      stages.forEach((stage, index) => {
+        expect(items[index].textContent).toContain(stage.name);
+        expect(items[index].textContent).toContain(stage.role);
+        expect(items[index].textContent).toContain(stage.brief);
+      });
+      expect(container.textContent).toContain("Preserve existing behavior");
+      expect(container.textContent).toContain("0/0 steps");
+      expect(list.textContent).not.toMatch(/running|completed|pending/i);
+      expect(disclosure!.querySelector("details")?.open).toBe(false);
+    }
+  );
+
+  test("expands inert briefs and preserves unknown fields in original arguments", () => {
+    const name = '<img src=x onerror="alert(1)">';
+    const brief = `<script>alert(1)</script> ${"long brief ".repeat(60)}`;
+    const stages = [Object.freeze({ name, role: "<b>Reviewer</b>", brief, extra: { keep: true } })];
+    const { container, getByRole, getByLabelText } = renderHeader({
+      args: Object.freeze({ stages: Object.freeze(stages) }),
+    });
+    const disclosure = container.querySelector("details");
+    expect(disclosure).not.toBeNull();
+    expect(disclosure!.querySelector("summary")!.textContent).toContain(name);
+    disclosure!.open = true;
+    const list = getByRole("list", { name: "Planned stages" });
+    expect(list.textContent).toContain(name);
+    expect(list.textContent).toContain("<b>Reviewer</b>");
+    expect(list.textContent).not.toContain(brief);
+    const expand = getByLabelText(`Show more of Stage 1: ${name}`);
+    expect(expand.getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(expand);
+    expect(expand.getAttribute("aria-expanded")).toBe("true");
+    expect(list.textContent).toContain(brief);
+    fireEvent.click(expand);
+    expect(list.textContent).not.toContain(brief);
+
+    const raw = disclosure!.querySelector("details");
+    expect(raw).not.toBeNull();
+    // Native details keyboard behavior is covered in the real-browser story.
+    raw!.open = true;
+    fireEvent.click(getByLabelText("Show more of Argument: stages"));
+    expect(raw!.textContent).toContain(JSON.stringify(stages));
+    expect(container.querySelector("img, script, b")).toBeNull();
+  });
+
+  test("keeps the whole malformed array on the generic path", () => {
+    const stages = [{ name: "valid", unknown: "preserved" }, { name: 123 }];
+    const { container, queryByRole } = renderHeader({ args: { stages } });
+    expect(queryByRole("list")).toBeNull();
+    expect(container.querySelector("details")).toBeNull();
+    expect(container.textContent).toContain(JSON.stringify(stages));
+  });
+});
 
 describe("getWorkflowRunRerunScriptPath", () => {
   test("returns path-based workflow script paths", () => {

--- a/src/browser/features/RightSidebar/Workflows/WorkflowRunHeader.tsx
+++ b/src/browser/features/RightSidebar/Workflows/WorkflowRunHeader.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Check, Clock, Coins, Play, RotateCcw, Square, Workflow } from "lucide-react";
+import { Check, ChevronRight, Clock, Coins, Play, RotateCcw, Square, Workflow } from "lucide-react";
 
 import { useAPI } from "@/browser/contexts/API";
 import type { WorkflowRunRecord } from "@/common/types/workflow";
@@ -128,17 +128,69 @@ export const WorkflowRunHeader: React.FC<WorkflowRunHeaderProps> = (props) => {
           {view.argEntries.map((entry, index) => (
             <div
               key={entry.key ?? index}
-              className="border-border bg-surface-secondary text-content-secondary flex gap-1.5 rounded-md border px-2 py-1 text-xs"
+              className="border-border bg-surface-secondary text-content-secondary flex min-w-0 gap-1.5 rounded-md border px-2 py-1 text-xs"
             >
-              {entry.key != null && (
-                <span className="text-muted shrink-0 font-mono text-[11px]">{entry.key}</span>
+              {entry.stages != null ? (
+                // Keep the step stream visible until details are requested; launch metadata
+                // describes a plan, not evidence of runtime progress.
+                <details className="group/stages min-w-0 flex-1">
+                  <summary className="focus-visible:outline-accent cursor-pointer list-none rounded focus-visible:outline-2 [&::-webkit-details-marker]:hidden">
+                    <span className="text-muted flex items-center gap-1 font-medium">
+                      <ChevronRight className="h-3 w-3 shrink-0 group-open/stages:rotate-90" />
+                      <span>Planned stages</span>
+                      <span className="counter-nums">· {entry.stages.length}</span>
+                    </span>
+                    <span className="text-content-primary mt-1 flex flex-wrap gap-x-3 gap-y-1 group-open/stages:hidden">
+                      {entry.stages.map((stage, stageIndex) => (
+                        <span key={stageIndex} className="max-w-full min-w-0 break-words">
+                          <span className="text-muted counter-nums">{stageIndex + 1}.</span>{" "}
+                          {stage.name}
+                        </span>
+                      ))}
+                    </span>
+                  </summary>
+                  <ol
+                    aria-label="Planned stages"
+                    className="counter-nums mt-2 list-decimal space-y-2 pl-5"
+                  >
+                    {entry.stages.map((stage, stageIndex) => (
+                      <li key={stageIndex} className="min-w-0 space-y-0.5 break-words">
+                        <div className="text-content-primary font-medium">{stage.name}</div>
+                        {stage.role && <div className="text-muted">{stage.role}</div>}
+                        {stage.brief && (
+                          <WorkflowLongText
+                            text={stage.brief}
+                            title={`Stage ${stageIndex + 1}: ${stage.name}`}
+                          />
+                        )}
+                      </li>
+                    ))}
+                  </ol>
+                  <details className="group mt-2 min-w-0">
+                    <summary className="text-muted hover:text-foreground focus-visible:outline-accent flex cursor-pointer list-none items-center gap-1 rounded focus-visible:outline-2 [&::-webkit-details-marker]:hidden">
+                      <ChevronRight className="h-3 w-3 shrink-0 group-open:rotate-90" />
+                      Original argument
+                    </summary>
+                    <WorkflowLongText
+                      className="mt-1"
+                      text={entry.value}
+                      title="Argument: stages"
+                    />
+                  </details>
+                </details>
+              ) : (
+                <>
+                  {entry.key != null && (
+                    <span className="text-muted shrink-0 font-mono text-[11px]">{entry.key}</span>
+                  )}
+                  {/* Long values preview-truncate; expand inline or open the full view. */}
+                  <WorkflowLongText
+                    className="flex-1"
+                    text={entry.value}
+                    title={entry.key != null ? `Argument: ${entry.key}` : "Workflow argument"}
+                  />
+                </>
               )}
-              {/* Long values (often full prompts) preview-truncate; expand inline or open the full view. */}
-              <WorkflowLongText
-                className="flex-1"
-                text={entry.value}
-                title={entry.key != null ? `Argument: ${entry.key}` : "Workflow argument"}
-              />
             </div>
           ))}
         </div>

--- a/src/browser/features/RightSidebar/Workflows/projectWorkflowRun.test.ts
+++ b/src/browser/features/RightSidebar/Workflows/projectWorkflowRun.test.ts
@@ -38,6 +38,75 @@ function makeRun(overrides: Partial<WorkflowRunRecord>): WorkflowRunRecord {
   };
 }
 
+describe("planned stage argument projection", () => {
+  test("preserves order, duplicate names, optional fields and the entire frozen input", () => {
+    const stages = Object.freeze([
+      Object.freeze({
+        name: " foundation ",
+        role: "Architect",
+        brief: "Build the base",
+        extra: 42,
+      }),
+      Object.freeze({ name: " foundation " }),
+      Object.freeze({ name: "implement", role: undefined, brief: undefined }),
+      Object.freeze({ name: "verify", role: "", brief: "" }),
+    ] as const);
+    const args = Object.freeze({ contract: "No regressions", stages });
+    const run = makeRun({ args });
+    const before = JSON.stringify(run);
+    const view = projectWorkflowRun(run);
+    expect(view.argEntries.map((entry) => entry.key)).toEqual(["contract", "stages"]);
+    expect(view.argEntries[0]).toEqual({ key: "contract", value: args.contract });
+    const entry = view.argEntries[1];
+    expect(entry.stages?.map((stage) => stage.name)).toEqual(stages.map((stage) => stage.name));
+    expect(entry.stages?.[0]).toEqual({
+      name: stages[0].name,
+      role: stages[0].role,
+      brief: stages[0].brief,
+    });
+    expect(entry.value).toBe(JSON.stringify(stages));
+    expect(run.args).toBe(args);
+    expect(JSON.stringify(run)).toBe(before);
+    expect(view.phases).toEqual([]);
+    expect(view.stats.total).toBe(0);
+  });
+
+  test.each(
+    [
+      null,
+      {},
+      [],
+      '[{"name":"foundation"}]',
+      ["foundation"],
+      [{ name: "valid" }, null],
+      [{ name: "valid" }, []],
+      [{ name: "valid" }, {}],
+      [{ name: "valid" }, { name: "  " }],
+      [{ name: "valid" }, { name: 123 }],
+      [{ name: "valid" }, { name: "invalid", role: null }],
+      [{ name: "invalid", role: 1 }],
+      [{ name: "invalid", brief: null }],
+      [{ name: "invalid", brief: [] }],
+      Array.from({ length: 2 }, (_, index) => (index === 0 ? { name: "valid" } : undefined)),
+      Object.assign(new Array<unknown>(2), { 0: { name: "valid" } }),
+    ].map((stages) => ({ stages }))
+  )("falls back for the entire unsupported value: %j", ({ stages }) => {
+    const entry = projectWorkflowRun(makeRun({ args: { stages } })).argEntries[0];
+    expect(entry).not.toHaveProperty("stages");
+    expect(entry.value).toBe(
+      stages == null ? "" : typeof stages === "string" ? stages : JSON.stringify(stages)
+    );
+  });
+
+  test("does not specialize other keys or positional arrays", () => {
+    const stages = [{ name: "foundation" }];
+    const named = projectWorkflowRun(makeRun({ args: { steps: stages } }));
+    const positional = projectWorkflowRun(makeRun({ args: stages }));
+    expect(named.argEntries).toEqual([{ key: "steps", value: JSON.stringify(stages) }]);
+    expect(positional.argEntries).toEqual([{ key: null, value: JSON.stringify(stages) }]);
+  });
+});
+
 // A representative in-flight deep-research run: scope → search-fetch (fan-out)
 // → verify (one still running) → synthesize (announced, no steps yet).
 function makeRunningResearchRun(): WorkflowRunRecord {

--- a/src/browser/features/RightSidebar/Workflows/projectWorkflowRun.ts
+++ b/src/browser/features/RightSidebar/Workflows/projectWorkflowRun.ts
@@ -96,6 +96,7 @@ export interface WorkflowArgEntry {
   /** null for a single positional/primitive arg with no name. */
   key: string | null;
   value: string;
+  stages?: Array<{ name: string; role?: string; brief?: string }>;
 }
 
 export interface WorkflowRunView {
@@ -149,12 +150,42 @@ export function stringifyWorkflowArgValue(value: unknown): string {
   }
 }
 
+function derivePlannedStages(value: unknown): WorkflowArgEntry["stages"] {
+  if (!Array.isArray(value) || value.length === 0) return undefined;
+  const items: unknown[] = value;
+  const stages: NonNullable<WorkflowArgEntry["stages"]> = [];
+  for (const item of items) {
+    if (
+      item == null ||
+      typeof item !== "object" ||
+      Array.isArray(item) ||
+      !("name" in item) ||
+      typeof item.name !== "string" ||
+      item.name.trim().length === 0
+    ) {
+      return undefined;
+    }
+    const role = "role" in item ? item.role : undefined;
+    const brief = "brief" in item ? item.brief : undefined;
+    if (
+      (role !== undefined && typeof role !== "string") ||
+      (brief !== undefined && typeof brief !== "string")
+    ) {
+      return undefined;
+    }
+    stages.push({ name: item.name, role, brief });
+  }
+  return stages;
+}
+
 function deriveArgEntries(args: unknown): WorkflowArgEntry[] {
   if (args != null && typeof args === "object" && !Array.isArray(args)) {
-    return Object.entries(args as Record<string, unknown>).map(([key, value]) => ({
-      key,
-      value: stringifyWorkflowArgValue(value),
-    }));
+    return Object.entries(args as Record<string, unknown>).map(([key, value]) => {
+      const entry: WorkflowArgEntry = { key, value: stringifyWorkflowArgValue(value) };
+      const stages = key === "stages" ? derivePlannedStages(value) : undefined;
+      if (stages != null) entry.stages = stages;
+      return entry;
+    });
   }
   const value = stringifyWorkflowArgValue(args);
   return value.length > 0 ? [{ key: null, value }] : [];

--- a/src/browser/stories/App.workflows.stories.tsx
+++ b/src/browser/stories/App.workflows.stories.tsx
@@ -1,0 +1,482 @@
+import { wrapAsyncIterator } from "@orpc/shared";
+import { expect, userEvent, waitFor, within } from "@storybook/test";
+
+import { updatePersistedState } from "@/browser/hooks/usePersistedState";
+import { getDefaultRightSidebarLayoutState } from "@/browser/utils/rightSidebarLayout";
+import { EXPERIMENT_IDS, getExperimentKey } from "@/common/constants/experiments";
+import {
+  LEFT_SIDEBAR_COLLAPSED_KEY,
+  RIGHT_SIDEBAR_COLLAPSED_KEY,
+  RIGHT_SIDEBAR_TAB_KEY,
+  RIGHT_SIDEBAR_WIDTH_KEY,
+  getRightSidebarLayoutKey,
+} from "@/common/constants/storage";
+import type { WorkflowRunRecord, WorkflowRunStreamEvent } from "@/common/types/workflow";
+import { createAsyncMessageQueue } from "@/common/utils/asyncMessageQueue";
+
+import { setupSimpleChatStory } from "./helpers/chatSetup";
+import { appMeta, AppWithMocks, type AppStory } from "./meta.js";
+import { createAssistantMessage, createUserMessage } from "./mocks/messages";
+import { waitForChatInputAutofocusDone } from "./storyPlayHelpers.js";
+
+export default {
+  ...appMeta,
+  title: "App/Workflows",
+  beforeEach: () => () => {
+    updatePersistedState(getExperimentKey(EXPERIMENT_IDS.DYNAMIC_WORKFLOWS), undefined);
+  },
+  parameters: {
+    ...appMeta.parameters,
+    viewport: {
+      options: {
+        phone390: {
+          name: "Phone 390",
+          styles: { width: "390px", height: "844px" },
+          type: "mobile",
+        },
+        laptop1200: {
+          name: "Laptop 1200",
+          styles: { width: "1200px", height: "900px" },
+          type: "desktop",
+        },
+      },
+    },
+  },
+};
+
+const WORKSPACE_ID = "ws-planned-stages";
+const CREATED_AT = "2026-05-29T12:00:00.000Z";
+const STARTED_AT = "2026-05-29T12:00:02.000Z";
+const UPDATED_AT = "2026-05-29T12:00:08.000Z";
+const COMPLETED_AT = "2026-05-29T12:00:18.000Z";
+const CONTRACT = "Restore structured workflow-stage presentation without changing execution.";
+const STAGES = [
+  {
+    name: "foundation",
+    role: "Implementation engineer",
+    brief:
+      "Build the presentation seam while retaining the original workflow arguments. " +
+      "Keep the runtime phase stream authoritative: planned work is not proof of execution. ".repeat(
+        5
+      ) +
+      "Foundation acceptance: every original input remains available.",
+  },
+  {
+    name: "verification",
+    role: "Independent reviewer",
+    brief:
+      "Exercise recognized stages, unsupported shapes, duplicate names, and long content. " +
+      "Verify that no planned stage acquires an inferred execution status. ".repeat(5) +
+      "Verification acceptance: malformed arrays fall back as a whole.",
+  },
+  {
+    name: "delivery",
+    role: "Release coordinator",
+    brief:
+      "Review the full application at desktop and phone widths before delivering the change. " +
+      "Keep the contract readable and retain access to raw arguments and full briefs. ".repeat(5) +
+      "Delivery acceptance: capture the final visual evidence.",
+  },
+];
+
+const RUN: WorkflowRunRecord = {
+  id: "wfr_planned_stages_story",
+  workspaceId: WORKSPACE_ID,
+  workflow: {
+    name: "staged-implementation",
+    description: "Implement, verify, and deliver a bounded change",
+    scope: "project",
+    sourceKind: "inline",
+    executable: true,
+  },
+  source: "export default function workflow() { return null; }",
+  sourceHash: "sha256:planned-stages-story",
+  args: { contract: CONTRACT, stages: STAGES },
+  status: "running",
+  createdAt: CREATED_AT,
+  updatedAt: UPDATED_AT,
+  events: [
+    { sequence: 1, type: "status", at: CREATED_AT, status: "running" },
+    { sequence: 2, type: "phase", at: STARTED_AT, name: "foundation" },
+    {
+      sequence: 3,
+      type: "task",
+      at: STARTED_AT,
+      stepId: "implement-presentation",
+      taskId: "task_planned_stages_implementation",
+      status: "started",
+      title: "Implement stage presentation",
+    },
+  ],
+  steps: [
+    {
+      stepId: "implement-presentation",
+      inputHash: "sha256:planned-stages-implementation",
+      status: "started",
+      taskId: "task_planned_stages_implementation",
+      startedAt: STARTED_AT,
+    },
+  ],
+};
+
+// Each story owns its feed; updates use the real snapshot/run-changed protocol rather
+// than replacing React props or adding a product-only API for the interaction test.
+function createWorkflowFixture(initialRun: WorkflowRunRecord, sidebarWidth = 480) {
+  let currentRun = initialRun;
+  const listeners = new Set<(event: WorkflowRunStreamEvent) => void>();
+
+  return {
+    publish(run: WorkflowRunRecord) {
+      currentRun = run;
+      for (const listener of listeners) listener({ type: "run-changed", run });
+    },
+    setup: () => {
+      currentRun = initialRun;
+      const client = setupSimpleChatStory({
+        workspaceId: WORKSPACE_ID,
+        workspaceName: "stage-presentation",
+        projectName: "mux",
+        messages: [
+          createUserMessage("stages-user", CONTRACT, {
+            historySequence: 1,
+            timestamp: Date.parse(CREATED_AT),
+          }),
+          createAssistantMessage(
+            "stages-assistant",
+            "The workflow is available in the Workflows panel. Its launch plan is separate from the live step stream.",
+            { historySequence: 2, timestamp: Date.parse(STARTED_AT) }
+          ),
+        ],
+      });
+      updatePersistedState(getExperimentKey(EXPERIMENT_IDS.DYNAMIC_WORKFLOWS), true);
+      updatePersistedState(LEFT_SIDEBAR_COLLAPSED_KEY, true);
+      updatePersistedState(RIGHT_SIDEBAR_COLLAPSED_KEY, false);
+      updatePersistedState(RIGHT_SIDEBAR_TAB_KEY, "workflows");
+      updatePersistedState(RIGHT_SIDEBAR_WIDTH_KEY, sidebarWidth);
+      updatePersistedState(
+        getRightSidebarLayoutKey(WORKSPACE_ID),
+        getDefaultRightSidebarLayoutState("workflows")
+      );
+      client.workflows.listScripts = () => Promise.resolve([]);
+      client.workflows.listRuns = () => Promise.resolve([]);
+      client.workflows.getRun = () => Promise.resolve(currentRun);
+      client.workflows.subscribe = (_input, options) => {
+        const queue = createAsyncMessageQueue<WorkflowRunStreamEvent>();
+        listeners.add(queue.push);
+        queue.push({ type: "snapshot", runs: [currentRun] });
+        const signal = options?.signal;
+        signal?.addEventListener("abort", queue.end, { once: true });
+        if (signal?.aborted) queue.end();
+        async function* iterate() {
+          try {
+            yield* queue.iterate();
+          } finally {
+            listeners.delete(queue.push);
+            signal?.removeEventListener("abort", queue.end);
+          }
+        }
+        return Promise.resolve(wrapAsyncIterator(iterate(), {}));
+      };
+      return client;
+    },
+  };
+}
+
+const COMPLETED_RUN: WorkflowRunRecord = {
+  ...RUN,
+  status: "completed",
+  updatedAt: COMPLETED_AT,
+  events: [
+    ...RUN.events,
+    {
+      sequence: 4,
+      type: "task",
+      at: COMPLETED_AT,
+      stepId: "implement-presentation",
+      taskId: "task_planned_stages_implementation",
+      status: "completed",
+      title: "Implement stage presentation",
+    },
+    { sequence: 5, type: "status", at: COMPLETED_AT, status: "completed" },
+  ],
+  steps: RUN.steps.map((step) => ({ ...step, status: "completed", completedAt: COMPLETED_AT })),
+};
+const noPhaseFixture = createWorkflowFixture({
+  ...RUN,
+  events: [{ sequence: 1, type: "status", at: CREATED_AT, status: "running" }],
+  steps: [],
+});
+const completedFixture = createWorkflowFixture(COMPLETED_RUN);
+const liveFixture = createWorkflowFixture(RUN);
+const LONG_STAGES = [
+  {
+    name: `foundation-${"unbroken".repeat(30)}`,
+    role: `reviewer-${"unbroken".repeat(25)}`,
+    brief: "brief-without-whitespace-".repeat(40),
+    reviewMetadata: { approvalsRequired: 2, preserveUnknownFields: true },
+  },
+  STAGES[1],
+  STAGES[2],
+];
+const NARROW_SIDEBAR_WIDTH = 340;
+const narrowFixture = createWorkflowFixture(
+  { ...RUN, args: { contract: CONTRACT, stages: LONG_STAGES } },
+  NARROW_SIDEBAR_WIDTH
+);
+const MALFORMED_STAGES = [STAGES[0], { name: "unsupported", role: 7 }, STAGES[2]];
+const malformedFixture = createWorkflowFixture({
+  ...RUN,
+  args: { contract: CONTRACT, stages: MALFORMED_STAGES },
+});
+
+async function expectCompactStages(
+  canvasElement: HTMLElement,
+  stages: Array<{ name: string; role: string }>
+) {
+  const label = await within(canvasElement).findByText("Planned stages", { selector: "span" });
+  const summary = label.closest("summary");
+  const details = summary?.closest("details");
+  if (!summary || !details) throw new Error("Planned stages must use a native disclosure");
+  await waitFor(() => expect(summary).toBeVisible());
+  await expect(details).not.toHaveAttribute("open");
+  const list = within(details).getByRole("list", { hidden: true });
+  await expect(list).not.toBeVisible();
+  for (const [index, stage] of stages.entries()) {
+    await expect(within(summary).getByText(stage.name, { exact: false })).toBeVisible();
+    await expect(within(list).getByText(stage.role, { exact: true })).not.toBeVisible();
+    await expect(
+      within(details).getByRole("button", {
+        name: `Open Stage ${index + 1}: ${stage.name} in full view`,
+      })
+    ).not.toBeVisible();
+  }
+  return summary;
+}
+
+async function expectPlannedStages(
+  canvasElement: HTMLElement,
+  stages: Array<{ name: string; role: string }>
+) {
+  const list = await within(canvasElement).findByRole("list", { name: "Planned stages" });
+  await waitFor(() => expect(list).toBeVisible());
+  await expect(list.tagName).toBe("OL");
+  const items = within(list).getAllByRole("listitem");
+  await expect(items).toHaveLength(stages.length);
+  for (const [index, stage] of stages.entries()) {
+    await expect(within(items[index]).getByText(stage.name, { exact: true })).toBeVisible();
+    await expect(within(items[index]).getByText(stage.role, { exact: true })).toBeVisible();
+  }
+  await expect(within(list).queryByText(/^(running|completed|pending)$/i)).not.toBeInTheDocument();
+  return list;
+}
+
+async function expectRawStages(canvasElement: HTMLElement, stages: unknown[]) {
+  const canvas = within(canvasElement);
+  const summary = canvas.getByText("Original argument", { selector: "summary" });
+  // user-event does not emulate native summary keyboard activation; dogfood covers Enter/Space.
+  await expect(summary.parentElement).not.toHaveAttribute("open");
+  summary.focus();
+  await expect(summary).toHaveFocus();
+  await userEvent.click(summary);
+  await expect(summary.parentElement).toHaveAttribute("open");
+  await userEvent.click(canvas.getByRole("button", { name: "Open Argument: stages in full view" }));
+  const page = within(canvasElement.ownerDocument.body);
+  const dialog = await page.findByRole("dialog", { name: "Argument: stages" });
+  const json = within(dialog).getByText((text) => text.startsWith("[")).textContent;
+  await expect(JSON.parse(json ?? "null")).toEqual(stages);
+  await userEvent.click(within(dialog).getByRole("button", { name: /^Close$/ }));
+  await waitFor(() => expect(page.queryByRole("dialog")).not.toBeInTheDocument());
+  summary.focus();
+  await expect(summary).toHaveFocus();
+  await userEvent.click(summary);
+  await expect(summary.parentElement).not.toHaveAttribute("open");
+}
+
+const runningFixture = createWorkflowFixture(RUN);
+
+export const PlannedStages: AppStory = {
+  globals: { viewport: { value: "laptop1200", isRotated: false } },
+  parameters: { pixel: { matrix: { viewports: ["laptop"] } } },
+  render: () => <AppWithMocks setup={runningFixture.setup} />,
+  play: async ({ canvasElement }) => {
+    await waitForChatInputAutofocusDone(canvasElement);
+    const summary = await expectCompactStages(canvasElement, STAGES);
+    await userEvent.click(summary);
+    await expectPlannedStages(canvasElement, STAGES);
+    await userEvent.click(summary);
+    await expectCompactStages(canvasElement, STAGES);
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("0/1 steps")).toBeVisible();
+    await expect(canvas.getByText("Step stream")).toBeVisible();
+    const phase = canvas.getByRole("button", { name: /^foundation/ });
+    await expect(phase).toHaveAttribute("aria-expanded", "false");
+    await userEvent.click(phase);
+    await expect(canvas.getByText("Implement stage presentation")).toBeVisible();
+  },
+};
+
+export const PlannedStagesExpanded: AppStory = {
+  ...PlannedStages,
+  play: async ({ canvasElement }) => {
+    await waitForChatInputAutofocusDone(canvasElement);
+    const summary = await expectCompactStages(canvasElement, STAGES);
+    await userEvent.click(summary);
+    await expectPlannedStages(canvasElement, STAGES);
+  },
+};
+
+export const PlannedStagesPhone: AppStory = {
+  ...PlannedStages,
+  globals: { viewport: { value: "phone390", isRotated: false } },
+  parameters: { pixel: { matrix: { viewports: ["phone"] } } },
+  play: async ({ canvasElement, parameters, globals }) => {
+    await waitForChatInputAutofocusDone(canvasElement);
+    const canvas = within(canvasElement);
+    await expect(parameters).toMatchObject({ pixel: { matrix: { viewports: ["phone"] } } });
+    await expect(globals).toMatchObject({ viewport: { value: "phone390" } });
+    await waitFor(() =>
+      expect(canvas.getByRole("log", { name: "Conversation transcript" })).toBeVisible()
+    );
+    const sidebar = canvasElement.querySelector('[aria-label="Workspace insights"]');
+    await expect(sidebar).toBeInTheDocument();
+    // The real app hides this whole panel on phones. The test-runner does not
+    // apply viewport globals, so only assert hidden at an actual phone width.
+    if (window.innerWidth <= 390 || canvasElement.getBoundingClientRect().width <= 390) {
+      await expect(sidebar).not.toBeVisible();
+      await expect(canvas.queryByRole("list", { name: "Planned stages" })).not.toBeInTheDocument();
+    } else {
+      await expect(sidebar).toBeVisible();
+    }
+  },
+};
+
+export const PlannedStagesBeforeExecution: AppStory = {
+  ...PlannedStages,
+  render: () => <AppWithMocks setup={noPhaseFixture.setup} />,
+  play: async ({ canvasElement }) => {
+    await waitForChatInputAutofocusDone(canvasElement);
+    const summary = await expectCompactStages(canvasElement, STAGES);
+    await userEvent.click(summary);
+    await expectPlannedStages(canvasElement, STAGES);
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("0/0 steps")).toBeVisible();
+    await expect(canvas.getByText("No steps yet.")).toBeVisible();
+    await expect(canvas.queryByRole("button", { name: /^foundation/ })).not.toBeInTheDocument();
+  },
+};
+
+export const PlannedStagesCompleted: AppStory = {
+  ...PlannedStages,
+  render: () => <AppWithMocks setup={completedFixture.setup} />,
+  play: async ({ canvasElement }) => {
+    await waitForChatInputAutofocusDone(canvasElement);
+    const summary = await expectCompactStages(canvasElement, STAGES);
+    await userEvent.click(summary);
+    await expectPlannedStages(canvasElement, STAGES);
+    await expect(within(canvasElement).getByText("1/1 steps")).toBeVisible();
+    await expect(
+      within(canvasElement).queryByRole("button", { name: "Interrupt" })
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const PlannedStagesNarrowSidebar: AppStory = {
+  ...PlannedStages,
+  render: () => <AppWithMocks setup={narrowFixture.setup} />,
+  play: async ({ canvasElement, parameters, globals }) => {
+    await waitForChatInputAutofocusDone(canvasElement);
+    const summary = await expectCompactStages(canvasElement, LONG_STAGES);
+    await expect(parameters).toMatchObject({ pixel: { matrix: { viewports: ["laptop"] } } });
+    await expect(globals).toMatchObject({ viewport: { value: "laptop1200" } });
+    const sidebar = within(canvasElement).getByRole("complementary", {
+      name: "Workspace insights",
+    });
+    const expectNoOverflow = async (content: HTMLElement) => {
+      await waitFor(async () => {
+        await expect(sidebar.getBoundingClientRect().width).toBe(NARROW_SIDEBAR_WIDTH);
+        await expect(content.getBoundingClientRect().right).toBeLessThanOrEqual(
+          sidebar.getBoundingClientRect().right
+        );
+        await expect(content.scrollWidth).toBeLessThanOrEqual(content.clientWidth);
+      });
+    };
+    await expectNoOverflow(summary);
+    await userEvent.click(summary);
+    const list = await expectPlannedStages(canvasElement, LONG_STAGES);
+    await expectNoOverflow(list);
+    await expectRawStages(canvasElement, LONG_STAGES);
+    await userEvent.click(summary);
+    await expectCompactStages(canvasElement, LONG_STAGES);
+    await expectNoOverflow(summary);
+    within(canvasElement).getByText(RUN.workflow.name, { exact: true }).scrollIntoView();
+  },
+};
+
+export const PlannedStagesMalformedFallback: AppStory = {
+  ...PlannedStages,
+  render: () => <AppWithMocks setup={malformedFixture.setup} />,
+  play: async ({ canvasElement }) => {
+    await waitForChatInputAutofocusDone(canvasElement);
+    const canvas = within(canvasElement);
+    const fullView = await canvas.findByRole("button", {
+      name: "Open Argument: stages in full view",
+    });
+    await expect(canvas.queryByRole("list", { name: "Planned stages" })).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByText("Original argument", { selector: "summary" })
+    ).not.toBeInTheDocument();
+    await userEvent.click(fullView);
+    const dialog = await within(canvasElement.ownerDocument.body).findByRole("dialog", {
+      name: "Argument: stages",
+    });
+    const json = within(dialog).getByText((text) => text.startsWith("[")).textContent;
+    await expect(JSON.parse(json ?? "null")).toEqual(MALFORMED_STAGES);
+    await userEvent.click(within(dialog).getByRole("button", { name: /^Close$/ }));
+  },
+};
+
+export const PlannedStagesLiveUpdates: AppStory = {
+  ...PlannedStages,
+  render: () => <AppWithMocks setup={liveFixture.setup} />,
+  play: async ({ canvasElement }) => {
+    await waitForChatInputAutofocusDone(canvasElement);
+    const canvas = within(canvasElement);
+    const summary = await expectCompactStages(canvasElement, STAGES);
+    liveFixture.publish({ ...RUN, updatedAt: COMPLETED_AT });
+    await waitFor(() => expect(canvas.getByText("18s elapsed")).toBeVisible());
+    await expectCompactStages(canvasElement, STAGES);
+    await userEvent.click(summary);
+    const list = await expectPlannedStages(canvasElement, STAGES);
+    await expect(canvas.getByText("0/1 steps")).toBeVisible();
+    const expand = within(list).getByRole("button", { name: "Show more of Stage 1: foundation" });
+    expand.focus();
+    await userEvent.keyboard(" ");
+    await expect(expand).toHaveAttribute("aria-expanded", "true");
+    await expect(within(list).getByText(STAGES[0].brief, { exact: true })).toBeVisible();
+    await userEvent.keyboard(" ");
+    await expect(expand).toHaveAttribute("aria-expanded", "false");
+
+    const fullView = within(list).getByRole("button", {
+      name: "Open Stage 1: foundation in full view",
+    });
+    await userEvent.click(fullView);
+    const page = within(canvasElement.ownerDocument.body);
+    const dialog = await page.findByRole("dialog", { name: "Stage 1: foundation" });
+    await expect(within(dialog).getByText(STAGES[0].brief, { exact: true })).toBeVisible();
+    await userEvent.keyboard("{Escape}");
+    await waitFor(() => expect(page.queryByRole("dialog")).not.toBeInTheDocument());
+    await waitFor(() => expect(fullView).toHaveFocus());
+    await expectRawStages(canvasElement, STAGES);
+
+    await userEvent.click(canvas.getByRole("button", { name: /^foundation/ }));
+    await expect(canvas.getByText("Implement stage presentation")).toBeVisible();
+    const plannedText = list.textContent;
+    liveFixture.publish(COMPLETED_RUN);
+    await waitFor(() => expect(canvas.getByText("1/1 steps")).toBeVisible());
+    await expect(canvas.queryByRole("button", { name: "Interrupt" })).not.toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: /^foundation/ })).toHaveTextContent("1/1");
+    await expect(list.textContent).toBe(plannedText);
+    await expect(summary.closest("details")).toHaveAttribute("open");
+    await expectPlannedStages(canvasElement, STAGES);
+  },
+};


### PR DESCRIPTION
## Summary

Present supported workflow `stages` arguments as a compact, numbered plan instead of a JSON blob. A keyboard-accessible disclosure expands the plan into names, roles, and brief previews while leaving the runtime Step Stream authoritative for execution status.

## Implementation

- Recognize only non-empty top-level `stages` arrays with supported fields. Unsupported arrays fall back as a whole; original arguments and unknown fields remain available without mutation.
- Keep every stage name visible in the compact view, with full details and original JSON available on expansion. No dependency arrows or inferred progress indicators.
- Use the shared dialog trigger to restore focus after Full view closes.
- Add full-app coverage for compact/expanded states, malformed input, live updates, long content, and narrow layouts.

## Validation

After rebasing onto `main`:
- `make static-check` passed, including both TypeScript configurations.
- `bun test src/browser/features/RightSidebar/Workflows/` passed: **84 tests**.
- Focused full-app Storybook interaction suite passed: **8 stories**.
- Independent final review found no blocking issues.

Browser dogfood verified Enter/Space disclosure controls, Escape focus restoration, complete raw input, simulated subscription updates, and no horizontal overflow in a real **340px sidebar**. Phone390 retains the app's existing behavior: the entire right sidebar is hidden. No story-only CSS overrides, live workflows, or model calls were used.

## Visual evidence

### Compact default

![Compact workflow-stage summary](https://github.com/user-attachments/assets/23466665-188f-4680-8ba2-1a7b9e5b971d)

### Expanded details

![Expanded workflow-stage details](https://github.com/user-attachments/assets/b05d6dcf-9c05-4af7-91eb-fb34d200e2cf)

### Keyboard and disclosure walkthrough

https://github.com/user-attachments/assets/63caeb96-0819-407e-95d5-3442776de9e2

## Plan refinements

The follow-up user request made the stage list compact by default. During implementation, phone validation was adjusted to reflect the app's intentionally hidden right sidebar; the renderer's narrow layout is instead exercised in a real 340px sidebar. The reused Full view dialog's focus-return issue was also fixed.

---

<details>
<summary>📋 Implementation Plan</summary>

# Restore structured workflow-stage presentation

## Goal and reported symptom

The Workflows detail panel in the supplied screenshot renders the `stages` argument as a large JSON array of `{ name, role, brief }` objects above the Step Stream. The user expects the richer stage visualization previously added to the app.

Produce a minimal, backward-compatible fix that presents supported stage data clearly while preserving access to full inputs, accurate execution status, and the existing step stream. This is an implementation plan only; no tracked source changes or live-workflow mutations are authorized by this planning task.

## Diagnosis and evidence

Investigated baseline: commit `2a1b5b267`; working tree was clean. No implementation tests or live reproduction have been run during this read-only planning task.

| Location | Verified behavior | Implication |
| --- | --- | --- |
| `src/browser/features/RightSidebar/Workflows/projectWorkflowRun.ts`, `WorkflowArgEntry`, `deriveArgEntries`, `stringifyWorkflowArgValue` | Argument entries contain a string `value`; object/array values use `JSON.stringify`. | `args.stages` loses its structured presentation before reaching the header. |
| `src/browser/features/RightSidebar/Workflows/WorkflowRunHeader.tsx`, argument mapping | Every entry uses `WorkflowLongText`, without a structured-stage branch. | The screenshot follows the current generic rendering path. |
| `src/browser/features/RightSidebar/Workflows/WorkflowTimeline.tsx`, `WorkflowPhaseSection` | The Step Stream renders projected runtime phases and their actual steps. | The richer visualization still exists, but represents execution rather than input arguments. |
| `src/node/services/workflows/WorkflowRunner.ts`, phase event; `projectWorkflowRun.ts`, phase projection | Runtime `phase(...)` announcements and step events establish phase membership. | A declared stage is not proof that a phase started, completed, or will execute. |
| Relevant history: `3f86fa066` (#3624), `82839cafb` (#3975), `e41ba293f` (#3987) | Initial sidebar used generic argument strings; later changes added long-text disclosure and chat workflow cards. | In the inspected path/history this appears to be missing structured argument presentation, not removal of a stage renderer. This does not establish which earlier UI the user recalls. |

**Why this happens:** there is no bridge from the structured launch argument `stages` to the header's visual presentation. The single `foundation` group below the JSON is compatible with only that runtime phase having been announced so far; the screenshot alone cannot prove the exact event history.

## Recommended approach and scope

**Add a small, frontend-only presentation specialization for `args.stages`, recognized from raw values in the existing pure projection.** Retain the generic serialized value, add validated stage summaries, and render them as a compact ordered list in the existing argument position. Keep the Step Stream unchanged and authoritative for execution.

**Estimated net product-code change: +60–100 LoC** across `projectWorkflowRun.ts` and `WorkflowRunHeader.tsx`. Keep rendering inline or in a small local helper; a separate `WorkflowStagesArg.tsx` is unnecessary unless readability demonstrably benefits. Tests, Storybook fixtures, and test-only mock support are excluded. This is an estimate, not a target to fill.

Why this approach:
- Recognition before stringification avoids parsing serialized display text back into data.
- Keeping `value: string` preserves the existing argument-entry contract and full-input access. `WorkflowRunHistory.primaryArgValue` reads `run.args` directly, so leaving that object and the shared stringifier unchanged also preserves history previews.
- A stage list addresses the screenshot without introducing a second execution graph or backend contract.
- Reuse `WorkflowLongText` and existing styles/disclosure behavior instead of building another long-text viewer.

**Non-goals:** changing workflow scheduling, authoring API, persisted records, rerun arguments, phase/status logic, chat tool-call JSON display, or rendering every arbitrary JSON argument as a bespoke widget. No migrations, dependencies, automated scrolling, animations, stage-to-phase matching, or new React effects/manual memoization.

## Presentation contract

### Recognize conservatively; never lose data

1. Specialize only the exact top-level argument key `stages` when its raw value is a non-empty array. This is a local presentation heuristic for the screenshot's shape, **not** a new official workflow schema or a claim that arbitrary workflow args follow a standard stage contract.
2. Every item must be a non-null, non-array object with a nonblank string `name`. `role` and `brief` may be absent/undefined; otherwise require strings (including rejecting null). Empty optional strings may omit the corresponding visual element. Validate blank names with trimming but preserve the original display string. Treat `role` as arbitrary display text (the screenshot uses human role names), not a known agent ID.
3. If any item fails validation, render the **whole argument** using the existing generic `WorkflowLongText` fallback. Do not silently filter malformed items or partially hide the array. A simple `for...of` validator also encounters sparse slots as undefined; do not rely on `.every()` alone, which skips holes. Do not add generalized hostile-object/prototype machinery for this JSON-shaped transport boundary.
4. Empty arrays, JSON-looking strings, alternate keys, primitive stages, and unsupported shapes stay generic. Do not `JSON.parse` strings or invent coercion rules.
5. Preserve original ordering, duplicate stage names, unknown fields, and unmodified original `run.args`. Duplicate names are valid input; use a positional key for this immutable ordered presentation, not name-only keys.
6. Keep the original serialized value for a closed-by-default raw-argument disclosure within the specialized stage section. It must expose **all** data, including unknown fields, through existing long-text/full-view controls. No changes to rerun serialization.
7. Incoming workflow args are untrusted data: validation returns a fallback rather than throwing. Assertions are for internal impossible states, not malformed persisted/model-produced inputs. Avoid `as any`, hidden coercions, and new backend validation.

### Render planned stages, not inferred execution

- Render an accessible ordered list, clearly identified as **Planned stages**. Preserve its position among other argument rows; keep `contract` and other args unchanged.
- Each item shows its sequence, complete name, optional role, and a short brief preview with the existing expand/full-view behavior. Prefer wrapping names/roles so identifiers remain readable; bound the brief by reusing long-text preview logic.
- Do not display running/completed/pending badges or imply the list is a guaranteed serial execution order. Input order is presentation order only. Runtime phases may be repeated, absent, parallel, retried, or named differently.
- Use standard React text nodes for names and roles and the established safe plain-text default for briefs; never introduce raw HTML sinks.
- Use theme tokens, existing numeric typography, and no emoji icons. Ensure `min-w-0`/wrapping for long unbroken strings and no horizontal overflow at a 375–390px viewport or narrow sidebar.
- Every disclosure must be keyboard-operable with visible focus and exposed expanded state. Reuse existing controls; do not invent additional keyboard-shortcut infrastructure for this presentation-only change.

## Implementation sequence and intermediate quality gates

### Phase 1 — Lock down the regression and compatibility contract

Files:
- `src/browser/features/RightSidebar/Workflows/projectWorkflowRun.test.ts`
- `src/browser/features/RightSidebar/Workflows/WorkflowRunHeader.test.tsx`
- Existing `WorkflowLongText.test.tsx`/`WorkflowTimeline.test.tsx` as harness references, not automatic expansion targets.

Add tests at the pure projection and colocated header-render seams before changing product code:
- The screenshot-shaped three-stage array yields an ordered structured list; other argument rows still render normally.
- Every planned stage is visible even with no phase events or only the first runtime phase announced.
- Verify behavior and accessible structure rather than snapshotting exact copy/CSS or asserting hardcoded prose.
- Cover recognized optional fields and the fallback/preservation matrix below.

**Gate 1:** run the new focused regression against the pre-fix code, capture the expected failure, and confirm it fails because the stages render generically—not due to test environment/setup. Add no production changes until that signal is reliable.

### Phase 2 — Preserve structure at projection, then render it

1. In `projectWorkflowRun.ts`, extend `WorkflowArgEntry` minimally with an optional validated stage presentation, retaining `key` and `value`. Keep each stage summary limited to display-safe `name`, `role`, and `brief` strings; use retained `value` for unknown/raw fields rather than spreading arbitrary input properties into the view model. Implement a small pure validator/projector alongside `deriveArgEntries`; do not introduce a generic schema registry.
2. In `deriveArgEntries`, compute stage summaries from the raw value and preserve existing stringification/fallback semantics. Avoid attaching an explicit undefined property to every legacy entry if doing so changes existing equality tests unnecessarily.
3. In `WorkflowRunHeader.tsx`, branch only for recognized stage entries; otherwise retain the current generic path. Place the list and raw disclosure within the stages row without duplicating the entire JSON in the default view.
4. Reuse `WorkflowLongText` with `text`, contextual `title`, and optional `className`; leave `markdown` disabled. Its existing truncation policy (280-character limit plus tolerance), expansion, and full-view dialog handle lengthy briefs/raw JSON; short values render inline without unnecessary controls. For raw input, use a small native `<details><summary>` disclosure following the existing `WorkflowRunToolCall` pattern, with a Lucide chevron and visible focus. Do not export/refactor the tool-card's private helper merely to reuse a few tags. Native disclosure state avoids another effect/hook.
5. Add one concise rationale comment explaining that launch-stage metadata describes a plan and must not fabricate runtime status.
6. Preserve consumer contracts: `WorkflowRunHeader` is the only UI consumer of `argEntries`; projector equality tests and a timeline test fixture also reference it. `WorkflowRunHistory.tsx` reads `run.args` directly and should need no changes. `run.args` remains the source of truth for rerun.

**Gate 2:** targeted projector/header/long-text/timeline tests green; typecheck passes. Review the diff for untouched backend/runtime logic, lossless raw access, safe rendering, and no inferred progress state.

### Phase 3 — Full-app regression coverage and responsive verification

Add **`src/browser/stories/App.workflows.stories.tsx`**, using the existing `./meta.js` import for `AppWithMocks`/app metadata, the `helpers/chatSetup.ts` setup pattern, and `mocks/orpc.ts`. Enable `EXPERIMENT_IDS.DYNAMIC_WORKFLOWS`, uncollapse the sidebar, and select `workflows` through the existing persisted-state/layout helpers in story setup. Reuse valid workflow record and subscription fixtures from the existing `WorkflowsTab.stories.tsx`, typed against the actual `WorkflowRunRecord`; do not invent wire fields. Keep shared mock changes limited to the workflow overrides the full-app fixture actually needs. In play functions, drive disclosures/run selection as a user would.

Do not add another isolated component story. Use `App.phoneViewports.stories.tsx` as the reference for full-app phone sizing and sidebar navigation. Fix IDs/timestamps and any clock used by the fixture so visuals do not drift.

Fixture variants:
- Screenshot-equivalent three-stage input with substantial role/brief text and only the first phase started.
- Same plan before any steps, plus a terminal run, proving plan visibility is independent of runtime phase count.
- Long unbroken names/roles, unknown properties, and malformed-stage fallback.
- Explicit pinned phone390 and desktop/laptop Pixel variants; mirror with `globals.viewport`. Narrow-dependent play assertions must force a narrow wrapper or guard actual width because the Storybook test runner does not apply viewport globals/matrices.

**Gate 3:** Storybook interaction checks pass; inspect through the Storybook manager or equivalent pinned-viewport route, not only a resized iframe. Confirm keyboard behavior, no overflow, and that raw input remains available without overwhelming the default view.

## Behavioral acceptance matrix

| Case | Required outcome |
| --- | --- |
| Screenshot `{ contract, stages: [{ name, role, brief }, ...] }` | Three individually readable planned stages in input order; contract remains generic; no raw array blob in the default stage view. |
| No runtime phases / first phase only / terminal run | Planned list stays complete; existing runtime step counts and status remain unchanged. |
| Missing optional fields; duplicate names | Readable stages; no bogus placeholders, invalid React keys, or deduplication. |
| Invalid/mixed array, null/non-array, empty array, blank name, invalid optional-field types | Entire `stages` arg takes the existing generic route without exceptions or partial data loss. |
| JSON string that resembles stage objects; non-`stages` arrays; primitive args | Existing generic behavior unchanged. |
| Extra per-stage fields | All original fields remain available in raw disclosure/full view; renderer does not mutate the source. |
| Frozen input record | Projection/rendering succeeds without mutation; rerun receives the unchanged original args. |
| HTML-like names/roles/briefs | Text is inert; no injected elements or event-handler execution. |
| Long text, narrow viewport/panel | Readable wrapping/preview, working expansion/full view, no right-edge overflow. |
| Keyboard-only interaction | Logical focus order, operable disclosure/full view, exposed state, and normal focus return. |

## Dogfooding and evidence (required before completion)

1. Use deterministic local workflow fixtures with fixed IDs/timestamps and no paid/model calls. Capture the pre-fix symptom through the full-app fixture before implementing; use the same scenario after the fix.
2. Start Storybook on an available isolated port using the repository's verified Make target. Load the manager at the pinned desktop and phone variants with `agent-browser`; consult `agent-browser skills get core` for installed-version syntax before automation.
3. Record a video of opening the Workflows tab/run, inspecting all planned stages alongside the first runtime phase, expanding/collapsing a brief, opening/closing full view, and revealing original args. Capture desktop and phone screenshots plus the raw/fallback state. Use snapshots to check controls, screenshots to evaluate actual layout, and DOM geometry to catch overflow.
4. Use the full-app mock subscription to deliver a deterministic updated run record and verify the Step Stream changes while all planned stages remain visible. Reuse existing workflow subscription-event shapes, synchronize on actual DOM changes, and avoid sleep-based coordination. This is simulated-stream UI validation, not proof of backend execution.
5. **Optional real-server smoke:** start `make dev-server-sandbox DEV_SERVER_SANDBOX_ARGS="--clean-providers --clean-projects"` as a bounded background task with only a disposable local project/workspace. Do not make live workflow execution a requirement or add APIs just for this renderer fix. Verified limitation: `src/cli/workflow.ts` creates a private temporary backend/workspace; its `--dir` does not select a running app's workspace, and it has no workspace-ID/server-connection flags. A phase-only conductor also produces 0/0 phase groups, not the screenshot's running task. Do not present that CLI run as live UI validation. Never use real credentials or mutate the original run in the screenshot.
6. Save screenshots and video under a workspace-specific directory outside the checkout; attach screenshots and recording with `attach_file`. If publishing evidence to GitHub is separately authorized, upload with native `gh ... --attach`, never cookies or `gh-image`.
7. Stop only the sandbox/Storybook/browser processes created for this task and clean disposable fixtures. Never kill the user's running app.

**Gate 4:** inspect evidence, run the final validation pass after all fixes, and report exact commands/results and any environment blockers. An unavailable browser/test gate must be reported as unverified, not claimed as passed.

## Final validation and delivery

Run these gates from the implementation worktree, recording each command's own exit status:

```bash
# Colocated pure/component tests (use the existing happy-dom setup where needed).
bun test src/browser/features/RightSidebar/Workflows/
make typecheck

# In a separate bounded background task; Makefile defaults to port 6006.
make storybook
# If 6006 is occupied, use the same recipe with an explicitly free port:
# bun x storybook dev -p "$STORYBOOK_PORT" --no-open

# Standard repository interaction gate against default-port Storybook:
make test-storybook
# For the isolated alternate port / focused full-app story run:
# bun x test-storybook --url "$STORYBOOK_URL" --testTimeout 30000 -- App.workflows

make static-check
git diff --check
```

- Start the header's DOM tests with the same `installDom` and teardown convention as neighboring component tests; leave Radix full-view/focus behavior to real-browser Storybook checks if happy-dom cannot represent it. Do not create a second DOM harness.
- No `tests/ui` addition is required for this small renderer branch. If an integration seam is needed, render the full app and use `TEST_INTEGRATION=1 bun x jest <specific-test-file>`, **not** `bun test tests/ui/`. Do not validate API keys for no-AI tests.
- Resolve environment prerequisites in Exec mode only (Bun dependencies/browser installation if absent); report baseline failures separately rather than fixing unrelated code.
- Re-run typecheck after every final lint/format/source change.
- Check `git diff --check`, ensure no accidental fixtures/artifacts/credentials entered the source diff, and review scope/minimality.
- Deliver a concise explanation distinguishing planned arguments from actual runtime phases, the changed files, test results, screenshots, and video. No PR creation, pushing, or unrelated fixes without authorization.

## Advisor review

**APPROVED — `openai:gpt-5.5-pro`, reasoning `xhigh`.** After two empty tool responses, the third advisor consultation reviewed the complete revised plan and returned:

> “APPROVE. I’m confident this plan is ready for implementation; no blocking revisions remain.”

The advisor explicitly endorsed the raw-value projection seam, preserved argument/history/rerun contracts, conservative recognition and generic fallback, separation of planned stages from execution status, raw-data/security handling, red-first tests, responsive full-app dogfooding, and frontend-only scope.

Non-blocking guardrails incorporated: keep summaries limited to display-safe fields; omit `stages: undefined` on legacy entries; keep Storybook router overrides narrow; adjust the focused Storybook filter if required by the installed runner and record the actual successful command.

An independent read-only plan reviewer also approved. Its useful amendments were incorporated: prefer an in-header implementation, tighten the product-code estimate, explicitly handle sparse arrays without overbuilding hostile-object defenses, and keep live-server smoke optional rather than claiming a standalone CLI workflow validates the UI.

**Planning completion:** repository investigation and plan reviews are complete. No production edits, automated implementation tests, or browser dogfood runs were performed; those remain required implementation gates above.

</details>

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `coder:openai/gpt-6-astra` • Thinking: `high` • Cost: `$59.43`_

<!-- mux-attribution: model=coder:openai/gpt-6-astra thinking=high costs=59.43 -->
