### PR TITLE
🤖 refactor: deslop pass 2, remove unused re-exports and single-call alias wrappers

### DIFF
--- a/src/browser/components/Button/Button.tsx
+++ b/src/browser/components/Button/Button.tsx
@@ -97,4 +97,4 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 );
 Button.displayName = "Button";
 
-export { Button, buttonVariants };
+export { Button };

--- a/src/browser/components/ScrollArea/ScrollArea.tsx
+++ b/src/browser/components/ScrollArea/ScrollArea.tsx
@@ -28,18 +28,6 @@ const ScrollArea = React.forwardRef<
 ));
 ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
 
-const ScrollAreaViewport = React.forwardRef<
-  React.ElementRef<typeof ScrollAreaPrimitive.Viewport>,
-  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Viewport>
->(({ className, ...props }, ref) => (
-  <ScrollAreaPrimitive.Viewport
-    ref={ref}
-    className={cn("h-full w-full rounded-[inherit]", className)}
-    {...props}
-  />
-));
-ScrollAreaViewport.displayName = ScrollAreaPrimitive.Viewport.displayName;
-
 const ScrollBar = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
   React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
@@ -59,4 +47,4 @@ const ScrollBar = React.forwardRef<
 ));
 ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;
 
-export { ScrollArea, ScrollAreaViewport, ScrollBar };
+export { ScrollArea };

--- a/src/browser/components/SelectPrimitive/SelectPrimitive.tsx
+++ b/src/browser/components/SelectPrimitive/SelectPrimitive.tsx
@@ -93,18 +93,6 @@ const SelectContent = React.forwardRef<
 ));
 SelectContent.displayName = SelectPrimitive.Content.displayName;
 
-const SelectLabel = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.Label
-    ref={ref}
-    className={cn("py-1.5 pl-6 pr-2 text-xs font-semibold", className)}
-    {...props}
-  />
-));
-SelectLabel.displayName = SelectPrimitive.Label.displayName;
-
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
@@ -128,26 +116,4 @@ const SelectItem = React.forwardRef<
 ));
 SelectItem.displayName = SelectPrimitive.Item.displayName;
 
-const SelectSeparator = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.Separator
-    ref={ref}
-    className={cn("bg-border-medium -mx-1 my-1 h-px", className)}
-    {...props}
-  />
-));
-SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
-
-export {
-  Select,
-  SelectValue,
-  SelectTrigger,
-  SelectContent,
-  SelectLabel,
-  SelectItem,
-  SelectSeparator,
-  SelectScrollUpButton,
-  SelectScrollDownButton,
-};
+export { Select, SelectValue, SelectTrigger, SelectContent, SelectItem };

--- a/src/browser/features/RightSidebar/RightSidebar.tsx
+++ b/src/browser/features/RightSidebar/RightSidebar.tsx
@@ -59,7 +59,6 @@ import {
 } from "@/browser/stores/WorkspaceStore";
 import { shouldAutoActivateWorkflowsTab } from "@/browser/features/RightSidebar/Workflows/workflowDisplay";
 import {
-  RIGHT_SIDEBAR_TABS,
   isTabType,
   isTerminalTab,
   getTerminalSessionId,
@@ -119,9 +118,6 @@ import {
   type DragEndEvent,
 } from "@dnd-kit/core";
 import { SortableContext, rectSortingStrategy } from "@dnd-kit/sortable";
-
-// Re-export for consumers
-export type { ReviewStats };
 
 interface SidebarContainerProps {
   collapsed: boolean;
@@ -201,9 +197,6 @@ const SidebarContainer: React.FC<SidebarContainerProps> = ({
     </div>
   );
 };
-
-export { RIGHT_SIDEBAR_TABS, isTabType };
-export type { TabType };
 
 function getGoalSetErrorMessage(error: GoalSetError): string {
   if (error.type === "goal_conflict") {

--- a/src/browser/features/RightSidebar/Tabs/index.ts
+++ b/src/browser/features/RightSidebar/Tabs/index.ts
@@ -9,30 +9,13 @@
 
 export {
   TAB_REGISTRY,
-  BASE_TAB_IDS,
   isBaseTabId,
-  getTabRegistration,
-  getDefaultLayoutTabIds,
-  getOrderedBaseTabIds,
   type BaseTabType,
-  type TabRegistration,
   type TabPanelContext,
-  type TabLabelContext,
   type ReviewStats,
 } from "./tabRegistry";
 
 export { getTabName, getTabContentClassName } from "./registry";
 
-// Label components are still exported for legacy/test consumers.
-export {
-  StatsTabLabel,
-  OutputTabLabel,
-  ReviewTabLabel,
-  TerminalTabLabel,
-  InstructionsTabLabel,
-  BrowserTabLabel,
-  DebugTabLabel,
-  DesktopTabLabel,
-  GoalTabLabel,
-  WorkflowsTabLabel,
-} from "./TabLabels";
+// Still exported for legacy/test consumers.
+export { TerminalTabLabel } from "./TabLabels";

--- a/src/browser/features/RightSidebar/Tabs/registry.ts
+++ b/src/browser/features/RightSidebar/Tabs/registry.ts
@@ -8,15 +8,10 @@
 
 import type { TabType } from "@/browser/types/rightSidebar";
 import { getTabConfig, isBaseTabId } from "./tabConfig";
-import type {
-  ReviewStats as RegistryReviewStats,
-  TabLabelContext,
-  TabPanelContext,
-} from "./tabRegistry";
+import type { ReviewStats as RegistryReviewStats } from "./tabRegistry";
 
 /** Re-exported review stats type (used by RightSidebar wrapper props). */
 export type ReviewStats = RegistryReviewStats;
-export type { TabPanelContext, TabLabelContext };
 
 /** Configuration for a terminal tab (still special-cased outside the registry). */
 const TERMINAL_TAB_CONTENT_CLASS_NAME = "overflow-hidden p-0";

--- a/src/browser/features/RightSidebar/Tabs/tabRegistry.tsx
+++ b/src/browser/features/RightSidebar/Tabs/tabRegistry.tsx
@@ -42,15 +42,7 @@ import {
   WorkflowsTabLabel,
 } from "./TabLabels";
 
-export {
-  BASE_TAB_IDS,
-  getDefaultLayoutTabIds,
-  getOrderedBaseTabIds,
-  getTabConfig,
-  isBaseTabId,
-  type BaseTabType,
-  type TabConfig,
-} from "./tabConfig";
+export { isBaseTabId, type BaseTabType } from "./tabConfig";
 
 /** Stats reported by ReviewPanel for tab display (kept local to the registry). */
 export interface ReviewStats {
@@ -223,7 +215,3 @@ const TAB_RENDERERS = {
 export const TAB_REGISTRY: Record<BaseTabType, TabRegistration> = Object.fromEntries(
   BASE_TAB_IDS.map((id) => [id, { ...TAB_CONFIG[id], ...TAB_RENDERERS[id] }])
 ) as Record<BaseTabType, TabRegistration>;
-
-export function getTabRegistration(id: BaseTabType): TabRegistration {
-  return TAB_REGISTRY[id];
-}

--- a/src/browser/features/Tools/Shared/codeExecutionTypes.ts
+++ b/src/browser/features/Tools/Shared/codeExecutionTypes.ts
@@ -3,7 +3,6 @@ import type { WorkflowRunToolAttachment } from "@/common/orpc/schemas/message";
 export type {
   CodeExecutionConsoleRecord as ConsoleRecord,
   CodeExecutionResult,
-  CodeExecutionToolCallRecord as ToolCallRecord,
 } from "@/common/types/codeExecution";
 
 /** Nested tool call shape from streaming aggregator */

--- a/src/browser/hooks/useExperiments.ts
+++ b/src/browser/hooks/useExperiments.ts
@@ -9,10 +9,8 @@ import { hasLegacyPtcExclusiveOverride } from "@/browser/contexts/ExperimentsCon
 
 // Re-export reactive hooks from context for convenience
 export {
-  useExperiment,
   useExperimentValue,
   useExperimentOverrideValue,
-  useSetExperiment,
 } from "@/browser/contexts/ExperimentsContext";
 
 /**

--- a/src/browser/types/rightSidebar.ts
+++ b/src/browser/types/rightSidebar.ts
@@ -8,14 +8,7 @@
  * to pattern-match on tab ids.
  */
 
-import {
-  BASE_TAB_IDS,
-  isBaseTabId,
-  type BaseTabType,
-} from "@/browser/features/RightSidebar/Tabs/tabConfig";
-
-/** Runtime list of static (non-terminal) tab ids — useful for iteration. */
-export const RIGHT_SIDEBAR_TABS = BASE_TAB_IDS;
+import { isBaseTabId, type BaseTabType } from "@/browser/features/RightSidebar/Tabs/tabConfig";
 export type { BaseTabType };
 
 /**

--- a/src/browser/utils/goals/resolveGoalSetIntent.ts
+++ b/src/browser/utils/goals/resolveGoalSetIntent.ts
@@ -3,20 +3,10 @@ import type { APIClient } from "@/browser/contexts/API";
 import {
   mergeGoalDefaults,
   resolveGoalSetIntent,
-  resolveModelGoalSetIntent,
-  type GoalSetIntent,
-  type GoalSetIntentInput,
   type WorkspaceGoalDefaultsOverride,
 } from "@/common/utils/goals/resolveGoalSetIntent";
 
-export {
-  mergeGoalDefaults,
-  resolveGoalSetIntent,
-  resolveModelGoalSetIntent,
-  type GoalSetIntent,
-  type GoalSetIntentInput,
-  type WorkspaceGoalDefaultsOverride,
-};
+export { mergeGoalDefaults, resolveGoalSetIntent, type WorkspaceGoalDefaultsOverride };
 
 /**
  * Load *effective* goal defaults via the API client.

--- a/src/browser/utils/imageResize.ts
+++ b/src/browser/utils/imageResize.ts
@@ -2,10 +2,7 @@ import { MAX_IMAGE_DIMENSION } from "@/common/constants/imageAttachments";
 import {
   computeResizedDimensions,
   getResizedRasterOutputMediaType,
-  type ResizeDimensions,
 } from "@/common/utils/attachments/rasterImageResize";
-
-export type { ResizeDimensions };
 
 export interface ResizeResult {
   dataUrl: string;

--- a/src/browser/utils/slashCommands/registry.ts
+++ b/src/browser/utils/slashCommands/registry.ts
@@ -75,9 +75,6 @@ function parseCommandHeaderBody(rawInput: string): CommandHeaderBody {
   };
 }
 
-// Re-export MODEL_ABBREVIATIONS from constants for backwards compatibility
-export { MODEL_ABBREVIATIONS };
-
 // Suggestion helper functions
 function filterAndMapSuggestions<T extends SuggestionDefinition>(
   definitions: readonly T[],

--- a/src/browser/utils/slashCommands/suggestions.ts
+++ b/src/browser/utils/slashCommands/suggestions.ts
@@ -14,8 +14,6 @@ import type {
   SuggestionDefinition,
 } from "./types";
 
-export type { SlashSuggestion } from "./types";
-
 const COMMAND_DEFINITIONS = getSlashCommandDefinitions();
 
 function filterAndMapSuggestions<T extends SuggestionDefinition>(

--- a/src/browser/utils/workflowRunMessages.ts
+++ b/src/browser/utils/workflowRunMessages.ts
@@ -17,7 +17,6 @@ import {
 } from "@/common/utils/workflowRunMessages";
 
 export { buildWorkflowRunCardMessage, filterWorkflowDisplayOnlyMessages };
-export type { WorkflowRunCardInput, WorkflowRunCardResult };
 
 function getLatestWorkflowResult(run: WorkflowRunRecord): unknown {
   return run.events.findLast((event) => event.type === "result")?.result ?? null;

--- a/src/common/constants/muxGovernorOAuth.ts
+++ b/src/common/constants/muxGovernorOAuth.ts
@@ -8,9 +8,6 @@ import {
   MUX_GATEWAY_CLIENT_SECRET,
 } from "@/common/constants/muxGatewayOAuth";
 
-// Re-export gateway credentials for use by governor
-export { MUX_GATEWAY_CLIENT_ID, MUX_GATEWAY_CLIENT_SECRET };
-
 /**
  * Normalize a user-entered URL to an origin (scheme + host + port).
  * Throws if URL is invalid or uses unsupported scheme.

--- a/src/common/orpc/schemas.ts
+++ b/src/common/orpc/schemas.ts
@@ -1,43 +1,14 @@
-// Re-export all schemas from subdirectory modules
-// This file serves as the single entry point for all schema imports
-
-// Result helper
-export { ResultSchema } from "./schemas/result";
+// Schemas re-exported for consumers that import from "@/common/orpc/schemas".
 
 // Runtime schemas
 export {
   RuntimeConfigSchema,
   RuntimeModeSchema,
   RuntimeEnablementIdSchema,
-  RuntimeAvailabilitySchema,
-  RuntimeAvailabilityStatusSchema,
-  DevcontainerConfigInfoSchema,
 } from "./schemas/runtime";
 
 // Project schemas
 export { ProjectConfigSchema, WorkspaceConfigSchema } from "./schemas/project";
-
-// Goal schemas
-export {
-  GoalBoardAddUpcomingInputSchema,
-  GoalBoardArchiveInputSchema,
-  GoalBoardEntrySchema,
-  GoalBoardGetInputSchema,
-  GoalBoardPromoteInputSchema,
-  GoalBoardReorderInputSchema,
-  GoalBoardReviveInputSchema,
-  GoalBoardUpdateUpcomingInputSchema,
-  GoalBoardSectionSchema,
-  GoalBoardSnapshotSchema,
-  GoalBoardV1Schema,
-  GoalClearInputSchema,
-  GoalGetInputSchema,
-  GoalRecordV1Schema,
-  GoalSetErrorSchema,
-  GoalSetInputSchema,
-  GoalSnapshotSchema,
-  GoalStatusSchema,
-} from "./schemas/goal";
 
 // Workspace schemas
 export { WorkspaceAISettingsSchema } from "./schemas/workspaceAiSettings";
@@ -46,7 +17,6 @@ export {
   FrontendWorkspaceMetadataSchema,
   GitStatusSchema,
   ProjectRefSchema,
-  WorkflowTaskMetadataSchema,
   WorkspaceActivitySnapshotSchema,
   WorkspaceGoalDefaultsOverrideSchema,
   WorkspaceHeartbeatSettingsSchema,
@@ -54,46 +24,10 @@ export {
 } from "./schemas/workspace";
 
 // Workspace stats schemas
-export {
-  ActiveStreamStatsSchema,
-  CompletedStreamStatsSchema,
-  ModelTimingStatsSchema,
-  SessionTimingFileSchema,
-  SessionTimingStatsSchema,
-  TimingAnomalySchema,
-  WorkspaceStatsSnapshotSchema,
-} from "./schemas/workspaceStats";
-
-// Analytics schemas
-export {
-  AgentCostRowSchema,
-  EventRowSchema,
-  HistogramBucketSchema,
-  SpendByModelRowSchema,
-  SpendByProjectRowSchema,
-  SpendOverTimeRowSchema,
-  SummaryRowSchema,
-  TimingPercentilesRowSchema,
-} from "./schemas/analytics";
-export type {
-  AgentCostRow,
-  EventRow,
-  HistogramBucket,
-  SpendByModelRow,
-  SpendByProjectRow,
-  SpendOverTimeRow,
-  SummaryRow,
-  TimingPercentilesRow,
-} from "./schemas/analytics";
+export { WorkspaceStatsSnapshotSchema } from "./schemas/workspaceStats";
 
 // Chat stats schemas
-export {
-  ChatStatsSchema,
-  ChatUsageComponentSchema,
-  ChatUsageDisplaySchema,
-  SessionUsageFileSchema,
-  TokenConsumerSchema,
-} from "./schemas/chatStats";
+export { ChatStatsSchema, TokenConsumerSchema } from "./schemas/chatStats";
 
 // Agent Skill schemas
 export {
@@ -108,19 +42,9 @@ export {
   resolveSkillWhenToUse,
 } from "./schemas/agentSkill";
 
-// Agent Plugins schemas (contributed slash commands + composition inspector)
-export {
-  PluginSlashCommandDescriptorSchema,
-  WorkspaceCompositionDiagnosticSchema,
-  WorkspaceCompositionEntrySchema,
-  WorkspaceCompositionPluginSchema,
-  WorkspaceCompositionSchema,
-} from "./schemas/agentPlugins";
-
 // Workflow schemas
 export {
   AvailableWorkflowSchema,
-  JsonValueSchema,
   StructuredTaskOutputSchema,
   WorkflowArgSummarySchema,
   WorkflowScriptDescriptorSchema,
@@ -138,17 +62,6 @@ export {
   WorkflowStepStatusSchema,
 } from "./schemas/workflow";
 
-// Instruction context schemas (AGENTS.md, CLAUDE.md, …)
-export {
-  AdditionalSystemContextSchema,
-  INSTRUCTION_SCOPE,
-  InstructionFileSchema,
-  InstructionScopeSchema,
-  InstructionSetSchema,
-  InstructionSourcesSchema,
-  WorkspaceInstructionsSchema,
-} from "./schemas/instructions";
-
 // Error schemas
 // Agent Definition schemas
 export {
@@ -165,23 +78,11 @@ export {
   NameGenerationErrorSchema,
 } from "./schemas/errors";
 
-// Tool schemas
-export { BashToolResultSchema, FileTreeNodeSchema } from "./schemas/tools";
-
-// Memory schemas (Memory tab)
-export {
-  MemoryChangeEventSchema,
-  MemoryFileInfoSchema,
-  MemorySaveErrorSchema,
-} from "./schemas/memory";
-export type { MemoryFileInfo, MemorySaveError } from "./schemas/memory";
-
 // Secrets schemas
 export { SecretSchema } from "./schemas/secrets";
 
 // Policy schemas
 export {
-  PolicyFileSchema,
   PolicySourceSchema,
   PolicyStatusSchema,
   EffectivePolicySchema,
@@ -191,29 +92,7 @@ export {
 // Provider options schemas
 export { MuxProviderOptionsSchema } from "./schemas/providerOptions";
 
-// MCP schemas
-export {
-  MCPAddParamsSchema,
-  MCPRemoveParamsSchema,
-  MCPServerMapSchema,
-  MCPSetEnabledParamsSchema,
-  MCPTestParamsSchema,
-  MCPTestResultSchema,
-} from "./schemas/mcp";
-
 export { backup } from "./schemas/backup";
-
-// UI Layouts schemas
-export {
-  KeybindSchema,
-  LayoutPresetSchema,
-  LayoutPresetsConfigSchema,
-  LayoutSlotSchema,
-  RightSidebarLayoutPresetNodeSchema,
-  RightSidebarLayoutPresetStateSchema,
-  RightSidebarPresetTabSchema,
-  RightSidebarWidthPresetSchema,
-} from "./schemas/uiLayouts";
 // Terminal schemas
 export {
   TerminalCreateParamsSchema,
@@ -227,13 +106,9 @@ export {
   DynamicToolPartPendingSchema,
   DynamicToolPartSchema,
   FilePartSchema,
-  MuxFilePartSchema,
-  MuxMessageSchema,
-  MuxReasoningPartSchema,
-  MuxTextPartSchema,
   MuxToolPartSchema,
 } from "./schemas/message";
-export type { FilePart, MuxFilePart } from "./schemas/message";
+export type { FilePart } from "./schemas/message";
 
 // Stream event schemas
 export {
@@ -242,16 +117,12 @@ export {
   AutoRetryStartingEventSchema,
   CaughtUpMessageSchema,
   ChatMuxMessageSchema,
-  CompletedMessagePartSchema,
   DeleteMessageSchema,
   ErrorEventSchema,
   GoalBudgetLimitedEventSchema,
-  LanguageModelV2UsageSchema,
   OnChatDowngradeReasonSchema,
-  QueuedMessageChangedEventSchema,
   ReasoningDeltaEventSchema,
   ReasoningEndEventSchema,
-  RestoreToInputEventSchema,
   RuntimeStatusEventSchema,
   SendMessageOptionsSchema,
   StreamAbortReasonSchema,
@@ -278,34 +149,12 @@ export {
   WorkspaceInitEventSchema,
 } from "./schemas/stream";
 
-export {
-  TIMELINE_EVENT_KINDS,
-  TimelineAnchorSchema,
-  TimelineEventDataSchema,
-  TimelineEventDraftSchema,
-  TimelineEventKindSchema,
-  TimelineEventSchema,
-  TimelineListInputSchema,
-  TimelinePageSchema,
-  TimelinePreviewInputSchema,
-  TimelinePreviewSchema,
-  TimelineSourceSchema,
-  TimelineStatusSchema,
-  TimelineSubscriptionEventSchema,
-} from "./schemas/timeline";
-
 // API router schemas
 export {
   ApiServerStatusSchema,
   AWSCredentialStatusSchema,
   analytics,
   coder,
-  CoderInfoSchema,
-  CoderPresetSchema,
-  CoderTemplateSchema,
-  CoderWorkspaceConfigSchema,
-  CoderWorkspaceSchema,
-  CoderWorkspaceStatusSchema,
   config,
   browser,
   devtools,
@@ -344,7 +193,6 @@ export {
   tasks,
   experiments,
   telemetry,
-  TelemetryEventSchema,
   ssh,
   terminal,
   tokenizer,

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -161,7 +161,7 @@ export const experiments = {
   },
 };
 // Re-export telemetry schemas
-export { telemetry, TelemetryEventSchema } from "./telemetry";
+export { telemetry } from "./telemetry";
 
 // Re-export analytics schemas
 export { analytics } from "./analytics";
@@ -1111,15 +1111,7 @@ export const secrets = {
 };
 
 // Re-export Coder schemas from dedicated file
-export {
-  coder,
-  CoderInfoSchema,
-  CoderPresetSchema,
-  CoderTemplateSchema,
-  CoderWorkspaceConfigSchema,
-  CoderWorkspaceSchema,
-  CoderWorkspaceStatusSchema,
-} from "./coder";
+export { coder } from "./coder";
 
 // Workspace
 const DebugLlmRequestSnapshotSchema = z

--- a/src/common/orpc/schemas/message.ts
+++ b/src/common/orpc/schemas/message.ts
@@ -111,7 +111,6 @@ export const MuxFilePartSchema = FilePartSchema.extend({
 
 // Export types inferred from schemas for reuse across app/test code.
 export type FilePart = z.infer<typeof FilePartSchema>;
-export type MuxFilePart = z.infer<typeof MuxFilePartSchema>;
 
 const CompactionEpochSchema = z.optional(
   z.preprocess(

--- a/src/common/orpc/schemas/stream.ts
+++ b/src/common/orpc/schemas/stream.ts
@@ -888,6 +888,3 @@ export const SendMessageOptionsSchema = z.object({
   goalInterventionPolicy: GoalInterventionPolicySchema.nullish(),
   queueDispatchMode: z.enum(["tool-end", "turn-end"]).nullish(),
 });
-
-// Re-export ChatUsageDisplaySchema for convenience
-export { ChatUsageDisplaySchema };

--- a/src/common/schemas/project.ts
+++ b/src/common/schemas/project.ts
@@ -56,9 +56,6 @@ export const WorktreeArchiveSnapshotSchema = z.object({
   }),
 });
 
-// Shared with workspace metadata IPC; see src/common/orpc/schemas/workspace.ts.
-export { WorkflowTaskMetadataSchema };
-
 export const WorkspaceConfigSchema = z.object({
   path: z.string().meta({
     description: "Absolute path to workspace directory - REQUIRED for backward compatibility",

--- a/src/common/telemetry/index.ts
+++ b/src/common/telemetry/index.ts
@@ -11,7 +11,7 @@
  * - Use getRuntimeTypeForTelemetry to convert RuntimeConfig to telemetry-safe type
  */
 
-export { initTelemetry, shutdownTelemetry } from "./client";
+export { initTelemetry } from "./client";
 export { trackAppStarted } from "./lifecycle";
 
 // Tracking functions - callers pass raw values, rounding handled internally
@@ -30,12 +30,3 @@ export {
 
 // Utility for converting RuntimeConfig to telemetry-safe runtime type
 export { getRuntimeTypeForTelemetry } from "./utils";
-
-// Type exports for callers that need them
-export type {
-  TelemetryEventPayload,
-  ErrorContext,
-  TelemetryRuntimeType,
-  TelemetryThinkingLevel,
-  TelemetryCommandType,
-} from "./payload";

--- a/src/common/types/tasks.ts
+++ b/src/common/types/tasks.ts
@@ -19,14 +19,6 @@ export const DEFAULT_TASK_SETTINGS: TaskSettings = {
   preserveSubagentsUntilArchive: true,
 };
 
-export {
-  BACKGROUND_WORK_ATTENTION_POLICIES,
-  BackgroundWorkAttentionPolicySchema,
-  DEFAULT_BACKGROUND_WORK_ATTENTION_POLICY,
-  resolveBackgroundWorkAttentionPolicy,
-  type BackgroundWorkAttentionPolicy,
-} from "./backgroundWorkAttention";
-
 function clampInt(value: unknown, fallback: number, min: number, max: number): number {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     return fallback;

--- a/src/common/utils/messages/compactionBoundary.ts
+++ b/src/common/utils/messages/compactionBoundary.ts
@@ -8,7 +8,7 @@ import { hasProviderReplayableContent } from "@/common/utils/messages/providerEl
 
 import type { MuxMessage } from "@/common/types/message";
 
-export { CONTEXT_BOUNDARY_KINDS, type ContextBoundaryKind };
+export { CONTEXT_BOUNDARY_KINDS };
 
 export function isDurableCompactedMarker(
   value: unknown

--- a/src/node/runtime/transports/index.ts
+++ b/src/node/runtime/transports/index.ts
@@ -4,7 +4,7 @@ import { SSH2Transport } from "./SSH2Transport";
 import type { SSHTransport } from "./SSHTransport";
 
 export type { SSHTransport, PtyHandle, PtySessionParams } from "./SSHTransport";
-export { OpenSSHTransport, SSH2Transport };
+export { OpenSSHTransport };
 
 export function createSSHTransport(config: SSHConnectionConfig, useSSH2: boolean): SSHTransport {
   return useSSH2 ? new SSH2Transport(config) : new OpenSSHTransport(config);

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -213,7 +213,7 @@ type AgentSessionResult<T> =
  * Uses timestamp-based polling with diff injection.
  */
 // Re-export types from FileChangeTracker for backward compatibility
-export type { FileState, EditedFileAttachment } from "@/node/services/utils/fileChangeTracker";
+export type { FileState } from "@/node/services/utils/fileChangeTracker";
 
 // Type guard for compaction request metadata
 // Supports both new `followUpContent` and legacy `continueMessage` for backwards compatibility

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -536,8 +536,6 @@ async function extractBearerOauthChallenge(options: {
   };
 }
 
-export type { MCPTestResult } from "@/common/types/mcp";
-
 /** Shell command + exec options composed for a stdio server launch. */
 interface StdioLaunch {
   command: string;

--- a/src/node/services/memoryConsolidationService.ts
+++ b/src/node/services/memoryConsolidationService.ts
@@ -72,10 +72,6 @@ import { runMemoryConsolidation } from "@/node/services/memoryConsolidation";
 import type { MemoryScopeContext, MemoryService } from "@/node/services/memoryService";
 import { memoryLogicalKey, type MemoryMetaService } from "@/node/services/memoryMeta";
 import { MutexMap } from "@/node/utils/concurrency/mutexMap";
-
-// Types derive from the oRPC schemas (z.infer single source) so node-side
-// fields can never silently be stripped by output validation.
-export type { MemoryConsolidationTrigger };
 export type MemoryConsolidationRecord = MemoryConsolidationRecordPayload;
 
 type MemoryHarvestRecord = MemoryHarvestRecordPayload;

--- a/src/node/services/providerService.ts
+++ b/src/node/services/providerService.ts
@@ -33,7 +33,6 @@ import type { BaseProviderConfig } from "@/common/config/schemas/providersConfig
 import type { Result } from "@/common/types/result";
 import type {
   AddCustomProviderInput,
-  AWSCredentialStatus,
   CustomProviderMutationError,
   ProviderConfigInfo,
   ProviderModelEntry,
@@ -73,9 +72,6 @@ import { parseCoderOauthAuth } from "@/node/utils/coderOauthAuth";
 import type { PolicyService } from "@/node/services/policyService";
 import { getErrorMessage } from "@/common/utils/errors";
 import { WORKSPACE_DEFAULTS } from "@/constants/workspaceDefaults";
-
-// Re-export types for backward compatibility
-export type { AWSCredentialStatus, ProviderConfigInfo, ProvidersConfigMap };
 
 function filterProviderModelsByPolicy(
   models: ProviderModelEntry[] | undefined,

--- a/src/node/services/systemMessage.test.ts
+++ b/src/node/services/systemMessage.test.ts
@@ -169,7 +169,7 @@ describe("buildSystemMessage", () => {
     await fs.mkdir(workspaceDir, { recursive: true });
     await fs.mkdir(globalDir, { recursive: true });
 
-    // Mock homedir to return our test directory (getSystemDirectory will append .mux)
+    // Mock homedir to return our test directory (getXumHome will append .mux)
     mockHomedir = spyOn(os, "homedir");
     mockHomedir.mockReturnValue(tempDir);
 

--- a/src/node/services/systemMessage.ts
+++ b/src/node/services/systemMessage.ts
@@ -251,14 +251,6 @@ Manage servers in Settings → MCP.
 // #endregion SYSTEM_PROMPT_DOCS
 
 /**
- * Get the system directory where global Xum configuration lives.
- * Users can place global AGENTS.md and PLAN.md files here.
- */
-function getSystemDirectory(): string {
-  return getXumHome();
-}
-
-/**
  * Extract tool-specific instructions from instruction sources.
  * Searches agent instructions first, then context (workspace/project), then global.
  *
@@ -507,7 +499,7 @@ export async function loadInstructionSources(
           path.join(os.homedir(), CLAUDE_COMPAT_INSTRUCTIONS_DIRECTORY)
         )
       : Promise.resolve(null),
-    readInstructionSet(getSystemDirectory(), INSTRUCTION_SCOPE.GLOBAL),
+    readInstructionSet(getXumHome(), INSTRUCTION_SCOPE.GLOBAL),
   ]);
   const global = [claudeCompatGlobal, nativeGlobal].filter(
     (set): set is InstructionSet => set != null

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -26,11 +26,6 @@ import {
   workspaceTurnTerminalAttentionSuppressed,
   type WorkspaceTurnManager,
 } from "@/node/services/workspaceTurnManager";
-export type {
-  WorkspaceTurnCreateArgs,
-  WorkspaceTurnCreateResult,
-  WorkspaceTurnWaitResult,
-} from "@/node/services/workspaceTurnManager";
 import {
   TASK_RECOVERY_FALLBACK_AGENT_ID,
   formatSubagentFailureUserMessage,
@@ -48,7 +43,7 @@ import {
   type WorkspaceHost,
   type WorkspaceLifecycleResult,
 } from "@/node/services/taskWorkspaceSeam";
-export type { TaskCreateArgs, TaskKind } from "@/node/services/taskWorkspaceSeam";
+export type { TaskKind } from "@/node/services/taskWorkspaceSeam";
 import type { HistoryService } from "@/node/services/historyService";
 import type { InitStateManager } from "@/node/services/initStateManager";
 import { STRUCTURED_WORKFLOW_REPORT_PLACEHOLDER_MARKDOWN } from "@/common/constants/workflowReports";

--- a/src/node/services/tools/task_await.ts
+++ b/src/node/services/tools/task_await.ts
@@ -105,10 +105,6 @@ function buildTaskAwaitSequencingError(taskId: string, suggestedTaskIds: string[
   };
 }
 
-function parseWorkflowRun(value: unknown): WorkflowRunRecord {
-  return WorkflowRunRecordSchema.parse(value);
-}
-
 function getWorkflowRunElapsedMs(run: WorkflowRunRecord): number | undefined {
   const createdAtMs = parseTimestampMs(run.createdAt);
   if (createdAtMs == null) {
@@ -404,7 +400,7 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
         if (run == null) {
           return null;
         }
-        return parseWorkflowRun(run);
+        return WorkflowRunRecordSchema.parse(run);
       };
 
       const markWorkflowTerminalAttentionConsumed = async (

--- a/src/node/services/workspaceGoalService.ts
+++ b/src/node/services/workspaceGoalService.ts
@@ -145,7 +145,7 @@ export interface SetGoalInput {
   editInPlace?: boolean | null;
 }
 
-export type { GoalContinuationSkipReason, GoalStreamOriginKind } from "./goalContinuationPolicy";
+export type { GoalStreamOriginKind } from "./goalContinuationPolicy";
 
 export interface GoalContinuationRuntimeState {
   isInitializing?: boolean;


### PR DESCRIPTION
## Summary

Pass 2 of the behaviour-preserving deslop (stacked on #4089, pass 1): needless re-exports and redundant wrappers. Removes 191 re-export entries that nothing imports through their barrel, the 3 shadcn sub-components, 3 orphaned exports and 8 import bindings that only existed to feed those entries, and inlines 2 single-call alias functions. 34 files, +24 / -354 lines. No behaviour changes.

## Stack context

- #4089 (pass 1, base): dead exports and unreachable files.
- **this PR (pass 2)**: unused re-exports, dead barrel-only symbols, single-call alias wrappers.
- pass 3 (planned): useless tests. pass 4 (planned): comments and defensive noise.

## Why

knip reports an export as unused when no module imports it, and a barrel re-export is exactly that kind of export: a name listed in `export { ... } from` that no consumer ever imports through the barrel. After pass 1 the repo's own `make check-deadcode` output was still dominated by these entries (588 findings, most of them barrel lines and story exports), which hides real dead code. This pass removes the entries that are provably unused so the check regains signal.

## Implementation

1. Candidates: every knip "unused export" (round 3 run on top of pass 1) whose declaration is an `export { ... }` specifier rather than a definition: 227 entries in 30 files.
2. Usage proof per entry with a TypeScript-API pass over every `src`, `tests`, `scripts`, `vscode`, `packages` and `.storybook` file: resolve each import/re-export specifier to its file, and mark an entry used if any importer of that barrel imports the name (named import, `export { name } from`, `export *`, dynamic `import()`), or references it as a member of a namespace import (`import * as schemas` then `schemas.Name` or `typeof schemas.Name`). knip misses the namespace-member case: it flagged 36 `schemas.ts` entries that `src/common/orpc/types.ts` reads via `import type * as schemas`. Those 36 are kept. 181 entries passed, and a second round after removing them found 10 more re-exports whose only consumer had been the removed barrel line (`schemas/api.ts` -> `schemas.ts`, `tabRegistry.tsx` -> `Tabs/index.ts`).
3. Cascade: `tsgo --noEmit` (`noUnusedLocals`) after each round. It flagged 8 import bindings that existed only to be re-exported (removed) and, once un-exported, three shadcn sub-components that nothing renders (`SelectLabel`, `SelectSeparator`, `ScrollAreaViewport`; the ones `SelectContent`/`ScrollArea` render internally, `SelectScrollUp/DownButton` and `ScrollBar`, are kept as module-private).
4. Wrappers: a TypeScript-API scan for functions whose body is a single `return callee(sameArgs)` found 68 forwarders; 9 have a single call site. Only the two with no type-narrowing, DI, or public-API purpose are inlined here (`getSystemDirectory` -> `getXumHome`, `parseWorkflowRun` -> `WorkflowRunRecordSchema.parse`). The other 7 are kept and listed under Deferred with the reason.

## Evidence per deletion

Verification for every entry below: knip reports it unused; the barrel-usage pass finds no importer of that barrel that imports or dereferences the name; both tsconfigs typecheck after removal; `make static-check` and the full unit suite pass (see Validation).

<details>
<summary>Re-export entries removed (191, by barrel)</summary>

| Barrel | Entries removed | Notes |
| --- | --- | --- |
| `src/common/orpc/schemas.ts` | 112 | From `result` (`ResultSchema`), `runtime` (3), `goal` (all 18 goal schemas), `workspace` (`WorkflowTaskMetadataSchema`), `workspaceStats` (6), `analytics` (16 schemas + row types), `chatStats` (3), `agentPlugins` (5), `workflow` (`JsonValueSchema`), `instructions` (7), `tools` (2), `memory` (5), `policy` (`PolicyFileSchema`), `mcp` (6), `uiLayouts` (8), `message` (5), `stream` (4), `timeline` (13), `api` (7). Every one of these is imported directly from its `./schemas/*` module by its consumers; the header comment now says what the file re-exports instead of claiming to re-export everything. The 36 entries read through `import type * as schemas` in `orpc/types.ts` stay. |
| `src/browser/features/RightSidebar/Tabs/index.ts` | 15 | 6 from `tabRegistry`, 9 label components from `TabLabels` (`TerminalTabLabel` stays, it has an importer) |
| `src/common/orpc/schemas/api.ts` | 7 | `TelemetryEventSchema` and the 6 `Coder*Schema` re-exports; their only importer was the removed `schemas.ts` line |
| `src/common/telemetry/index.ts` | 6 | `shutdownTelemetry` plus 5 payload types; consumers import them from `./client` / `./payload` |
| `src/common/types/tasks.ts` | 5 | `backgroundWorkAttention` re-exports; consumers import from `backgroundWorkAttention` directly |
| `src/browser/features/RightSidebar/Tabs/tabRegistry.tsx` | 5 | `tabConfig` re-exports |
| `src/node/services/taskService.ts` | 4 | `WorkspaceTurn*` and `TaskCreateArgs` type re-exports |
| `src/browser/features/RightSidebar/RightSidebar.tsx` | 4 | "Re-export for consumers" block (`RIGHT_SIDEBAR_TABS`, `isTabType`, `ReviewStats`, `TabType`); no consumer imports them from here |
| `src/browser/components/SelectPrimitive/SelectPrimitive.tsx` | 4 | shadcn export list: `SelectLabel`, `SelectSeparator` (deleted, unused), `SelectScrollUpButton`, `SelectScrollDownButton` (kept private, rendered by `SelectContent`) |
| `src/browser/utils/goals/resolveGoalSetIntent.ts` | 3 | `resolveModelGoalSetIntent`, `GoalSetIntent`, `GoalSetIntentInput` re-exports |
| `src/node/services/providerService.ts` | 3 | "Re-export types for backward compatibility" block |
| `src/browser/hooks/useExperiments.ts` | 2 | `useExperiment`, `useSetExperiment` (consumers import from `ExperimentsContext`) |
| `src/browser/utils/workflowRunMessages.ts` | 2 | `WorkflowRunCardInput`, `WorkflowRunCardResult` |
| `src/common/constants/muxGovernorOAuth.ts` | 2 | gateway credential re-exports "for use by governor"; the module still imports them from `muxGatewayOAuth` for its own use, nothing imports them from here |
| `src/browser/components/ScrollArea/ScrollArea.tsx` | 2 | `ScrollAreaViewport` (deleted, unused), `ScrollBar` (kept private, rendered by `ScrollArea`) |
| `src/browser/features/RightSidebar/Tabs/registry.ts` | 2 | `TabPanelContext`, `TabLabelContext` type re-exports |
| one entry each | 12 | `transports/index.ts` (`SSH2Transport`), `common/schemas/project.ts` (`WorkflowTaskMetadataSchema`), `mcpServerManager.ts` (`MCPTestResult`), `schemas/stream.ts` (`ChatUsageDisplaySchema`), `compactionBoundary.ts` (`ContextBoundaryKind`), `Button.tsx` (`buttonVariants`, kept private), `slashCommands/registry.ts` (`MODEL_ABBREVIATIONS`), `imageResize.ts` (`ResizeDimensions`), `agentSession.ts` (`EditedFileAttachment`), `workspaceGoalService.ts` (`GoalContinuationSkipReason`), `memoryConsolidationService.ts` (`MemoryConsolidationTrigger`), `codeExecutionTypes.ts` (`ToolCallRecord` alias), `slashCommands/suggestions.ts` (`SlashSuggestion`) |

</details>

<details>
<summary>Symbols deleted because the removed entries were their only reader (14)</summary>

| Symbol | File | Notes |
| --- | --- | --- |
| `SelectLabel`, `SelectSeparator` | `SelectPrimitive.tsx` | shadcn sub-components never rendered anywhere (only their own `displayName` assignment referenced them) |
| `ScrollAreaViewport` | `ScrollArea.tsx` | same |
| `getTabRegistration` | `Tabs/tabRegistry.tsx` | only reachable through the removed `Tabs/index.ts` re-export; no caller |
| `RIGHT_SIDEBAR_TABS` (+ its now-unused `BASE_TAB_IDS` import) | `src/browser/types/rightSidebar.ts` | only reachable through the removed `RightSidebar.tsx` re-export; no caller |
| `MuxFilePart` type alias | `src/common/orpc/schemas/message.ts` | duplicate of the `MuxFilePart` interface in `common/types/message.ts`, which is what every consumer imports; only the removed barrel line referenced this one |
| import bindings `RIGHT_SIDEBAR_TABS` (RightSidebar.tsx), `TabLabelContext`/`TabPanelContext` (Tabs/registry.ts), `resolveModelGoalSetIntent`/`GoalSetIntent`/`GoalSetIntentInput` (resolveGoalSetIntent.ts), `ResizeDimensions` (imageResize.ts), `AWSCredentialStatus` (providerService.ts) | | imported solely to be re-exported; flagged by `tsgo` once the re-export went |

</details>

<details>
<summary>Alias wrappers inlined (2)</summary>

| Wrapper | Replaced by | Notes |
| --- | --- | --- |
| `getSystemDirectory()` in `src/node/services/systemMessage.ts` | `getXumHome()` | private zero-arg alias with one call site; the test comment that named it now names `getXumHome` |
| `parseWorkflowRun(value)` in `src/node/services/tools/task_await.ts` | `WorkflowRunRecordSchema.parse(run)` | private one-line alias with one call site |

</details>

## Deferred (found, intentionally not in this pass)

- 7 single-call forwarders kept on purpose: `isCoderWorkspaceConfig` (type predicate), `writeOptionField` (typed mirror of `readOptionField`), `createTypedClient` (pins the oRPC client generic), `clearLogFiles` (public API used by tests and `clearLogsForApi`), `shouldWaitForStreamStart` (named regex test in the mock router), `defaultExecSync` (DI default typed as `ExecSyncFn`), `getTodosForSessionDir` (test-only wrapper; removing it means repointing 18 test call sites at `readTodosForSessionDir`, a test-scaffolding change for pass 3).
- Interfaces with exactly one implementation (`CoderCallbackChannel`, `MemoryStore`, `NotificationSource`) are each the type used at several call sites and `Pick<>` sites in their module, so they are abstraction seams rather than redundant wrappers; left alone.
- 36 `schemas.ts` entries are only reachable through `import type * as schemas` in `src/common/orpc/types.ts`; knip cannot see that usage, so they are kept and this is a known knip false positive for future runs.
- ~780 exports that are used only inside their own module (knip "unused export", symbol live): dropping the `export` keyword is mechanical and adds no deletions; not done.

## Validation

- `make static-check` (lint, typecheck, fmt-check, eager-import check, code docs links, shellcheck, hadolint): green.
- `bun test src` (full unit suite, 842 files): 14,368 pass, 8 skip, 7 fail; the identical 7 order-dependent failures as origin/main and as pass 1 (`WorkspaceFooterBar last prompt` x3, `WorkflowLongText` x3, `WorkflowRunHeader planned stages` x1), all passing in isolation. The RightSidebar, browser types, and oRPC schema test directories were re-run after the last edits: 361 pass.
- `make check-deadcode` (ts-prune, repo filters): 647 findings on main, 588 after pass 1, 454 after this PR. The three exports this pass orphaned (`getTabRegistration`, `RIGHT_SIDEBAR_TABS` in `types/rightSidebar.ts`, the duplicate `MuxFilePart` alias in `schemas/message.ts`) were deleted in the same pass, so no finding is introduced.

## Risks

Low. Removing a re-export line cannot change runtime behaviour when nothing imports it, and the compiler proves that for every entry. The three deleted shadcn sub-components were never rendered. The two inlined aliases are private and had one call site each.

## Declined review findings

(none yet)

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$43.42`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=43.42 -->

