### PR TITLE
🤖 fix: route GPT-6 Astra through Codex OAuth

### DIFF
--- a/src/browser/features/Settings/Sections/ModelsSection.test.ts
+++ b/src/browser/features/Settings/Sections/ModelsSection.test.ts
@@ -11,6 +11,11 @@ describe("shouldShowModelInSettings", () => {
     expect(shouldShowModelInSettings(KNOWN_MODELS.GPT_53_CODEX_SPARK.id, true)).toBe(true);
   });
 
+  test("shows OAuth-required Codex model without OAuth when a gateway route is configured", () => {
+    expect(shouldShowModelInSettings(KNOWN_MODELS.GPT_53_CODEX_SPARK.id, false, true)).toBe(true);
+    expect(shouldShowModelInSettings(KNOWN_MODELS.GPT_53_CODEX_SPARK.id, false, false)).toBe(false);
+  });
+
   test("shows GPT-5.5 when OpenAI OAuth is not configured", () => {
     expect(shouldShowModelInSettings(KNOWN_MODELS.GPT.id, false)).toBe(true);
   });

--- a/src/browser/features/Settings/Sections/ModelsSection.tsx
+++ b/src/browser/features/Settings/Sections/ModelsSection.tsx
@@ -27,7 +27,7 @@ import {
   getModelProvider,
   supports1MContext,
 } from "@/common/utils/ai/models";
-import { getAllowedProvidersForUi, isModelAllowedByPolicy } from "@/browser/utils/policyUi";
+import { getAllowedProvidersForUi } from "@/browser/utils/policyUi";
 import { LAST_CUSTOM_MODEL_PROVIDER_KEY } from "@/common/constants/storage";
 import type { ProviderModelEntry } from "@/common/orpc/types";
 import {
@@ -157,8 +157,14 @@ export function ModelsSection() {
     setLastProvider(allowedProviders[0] ?? "");
   }, [config, allowedProviders, lastProvider, setLastProvider]);
 
-  const { defaultModel, setDefaultModel, hiddenModels, hideModel, unhideModel } =
-    useModelsFromSettings();
+  const {
+    defaultModel,
+    setDefaultModel,
+    hiddenModels,
+    hideModel,
+    unhideModel,
+    isAllowedByPolicyOnActiveRoute,
+  } = useModelsFromSettings();
   const routing = useRouting();
   const minThinking = useMinThinkingLevels();
   const { has1MContext, toggle1MContext } = useProviderOptions();
@@ -383,6 +389,8 @@ export function ModelsSection() {
 
   // Get built-in models from KNOWN_MODELS.
   // Filter by policy so the settings table doesn't list models users can't ever select.
+  // The policy applies to the active route's identity (like the backend), so a
+  // gateway-only policy keeps rows whose route is that gateway.
   const builtInModels = Object.values(KNOWN_MODELS)
     .map((model) => ({
       provider: model.provider,
@@ -399,7 +407,7 @@ export function ModelsSection() {
           .some((route) => route.route !== "direct" && route.isConfigured)
       )
     )
-    .filter((model) => isModelAllowedByPolicy(effectivePolicy, model.fullId));
+    .filter((model) => isAllowedByPolicyOnActiveRoute(model.fullId));
 
   const customModels = getCustomModels();
 

--- a/src/browser/features/Settings/Sections/ModelsSection.tsx
+++ b/src/browser/features/Settings/Sections/ModelsSection.tsx
@@ -102,16 +102,22 @@ function buildProviderModelEntry(
   return entry;
 }
 
-export function shouldShowModelInSettings(modelId: string, codexOauthConfigured: boolean): boolean {
+export function shouldShowModelInSettings(
+  modelId: string,
+  codexOauthConfigured: boolean,
+  // A configured gateway (mux-gateway, openrouter, ...) supplies its own
+  // credentials, so the row must stay visible for users to pick that route.
+  hasConfiguredGatewayRoute = false
+): boolean {
   // OpenAI OAuth gating only applies to OpenAI-routed models; other providers can
   // reuse the same providerModelId string without requiring OpenAI OAuth.
   if (getModelProvider(modelId) !== "openai") {
     return true;
   }
 
-  // Keep OAuth-required OpenAI models out of Settings until OAuth is connected,
-  // so users don't pick defaults that fail at send time.
-  return codexOauthConfigured || !isCodexOauthRequiredModelId(modelId);
+  // Keep OAuth-required OpenAI models out of Settings until OAuth is connected
+  // or a gateway can serve them, so users don't pick defaults that fail at send time.
+  return codexOauthConfigured || hasConfiguredGatewayRoute || !isCodexOauthRequiredModelId(modelId);
 }
 
 export function shouldAllowRouteOverrideInSettings(modelId: string): boolean {
@@ -384,7 +390,15 @@ export function ModelsSection() {
       fullId: model.id,
       aliases: model.aliases,
     }))
-    .filter((model) => shouldShowModelInSettings(model.fullId, codexOauthConfigured))
+    .filter((model) =>
+      shouldShowModelInSettings(
+        model.fullId,
+        codexOauthConfigured,
+        routing
+          .availableRoutes(model.fullId)
+          .some((route) => route.route !== "direct" && route.isConfigured)
+      )
+    )
     .filter((model) => isModelAllowedByPolicy(effectivePolicy, model.fullId));
 
   const customModels = getCustomModels();

--- a/src/browser/hooks/useModelsFromSettings.test.ts
+++ b/src/browser/hooks/useModelsFromSettings.test.ts
@@ -443,6 +443,59 @@ describe("useModelsFromSettings OpenAI Codex OAuth gating", () => {
     expect(result.current.models).not.toContain("openai:gpt-5.3-codex-spark");
   });
 
+  test("codex oauth only: a gateway route bypasses the OpenAI auth gate", () => {
+    providersConfig = {
+      openai: {
+        apiKeySet: false,
+        isEnabled: true,
+        isConfigured: true,
+        codexOauthSet: true,
+        models: SEEDED_OPENAI_CUSTOM_MODELS,
+      },
+      "mux-gateway": {
+        apiKeySet: false,
+        isEnabled: true,
+        isConfigured: true,
+        couponCodeSet: true,
+      },
+    };
+    routePriority = ["mux-gateway", "direct"];
+
+    const { result } = renderHook(() => useModelsFromSettings());
+
+    // The gateway supplies its own credentials, so API-key-only models stay visible.
+    expect(result.current.models).toContain(KNOWN_MODELS.GPT_PRO.id);
+    expect(result.current.models).toContain("openai:gpt-5.2-pro");
+    expect(result.current.models).toContain(KNOWN_MODELS.GPT.id);
+    expect(result.current.hiddenModelsForSelector).not.toContain(KNOWN_MODELS.GPT_PRO.id);
+  });
+
+  test("codex oauth only: a per-model gateway override bypasses the gate for that model only", () => {
+    providersConfig = {
+      openai: {
+        apiKeySet: false,
+        isEnabled: true,
+        isConfigured: true,
+        codexOauthSet: true,
+        models: SEEDED_OPENAI_CUSTOM_MODELS,
+      },
+      "mux-gateway": {
+        apiKeySet: false,
+        isEnabled: true,
+        isConfigured: true,
+        couponCodeSet: true,
+      },
+    };
+    routePriority = ["direct", "mux-gateway"];
+    routeOverrides = { [KNOWN_MODELS.GPT_PRO.id]: "mux-gateway" };
+
+    const { result } = renderHook(() => useModelsFromSettings());
+
+    expect(result.current.models).toContain(KNOWN_MODELS.GPT_PRO.id);
+    // Direct-routed models keep the OAuth-only gate.
+    expect(result.current.models).not.toContain("openai:gpt-5.2-pro");
+  });
+
   test("exposes OpenAI auth state flags", () => {
     providersConfig = {
       openai: { apiKeySet: false, isEnabled: true, isConfigured: true, codexOauthSet: true },

--- a/src/browser/hooks/useModelsFromSettings.test.ts
+++ b/src/browser/hooks/useModelsFromSettings.test.ts
@@ -496,6 +496,35 @@ describe("useModelsFromSettings OpenAI Codex OAuth gating", () => {
     expect(result.current.models).not.toContain("openai:gpt-5.2-pro");
   });
 
+  test("oauth disconnected: requiresCodexOauth follows the active route", () => {
+    providersConfig = {
+      openai: {
+        apiKeySet: false,
+        isEnabled: true,
+        isConfigured: false,
+        codexOauthSet: false,
+      },
+      "mux-gateway": {
+        apiKeySet: false,
+        isEnabled: true,
+        isConfigured: true,
+        couponCodeSet: true,
+      },
+    };
+    routePriority = ["mux-gateway", "direct"];
+
+    const { result } = renderHook(() => useModelsFromSettings());
+
+    // The gateway serves the OAuth-required model, so it is selectable and the
+    // ChatInput warning must not ask the user to connect OpenAI.
+    expect(result.current.models).toContain("openai:gpt-5.3-codex-spark");
+    expect(result.current.requiresCodexOauth("openai:gpt-5.3-codex-spark")).toBe(false);
+    // A gateway-less model still resolves to direct, so the warning stays.
+    routePriority = ["direct"];
+    const { result: directOnly } = renderHook(() => useModelsFromSettings());
+    expect(directOnly.current.requiresCodexOauth("openai:gpt-5.3-codex-spark")).toBe(true);
+  });
+
   test("exposes OpenAI auth state flags", () => {
     providersConfig = {
       openai: { apiKeySet: false, isEnabled: true, isConfigured: true, codexOauthSet: true },

--- a/src/browser/hooks/useModelsFromSettings.test.ts
+++ b/src/browser/hooks/useModelsFromSettings.test.ts
@@ -572,6 +572,44 @@ describe("useModelsFromSettings OpenAI Codex OAuth gating", () => {
     expect(result.current.models).not.toContain("openai:gpt-5.2-pro");
   });
 
+  test("a gateway-only policy keeps models whose active route is that gateway", () => {
+    providersConfig = {
+      openai: {
+        apiKeySet: true,
+        isEnabled: true,
+        isConfigured: true,
+        models: SEEDED_OPENAI_CUSTOM_MODELS,
+      },
+      "mux-gateway": {
+        apiKeySet: false,
+        isEnabled: true,
+        isConfigured: true,
+        couponCodeSet: true,
+      },
+    };
+    // The policy lists only the gateway. The backend checks the resolved route
+    // identity (mux-gateway:openai/...), so the picker must keep those models
+    // while the gateway is their active route.
+    enforcedPolicy = buildEnforcedPolicy([{ id: "mux-gateway", allowedModels: null }]);
+
+    routePriority = ["mux-gateway", "direct"];
+    const viaGateway = renderHook(() => useModelsFromSettings());
+    expect(viaGateway.result.current.models).toContain(KNOWN_MODELS.GPT_PRO.id);
+    expect(viaGateway.result.current.models).toContain(KNOWN_MODELS.GPT.id);
+    expect(viaGateway.result.current.isAllowedByPolicyOnActiveRoute(KNOWN_MODELS.GPT_PRO.id)).toBe(
+      true
+    );
+
+    // Direct-only routing resolves to openai:*, which this policy does not allow.
+    routePriority = ["direct"];
+    const direct = renderHook(() => useModelsFromSettings());
+    expect(direct.result.current.models).not.toContain(KNOWN_MODELS.GPT_PRO.id);
+    expect(direct.result.current.models).not.toContain(KNOWN_MODELS.GPT.id);
+    expect(direct.result.current.isAllowedByPolicyOnActiveRoute(KNOWN_MODELS.GPT_PRO.id)).toBe(
+      false
+    );
+  });
+
   test("exposes OpenAI auth state flags", () => {
     providersConfig = {
       openai: { apiKeySet: false, isEnabled: true, isConfigured: true, codexOauthSet: true },

--- a/src/browser/hooks/useModelsFromSettings.test.ts
+++ b/src/browser/hooks/useModelsFromSettings.test.ts
@@ -13,6 +13,7 @@ import {
 } from "./useModelsFromSettings";
 import { KNOWN_MODELS } from "@/common/constants/knownModels";
 import type {
+  EffectivePolicy,
   ProviderConfigInfo,
   ProviderModelEntry,
   ProvidersConfigMap,
@@ -60,6 +61,19 @@ interface TestApi {
 }
 
 let apiMock: TestApi | null = null;
+// null = policy disabled (the default); a value = enforced policy.
+let enforcedPolicy: EffectivePolicy | null = null;
+
+function buildEnforcedPolicy(
+  providerAccess: NonNullable<EffectivePolicy["providerAccess"]>
+): EffectivePolicy {
+  return {
+    policyFormatVersion: "0.1",
+    providerAccess,
+    mcp: { allowUserDefined: { stdio: true, remote: true } },
+    runtimes: null,
+  };
+}
 
 const useProvidersConfigMock = mock(() => ({
   config: providersConfig,
@@ -110,10 +124,10 @@ async function installUseModelsModuleMocks() {
   }));
   await mock.module(POLICY_CONTEXT_MODULE, () => ({
     ...actualPolicyContextModule,
-    usePolicy: () => ({
-      status: { state: "disabled" as const },
-      policy: null,
-    }),
+    usePolicy: () =>
+      enforcedPolicy
+        ? { status: { state: "enforced" as const }, policy: enforcedPolicy }
+        : { status: { state: "disabled" as const }, policy: null },
   }));
 }
 
@@ -135,6 +149,7 @@ async function setupUseModelsHookTest() {
   routePriority = ["direct"];
   routeOverrides = {};
   apiMock = null;
+  enforcedPolicy = null;
   await installUseModelsModuleMocks();
 }
 
@@ -523,6 +538,38 @@ describe("useModelsFromSettings OpenAI Codex OAuth gating", () => {
     routePriority = ["direct"];
     const { result: directOnly } = renderHook(() => useModelsFromSettings());
     expect(directOnly.current.requiresCodexOauth("openai:gpt-5.3-codex-spark")).toBe(true);
+  });
+
+  test("codex oauth only: a policy-blocked gateway model does not bypass the gate", () => {
+    providersConfig = {
+      openai: {
+        apiKeySet: false,
+        isEnabled: true,
+        isConfigured: true,
+        codexOauthSet: true,
+        models: SEEDED_OPENAI_CUSTOM_MODELS,
+      },
+      "mux-gateway": {
+        apiKeySet: false,
+        isEnabled: true,
+        isConfigured: true,
+        couponCodeSet: true,
+      },
+    };
+    routePriority = ["mux-gateway", "direct"];
+    // The policy allows the canonical OpenAI models but lets the gateway serve
+    // only Sol. The backend then routes GPT Pro direct, where OAuth-only auth
+    // fails, so the picker must keep the gate for it.
+    enforcedPolicy = buildEnforcedPolicy([
+      { id: "openai", allowedModels: null },
+      { id: "mux-gateway", allowedModels: [`openai/${KNOWN_MODELS.GPT.providerModelId}`] },
+    ]);
+
+    const { result } = renderHook(() => useModelsFromSettings());
+
+    expect(result.current.models).toContain(KNOWN_MODELS.GPT.id);
+    expect(result.current.models).not.toContain(KNOWN_MODELS.GPT_PRO.id);
+    expect(result.current.models).not.toContain("openai:gpt-5.2-pro");
   });
 
   test("exposes OpenAI auth state flags", () => {

--- a/src/browser/hooks/useModelsFromSettings.ts
+++ b/src/browser/hooks/useModelsFromSettings.ts
@@ -15,7 +15,7 @@ import {
   normalizeSelectedModel,
   normalizeToCanonical,
 } from "@/common/utils/ai/models";
-import { isModelAvailable } from "@/common/routing";
+import { isModelAvailable, resolveRoute } from "@/common/routing";
 import type { ProviderModelEntry, ProvidersConfigMap } from "@/common/orpc/types";
 import { DEFAULT_MODEL_KEY, HIDDEN_MODELS_KEY } from "@/common/constants/storage";
 
@@ -314,13 +314,28 @@ export function useModelsFromSettings() {
     const hasOpenaiApiKey = openaiApiKeySet === true;
     const hasCodexOauth = codexOauthSet === true;
 
-    // OpenAI model gating:
+    // OpenAI model gating (direct route only):
     // - API key + OAuth: allow everything.
     // - API key only: hide models that require OAuth.
     // - OAuth only: show only models routable via OAuth.
     // - Neither: hide models that require OAuth (status quo).
+    // A gateway route (mux-gateway, openrouter, ...) supplies its own
+    // credentials, so the user's OpenAI auth state must not hide models the
+    // gateway serves. providerFiltered already guarantees an active route, so
+    // resolveRoute returns that route rather than its direct fallback.
     const next = providerFiltered.filter((modelId) => {
       if (!modelId.startsWith("openai:")) {
+        return true;
+      }
+
+      const route = resolveRoute(
+        modelId,
+        routePriority,
+        routeOverrides,
+        isConfigured,
+        isGatewayModelAccessible
+      );
+      if (route.routeProvider !== "openai") {
         return true;
       }
 

--- a/src/browser/hooks/useModelsFromSettings.ts
+++ b/src/browser/hooks/useModelsFromSettings.ts
@@ -16,7 +16,7 @@ import {
   normalizeToCanonical,
 } from "@/common/utils/ai/models";
 import { isModelAvailable, resolveRoute } from "@/common/routing";
-import type { ProviderModelEntry, ProvidersConfigMap } from "@/common/orpc/types";
+import type { EffectivePolicy, ProviderModelEntry, ProvidersConfigMap } from "@/common/orpc/types";
 import { DEFAULT_MODEL_KEY, HIDDEN_MODELS_KEY } from "@/common/constants/storage";
 
 import { isProviderModelAccessibleFromAuthoritativeCatalog } from "@/common/utils/providers/gatewayModelCatalog";
@@ -120,6 +120,31 @@ function resolvesToDirectOpenAI(
     resolveRoute(modelId, routePriority, routeOverrides, isConfigured, isGatewayModelAccessible)
       .routeProvider === "openai"
   );
+}
+
+/**
+ * Policy check on the identity the backend enforces. createModel resolves the
+ * route first and then checks `isModelAllowed(routeProvider, routeModelId)`,
+ * so a policy that lists only a gateway permits a canonical model whose active
+ * route is that gateway. A model with no active route resolves to direct and is
+ * checked under its canonical identity.
+ */
+function isModelAllowedByPolicyOnActiveRoute(
+  policy: EffectivePolicy | null,
+  modelId: string,
+  routePriority: string[],
+  routeOverrides: Record<string, string>,
+  isConfigured: (provider: string) => boolean,
+  isGatewayModelAccessible: (gateway: string, modelId: string) => boolean
+): boolean {
+  const route = resolveRoute(
+    modelId,
+    routePriority,
+    routeOverrides,
+    isConfigured,
+    isGatewayModelAccessible
+  );
+  return isModelAllowedByPolicy(policy, `${route.routeProvider}:${route.routeModelId}`);
 }
 
 export function getDefaultModel(): string {
@@ -228,6 +253,16 @@ export function useModelsFromSettings() {
   const openaiApiKeySet = config === null ? null : config.openai?.apiKeySet === true;
   const codexOauthSet = config === null ? null : config.openai?.codexOauthSet === true;
 
+  const isAllowedByPolicyOnActiveRoute = (modelId: string) =>
+    isModelAllowedByPolicyOnActiveRoute(
+      effectivePolicy,
+      modelId,
+      routePriority,
+      routeOverrides,
+      isConfigured,
+      isGatewayModelAccessible
+    );
+
   const requiresCodexOauth = (modelId: string) =>
     isCodexOauthRequiredModel(modelId, config) &&
     resolvesToDirectOpenAI(
@@ -325,10 +360,17 @@ export function useModelsFromSettings() {
               )
           );
 
+    const allowedByPolicy = (modelId: string) =>
+      isModelAllowedByPolicyOnActiveRoute(
+        effectivePolicy,
+        modelId,
+        routePriority,
+        routeOverrides,
+        isConfigured,
+        isGatewayModelAccessible
+      );
     if (config == null) {
-      return effectivePolicy
-        ? providerFiltered.filter((m) => isModelAllowedByPolicy(effectivePolicy, m))
-        : providerFiltered;
+      return effectivePolicy ? providerFiltered.filter(allowedByPolicy) : providerFiltered;
     }
     const hasOpenaiApiKey = openaiApiKeySet === true;
     const hasCodexOauth = codexOauthSet === true;
@@ -368,7 +410,7 @@ export function useModelsFromSettings() {
       return !isCodexOauthRequiredModel(modelId, config);
     });
 
-    return effectivePolicy ? next.filter((m) => isModelAllowedByPolicy(effectivePolicy, m)) : next;
+    return effectivePolicy ? next.filter(allowedByPolicy) : next;
   }, [
     config,
     hiddenModels,
@@ -482,5 +524,6 @@ export function useModelsFromSettings() {
     openaiApiKeySet,
     codexOauthSet,
     requiresCodexOauth,
+    isAllowedByPolicyOnActiveRoute,
   };
 }

--- a/src/browser/hooks/useModelsFromSettings.ts
+++ b/src/browser/hooks/useModelsFromSettings.ts
@@ -217,7 +217,20 @@ export function useModelsFromSettings() {
   const openaiApiKeySet = config === null ? null : config.openai?.apiKeySet === true;
   const codexOauthSet = config === null ? null : config.openai?.codexOauthSet === true;
 
-  const requiresCodexOauth = (modelId: string) => isCodexOauthRequiredModel(modelId, config);
+  // The OpenAI auth gates below apply to the direct route only. A gateway
+  // route (mux-gateway, openrouter, ...) supplies its own credentials, so the
+  // user's OpenAI auth state must not hide, or warn about, models the gateway
+  // serves. For a model with no active route, resolveRoute falls back to
+  // direct, which keeps the gate in place.
+  const resolvesToDirectOpenAI = useCallback(
+    (modelId: string) =>
+      resolveRoute(modelId, routePriority, routeOverrides, isConfigured, isGatewayModelAccessible)
+        .routeProvider === "openai",
+    [routePriority, routeOverrides, isConfigured, isGatewayModelAccessible]
+  );
+
+  const requiresCodexOauth = (modelId: string) =>
+    isCodexOauthRequiredModel(modelId, config) && resolvesToDirectOpenAI(modelId);
 
   const providerHiddenModels = useMemo(() => {
     if (config == null) {
@@ -314,28 +327,19 @@ export function useModelsFromSettings() {
     const hasOpenaiApiKey = openaiApiKeySet === true;
     const hasCodexOauth = codexOauthSet === true;
 
-    // OpenAI model gating (direct route only):
+    // OpenAI model gating (direct route only; see resolvesToDirectOpenAI):
     // - API key + OAuth: allow everything.
     // - API key only: hide models that require OAuth.
     // - OAuth only: show only models routable via OAuth.
     // - Neither: hide models that require OAuth (status quo).
-    // A gateway route (mux-gateway, openrouter, ...) supplies its own
-    // credentials, so the user's OpenAI auth state must not hide models the
-    // gateway serves. providerFiltered already guarantees an active route, so
-    // resolveRoute returns that route rather than its direct fallback.
+    // providerFiltered already guarantees an active route, so the resolved
+    // route is the real one rather than the direct fallback.
     const next = providerFiltered.filter((modelId) => {
       if (!modelId.startsWith("openai:")) {
         return true;
       }
 
-      const route = resolveRoute(
-        modelId,
-        routePriority,
-        routeOverrides,
-        isConfigured,
-        isGatewayModelAccessible
-      );
-      if (route.routeProvider !== "openai") {
+      if (!resolvesToDirectOpenAI(modelId)) {
         return true;
       }
 
@@ -358,6 +362,7 @@ export function useModelsFromSettings() {
     isConfigured,
     isGatewayModelAccessible,
     isAuthoritativeProviderModelAccessible,
+    resolvesToDirectOpenAI,
     routePriority,
     routeOverrides,
     openaiApiKeySet,

--- a/src/browser/hooks/useModelsFromSettings.ts
+++ b/src/browser/hooks/useModelsFromSettings.ts
@@ -9,7 +9,7 @@ import { usePolicy } from "@/browser/contexts/PolicyContext";
 import { useAPI } from "@/browser/contexts/API";
 import { isValidProvider } from "@/common/constants/providers";
 import { isCustomProviderConfig } from "@/common/utils/providers/customProviders";
-import { isModelAllowedByPolicy } from "@/browser/utils/policyUi";
+import { isGatewayModelAccessibleForUi, isModelAllowedByPolicy } from "@/browser/utils/policyUi";
 import {
   getExplicitGatewayPrefix,
   normalizeSelectedModel,
@@ -19,10 +19,7 @@ import { isModelAvailable, resolveRoute } from "@/common/routing";
 import type { ProviderModelEntry, ProvidersConfigMap } from "@/common/orpc/types";
 import { DEFAULT_MODEL_KEY, HIDDEN_MODELS_KEY } from "@/common/constants/storage";
 
-import {
-  isGatewayModelAccessibleFromAuthoritativeCatalog,
-  isProviderModelAccessibleFromAuthoritativeCatalog,
-} from "@/common/utils/providers/gatewayModelCatalog";
+import { isProviderModelAccessibleFromAuthoritativeCatalog } from "@/common/utils/providers/gatewayModelCatalog";
 import { getProviderModelEntryId } from "@/common/utils/providers/modelEntries";
 
 const BUILT_IN_MODELS: string[] = Object.values(KNOWN_MODELS).map((m) => m.id);
@@ -197,17 +194,7 @@ export function useModelsFromSettings() {
 
   const isGatewayModelAccessible = useCallback(
     (gateway: string, modelId: string) =>
-      // Mirror the backend's routing-time policy gate
-      // (createGatewayModelAccessibilityChecker): a gateway model the policy
-      // disallows falls back to other routes, so it must not count as a route here.
-      isModelAllowedByPolicy(effectivePolicy, `${gateway}:${modelId}`) &&
-      isGatewayModelAccessibleFromAuthoritativeCatalog(
-        gateway,
-        modelId,
-        config?.[gateway]?.models,
-        config?.[gateway]?.discoveredModels,
-        config?.[gateway]?.removedModels
-      ),
+      isGatewayModelAccessibleForUi(effectivePolicy, config, gateway, modelId),
     [config, effectivePolicy]
   );
 

--- a/src/browser/hooks/useModelsFromSettings.ts
+++ b/src/browser/hooks/useModelsFromSettings.ts
@@ -105,6 +105,26 @@ export function getSuggestedModels(config: ProvidersConfigMap | null): string[] 
   return dedupeKeepFirst([...customModels, ...BUILT_IN_MODELS]);
 }
 
+/**
+ * The OpenAI auth gates in this hook apply to the direct route only. A gateway
+ * route (mux-gateway, openrouter, ...) supplies its own credentials, so the
+ * user's OpenAI auth state must not hide, or warn about, models the gateway
+ * serves. For a model with no active route, resolveRoute falls back to direct,
+ * which keeps the gate in place.
+ */
+function resolvesToDirectOpenAI(
+  modelId: string,
+  routePriority: string[],
+  routeOverrides: Record<string, string>,
+  isConfigured: (provider: string) => boolean,
+  isGatewayModelAccessible: (gateway: string, modelId: string) => boolean
+): boolean {
+  return (
+    resolveRoute(modelId, routePriority, routeOverrides, isConfigured, isGatewayModelAccessible)
+      .routeProvider === "openai"
+  );
+}
+
 export function getDefaultModel(): string {
   const fallback = WORKSPACE_DEFAULTS.model;
   const persisted = readPersistedString(DEFAULT_MODEL_KEY);
@@ -177,6 +197,10 @@ export function useModelsFromSettings() {
 
   const isGatewayModelAccessible = useCallback(
     (gateway: string, modelId: string) =>
+      // Mirror the backend's routing-time policy gate
+      // (createGatewayModelAccessibilityChecker): a gateway model the policy
+      // disallows falls back to other routes, so it must not count as a route here.
+      isModelAllowedByPolicy(effectivePolicy, `${gateway}:${modelId}`) &&
       isGatewayModelAccessibleFromAuthoritativeCatalog(
         gateway,
         modelId,
@@ -184,7 +208,7 @@ export function useModelsFromSettings() {
         config?.[gateway]?.discoveredModels,
         config?.[gateway]?.removedModels
       ),
-    [config]
+    [config, effectivePolicy]
   );
 
   const isAuthoritativeProviderModelAccessible = useCallback(
@@ -217,20 +241,15 @@ export function useModelsFromSettings() {
   const openaiApiKeySet = config === null ? null : config.openai?.apiKeySet === true;
   const codexOauthSet = config === null ? null : config.openai?.codexOauthSet === true;
 
-  // The OpenAI auth gates below apply to the direct route only. A gateway
-  // route (mux-gateway, openrouter, ...) supplies its own credentials, so the
-  // user's OpenAI auth state must not hide, or warn about, models the gateway
-  // serves. For a model with no active route, resolveRoute falls back to
-  // direct, which keeps the gate in place.
-  const resolvesToDirectOpenAI = useCallback(
-    (modelId: string) =>
-      resolveRoute(modelId, routePriority, routeOverrides, isConfigured, isGatewayModelAccessible)
-        .routeProvider === "openai",
-    [routePriority, routeOverrides, isConfigured, isGatewayModelAccessible]
-  );
-
   const requiresCodexOauth = (modelId: string) =>
-    isCodexOauthRequiredModel(modelId, config) && resolvesToDirectOpenAI(modelId);
+    isCodexOauthRequiredModel(modelId, config) &&
+    resolvesToDirectOpenAI(
+      modelId,
+      routePriority,
+      routeOverrides,
+      isConfigured,
+      isGatewayModelAccessible
+    );
 
   const providerHiddenModels = useMemo(() => {
     if (config == null) {
@@ -339,7 +358,15 @@ export function useModelsFromSettings() {
         return true;
       }
 
-      if (!resolvesToDirectOpenAI(modelId)) {
+      if (
+        !resolvesToDirectOpenAI(
+          modelId,
+          routePriority,
+          routeOverrides,
+          isConfigured,
+          isGatewayModelAccessible
+        )
+      ) {
         return true;
       }
 
@@ -362,7 +389,6 @@ export function useModelsFromSettings() {
     isConfigured,
     isGatewayModelAccessible,
     isAuthoritativeProviderModelAccessible,
-    resolvesToDirectOpenAI,
     routePriority,
     routeOverrides,
     openaiApiKeySet,

--- a/src/browser/hooks/useRouting.test.ts
+++ b/src/browser/hooks/useRouting.test.ts
@@ -4,8 +4,9 @@ import { GlobalWindow } from "happy-dom";
 import React from "react";
 
 import { APIProvider, type APIClient } from "@/browser/contexts/API";
+import { PolicyProvider } from "@/browser/contexts/PolicyContext";
 import { KNOWN_MODELS } from "@/common/constants/knownModels";
-import type { ProvidersConfigMap } from "@/common/orpc/types";
+import type { PolicyGetResponse, ProvidersConfigMap } from "@/common/orpc/types";
 import { getAppConfigStore } from "@/browser/stores/AppConfigStore";
 import { getProvidersConfigStore } from "@/browser/stores/ProvidersConfigStore";
 
@@ -19,6 +20,12 @@ let configGetConfig: () => Promise<{
   routeOverrides: Record<string, string>;
 }>;
 let updateRoutePreferencesImpl: () => Promise<undefined>;
+const POLICY_DISABLED: PolicyGetResponse = {
+  source: "none",
+  status: { state: "disabled" },
+  policy: null,
+};
+let policyResponse: PolicyGetResponse = POLICY_DISABLED;
 
 async function* emptyStream() {
   await Promise.resolve();
@@ -38,16 +45,22 @@ function createStubApiClient(): APIClient {
       onConfigChanged: () => Promise.resolve(emptyStream()),
       updateRoutePreferences: () => updateRoutePreferencesImpl(),
     },
+    policy: {
+      get: () => Promise.resolve(policyResponse),
+      onChanged: () => Promise.resolve(emptyStream()),
+    },
   } as unknown as APIClient;
 }
 
 const stubClient = createStubApiClient();
 
+// useRouting reads the policy (like AppLoader provides in the real app), so the
+// hook test tree needs a PolicyProvider under the API provider.
 const wrapper: React.FC<{ children: React.ReactNode }> = (props) =>
   React.createElement(
     APIProvider,
     { client: stubClient } as React.ComponentProps<typeof APIProvider>,
-    props.children
+    React.createElement(PolicyProvider, null, props.children)
   );
 
 describe("useRouting", () => {
@@ -66,6 +79,7 @@ describe("useRouting", () => {
     routeOverrides = {};
     configGetConfig = () => Promise.resolve({ routePriority, routeOverrides });
     updateRoutePreferencesImpl = () => Promise.resolve(undefined);
+    policyResponse = POLICY_DISABLED;
   });
 
   afterEach(() => {
@@ -110,6 +124,48 @@ describe("useRouting", () => {
       route: "direct",
       isAuto: true,
       displayName: "Direct",
+    });
+  });
+
+  test("an enforced policy that blocks the gateway model removes that route", async () => {
+    providersConfig = {
+      openai: { apiKeySet: true, isEnabled: true, isConfigured: true },
+      "mux-gateway": {
+        apiKeySet: false,
+        isEnabled: true,
+        isConfigured: true,
+        couponCodeSet: true,
+      },
+    };
+    routePriority = ["mux-gateway", "direct"];
+    // The policy allows the canonical OpenAI models but lets the gateway serve
+    // only Sol. The backend rejects the gateway for GPT Pro at send time, so the
+    // UI must not offer or resolve that route either.
+    policyResponse = {
+      source: "env",
+      status: { state: "enforced" },
+      policy: {
+        policyFormatVersion: "0.1",
+        providerAccess: [
+          { id: "openai", allowedModels: null },
+          { id: "mux-gateway", allowedModels: [`openai/${KNOWN_MODELS.GPT.providerModelId}`] },
+        ],
+        mcp: { allowUserDefined: { stdio: true, remote: true } },
+        runtimes: null,
+      },
+    };
+    getProvidersConfigStore().setClient(stubClient);
+    getAppConfigStore().setClient(stubClient);
+
+    const { result } = renderHook(() => useRouting(), { wrapper });
+
+    const viaGateway = (modelId: string) =>
+      result.current.availableRoutes(modelId).some((route) => route.route === "mux-gateway");
+    await waitFor(() => {
+      expect(viaGateway(KNOWN_MODELS.GPT_PRO.id)).toBe(false);
+      expect(result.current.resolveRoute(KNOWN_MODELS.GPT_PRO.id).route).toBe("direct");
+      expect(viaGateway(KNOWN_MODELS.GPT.id)).toBe(true);
+      expect(result.current.resolveRoute(KNOWN_MODELS.GPT.id).route).toBe("mux-gateway");
     });
   });
 

--- a/src/browser/hooks/useRouting.ts
+++ b/src/browser/hooks/useRouting.ts
@@ -8,8 +8,9 @@ import {
   type AvailableRoute,
   type RouteContext,
 } from "@/common/routing";
+import { usePolicy } from "@/browser/contexts/PolicyContext";
+import { isGatewayModelAccessibleForUi } from "@/browser/utils/policyUi";
 import { normalizeToCanonical } from "@/common/utils/ai/models";
-import { isGatewayModelAccessibleFromAuthoritativeCatalog } from "@/common/utils/providers/gatewayModelCatalog";
 
 import { useProvidersConfig } from "./useProvidersConfig";
 
@@ -65,6 +66,9 @@ export interface RoutingState {
 export function useRouting(): RoutingState {
   const { api } = useAPI();
   const { config: providersConfig } = useProvidersConfig();
+  const policyState = usePolicy();
+  const effectivePolicy =
+    policyState.status.state === "enforced" ? (policyState.policy ?? null) : null;
   // Shared AppConfigStore (one fetch + one onConfigChanged subscription per
   // app session) instead of per-mount fetches: surfaces render one picker per
   // row, so per-instance subscriptions fanned out O(rows) backend reads.
@@ -80,16 +84,12 @@ export function useRouting(): RoutingState {
     [providersConfig]
   );
 
+  // Policy-aware so route pickers, availability, and resolution never offer a
+  // gateway route the backend rejects at send time.
   const isGatewayModelAccessible = useCallback(
     (gateway: string, modelId: string) =>
-      isGatewayModelAccessibleFromAuthoritativeCatalog(
-        gateway,
-        modelId,
-        providersConfig?.[gateway]?.models,
-        providersConfig?.[gateway]?.discoveredModels,
-        providersConfig?.[gateway]?.removedModels
-      ),
-    [providersConfig]
+      isGatewayModelAccessibleForUi(effectivePolicy, providersConfig, gateway, modelId),
+    [effectivePolicy, providersConfig]
   );
 
   const persistRoutePreferences = useCallback(

--- a/src/browser/utils/policyUi.ts
+++ b/src/browser/utils/policyUi.ts
@@ -1,10 +1,11 @@
 import { SUPPORTED_PROVIDERS, type ProviderName } from "@/common/constants/providers";
 import { RUNTIME_MODE, type ParsedRuntime, type RuntimeMode } from "@/common/types/runtime";
-import type { EffectivePolicy, PolicyRuntimeId } from "@/common/orpc/types";
+import type { EffectivePolicy, PolicyRuntimeId, ProvidersConfigMap } from "@/common/orpc/types";
 import {
   getCustomProviderIds,
   type ProvidersConfigWithProviderType,
 } from "@/common/utils/providers/customProviders";
+import { isGatewayModelAccessibleFromAuthoritativeCatalog } from "@/common/utils/providers/gatewayModelCatalog";
 
 /**
  * Parse a model string into provider and modelId.
@@ -54,6 +55,31 @@ export function isModelAllowedByPolicy(
   }
 
   return allowedModels.includes(parsed.modelId);
+}
+
+/**
+ * Can this gateway serve the model? Mirrors the backend's routing-time check
+ * (createGatewayModelAccessibilityChecker): the gateway's authoritative catalog
+ * must list the model and the policy must allow the gateway model. A gateway
+ * model that fails either check falls back to other routes on the backend, so
+ * UI route resolution must not count it as a route.
+ */
+export function isGatewayModelAccessibleForUi(
+  policy: EffectivePolicy | null,
+  providersConfig: ProvidersConfigMap | null,
+  gateway: string,
+  modelId: string
+): boolean {
+  return (
+    isModelAllowedByPolicy(policy, `${gateway}:${modelId}`) &&
+    isGatewayModelAccessibleFromAuthoritativeCatalog(
+      gateway,
+      modelId,
+      providersConfig?.[gateway]?.models,
+      providersConfig?.[gateway]?.discoveredModels,
+      providersConfig?.[gateway]?.removedModels
+    )
+  );
 }
 
 export function getAllowedProvidersForUi(policy: EffectivePolicy | null): ProviderName[];

--- a/src/common/constants/codexOAuth.test.ts
+++ b/src/common/constants/codexOAuth.test.ts
@@ -39,6 +39,15 @@ describe("codexOAuth model gating", () => {
     }
   });
 
+  it("allows GPT-6 Astra through Codex OAuth with the GPT-5.6 context cap", () => {
+    expect(isCodexOauthAllowedModelId("gpt-6-astra")).toBe(true);
+    expect(isCodexOauthAllowedModelId("openai:gpt-6-astra")).toBe(true);
+    expect(isCodexOauthRequiredModelId("gpt-6-astra")).toBe(false);
+    expect(isCodexOauthRequiredModelId("openai:gpt-6-astra")).toBe(false);
+    expect(getCodexOauthContextWindowOverride("gpt-6-astra")).toBe(372_000);
+    expect(getCodexOauthContextWindowOverride("openai:gpt-6-astra")).toBe(372_000);
+  });
+
   it("does not allow GPT-5.5 Pro through the Codex OAuth route", () => {
     expect(isCodexOauthAllowedModelId("gpt-5.5-pro")).toBe(false);
     expect(isCodexOauthAllowedModelId("openai:gpt-5.5-pro")).toBe(false);

--- a/src/common/constants/codexOAuth.ts
+++ b/src/common/constants/codexOAuth.ts
@@ -112,6 +112,10 @@ export const CODEX_OAUTH_ALLOWED_MODELS = new Set<string>([
   "gpt-5.6-sol",
   "gpt-5.6-terra",
   "gpt-5.6-luna",
+  // GPT-6 Astra (September 3, 2026): served in Codex for ChatGPT subscribers and
+  // in the public API. Without this entry an OAuth-only user selecting Astra
+  // falls to the API-key path and fails with api_key_not_found.
+  "gpt-6-astra",
   "gpt-5.2-codex",
   "gpt-5.3-codex",
   "gpt-5.3-codex-spark",
@@ -145,6 +149,9 @@ const CODEX_OAUTH_CONTEXT_WINDOW_OVERRIDES: Record<string, number> = {
   "gpt-5.6-sol": 372_000,
   "gpt-5.6-terra": 372_000,
   "gpt-5.6-luna": 372_000,
+  // Astra shares the GPT-5.6 Codex cap: the catalog lists the same window for
+  // Astra and Sol.
+  "gpt-6-astra": 372_000,
 };
 
 function normalizeCodexOauthModelId(modelId: string): string {

--- a/src/common/types/providerOptions.ts
+++ b/src/common/types/providerOptions.ts
@@ -13,3 +13,6 @@ import type { MuxProviderOptionsSchema } from "../orpc/schemas";
  */
 
 export type MuxProviderOptions = z.infer<typeof MuxProviderOptionsSchema>;
+
+/** OpenAI wire format selected in provider settings or per request. */
+export type OpenAIWireFormat = NonNullable<NonNullable<MuxProviderOptions["openai"]>["wireFormat"]>;

--- a/src/common/utils/ai/cacheStrategy.test.ts
+++ b/src/common/utils/ai/cacheStrategy.test.ts
@@ -418,6 +418,28 @@ describe("cacheStrategy", () => {
       ).toBe(true);
     });
 
+    it("accepts a request-level Chat Completions wire format that falls back to the API key", () => {
+      // Stored config prefers OAuth and leaves wireFormat unset; the request selects
+      // Chat Completions, which Codex OAuth cannot serve, so the API key is used.
+      expect(
+        openaiExplicitPromptCachingAvailable(
+          "openai:gpt-5.6-sol",
+          "openai",
+          openaiProvidersConfig({ codexOauthSet: true }),
+          { openaiWireFormat: "chatCompletions" }
+        )
+      ).toBe(true);
+      // The stored wire format wins over the request-level value.
+      expect(
+        openaiExplicitPromptCachingAvailable(
+          "openai:gpt-5.6-sol",
+          "openai",
+          openaiProvidersConfig({ codexOauthSet: true, wireFormat: "responses" }),
+          { openaiWireFormat: "chatCompletions" }
+        )
+      ).toBe(false);
+    });
+
     it("rejects when the providers config view is unavailable", () => {
       expect(openaiExplicitPromptCachingAvailable("openai:gpt-5.6-sol", "openai", null)).toBe(
         false

--- a/src/common/utils/ai/cacheStrategy.ts
+++ b/src/common/utils/ai/cacheStrategy.ts
@@ -3,7 +3,10 @@ import type { ProvidersConfigMap } from "@/common/orpc/types";
 import { isGpt56FamilyModel } from "@/common/types/thinking";
 import assert from "@/common/utils/assert";
 import { cloneToolPreservingDescriptors } from "@/common/utils/tools/cloneToolPreservingDescriptors";
-import { wouldRouteOpenAIThroughCodexOauth } from "@/common/utils/providers/codexOauthRouting";
+import {
+  wouldRouteOpenAIThroughCodexOauth,
+  type CodexOauthRoutingOptions,
+} from "@/common/utils/providers/codexOauthRouting";
 import { resolveCoderWireCanonicalModel } from "@/common/constants/coderOAuth";
 import {
   customProviderWireOrigin,
@@ -256,7 +259,8 @@ function isOfficialOpenAIBaseUrl(baseUrl: string): boolean {
 export function openaiExplicitPromptCachingAvailable(
   modelString: string,
   routeProvider: string | undefined,
-  providersConfig: ProvidersConfigMap | null
+  providersConfig: ProvidersConfigMap | null,
+  options?: CodexOauthRoutingOptions
 ): boolean {
   if (routeProvider !== "openai") {
     return false;
@@ -293,7 +297,7 @@ export function openaiExplicitPromptCachingAvailable(
     return false;
   }
 
-  if (wouldRouteOpenAIThroughCodexOauth(normalized, providersConfig)) {
+  if (wouldRouteOpenAIThroughCodexOauth(normalized, providersConfig, options)) {
     return false;
   }
 
@@ -323,11 +327,12 @@ export function createOpenAICachedSystemMessage(
   systemContent: string,
   modelString: string,
   routeProvider: string | undefined,
-  providersConfig: ProvidersConfigMap | null
+  providersConfig: ProvidersConfigMap | null,
+  options?: CodexOauthRoutingOptions
 ): SystemModelMessage | null {
   if (
     !systemContent ||
-    !openaiExplicitPromptCachingAvailable(modelString, routeProvider, providersConfig)
+    !openaiExplicitPromptCachingAvailable(modelString, routeProvider, providersConfig, options)
   ) {
     return null;
   }

--- a/src/common/utils/ai/openaiProviderOptionsAvailability.ts
+++ b/src/common/utils/ai/openaiProviderOptionsAvailability.ts
@@ -3,6 +3,7 @@
  * forwarded by gateway or Codex OAuth routes.
  */
 import type { ProvidersConfigMap } from "@/common/orpc/types";
+import type { OpenAIWireFormat } from "@/common/types/providerOptions";
 import { PROVIDER_DEFINITIONS } from "@/common/constants/providers";
 import { getExplicitGatewayPrefix, normalizeToCanonical } from "@/common/utils/ai/models";
 import { wouldRouteOpenAIThroughCodexOauth } from "@/common/utils/providers/codexOauthRouting";
@@ -12,6 +13,8 @@ export interface OpenAIDirectProviderOptionsAvailability {
   resolvedRouteProvider?: string | null;
   /** Providers config for explicit gateway and Codex OAuth route detection. */
   providersConfig?: ProvidersConfigMap | null;
+  /** Request-level OpenAI wire format; the stored config value wins when set. */
+  openaiWireFormat?: OpenAIWireFormat | null;
 }
 
 export function openaiDirectProviderOptionsAvailable(
@@ -50,6 +53,8 @@ export function openaiDirectProviderOptionsAvailable(
   // API-only provider options, so toggles for those options must fail closed.
   return !(
     options?.providersConfig != null &&
-    wouldRouteOpenAIThroughCodexOauth(normalized, options.providersConfig)
+    wouldRouteOpenAIThroughCodexOauth(normalized, options.providersConfig, {
+      openaiWireFormat: options.openaiWireFormat,
+    })
   );
 }

--- a/src/common/utils/ai/proMode.ts
+++ b/src/common/utils/ai/proMode.ts
@@ -26,10 +26,7 @@ import {
 } from "@/common/utils/ai/openaiProviderOptionsAvailability";
 import { resolveModelForMetadata } from "@/common/utils/providers/modelEntries";
 
-export interface ProModeAvailabilityOptions extends OpenAIDirectProviderOptionsAvailability {
-  /** Overrides the providersConfig-derived OpenAI wire format when provided. */
-  openaiWireFormat?: "responses" | "chatCompletions" | null;
-}
+export type ProModeAvailabilityOptions = OpenAIDirectProviderOptionsAvailability;
 
 export function openaiProModeAvailable(
   modelString: string,

--- a/src/common/utils/ai/providerOptions.ts
+++ b/src/common/utils/ai/providerOptions.ts
@@ -521,7 +521,10 @@ export function buildProviderOptions(
           openaiExplicitPromptCachingAvailable(
             modelString,
             routeProvider,
-            providersConfig ?? null
+            providersConfig ?? null,
+            {
+              openaiWireFormat: wireFormat,
+            }
           ) && { promptCacheKey }),
         // Conditionally add reasoning configuration
         ...(reasoningEffort && {

--- a/src/common/utils/compaction/autoCompactionCheck.ts
+++ b/src/common/utils/compaction/autoCompactionCheck.ts
@@ -22,6 +22,7 @@ import {
   FORCE_COMPACTION_BUFFER_PERCENT,
 } from "@/common/constants/ui";
 import { getEffectiveContextLimit } from "./contextLimit";
+import type { CodexOauthRoutingOptions } from "@/common/utils/providers/codexOauthRouting";
 
 /**
  * Get context window tokens (input only).
@@ -71,6 +72,7 @@ const WARNING_ADVANCE_PERCENT = 10;
  * @param threshold - Usage percentage threshold (0.0-1.0, default 0.7 = 70%). If >= 1.0, auto-compaction is considered disabled.
  * @param warningAdvancePercent - Show warning this many percentage points before threshold (default 10)
  * @param providersConfig - Provider config used for custom model context overrides
+ * @param routingOptions - Request-level routing inputs (backend send path only)
  * @returns Check result with warning flag and usage percentage
  */
 export function checkAutoCompaction(
@@ -79,7 +81,8 @@ export function checkAutoCompaction(
   use1M: boolean,
   threshold: number = DEFAULT_AUTO_COMPACTION_THRESHOLD,
   warningAdvancePercent: number = WARNING_ADVANCE_PERCENT,
-  providersConfig: ProvidersConfigMap | null = null
+  providersConfig: ProvidersConfigMap | null = null,
+  routingOptions?: CodexOauthRoutingOptions
 ): AutoCompactionCheckResult {
   const thresholdPercentage = threshold * 100;
   const isEnabled = threshold < 1.0;
@@ -95,7 +98,7 @@ export function checkAutoCompaction(
   }
 
   // Determine max tokens for this model
-  const maxTokens = getEffectiveContextLimit(model, use1M, providersConfig);
+  const maxTokens = getEffectiveContextLimit(model, use1M, providersConfig, routingOptions);
 
   // No max tokens known - safe default (can't calculate percentage)
   if (!maxTokens) {

--- a/src/common/utils/compaction/contextLimit.test.ts
+++ b/src/common/utils/compaction/contextLimit.test.ts
@@ -158,6 +158,29 @@ describe("getEffectiveContextLimit", () => {
     expect(limit).toBe(1_050_000);
   });
 
+  test("keeps the API window for Chat Completions when an API key exists, even if OAuth is preferred", () => {
+    // Mirrors providerModelFactory: Codex OAuth serves only the Responses API.
+    const limit = getEffectiveContextLimit(
+      "openai:gpt-5.5",
+      false,
+      providersWithOpenAI({
+        apiKeySet: true,
+        codexOauthSet: true,
+        codexOauthDefaultAuth: "oauth",
+        wireFormat: "chatCompletions",
+      })
+    );
+    expect(limit).toBe(1_050_000);
+
+    // Without an API key there is nothing to fall back to; the OAuth cap stays.
+    const oauthOnlyLimit = getEffectiveContextLimit(
+      "openai:gpt-5.5",
+      false,
+      providersWithOpenAI({ codexOauthSet: true, wireFormat: "chatCompletions" })
+    );
+    expect(oauthOnlyLimit).toBe(272_000);
+  });
+
   test("does not treat unresolved API-key files as active API-key auth", () => {
     const limit = getEffectiveContextLimit(
       "openai:gpt-5.5",

--- a/src/common/utils/compaction/contextLimit.test.ts
+++ b/src/common/utils/compaction/contextLimit.test.ts
@@ -181,6 +181,48 @@ describe("getEffectiveContextLimit", () => {
     expect(oauthOnlyLimit).toBe(272_000);
   });
 
+  test("honors a request-level Chat Completions wire format, with the stored value winning", () => {
+    const bothCredsOauthPreferred = providersWithOpenAI({
+      apiKeySet: true,
+      codexOauthSet: true,
+      codexOauthDefaultAuth: "oauth",
+    });
+    // Stored config leaves wireFormat unset; the request selects Chat Completions,
+    // so the factory uses the API key and the OAuth cap must not apply.
+    expect(
+      getEffectiveContextLimit("openai:gpt-5.5", false, bothCredsOauthPreferred, {
+        openaiWireFormat: "chatCompletions",
+      })
+    ).toBe(1_050_000);
+
+    // A stored Responses wire format wins over the request-level value.
+    expect(
+      getEffectiveContextLimit(
+        "openai:gpt-5.5",
+        false,
+        providersWithOpenAI({
+          apiKeySet: true,
+          codexOauthSet: true,
+          codexOauthDefaultAuth: "oauth",
+          wireFormat: "responses",
+        }),
+        { openaiWireFormat: "chatCompletions" }
+      )
+    ).toBe(272_000);
+
+    // OAuth only: no API key to fall back to, so the OAuth cap stays.
+    expect(
+      getEffectiveContextLimit(
+        "openai:gpt-5.5",
+        false,
+        providersWithOpenAI({ codexOauthSet: true }),
+        {
+          openaiWireFormat: "chatCompletions",
+        }
+      )
+    ).toBe(272_000);
+  });
+
   test("does not treat unresolved API-key files as active API-key auth", () => {
     const limit = getEffectiveContextLimit(
       "openai:gpt-5.5",

--- a/src/common/utils/compaction/contextLimit.test.ts
+++ b/src/common/utils/compaction/contextLimit.test.ts
@@ -114,6 +114,26 @@ describe("getEffectiveContextLimit", () => {
     }
   });
 
+  test("caps GPT-6 Astra on the OAuth route but keeps the API window for API-key auth", () => {
+    const oauthOnlyLimit = getEffectiveContextLimit(
+      "openai:gpt-6-astra",
+      false,
+      providersWithOpenAI({ codexOauthSet: true })
+    );
+    expect(oauthOnlyLimit).toBe(372_000);
+
+    const apiKeyLimit = getEffectiveContextLimit(
+      "openai:gpt-6-astra",
+      false,
+      providersWithOpenAI({
+        apiKeySet: true,
+        codexOauthSet: true,
+        codexOauthDefaultAuth: "apiKey",
+      })
+    );
+    expect(apiKeyLimit).toBe(1_050_000);
+  });
+
   test("does not apply the GPT-5.5 OAuth cap to gateway-routed models", () => {
     const limit = getEffectiveContextLimit(
       "openrouter:openai/gpt-5.5",

--- a/src/common/utils/compaction/contextLimit.ts
+++ b/src/common/utils/compaction/contextLimit.ts
@@ -9,7 +9,10 @@ import {
   getCodexOauthCompatibilityModelId,
   getCodexOauthContextWindowOverride,
 } from "@/common/constants/codexOAuth";
-import { wouldRouteOpenAIThroughCodexOauth } from "@/common/utils/providers/codexOauthRouting";
+import {
+  wouldRouteOpenAIThroughCodexOauth,
+  type CodexOauthRoutingOptions,
+} from "@/common/utils/providers/codexOauthRouting";
 import type { ProvidersConfigMap } from "@/common/orpc/types";
 import { supports1MContext } from "@/common/utils/ai/models";
 import {
@@ -20,7 +23,8 @@ import { getModelStats } from "@/common/utils/tokens/modelStats";
 
 function getCodexOauthContextLimit(
   model: string,
-  providersConfig: ProvidersConfigMap | null
+  providersConfig: ProvidersConfigMap | null,
+  options: CodexOauthRoutingOptions | undefined
 ): number | null {
   const compatibilityModelId = getCodexOauthCompatibilityModelId(model, providersConfig);
   if (compatibilityModelId === null) {
@@ -32,7 +36,7 @@ function getCodexOauthContextLimit(
     return null;
   }
 
-  return wouldRouteOpenAIThroughCodexOauth(model, providersConfig) ? oauthLimit : null;
+  return wouldRouteOpenAIThroughCodexOauth(model, providersConfig, options) ? oauthLimit : null;
 }
 
 /**
@@ -41,12 +45,14 @@ function getCodexOauthContextLimit(
  * @param model - Model ID (e.g., "anthropic:claude-sonnet-4-5")
  * @param use1M - Whether 1M context is enabled in settings
  * @param providersConfig - Provider configuration map for custom model overrides
+ * @param options - Request-level routing inputs (backend send path); browser callers have none
  * @returns Max input tokens, or null if no limit is known
  */
 export function getEffectiveContextLimit(
   model: string,
   use1M: boolean,
-  providersConfig: ProvidersConfigMap | null = null
+  providersConfig: ProvidersConfigMap | null = null,
+  options?: CodexOauthRoutingOptions
 ): number | null {
   const metadataModel = resolveModelForMetadata(model, providersConfig);
   const customOverride = getModelContextWindowOverride(model, providersConfig);
@@ -57,7 +63,7 @@ export function getEffectiveContextLimit(
   // ChatGPT/Codex OAuth can impose a smaller routing-layer cap than the public OpenAI
   // API metadata. Cap the effective window so auto-compaction and token meters compact
   // before OAuth requests reach provider-side validation failures.
-  const codexOauthLimit = getCodexOauthContextLimit(model, providersConfig);
+  const codexOauthLimit = getCodexOauthContextLimit(model, providersConfig, options);
   if (codexOauthLimit != null) {
     return Math.min(baseLimit, codexOauthLimit);
   }

--- a/src/common/utils/providers/codexOauthRouting.ts
+++ b/src/common/utils/providers/codexOauthRouting.ts
@@ -63,8 +63,9 @@ export function hasOpenAIApiKey(config: unknown): boolean {
  * Would a direct-OpenAI request for this model route through Codex OAuth?
  *
  * Mirrors providerModelFactory: allowed model + stored OAuth tokens, then
- * required models always route OAuth; otherwise OAuth wins when no API key is
- * configured or when `codexOauthDefaultAuth` prefers OAuth over a present key.
+ * Chat Completions with an API key never routes OAuth, required models always
+ * route OAuth; otherwise OAuth wins when no API key is configured or when
+ * `codexOauthDefaultAuth` prefers OAuth over a present key.
  */
 export function wouldRouteOpenAIThroughCodexOauth(
   model: string,
@@ -75,6 +76,11 @@ export function wouldRouteOpenAIThroughCodexOauth(
     return false;
   }
   if (!hasCodexOauthTokens(openAIConfig)) {
+    return false;
+  }
+  // Codex OAuth serves only the Responses API. With Chat Completions selected,
+  // the factory falls back to the API key whenever one exists.
+  if (asRecord(openAIConfig)?.wireFormat === "chatCompletions" && hasOpenAIApiKey(openAIConfig)) {
     return false;
   }
   if (isCodexOauthRequiredModel(model, providersConfig ?? null)) {

--- a/src/common/utils/providers/codexOauthRouting.ts
+++ b/src/common/utils/providers/codexOauthRouting.ts
@@ -11,6 +11,16 @@
 
 import { isCodexOauthAllowedModel, isCodexOauthRequiredModel } from "@/common/constants/codexOAuth";
 import type { ProvidersConfigMap } from "@/common/orpc/types";
+import type { OpenAIWireFormat } from "@/common/types/providerOptions";
+
+/** Request-level inputs the stored providers config cannot carry. */
+export interface CodexOauthRoutingOptions {
+  /**
+   * Request-level OpenAI wire format (muxProviderOptions.openai.wireFormat).
+   * The stored `openai.wireFormat` wins when set, matching providerModelFactory.
+   */
+  openaiWireFormat?: OpenAIWireFormat | null;
+}
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
@@ -69,7 +79,8 @@ export function hasOpenAIApiKey(config: unknown): boolean {
  */
 export function wouldRouteOpenAIThroughCodexOauth(
   model: string,
-  providersConfig: ProvidersConfigMap | null | undefined
+  providersConfig: ProvidersConfigMap | null | undefined,
+  options?: CodexOauthRoutingOptions
 ): boolean {
   const openAIConfig = providersConfig?.openai;
   if (!isCodexOauthAllowedModel(model, providersConfig ?? null)) {
@@ -80,7 +91,8 @@ export function wouldRouteOpenAIThroughCodexOauth(
   }
   // Codex OAuth serves only the Responses API. With Chat Completions selected,
   // the factory falls back to the API key whenever one exists.
-  if (asRecord(openAIConfig)?.wireFormat === "chatCompletions" && hasOpenAIApiKey(openAIConfig)) {
+  const wireFormat = asRecord(openAIConfig)?.wireFormat ?? options?.openaiWireFormat;
+  if (wireFormat === "chatCompletions" && hasOpenAIApiKey(openAIConfig)) {
     return false;
   }
   if (isCodexOauthRequiredModel(model, providersConfig ?? null)) {

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -3691,6 +3691,7 @@ export class AgentSession {
           providersConfigForCompaction
         ),
         providersConfig: providersConfigForCompaction,
+        openaiWireFormat: optionsForStream.providerOptions?.openai?.wireFormat,
       });
 
       // On-send compaction uses the configured threshold directly so we compact
@@ -5974,6 +5975,7 @@ export class AgentSession {
           streamContext?.providersConfig ?? null
         ),
         providersConfig: streamContext?.providersConfig ?? null,
+        openaiWireFormat: streamOptions?.providerOptions?.openai?.wireFormat,
       });
 
       if (shouldInterruptForCompaction) {

--- a/src/node/services/compactionMonitor.test.ts
+++ b/src/node/services/compactionMonitor.test.ts
@@ -111,6 +111,42 @@ describe("CompactionMonitor", () => {
     expect(statusEvents).toHaveLength(1);
   });
 
+  test("checkMidStream applies the request wire format to the Codex OAuth cap", () => {
+    // API key + OAuth preferred: Responses requests route OAuth (272K cap), while a
+    // request-level Chat Completions selection falls back to the API key (1.05M).
+    const providersConfig: ProvidersConfigMap = {
+      openai: {
+        apiKeySet: true,
+        isEnabled: true,
+        isConfigured: true,
+        codexOauthSet: true,
+        codexOauthDefaultAuth: "oauth",
+      },
+    };
+    const usage = createMidStreamUsage(260_000);
+
+    const { monitor: oauthMonitor } = createMonitor();
+    expect(
+      oauthMonitor.checkMidStream({
+        model: "openai:gpt-5.5",
+        usage,
+        use1MContext: false,
+        providersConfig,
+      })
+    ).toBe(true);
+
+    const { monitor: apiKeyMonitor } = createMonitor();
+    expect(
+      apiKeyMonitor.checkMidStream({
+        model: "openai:gpt-5.5",
+        usage,
+        use1MContext: false,
+        providersConfig,
+        openaiWireFormat: "chatCompletions",
+      })
+    ).toBe(false);
+  });
+
   test("checkMidStream stays disabled when threshold is set to 1.0", () => {
     const { monitor, statusEvents } = createMonitor();
     monitor.setThreshold(1);

--- a/src/node/services/compactionMonitor.ts
+++ b/src/node/services/compactionMonitor.ts
@@ -11,6 +11,7 @@ import {
   type AutoCompactionUsageState,
 } from "@/common/utils/compaction/autoCompactionCheck";
 import { getEffectiveContextLimit } from "@/common/utils/compaction/contextLimit";
+import type { OpenAIWireFormat } from "@/common/types/providerOptions";
 
 export type CompactionStatusEvent =
   | {
@@ -28,6 +29,8 @@ interface CheckBeforeSendParams {
   usage: AutoCompactionUsageState | undefined;
   use1MContext: boolean;
   providersConfig: ProvidersConfigMap | null;
+  /** Request-level OpenAI wire format; decides whether the Codex OAuth cap applies. */
+  openaiWireFormat?: OpenAIWireFormat | null;
 }
 
 interface CheckMidStreamParams {
@@ -35,6 +38,8 @@ interface CheckMidStreamParams {
   usage: LanguageModelV2Usage;
   use1MContext: boolean;
   providersConfig: ProvidersConfigMap | null;
+  /** Request-level OpenAI wire format; decides whether the Codex OAuth cap applies. */
+  openaiWireFormat?: OpenAIWireFormat | null;
 }
 
 /**
@@ -71,7 +76,8 @@ export class CompactionMonitor {
       params.use1MContext,
       this.threshold,
       undefined,
-      params.providersConfig
+      params.providersConfig,
+      { openaiWireFormat: params.openaiWireFormat }
     );
   }
 
@@ -101,7 +107,8 @@ export class CompactionMonitor {
     const contextLimit = getEffectiveContextLimit(
       params.model,
       params.use1MContext,
-      params.providersConfig
+      params.providersConfig,
+      { openaiWireFormat: params.openaiWireFormat }
     );
     // Defensive: malformed provider overrides can yield invalid/non-positive limits.
     // Treat those as "no compaction signal" instead of throwing inside usage-delta handlers.

--- a/src/node/services/providerModelFactory.test.ts
+++ b/src/node/services/providerModelFactory.test.ts
@@ -1483,6 +1483,48 @@ describe("ProviderModelFactory modelCostsIncluded", () => {
     });
   });
 
+  it("uses the API key for Chat Completions even when Codex OAuth is preferred", async () => {
+    await withTempConfig(async (config, factory) => {
+      new ProvidersConfigStore(config.rootDir).saveProvidersConfig({
+        openai: {
+          apiKey: "sk-test",
+          wireFormat: "chatCompletions",
+          codexOauthDefaultAuth: "oauth",
+          codexOauth: {
+            type: "oauth",
+            access: "test-access-token",
+            refresh: "test-refresh-token",
+            expires: Date.now() + 60_000,
+            accountId: "test-account-id",
+          },
+        },
+      });
+
+      const originalOpenAIRegistry = PROVIDER_REGISTRY.openai;
+      let capturedApiKey: string | undefined;
+      PROVIDER_REGISTRY.openai = async () => {
+        const module = await originalOpenAIRegistry();
+        return {
+          ...module,
+          createOpenAI: (options) => {
+            capturedApiKey = options?.apiKey;
+            return module.createOpenAI(options);
+          },
+        };
+      };
+
+      try {
+        // Codex OAuth serves only the Responses API, so the factory must hand the
+        // SDK the real key instead of the "codex-oauth" placeholder.
+        const result = await factory.createModel(KNOWN_MODELS.GPT_53_CODEX.id);
+        expect(result.success).toBe(true);
+        expect(capturedApiKey).toBe("sk-test");
+      } finally {
+        PROVIDER_REGISTRY.openai = originalOpenAIRegistry;
+      }
+    });
+  });
+
   it("does not mark gpt-5.3-codex as subscription-covered when routed through API key", async () => {
     await withTempConfig(async (config, factory) => {
       new ProvidersConfigStore(config.rootDir).saveProvidersConfig({

--- a/src/node/services/providerModelFactory.ts
+++ b/src/node/services/providerModelFactory.ts
@@ -1605,7 +1605,15 @@ export class ProviderModelFactory {
             .codexOauthDefaultAuth;
           const codexOauthDefaultAuth = codexOauthDefaultAuthRaw === "apiKey" ? "apiKey" : "oauth";
 
+          // Codex OAuth only serves the Responses API. Resolve the wire format
+          // before choosing credentials so Chat Completions falls back to the API
+          // key instead of sending the "codex-oauth" placeholder to api.openai.com.
+          const earlyWireFormat =
+            (providerConfig.wireFormat as string | undefined) ??
+            muxProviderOptions?.openai?.wireFormat;
+
           // Codex OAuth routing:
+          // - Chat Completions never routes through OAuth when an API key exists.
           // - Required models route through ChatGPT OAuth when connected.
           // - If OAuth is not connected, fall back to API key (if available).
           // - Allowed models route through OAuth only when:
@@ -1613,6 +1621,10 @@ export class ProviderModelFactory {
           //   - the user prefers OAuth when both are set.
           const shouldRouteThroughCodexOauth = (() => {
             if (!codexOauthAllowed || !storedCodexOauth) {
+              return false;
+            }
+
+            if (earlyWireFormat === "chatCompletions" && creds.isConfigured) {
               return false;
             }
 
@@ -1634,17 +1646,9 @@ export class ProviderModelFactory {
             return Err({ type: "api_key_not_found", provider: providerName });
           }
 
-          // chatCompletions mode requires a real API key — Codex OAuth only supports
-          // the Responses API endpoint. Block early with a clear error instead of
-          // sending requests with the "codex-oauth" placeholder key.
-          const earlyWireFormat =
-            (providerConfig.wireFormat as string | undefined) ??
-            muxProviderOptions?.openai?.wireFormat;
-          if (
-            shouldRouteThroughCodexOauth &&
-            earlyWireFormat === "chatCompletions" &&
-            !creds.isConfigured
-          ) {
+          // Chat Completions with OAuth only (no API key to fall back to): block
+          // early with a clear error instead of sending the placeholder key.
+          if (shouldRouteThroughCodexOauth && earlyWireFormat === "chatCompletions") {
             return Err({ type: "api_key_not_found", provider: providerName });
           }
 

--- a/src/node/services/turnContextAssembler.ts
+++ b/src/node/services/turnContextAssembler.ts
@@ -24,6 +24,7 @@ import type { XumToolScope } from "@/common/types/toolScope";
 import type { AgentDefinitionScope } from "@/common/types/agentDefinition";
 import type { WorkspaceMetadata } from "@/common/types/workspace";
 import type { ProvidersConfigMap } from "@/common/orpc/types";
+import type { OpenAIWireFormat } from "@/common/types/providerOptions";
 import type { TaskSettings } from "@/common/types/tasks";
 import type { Runtime } from "@/node/runtime/Runtime";
 import { isPlanLikeInResolvedChain } from "@/common/utils/agentTools";
@@ -108,6 +109,8 @@ export interface AssemblePromptPayloadOptions {
   tools?: Record<string, Tool>;
   modelString: string;
   routeProvider?: string;
+  /** Effective request wire format; Chat Completions keeps API-key auth over Codex OAuth. */
+  openaiWireFormat?: OpenAIWireFormat | null;
   providerForMessages: string;
   effectiveThinkingLevel: ThinkingLevel;
   effectiveAgentId: string;
@@ -159,7 +162,8 @@ export async function assemblePromptPayload(
         options.systemMessage,
         options.modelString,
         options.routeProvider,
-        options.providersConfig ?? null
+        options.providersConfig ?? null,
+        { openaiWireFormat: options.openaiWireFormat }
       ) ?? options.systemMessage;
   }
 

--- a/src/node/services/turnRequestBuilder.ts
+++ b/src/node/services/turnRequestBuilder.ts
@@ -2431,6 +2431,7 @@ export class TurnRequestBuilder {
             tools: attemptTools,
             modelString: seed.rawModelString,
             routeProvider: seed.routeProvider,
+            openaiWireFormat: effectiveMuxProviderOptions.openai?.wireFormat,
             providerForMessages: seed.wireProviderName,
             effectiveThinkingLevel: level,
             effectiveAgentId,


### PR DESCRIPTION
## Summary

Fixes for OpenAI model access when ChatGPT (Codex) OAuth is the only OpenAI credential, plus route-aware OpenAI gating in the UI:

1. Route `gpt-6-astra` through Codex OAuth, with the GPT-5.6 Codex context cap (372K).
2. Apply the OpenAI auth gate (model picker, ChatInput OAuth warning, Settings > Models rows) only when the model's active route is direct OpenAI. Gateway routes (Xum Gateway, OpenRouter, ...) keep every model visible.
3. Chat Completions never routes through Codex OAuth when an API key exists.

## Background

**Astra.** GPT-6 Astra is served in Codex for ChatGPT subscribers and in the public API. It was not in `CODEX_OAUTH_ALLOWED_MODELS`, so `providerModelFactory` never set `shouldRouteThroughCodexOauth` for it. With no API key configured, the request fell to the API-key path and failed at send time:

> API key not configured for OpenAI. Please add your API key in settings.

The user hit this on a remote `xum server` after a successful device-code login. The login was fine; the model gate was the problem.

**Gateway.** After switching routing to Xum Gateway, Astra still did not appear in the model picker. `useModelsFromSettings` applied the OpenAI OAuth/API-key gate to every `openai:` model without checking which route serves it. The backend (`resolveModelRoute`) already sends such models through the gateway, which uses its own credentials, so the UI hid models that would work.

## Implementation

- `codexOAuth.ts`: add `gpt-6-astra` to `CODEX_OAUTH_ALLOWED_MODELS` and `"gpt-6-astra": 372_000` to `CODEX_OAUTH_CONTEXT_WINDOW_OVERRIDES`. API-key requests keep the public 1.05M window.
- `useModelsFromSettings.ts`: a module-level `resolvesToDirectOpenAI` predicate calls `resolveRoute` (same function the backend uses). The picker gate and `requiresCodexOauth` (ChatInput warning) skip when `routeProvider !== "openai"`. The list is already filtered by `isModelAvailable`, so `resolveRoute` returns the active route, not its direct fallback. The hidden-bucket logic is unchanged.
- `policyUi.ts` / `useRouting.ts` / `useModelsFromSettings.ts`: a shared `isGatewayModelAccessibleForUi` helper combines the gateway's authoritative catalog with the enforced policy, mirroring the backend's `createGatewayModelAccessibilityChecker`. `useRouting` now reads the policy, so `availableRoutes`, `resolveRoute`, the route pickers, and the Settings rows never offer a gateway route the backend rejects at send time. The final policy filter in the picker and the Settings rows checks the resolved route identity (`routeProvider:routeModelId`), like the backend, so a gateway-only policy keeps models whose active route is that gateway.
- `ModelsSection.tsx`: `shouldShowModelInSettings` accepts `hasConfiguredGatewayRoute` (from `routing.availableRoutes`) so OAuth-required rows stay visible when a gateway can serve them and users can set the route override.
- `providerModelFactory.ts`: resolve the wire format before choosing credentials. Codex OAuth serves only the Responses API, so Chat Completions falls back to the API key when one exists instead of sending the `codex-oauth` placeholder to `api.openai.com`. The OAuth-only Chat Completions case keeps the early `api_key_not_found`.
- `codexOauthRouting.ts`: `wouldRouteOpenAIThroughCodexOauth` mirrors the Chat Completions rule and accepts a request-level `openaiWireFormat` (the stored `openai.wireFormat` wins, matching the factory). The send path threads the effective request value through `buildProviderOptions` (prompt-cache key), `openaiDirectProviderOptionsAvailable`, `createOpenAICachedSystemMessage`, and `CompactionMonitor`, so context caps, prompt-cache gating, and provider options follow the real credential route. Browser callers stay config-only because no UI sets a request-level wire format.

Note: the current upstream Codex catalog (`codex-rs/models-manager/models.json` on `main`) lists `context_window: 272000` and `max_context_window: 872000` for Astra and the GPT-5.6 tiers. This PR keeps the repo's existing 372K value for consistency with GPT-5.6. Aligning both with the catalog, and making `getEffectiveContextLimit` route-aware for gateway-routed OpenAI models (pre-existing for GPT-5.5/5.6), are follow-ups.

## Validation

- New tests fail without the corresponding source change and pass with it: gateway route and per-model override bypass the picker gate; `requiresCodexOauth` follows the active route; settings rows stay visible with a configured gateway route; a policy-blocked gateway model keeps the picker gate; Chat Completions with API key + preferred OAuth hands the SDK the real key; the common OAuth predicate follows the Chat Completions rule; an enforced policy that blocks a gateway model removes that route from `useRouting`; a request-level Chat Completions wire format restores the API window and prompt-cache eligibility, with the stored value winning. A gateway-only policy keeps models routed through that gateway and hides them when routing is direct-only.

## Risks

Low. Astra routing changes only affect direct OpenAI requests for `gpt-6-astra` when Codex OAuth tokens are stored. The UI changes only widen visibility for models whose active route is a gateway; direct-routed models keep the existing gate. The policy-aware gateway check in `useRouting` can only narrow route pickers and the picker toward what the backend already routes; `useRouting` now requires a `PolicyProvider`, which `AppLoader` provides for every consumer. The Chat Completions change turns a request that failed with the placeholder key into an API-key request; OAuth-only Chat Completions behavior is unchanged.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$41.99`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=41.99 -->




