### PR TITLE
🤖 refactor: enforce workspace-turn settlement causes (Wave4 PR2)

### DIFF
--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -27284,6 +27284,7 @@ describe("TaskService", () => {
       workspaceTurnStreamEndEvent(completed.parentId, "msg_done", "Done")
     );
     await completedInternal.settleWorkspaceTurn({
+      cause: { kind: "user-stream-abort" },
       record: staleRunningRecord,
       next: {
         ...staleRunningRecord,
@@ -27326,6 +27327,7 @@ describe("TaskService", () => {
         settleWorkspaceTurn: (params: unknown) => Promise<void>;
       }
     ).settleWorkspaceTurn({
+      cause: { kind: "correlated-stream-end" },
       record: staleInterruptedRecord,
       next: {
         ...staleInterruptedRecord,

--- a/src/node/services/workspaceTurnManager.test.ts
+++ b/src/node/services/workspaceTurnManager.test.ts
@@ -4439,11 +4439,13 @@ describe("WorkspaceTurnManager", () => {
       settleWorkspaceTurn: (params: {
         record: WorkspaceTurnTaskHandleRecord;
         next: WorkspaceTurnTaskHandleRecord;
+        cause: { kind: "user-stream-abort" };
         waiterSettlement: { status: "error"; error: Error };
       }) => Promise<void>;
     };
 
     await internal.settleWorkspaceTurn({
+      cause: { kind: "user-stream-abort" },
       record: staleSnapshot,
       next: {
         ...staleSnapshot,

--- a/src/node/services/workspaceTurnManager.test.ts
+++ b/src/node/services/workspaceTurnManager.test.ts
@@ -4,17 +4,17 @@ import * as fsPromises from "fs/promises";
 import * as os from "os";
 import { execSync } from "node:child_process";
 import type { Config, Workspace as WorkspaceConfigEntry } from "@/node/config";
-import { HistoryService } from "@/node/services/historyService";
+import type { HistoryService } from "@/node/services/historyService";
 import { TerminalAttentionStore } from "@/node/services/terminalAttentionStore";
 import {
   TaskHandleStore,
   type WorkspaceTurnTaskHandleRecord,
 } from "@/node/services/taskHandleStore";
 import { ForegroundWaitBackgroundedError } from "@/node/services/taskService";
-import { WorkspaceTurnManager } from "@/node/services/workspaceTurnManager";
+import type { WorkspaceTurnManager } from "@/node/services/workspaceTurnManager";
+import { createWorkspaceTurnManagerHarness } from "@/node/services/workspaceTurnManager.testHarness";
 import { DesktopInputCoordinator } from "@/node/services/desktop/DesktopInputCoordinator";
 import { findWorkspaceEntry } from "@/node/services/taskUtils";
-import { MutexMap } from "@/node/utils/concurrency/mutexMap";
 import { WorkflowRunStore } from "@/node/services/workflows/WorkflowRunStore";
 import { Ok, Err, type Result } from "@/common/types/result";
 import { DEFAULT_TASK_SETTINGS } from "@/common/types/tasks";
@@ -22,18 +22,11 @@ import type { SendMessageError } from "@/common/types/errors";
 import type { ErrorEvent, StreamEndEvent } from "@/common/types/stream";
 import { createMuxMessage, type MuxMessageMetadata } from "@/common/types/message";
 import type { WorkspaceMetadata } from "@/common/types/workspace";
-import type { AIService } from "@/node/services/aiService";
-import type {
-  WorkspaceHost,
-  BackgroundableForegroundWaiter,
-  QueueCutAttributionSnapshot,
-  WorkspaceTurnManagerHost,
-} from "@/node/services/taskWorkspaceSeam";
+import type { QueueCutAttributionSnapshot } from "@/node/services/taskWorkspaceSeam";
 import type { InitStateManager } from "@/node/services/initStateManager";
 import assert from "node:assert";
 import {
   createAIServiceMocks,
-  createMockInitStateManager,
   createTestConfig,
   createTestProject,
   createWorkspaceServiceMocks,
@@ -73,231 +66,6 @@ function commitOwnerAgentFiles(projectPath: string): void {
 
 function makeCreateMockReturning(result: Result<{ metadata: WorkspaceMetadata }>) {
   return mock((): Promise<Result<{ metadata: WorkspaceMetadata }>> => Promise.resolve(result));
-}
-
-type WorkspaceTurnManagerHostFake = WorkspaceTurnManagerHost & {
-  backgroundForegroundWaitsForWorkspace(workspaceId: string): number;
-};
-
-function createWorkspaceTurnManagerHost(
-  config: Config,
-  workspaceService: WorkspaceHost,
-  aiService: AIService,
-  terminalAttentionStore: TerminalAttentionStore
-): WorkspaceTurnManagerHostFake {
-  const lifecycleLocks = new MutexMap<string>();
-  const foregroundWaiters = new Map<string, Set<BackgroundableForegroundWaiter>>();
-  const foregroundAwaitCounts = new Map<string, number>();
-  const agentTasks = (cfg: ReturnType<Config["loadConfigOrDefault"]>) =>
-    Array.from(cfg.projects.values())
-      .flatMap((project) => project.workspaces)
-      .filter((workspace) => workspace.id != null && workspace.parentWorkspaceId != null);
-  const isActiveAgentTask = (workspace: WorkspaceConfigEntry) => {
-    if (
-      workspace.archivedAt != null &&
-      (workspace.unarchivedAt == null || workspace.unarchivedAt < workspace.archivedAt)
-    ) {
-      return workspace.id != null && aiService.isStreaming(workspace.id);
-    }
-    return (
-      ["starting", "running", "awaiting_report"].includes(workspace.taskStatus ?? "running") ||
-      ["starting", "running"].includes(workspace.taskExecutionStatus ?? "")
-    );
-  };
-  const isDescendant = (
-    cfg: ReturnType<Config["loadConfigOrDefault"]>,
-    ancestorWorkspaceId: string,
-    taskId: string
-  ) => {
-    const parents = new Map(
-      agentTasks(cfg).map((workspace) => [workspace.id, workspace.parentWorkspaceId])
-    );
-    let current: string | undefined = taskId;
-    for (let depth = 0; depth < 32 && current != null; depth++) {
-      current = parents.get(current);
-      if (current === ancestorWorkspaceId) return true;
-    }
-    return false;
-  };
-  const backgroundForegroundWaitsForWorkspace = (workspaceId: string) => {
-    let signaled = 0;
-    for (const waiter of foregroundWaiters.get(workspaceId) ?? []) {
-      waiter.cleanup();
-      waiter.reject(new ForegroundWaitBackgroundedError());
-      signaled += 1;
-    }
-    return signaled;
-  };
-  return {
-    acquireTaskCreationLock: () =>
-      Promise.resolve({
-        [Symbol.asyncDispose]: () => Promise.resolve(),
-      }),
-    backgroundForegroundWaitIfQueued: (enabled, workspaceId) => {
-      if (
-        !enabled ||
-        workspaceId == null ||
-        !workspaceService.hasQueuedMessages(workspaceId, "tool-end")
-      )
-        return;
-      backgroundForegroundWaitsForWorkspace(workspaceId);
-    },
-    backgroundForegroundWaitsForWorkspace,
-    buildParentAiSettingsFallbacks: (parent, targetAgentId) =>
-      [
-        parent.aiSettingsByAgent?.[targetAgentId],
-        parent.agentId == null ? undefined : parent.aiSettingsByAgent?.[parent.agentId],
-        parent.aiSettings,
-      ].filter((settings) => settings != null),
-    bumpWorkspaceStopEpoch: () => undefined,
-    countActiveAgentTasks: (cfg) =>
-      agentTasks(cfg).filter(
-        (workspace) =>
-          isActiveAgentTask(workspace) &&
-          workspace.id != null &&
-          !foregroundAwaitCounts.has(workspace.id) &&
-          !(
-            workspace.taskExecutionId?.startsWith("wst_") === true &&
-            ["starting", "running"].includes(workspace.taskExecutionStatus ?? "")
-          )
-      ).length,
-    editWorkspaceEntry: async (workspaceId, updater, options) => {
-      let found = false;
-      await config.editConfig((cfg) => {
-        for (const project of cfg.projects.values()) {
-          const workspace = project.workspaces.find((candidate) => candidate.id === workspaceId);
-          if (workspace != null) {
-            updater(workspace, cfg);
-            found = true;
-            break;
-          }
-        }
-        return cfg;
-      });
-      if (!found && options?.allowMissing !== true)
-        throw new Error("Workspace not found: " + workspaceId);
-      return found;
-    },
-    emitWorkspaceMetadata: () => Promise.resolve(),
-    enqueueTerminalAttention: async (params) => {
-      await terminalAttentionStore.enqueueIfAbsent(params);
-    },
-    hasActiveDescendantAgentTasks: (cfg, workspaceId) =>
-      agentTasks(cfg).some(
-        (workspace) =>
-          workspace.id != null &&
-          isActiveAgentTask(workspace) &&
-          isDescendant(cfg, workspaceId, workspace.id)
-      ),
-    isDescendantAgentTaskInConfig: isDescendant,
-    isForegroundAwaiting: (workspaceId) => foregroundAwaitCounts.has(workspaceId),
-    latchWorkspaceStopsInProgress: () => () => undefined,
-    listActiveBackgroundWorkflowRunIds: async (workspaceId, referencedRunIds) => {
-      if (referencedRunIds.length === 0) return [];
-      const runs = await new WorkflowRunStore({
-        sessionDir: path.join(config.sessionsDir, workspaceId),
-      }).listRuns();
-      return runs
-        .filter(
-          (run) =>
-            referencedRunIds.includes(run.id) &&
-            run.workspaceId === workspaceId &&
-            ["pending", "running", "backgrounded"].includes(run.status)
-        )
-        .map((run) => run.id);
-    },
-    listActiveWorkflowRunIdsForWorkspaceStrict: async (workspaceId) => {
-      const runStore = new WorkflowRunStore({
-        sessionDir: path.join(config.sessionsDir, workspaceId),
-      });
-      const runs = await runStore.listRunsForActivityScan();
-      return runs
-        .filter(
-          (run) =>
-            run.workspaceId === workspaceId &&
-            run.parentWorkflow == null &&
-            ["pending", "running", "backgrounded"].includes(run.status)
-        )
-        .map((run) => run.id);
-    },
-    listAgentReferencedWorkflowRunIds: () => Promise.resolve([]),
-    listAgentTaskExecutionEntries: agentTasks,
-    markTaskForegroundRelevant: () => undefined,
-    maybeStartPatchGenerationForReportedTask: () => Promise.resolve(),
-    registerBackgroundableForegroundWaiter: (workspaceId, waiter) => {
-      const waiters = foregroundWaiters.get(workspaceId) ?? new Set();
-      waiters.add(waiter);
-      foregroundWaiters.set(workspaceId, waiters);
-    },
-    releaseRetainedStopLatches: () => undefined,
-    resolveWorkspaceAISettings: (workspace, agentId) =>
-      (agentId != null ? workspace.aiSettingsByAgent?.[agentId] : undefined) ??
-      workspace.aiSettings,
-    scheduleMaybeStartQueuedTasks: () => undefined,
-    scheduleTerminalAttentionDrain: () => undefined,
-    startForegroundAwait: (workspaceId) => {
-      foregroundAwaitCounts.set(workspaceId, (foregroundAwaitCounts.get(workspaceId) ?? 0) + 1);
-      return () => {
-        const count = foregroundAwaitCounts.get(workspaceId) ?? 0;
-        if (count <= 1) foregroundAwaitCounts.delete(workspaceId);
-        else foregroundAwaitCounts.set(workspaceId, count - 1);
-      };
-    },
-    unregisterBackgroundableForegroundWaiter: (workspaceId, waiter) => {
-      const waiters = foregroundWaiters.get(workspaceId);
-      waiters?.delete(waiter);
-      if (waiters?.size === 0) foregroundWaiters.delete(workspaceId);
-    },
-    withTaskTreeLifecycleLock: (workspaceId, operation) =>
-      lifecycleLocks.withLock(workspaceId, operation),
-  };
-}
-
-function createWorkspaceTurnManagerHarness(
-  config: Config,
-  overrides?: {
-    aiService?: AIService;
-    workspaceService?: WorkspaceHost;
-    initStateManager?: InitStateManager;
-  }
-): {
-  historyService: HistoryService;
-  taskService: WorkspaceTurnManager;
-  taskHost: WorkspaceTurnManagerHostFake;
-  aiService: AIService;
-  workspaceService: WorkspaceHost;
-  initStateManager: InitStateManager;
-} {
-  const historyService = new HistoryService(config);
-  const aiService = overrides?.aiService ?? createAIServiceMocks(config).aiService;
-  const workspaceService =
-    overrides?.workspaceService ?? createWorkspaceServiceMocks().workspaceService;
-  const initStateManager = overrides?.initStateManager ?? createMockInitStateManager();
-  const terminalAttentionStore = new TerminalAttentionStore(config);
-  const taskHost = createWorkspaceTurnManagerHost(
-    config,
-    workspaceService,
-    aiService,
-    terminalAttentionStore
-  );
-  const taskService = new WorkspaceTurnManager(
-    config,
-    historyService,
-    aiService,
-    workspaceService,
-    initStateManager,
-    taskHost,
-    terminalAttentionStore
-  );
-
-  return {
-    historyService,
-    taskService,
-    taskHost,
-    aiService,
-    workspaceService,
-    initStateManager,
-  };
 }
 
 describe("WorkspaceTurnManager", () => {

--- a/src/node/services/workspaceTurnManager.testHarness.ts
+++ b/src/node/services/workspaceTurnManager.testHarness.ts
@@ -1,0 +1,246 @@
+import * as path from "path";
+import type { Config, Workspace as WorkspaceConfigEntry } from "@/node/config";
+import type { AIService } from "@/node/services/aiService";
+import { HistoryService } from "@/node/services/historyService";
+import type { InitStateManager } from "@/node/services/initStateManager";
+import { ForegroundWaitBackgroundedError } from "@/node/services/taskService";
+import { TerminalAttentionStore } from "@/node/services/terminalAttentionStore";
+import { WorkspaceTurnManager } from "@/node/services/workspaceTurnManager";
+import { WorkflowRunStore } from "@/node/services/workflows/WorkflowRunStore";
+import { MutexMap } from "@/node/utils/concurrency/mutexMap";
+import type {
+  BackgroundableForegroundWaiter,
+  WorkspaceHost,
+  WorkspaceTurnManagerHost,
+} from "@/node/services/taskWorkspaceSeam";
+import {
+  createAIServiceMocks,
+  createMockInitStateManager,
+  createWorkspaceServiceMocks,
+} from "@/node/services/taskService.testHarness";
+
+type WorkspaceTurnManagerHostFake = WorkspaceTurnManagerHost & {
+  backgroundForegroundWaitsForWorkspace(workspaceId: string): number;
+};
+
+function createWorkspaceTurnManagerHost(
+  config: Config,
+  workspaceService: WorkspaceHost,
+  aiService: AIService,
+  terminalAttentionStore: TerminalAttentionStore
+): WorkspaceTurnManagerHostFake {
+  const lifecycleLocks = new MutexMap<string>();
+  const foregroundWaiters = new Map<string, Set<BackgroundableForegroundWaiter>>();
+  const foregroundAwaitCounts = new Map<string, number>();
+  const agentTasks = (cfg: ReturnType<Config["loadConfigOrDefault"]>) =>
+    Array.from(cfg.projects.values())
+      .flatMap((project) => project.workspaces)
+      .filter((workspace) => workspace.id != null && workspace.parentWorkspaceId != null);
+  const isActiveAgentTask = (workspace: WorkspaceConfigEntry) => {
+    if (
+      workspace.archivedAt != null &&
+      (workspace.unarchivedAt == null || workspace.unarchivedAt < workspace.archivedAt)
+    ) {
+      return workspace.id != null && aiService.isStreaming(workspace.id);
+    }
+    return (
+      ["starting", "running", "awaiting_report"].includes(workspace.taskStatus ?? "running") ||
+      ["starting", "running"].includes(workspace.taskExecutionStatus ?? "")
+    );
+  };
+  const isDescendant = (
+    cfg: ReturnType<Config["loadConfigOrDefault"]>,
+    ancestorWorkspaceId: string,
+    taskId: string
+  ) => {
+    const parents = new Map(
+      agentTasks(cfg).map((workspace) => [workspace.id, workspace.parentWorkspaceId])
+    );
+    let current: string | undefined = taskId;
+    for (let depth = 0; depth < 32 && current != null; depth++) {
+      current = parents.get(current);
+      if (current === ancestorWorkspaceId) return true;
+    }
+    return false;
+  };
+  const backgroundForegroundWaitsForWorkspace = (workspaceId: string) => {
+    let signaled = 0;
+    for (const waiter of foregroundWaiters.get(workspaceId) ?? []) {
+      waiter.cleanup();
+      waiter.reject(new ForegroundWaitBackgroundedError());
+      signaled += 1;
+    }
+    return signaled;
+  };
+  return {
+    acquireTaskCreationLock: () =>
+      Promise.resolve({
+        [Symbol.asyncDispose]: () => Promise.resolve(),
+      }),
+    backgroundForegroundWaitIfQueued: (enabled, workspaceId) => {
+      if (
+        !enabled ||
+        workspaceId == null ||
+        !workspaceService.hasQueuedMessages(workspaceId, "tool-end")
+      )
+        return;
+      backgroundForegroundWaitsForWorkspace(workspaceId);
+    },
+    backgroundForegroundWaitsForWorkspace,
+    buildParentAiSettingsFallbacks: (parent, targetAgentId) =>
+      [
+        parent.aiSettingsByAgent?.[targetAgentId],
+        parent.agentId == null ? undefined : parent.aiSettingsByAgent?.[parent.agentId],
+        parent.aiSettings,
+      ].filter((settings) => settings != null),
+    bumpWorkspaceStopEpoch: () => undefined,
+    countActiveAgentTasks: (cfg) =>
+      agentTasks(cfg).filter(
+        (workspace) =>
+          isActiveAgentTask(workspace) &&
+          workspace.id != null &&
+          !foregroundAwaitCounts.has(workspace.id) &&
+          !(
+            workspace.taskExecutionId?.startsWith("wst_") === true &&
+            ["starting", "running"].includes(workspace.taskExecutionStatus ?? "")
+          )
+      ).length,
+    editWorkspaceEntry: async (workspaceId, updater, options) => {
+      let found = false;
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const workspace = project.workspaces.find((candidate) => candidate.id === workspaceId);
+          if (workspace != null) {
+            updater(workspace, cfg);
+            found = true;
+            break;
+          }
+        }
+        return cfg;
+      });
+      if (!found && options?.allowMissing !== true)
+        throw new Error("Workspace not found: " + workspaceId);
+      return found;
+    },
+    emitWorkspaceMetadata: () => Promise.resolve(),
+    enqueueTerminalAttention: async (params) => {
+      await terminalAttentionStore.enqueueIfAbsent(params);
+    },
+    hasActiveDescendantAgentTasks: (cfg, workspaceId) =>
+      agentTasks(cfg).some(
+        (workspace) =>
+          workspace.id != null &&
+          isActiveAgentTask(workspace) &&
+          isDescendant(cfg, workspaceId, workspace.id)
+      ),
+    isDescendantAgentTaskInConfig: isDescendant,
+    isForegroundAwaiting: (workspaceId) => foregroundAwaitCounts.has(workspaceId),
+    latchWorkspaceStopsInProgress: () => () => undefined,
+    listActiveBackgroundWorkflowRunIds: async (workspaceId, referencedRunIds) => {
+      if (referencedRunIds.length === 0) return [];
+      const runs = await new WorkflowRunStore({
+        sessionDir: path.join(config.sessionsDir, workspaceId),
+      }).listRuns();
+      return runs
+        .filter(
+          (run) =>
+            referencedRunIds.includes(run.id) &&
+            run.workspaceId === workspaceId &&
+            ["pending", "running", "backgrounded"].includes(run.status)
+        )
+        .map((run) => run.id);
+    },
+    listActiveWorkflowRunIdsForWorkspaceStrict: async (workspaceId) => {
+      const runStore = new WorkflowRunStore({
+        sessionDir: path.join(config.sessionsDir, workspaceId),
+      });
+      const runs = await runStore.listRunsForActivityScan();
+      return runs
+        .filter(
+          (run) =>
+            run.workspaceId === workspaceId &&
+            run.parentWorkflow == null &&
+            ["pending", "running", "backgrounded"].includes(run.status)
+        )
+        .map((run) => run.id);
+    },
+    listAgentReferencedWorkflowRunIds: () => Promise.resolve([]),
+    listAgentTaskExecutionEntries: agentTasks,
+    markTaskForegroundRelevant: () => undefined,
+    maybeStartPatchGenerationForReportedTask: () => Promise.resolve(),
+    registerBackgroundableForegroundWaiter: (workspaceId, waiter) => {
+      const waiters = foregroundWaiters.get(workspaceId) ?? new Set();
+      waiters.add(waiter);
+      foregroundWaiters.set(workspaceId, waiters);
+    },
+    releaseRetainedStopLatches: () => undefined,
+    resolveWorkspaceAISettings: (workspace, agentId) =>
+      (agentId != null ? workspace.aiSettingsByAgent?.[agentId] : undefined) ??
+      workspace.aiSettings,
+    scheduleMaybeStartQueuedTasks: () => undefined,
+    scheduleTerminalAttentionDrain: () => undefined,
+    startForegroundAwait: (workspaceId) => {
+      foregroundAwaitCounts.set(workspaceId, (foregroundAwaitCounts.get(workspaceId) ?? 0) + 1);
+      return () => {
+        const count = foregroundAwaitCounts.get(workspaceId) ?? 0;
+        if (count <= 1) foregroundAwaitCounts.delete(workspaceId);
+        else foregroundAwaitCounts.set(workspaceId, count - 1);
+      };
+    },
+    unregisterBackgroundableForegroundWaiter: (workspaceId, waiter) => {
+      const waiters = foregroundWaiters.get(workspaceId);
+      waiters?.delete(waiter);
+      if (waiters?.size === 0) foregroundWaiters.delete(workspaceId);
+    },
+    withTaskTreeLifecycleLock: (workspaceId, operation) =>
+      lifecycleLocks.withLock(workspaceId, operation),
+  };
+}
+
+export function createWorkspaceTurnManagerHarness(
+  config: Config,
+  overrides?: {
+    historyService?: HistoryService;
+    aiService?: AIService;
+    workspaceService?: WorkspaceHost;
+    initStateManager?: InitStateManager;
+  }
+): {
+  historyService: HistoryService;
+  taskService: WorkspaceTurnManager;
+  taskHost: WorkspaceTurnManagerHostFake;
+  aiService: AIService;
+  workspaceService: WorkspaceHost;
+  initStateManager: InitStateManager;
+} {
+  const historyService = overrides?.historyService ?? new HistoryService(config);
+  const aiService = overrides?.aiService ?? createAIServiceMocks(config).aiService;
+  const workspaceService =
+    overrides?.workspaceService ?? createWorkspaceServiceMocks().workspaceService;
+  const initStateManager = overrides?.initStateManager ?? createMockInitStateManager();
+  const terminalAttentionStore = new TerminalAttentionStore(config);
+  const taskHost = createWorkspaceTurnManagerHost(
+    config,
+    workspaceService,
+    aiService,
+    terminalAttentionStore
+  );
+  const taskService = new WorkspaceTurnManager(
+    config,
+    historyService,
+    aiService,
+    workspaceService,
+    initStateManager,
+    taskHost,
+    terminalAttentionStore
+  );
+
+  return {
+    historyService,
+    taskService,
+    taskHost,
+    aiService,
+    workspaceService,
+    initStateManager,
+  };
+}

--- a/src/node/services/workspaceTurnManager.ts
+++ b/src/node/services/workspaceTurnManager.ts
@@ -110,6 +110,48 @@ import {
 // (delete_worktree/remove remain in the result schema for historical-transcript parsing only).
 type WorkspaceLifecycleAction = "archive" | "unarchive";
 
+// Internal evidence only: future terminal transitions must name and justify their cause.
+// An arbitrary synthetic stream-end is not completion; unknown history retains the existing
+// conservative interruption policy rather than pretending that a manual input was observed.
+type WorkspaceTurnSettlementCause =
+  | {
+      kind:
+        | "creation-admission-failure"
+        | "creation-validation-failure"
+        | "launch-canceled"
+        | "send-failure"
+        | "stale-history-recovery"
+        | "stale-restart"
+        | "correlated-stream-end"
+        | "user-stream-abort"
+        | "continuation-failure"
+        | "terminal-stream-error"
+        | "recovery-admission-failure"
+        | "explicit-interrupt";
+    }
+  | { kind: "manual-supersession"; messageId: string }
+  | {
+      kind: "uncorrelated-conservative-fallback";
+      reason: "history-read-failed" | "missing-stream-end" | "missing-turn-anchor";
+    };
+
+const WORKSPACE_TURN_SETTLEMENT_CAUSES: Record<WorkspaceTurnSettlementCause["kind"], true> = {
+  "creation-admission-failure": true,
+  "creation-validation-failure": true,
+  "launch-canceled": true,
+  "send-failure": true,
+  "stale-history-recovery": true,
+  "stale-restart": true,
+  "correlated-stream-end": true,
+  "user-stream-abort": true,
+  "continuation-failure": true,
+  "terminal-stream-error": true,
+  "recovery-admission-failure": true,
+  "explicit-interrupt": true,
+  "manual-supersession": true,
+  "uncorrelated-conservative-fallback": true,
+};
+
 interface WorkspaceLifecycleTarget {
   taskId?: string;
   workspaceId?: string;
@@ -1362,6 +1404,7 @@ export class WorkspaceTurnManager {
     if (typeof persisted === "object") {
       if (persistedHandle) {
         await this.settleWorkspaceTurn({
+          cause: { kind: "creation-admission-failure" },
           record,
           next: { ...record, status: "error", updatedAt: getIsoNow(), error: persisted.error },
           waiterSettlement: { status: "error", error: new Error(persisted.error) },
@@ -1408,6 +1451,7 @@ export class WorkspaceTurnManager {
         error: agentValidationError,
       };
       await this.settleWorkspaceTurn({
+        cause: { kind: "creation-validation-failure" },
         record,
         next,
         waiterSettlement: { status: "error", error: new Error(agentValidationError) },
@@ -1516,6 +1560,7 @@ export class WorkspaceTurnManager {
             error: reason,
           };
           await this.settleWorkspaceTurn({
+            cause: { kind: "launch-canceled" },
             record: current,
             next,
             waiterSettlement: { status: "error", error: new Error(reason) },
@@ -1540,6 +1585,7 @@ export class WorkspaceTurnManager {
             error,
           };
           await this.settleWorkspaceTurn({
+            cause: { kind: "send-failure" },
             record: current,
             next,
             waiterSettlement: { status: "error", error: new Error(error) },
@@ -1558,6 +1604,7 @@ export class WorkspaceTurnManager {
         error,
       };
       await this.settleWorkspaceTurn({
+        cause: { kind: "send-failure" },
         record,
         next,
         waiterSettlement: { status: "error", error: new Error(error) },
@@ -2124,7 +2171,30 @@ export class WorkspaceTurnManager {
     await markDirectParentResultDelivered();
   }
 
+  private assertWorkspaceTurnSettlementCause(cause: WorkspaceTurnSettlementCause): void {
+    assert(
+      cause != null &&
+        typeof cause.kind === "string" &&
+        Object.hasOwn(WORKSPACE_TURN_SETTLEMENT_CAUSES, cause.kind),
+      "Workspace turn settlement requires a recognized cause"
+    );
+    if (cause.kind === "manual-supersession") {
+      assert(
+        typeof cause.messageId === "string" && cause.messageId.trim().length > 0,
+        "Manual supersession requires the superseding input messageId"
+      );
+    } else if (cause.kind === "uncorrelated-conservative-fallback") {
+      assert(
+        cause.reason === "history-read-failed" ||
+          cause.reason === "missing-stream-end" ||
+          cause.reason === "missing-turn-anchor",
+        "Uncorrelated conservative fallback requires a recognized reason"
+      );
+    }
+  }
+
   private async settleWorkspaceTurn(params: {
+    cause: WorkspaceTurnSettlementCause;
     record: WorkspaceTurnTaskHandleRecord;
     next: WorkspaceTurnTaskHandleRecord;
     waiterSettlement:
@@ -2173,6 +2243,7 @@ export class WorkspaceTurnManager {
         settledRecord?: WorkspaceTurnTaskHandleRecord;
         foregroundWaiterWorkspaceIds?: Set<string>;
       } | null> => {
+        this.assertWorkspaceTurnSettlementCause(params.cause);
         const current = await this.taskHandleStore.getWorkspaceTurn(
           params.record.ownerWorkspaceId,
           params.record.handleId
@@ -3038,6 +3109,8 @@ export class WorkspaceTurnManager {
           status: "interrupted",
           updatedAt: getIsoNow(),
         };
+        // Keep explicit stop's latch/mirror ordering in this lock, not the central helper.
+        this.assertWorkspaceTurnSettlementCause({ kind: "explicit-interrupt" });
         await this.taskHandleStore.upsertWorkspaceTurn(next);
         interruptedRecord = next;
         // Latch the stop synchronously inside the settlement boundary: in-flight peer-send
@@ -3883,6 +3956,7 @@ export class WorkspaceTurnManager {
     const recovered = await this.recoverTerminalWorkspaceTurnFromHistory(record);
     if (recovered != null) {
       await this.settleWorkspaceTurn({
+        cause: { kind: "stale-history-recovery" },
         record,
         next: recovered,
         waiterSettlement:
@@ -3912,6 +3986,7 @@ export class WorkspaceTurnManager {
       error: WORKSPACE_TURN_STALE_RESTART_ERROR,
     };
     await this.settleWorkspaceTurn({
+      cause: { kind: "stale-restart" },
       record,
       next,
       waiterSettlement: {
@@ -4329,7 +4404,10 @@ export class WorkspaceTurnManager {
         handleId: record.handleId,
         error: historyResult.error,
       });
-      await this.settleWorkspaceTurnSupersededFromUncorrelatedStreamEnd(record, event);
+      await this.settleWorkspaceTurnSupersededFromUncorrelatedStreamEnd(record, event, {
+        kind: "uncorrelated-conservative-fallback",
+        reason: "history-read-failed",
+      });
       return true;
     }
 
@@ -4345,7 +4423,10 @@ export class WorkspaceTurnManager {
     }
 
     if (streamEndIndex === -1 || turnAnchorIndex === -1) {
-      await this.settleWorkspaceTurnSupersededFromUncorrelatedStreamEnd(record, event);
+      await this.settleWorkspaceTurnSupersededFromUncorrelatedStreamEnd(record, event, {
+        kind: "uncorrelated-conservative-fallback",
+        reason: streamEndIndex === -1 ? "missing-stream-end" : "missing-turn-anchor",
+      });
       return true;
     }
     if (streamEndIndex < turnAnchorIndex) {
@@ -4357,18 +4438,25 @@ export class WorkspaceTurnManager {
       return true;
     }
 
-    const hasManualSupersessionInput = historyResult.data
+    const manualSupersessionInput = historyResult.data
       .slice(turnAnchorIndex + 1, streamEndIndex)
-      .some(isManualChildWorkspaceInput);
-    if (hasManualSupersessionInput) {
-      await this.settleWorkspaceTurnSupersededFromUncorrelatedStreamEnd(record, event);
+      .find(isManualChildWorkspaceInput);
+    if (manualSupersessionInput) {
+      await this.settleWorkspaceTurnSupersededFromUncorrelatedStreamEnd(record, event, {
+        kind: "manual-supersession",
+        messageId: manualSupersessionInput.id,
+      });
     }
     return true;
   }
 
   private async settleWorkspaceTurnSupersededFromUncorrelatedStreamEnd(
     record: WorkspaceTurnTaskHandleRecord,
-    event: StreamEndEvent
+    event: StreamEndEvent,
+    cause: Extract<
+      WorkspaceTurnSettlementCause,
+      { kind: "manual-supersession" | "uncorrelated-conservative-fallback" }
+    >
   ): Promise<void> {
     const error = "Workspace turn superseded by an uncorrelated workspace stream-end";
     const next: WorkspaceTurnTaskHandleRecord = {
@@ -4380,6 +4468,7 @@ export class WorkspaceTurnManager {
     };
     delete next.deferredMessageIds;
     await this.settleWorkspaceTurn({
+      cause,
       record,
       next,
       waiterSettlement: { status: "error", error: new Error(error) },
@@ -4607,6 +4696,7 @@ export class WorkspaceTurnManager {
       }
     }
     await this.settleWorkspaceTurn({
+      cause: { kind: "correlated-stream-end" },
       record,
       next,
       waiterSettlement:
@@ -4649,6 +4739,7 @@ export class WorkspaceTurnManager {
       updatedAt: getIsoNow(),
     };
     await this.settleWorkspaceTurn({
+      cause: { kind: "user-stream-abort" },
       record,
       next,
       waiterSettlement: { status: "error", error: new Error("Workspace turn interrupted") },
@@ -4753,6 +4844,7 @@ export class WorkspaceTurnManager {
     };
     delete next.deferredMessageIds;
     await this.settleWorkspaceTurn({
+      cause: { kind: "continuation-failure" },
       record,
       next,
       waiterSettlement: { status: "error", error: new Error(error) },
@@ -4814,6 +4906,7 @@ export class WorkspaceTurnManager {
       error: event.error,
     };
     await this.settleWorkspaceTurn({
+      cause: { kind: "terminal-stream-error" },
       record,
       next,
       waiterSettlement: { status: "error", error: new Error(event.error) },
@@ -4924,6 +5017,7 @@ export class WorkspaceTurnManager {
             // active would reserve the desktop even after TaskService interrupts the task.
             const message = getErrorMessage(error);
             await this.settleWorkspaceTurn({
+              cause: { kind: "recovery-admission-failure" },
               record: normalized,
               next: { ...normalized, status: "error", updatedAt: getIsoNow(), error: message },
               waiterSettlement: { status: "error", error: new Error(message) },

--- a/src/node/services/workspaceTurnManager.ts
+++ b/src/node/services/workspaceTurnManager.ts
@@ -132,7 +132,11 @@ type WorkspaceTurnSettlementCause =
   | { kind: "manual-supersession"; messageId: string }
   | {
       kind: "uncorrelated-conservative-fallback";
-      reason: "history-read-failed" | "missing-stream-end" | "missing-turn-anchor";
+      reason:
+        | "history-read-failed"
+        | "missing-stream-end"
+        | "missing-turn-anchor"
+        | "invalid-manual-input-id";
     };
 
 const WORKSPACE_TURN_SETTLEMENT_CAUSES: Record<WorkspaceTurnSettlementCause["kind"], true> = {
@@ -2187,7 +2191,8 @@ export class WorkspaceTurnManager {
       assert(
         cause.reason === "history-read-failed" ||
           cause.reason === "missing-stream-end" ||
-          cause.reason === "missing-turn-anchor",
+          cause.reason === "missing-turn-anchor" ||
+          cause.reason === "invalid-manual-input-id",
         "Uncorrelated conservative fallback requires a recognized reason"
       );
     }
@@ -4442,10 +4447,15 @@ export class WorkspaceTurnManager {
       .slice(turnAnchorIndex + 1, streamEndIndex)
       .find(isManualChildWorkspaceInput);
     if (manualSupersessionInput) {
-      await this.settleWorkspaceTurnSupersededFromUncorrelatedStreamEnd(record, event, {
-        kind: "manual-supersession",
-        messageId: manualSupersessionInput.id,
-      });
+      // Readable JSON can still contain a malformed message ID. Preserve conservative
+      // interruption without inventing manual evidence or letting corrupt history strand waiters.
+      await this.settleWorkspaceTurnSupersededFromUncorrelatedStreamEnd(
+        record,
+        event,
+        coerceNonEmptyString(manualSupersessionInput.id) != null
+          ? { kind: "manual-supersession", messageId: manualSupersessionInput.id }
+          : { kind: "uncorrelated-conservative-fallback", reason: "invalid-manual-input-id" }
+      );
     }
     return true;
   }

--- a/src/node/services/workspaceTurnManager.uncorrelatedStreamEnd.test.ts
+++ b/src/node/services/workspaceTurnManager.uncorrelatedStreamEnd.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import assert from "node:assert";
-import { mkdir } from "node:fs/promises";
+import { appendFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { CHAT_FILE_NAME } from "@/common/constants/paths";
 import { createMuxMessage, type MuxMessage } from "@/common/types/message";
 import { Err, Ok } from "@/common/types/result";
 import type { StreamEndEvent } from "@/common/types/stream";
@@ -277,6 +279,39 @@ describe("WorkspaceTurnManager settlement authorization", () => {
     expect(await h.waiter).toBeInstanceOf(Error);
     expect(h.workspaceMocks.remove).toHaveBeenCalledTimes(1);
   });
+
+  test.each([undefined, null, 42, "", " \t"])(
+    "malformed persisted manual input id %j conservatively interrupts instead of stranding waiters",
+    async (id) => {
+      const h = await startTurn();
+      // Corruption can be valid JSON but not a valid MuxMessage; exercise the real disk parser.
+      await appendFile(
+        join(h.config.sessionsDir, h.workspaceId, CHAT_FILE_NAME),
+        JSON.stringify({
+          ...createMuxMessage("manual-input", "user", "Redirect the child", {
+            historySequence: 1,
+          }),
+          id,
+        }) + "\n"
+      );
+      await h.append(
+        createMuxMessage(h.uncorrelatedEnd.messageId, "assistant", "Manual response", {
+          ...h.uncorrelatedEnd.metadata,
+        })
+      );
+      const { causes } = observeCauseInsideLock(h.manager);
+      const reads = spyOn(h.historyService, "getHistoryFromLatestBoundary");
+      expect(await h.finish(h.uncorrelatedEnd)).toBe(true);
+      expect(causes).toHaveBeenCalledWith({
+        kind: "uncorrelated-conservative-fallback",
+        reason: "invalid-manual-input-id",
+      });
+      expect(reads).toHaveBeenCalledTimes(1);
+      expect(await h.readRecord()).toMatchObject({ status: "interrupted" });
+      expect(await h.waiter).toBeInstanceOf(Error);
+      expect(h.workspaceMocks.remove).toHaveBeenCalledTimes(1);
+    }
+  );
 
   test.each(["history-read-failed", "missing-stream-end", "missing-turn-anchor"] as const)(
     "conservative %s fallback interrupts with one history read and its exact internal reason",

--- a/src/node/services/workspaceTurnManager.uncorrelatedStreamEnd.test.ts
+++ b/src/node/services/workspaceTurnManager.uncorrelatedStreamEnd.test.ts
@@ -1,0 +1,451 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import assert from "node:assert";
+import { mkdir } from "node:fs/promises";
+import { createMuxMessage, type MuxMessage } from "@/common/types/message";
+import { Err, Ok } from "@/common/types/result";
+import type { StreamEndEvent } from "@/common/types/stream";
+import {
+  TaskHandleStore,
+  type WorkspaceTurnTaskHandleRecord,
+} from "@/node/services/taskHandleStore";
+import {
+  createAIServiceMocks,
+  createWorkspaceServiceMocks,
+  findWorkspaceInConfig,
+  makeWorkspaceTurnCreateMock,
+  saveLocalParentWorkspace,
+  stubStableIds,
+  workspaceTurnMuxMetadata,
+} from "@/node/services/taskService.testHarness";
+import type { WorkspaceHost } from "@/node/services/taskWorkspaceSeam";
+import { TerminalAttentionStore } from "@/node/services/terminalAttentionStore";
+import { createTestHistoryService } from "@/node/services/testHistoryService";
+import type { WorkspaceTurnManager } from "@/node/services/workspaceTurnManager";
+import { createWorkspaceTurnManagerHarness } from "@/node/services/workspaceTurnManager.testHarness";
+import type { MutexMap } from "@/node/utils/concurrency/mutexMap";
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  mock.restore();
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+async function startTurn() {
+  const fixture = await createTestHistoryService();
+  cleanups.push(fixture.cleanup);
+  const { config, historyService, tempDir } = fixture;
+  await mkdir(config.srcDir, { recursive: true });
+  const { parentId, projectPath } = await saveLocalParentWorkspace(config, tempDir);
+  stubStableIds(config, ["handle", "turn"]);
+  let activeStream: { messageId: string; muxMetadata: unknown } | undefined;
+  const aiMocks = createAIServiceMocks(config, {
+    isStreaming: mock(() => activeStream != null),
+    getStreamInfo: mock(() => activeStream),
+  });
+  const continuation = mock(() => false);
+  const workspaceMocks = createWorkspaceServiceMocks({
+    create: makeWorkspaceTurnCreateMock(config, projectPath),
+    hasPendingWorkspaceTurnContinuation: continuation,
+    sendMessage: mock(async (...args: Parameters<WorkspaceHost["sendMessage"]>) => {
+      const [workspaceId, prompt, options, internal] = args;
+      const muxMetadata = workspaceTurnMuxMetadata(parentId);
+      expect(options?.muxMetadata).toEqual(muxMetadata);
+      expect(
+        (
+          await historyService.appendToHistory(
+            workspaceId,
+            createMuxMessage("turn-anchor", "user", prompt, { muxMetadata })
+          )
+        ).success
+      ).toBe(true);
+      await internal?.onAccepted?.();
+      activeStream = { messageId: "turn-stream", muxMetadata };
+      return Ok(undefined);
+    }),
+  });
+  const { taskService: manager, taskHost } = createWorkspaceTurnManagerHarness(config, {
+    historyService,
+    aiService: aiMocks.aiService,
+    workspaceService: workspaceMocks.workspaceService,
+  });
+  const result = await manager.createWorkspaceTurn({
+    ownerWorkspaceId: parentId,
+    prompt: "Summarize the repository",
+    title: "Settlement regression",
+    workspace: { mode: "new", disposable: true },
+  });
+  assert(result.success, result.success ? undefined : result.error);
+  const { taskId, workspaceId } = result.data;
+  const store = new TaskHandleStore(config);
+  const readRecord = async () => {
+    const record = await store.getWorkspaceTurn(parentId, taskId);
+    assert(record);
+    return record;
+  };
+  expect(await readRecord()).toMatchObject({ status: "running", disposableWorkspace: true });
+  await manager.markWorkspaceTurnBackgroundWorkNotifyOnTerminal(taskId, parentId);
+  const attention = new TerminalAttentionStore(config);
+  const notify = spyOn(taskHost, "enqueueTerminalAttention");
+  const abort = new AbortController();
+  let waiterSettled = false;
+  const waiter = manager
+    .waitForWorkspaceTurn(taskId, { requestingWorkspaceId: parentId, abortSignal: abort.signal })
+    .then(
+      (value) => {
+        waiterSettled = true;
+        return value;
+      },
+      (error: unknown) => {
+        waiterSettled = true;
+        return error;
+      }
+    );
+  cleanups.push(async () => {
+    abort.abort();
+    await waiter;
+  });
+  const append = async (message: MuxMessage) => {
+    expect((await historyService.appendToHistory(workspaceId, message)).success).toBe(true);
+  };
+  const uncorrelatedEnd: StreamEndEvent = {
+    type: "stream-end",
+    workspaceId,
+    messageId: "wake-output",
+    metadata: { model: "anthropic:claude-opus-4-6", agentId: "exec", finishReason: "stop" },
+    parts: [{ type: "text", text: "Synthetic wake finished" }],
+  };
+  const final: StreamEndEvent = {
+    ...uncorrelatedEnd,
+    messageId: "turn-final",
+    metadata: {
+      ...uncorrelatedEnd.metadata,
+      muxMetadata: workspaceTurnMuxMetadata(parentId, taskId),
+    },
+    parts: [{ type: "text", text: "Delegated work finished" }],
+  };
+  const finish = async (event: StreamEndEvent) => {
+    activeStream = undefined;
+    return manager.finalizeWorkspaceTurnFromStreamEnd(
+      event,
+      manager.captureQueueCutAttributionSnapshot(workspaceId)
+    );
+  };
+  const appendWake = async (synthetic: boolean) => {
+    await append(createMuxMessage("wake-input", "user", "Continue", { synthetic }));
+    await append(
+      createMuxMessage(uncorrelatedEnd.messageId, "assistant", "Synthetic wake finished", {
+        ...uncorrelatedEnd.metadata,
+      })
+    );
+  };
+  return {
+    config,
+    historyService,
+    manager,
+    taskHost,
+    aiMocks,
+    workspaceMocks,
+    continuation,
+    parentId,
+    taskId,
+    workspaceId,
+    attention,
+    notify,
+    waiter,
+    readRecord,
+    append,
+    appendWake,
+    uncorrelatedEnd,
+    final,
+    finish,
+    waiterSettled: () => waiterSettled,
+  };
+}
+
+// Keep the behavioral oracle above and this first test independent of settlement-cause internals:
+// it also runs on the pre-fix revision to prove that a synthetic wake cannot finish delegated work.
+describe("WorkspaceTurnManager uncorrelated stream-end", () => {
+  test("synthetic end after the turn anchor preserves the pending turn until its correlated final", async () => {
+    const h = await startTurn();
+    await h.appendWake(true);
+    expect(await h.finish(h.uncorrelatedEnd)).toBe(true);
+    expect(await h.readRecord()).toMatchObject({ status: "running" });
+    expect(h.waiterSettled()).toBe(false);
+    expect(h.manager.getLiveWorkspaceTurnRegistration(h.workspaceId)).toMatchObject({
+      handleId: h.taskId,
+      accepted: true,
+    });
+    expect(h.workspaceMocks.remove).not.toHaveBeenCalled();
+    expect(h.notify).not.toHaveBeenCalled();
+    expect(await h.attention.listPending(h.parentId)).toEqual([]);
+
+    expect(await h.finish(h.final)).toBe(true);
+    expect(await h.readRecord()).toMatchObject({
+      status: "completed",
+      messageId: h.final.messageId,
+    });
+    expect(await h.waiter).toMatchObject({ reportMarkdown: "Delegated work finished" });
+    expect(h.workspaceMocks.remove).toHaveBeenCalledTimes(1);
+    expect(h.manager.getLiveWorkspaceTurnRegistration(h.workspaceId)).toBeUndefined();
+  });
+
+  test("same-turn tool-calls continuation survives a synthetic end and completes at the correlated final", async () => {
+    const h = await startTurn();
+    h.continuation.mockReturnValue(true);
+    const toolEnd: StreamEndEvent = {
+      ...h.final,
+      messageId: "tool-boundary",
+      metadata: { ...h.final.metadata, finishReason: "tool-calls" },
+    };
+    expect(await h.finish(toolEnd)).toBe(true);
+    expect(await h.readRecord()).toMatchObject({
+      status: "running",
+      deferredMessageIds: [toolEnd.messageId],
+    });
+    h.continuation.mockReturnValue(false);
+    await h.appendWake(true);
+    expect(await h.finish(h.uncorrelatedEnd)).toBe(true);
+    expect(await h.readRecord()).toMatchObject({ status: "running" });
+    expect(h.waiterSettled()).toBe(false);
+    expect(h.workspaceMocks.remove).not.toHaveBeenCalled();
+    expect(h.notify).not.toHaveBeenCalled();
+    expect(await h.finish(h.final)).toBe(true);
+    expect(await h.waiter).toMatchObject({ reportMarkdown: "Delegated work finished" });
+    const completed = await h.readRecord();
+    expect(completed.status).toBe("completed");
+    expect(completed.deferredMessageIds).toBeUndefined();
+    expect(h.workspaceMocks.remove).toHaveBeenCalledTimes(1);
+  });
+});
+
+// The production cause stays private and ephemeral. Widen only the test boundary so malformed
+// runtime inputs can exercise the assertion without exporting or persisting the internal union.
+interface SettlementSeam {
+  assertWorkspaceTurnSettlementCause(cause: unknown): void;
+  settleWorkspaceTurn(params: {
+    record: WorkspaceTurnTaskHandleRecord;
+    next: WorkspaceTurnTaskHandleRecord;
+    cause?: unknown;
+    waiterSettlement: { status: "error"; error: Error };
+  }): Promise<void>;
+  workspaceTurnSettlementLocks: MutexMap<string>;
+  taskHandleStore: TaskHandleStore;
+  settleWorkspaceTurnWaiters(...args: unknown[]): unknown;
+  cleanupDisposableWorkspaceTurn(record: WorkspaceTurnTaskHandleRecord): Promise<void>;
+}
+
+function observeCauseInsideLock(manager: WorkspaceTurnManager) {
+  const internal = manager as unknown as SettlementSeam;
+  let insideLock = false;
+  const withLock = internal.workspaceTurnSettlementLocks.withLock.bind(
+    internal.workspaceTurnSettlementLocks
+  );
+  spyOn(internal.workspaceTurnSettlementLocks, "withLock").mockImplementation(
+    <T>(key: string, operation: () => Promise<T>) =>
+      withLock(key, async () => {
+        insideLock = true;
+        try {
+          return await operation();
+        } finally {
+          insideLock = false;
+        }
+      })
+  );
+  const validate = internal.assertWorkspaceTurnSettlementCause.bind(internal);
+  const causes = spyOn(internal, "assertWorkspaceTurnSettlementCause").mockImplementation(
+    (cause) => {
+      expect(insideLock).toBe(true);
+      validate(cause);
+    }
+  );
+  return { internal, causes };
+}
+
+describe("WorkspaceTurnManager settlement authorization", () => {
+  test("manual input interrupts with the concrete superseding message as internal evidence", async () => {
+    const h = await startTurn();
+    const { causes } = observeCauseInsideLock(h.manager);
+    await h.appendWake(false);
+    const reads = spyOn(h.historyService, "getHistoryFromLatestBoundary");
+    expect(await h.finish(h.uncorrelatedEnd)).toBe(true);
+    expect(causes).toHaveBeenCalledWith({ kind: "manual-supersession", messageId: "wake-input" });
+    expect(reads).toHaveBeenCalledTimes(1);
+    const record = await h.readRecord();
+    expect(record).toMatchObject({ status: "interrupted", messageId: h.uncorrelatedEnd.messageId });
+    expect(record).not.toHaveProperty("cause");
+    expect(await h.waiter).toBeInstanceOf(Error);
+    expect(h.workspaceMocks.remove).toHaveBeenCalledTimes(1);
+  });
+
+  test.each(["history-read-failed", "missing-stream-end", "missing-turn-anchor"] as const)(
+    "conservative %s fallback interrupts with one history read and its exact internal reason",
+    async (reason) => {
+      const h = await startTurn();
+      await h.appendWake(true);
+      if (reason !== "history-read-failed") {
+        const messageId =
+          reason === "missing-stream-end" ? h.uncorrelatedEnd.messageId : "turn-anchor";
+        expect((await h.historyService.deleteMessage(h.workspaceId, messageId)).success).toBe(true);
+      }
+      const { causes } = observeCauseInsideLock(h.manager);
+      const reads = spyOn(h.historyService, "getHistoryFromLatestBoundary");
+      if (reason === "history-read-failed") reads.mockResolvedValueOnce(Err("unreadable history"));
+      expect(await h.finish(h.uncorrelatedEnd)).toBe(true);
+      expect(causes).toHaveBeenCalledWith({ kind: "uncorrelated-conservative-fallback", reason });
+      expect(reads).toHaveBeenCalledTimes(1);
+      const record = await h.readRecord();
+      expect(record).toMatchObject({
+        status: "interrupted",
+        messageId: h.uncorrelatedEnd.messageId,
+      });
+      expect(record).not.toHaveProperty("cause");
+      expect(await h.waiter).toBeInstanceOf(Error);
+      expect(h.workspaceMocks.remove).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  test.each([
+    undefined,
+    { kind: "unknown" },
+    { kind: "manual-supersession" },
+    { kind: "manual-supersession", messageId: "" },
+    { kind: "uncorrelated-conservative-fallback" },
+    { kind: "uncorrelated-conservative-fallback", reason: "unknown" },
+  ])("rejects malformed settlement cause %j before any terminal effects", async (cause) => {
+    const h = await startTurn();
+    const { internal, causes } = observeCauseInsideLock(h.manager);
+    const record = await h.readRecord();
+    const failure = await internal
+      .settleWorkspaceTurn({
+        record,
+        next: { ...record, status: "interrupted" },
+        ...(cause === undefined ? {} : { cause }),
+        waiterSettlement: { status: "error", error: new Error("Unauthorized settlement") },
+      })
+      .then(
+        () => null,
+        (error: unknown) => error
+      );
+    expect(failure).toBeInstanceOf(Error);
+    expect(causes).toHaveBeenCalledTimes(1);
+    expect(await h.readRecord()).toEqual(record);
+    expect(h.waiterSettled()).toBe(false);
+    expect(h.manager.getLiveWorkspaceTurnRegistration(h.workspaceId)).toMatchObject({
+      handleId: h.taskId,
+    });
+    expect(h.workspaceMocks.remove).not.toHaveBeenCalled();
+    expect(h.notify).not.toHaveBeenCalled();
+    expect(h.aiMocks.stopStream).not.toHaveBeenCalled();
+  });
+
+  test("explicit interrupt cannot write or stop when settlement authorization fails", async () => {
+    const h = await startTurn();
+    const { causes } = observeCauseInsideLock(h.manager);
+    const validate = causes.getMockImplementation()!;
+    const denied = new Error("Settlement authorization denied");
+    causes.mockImplementation((cause) => {
+      validate(cause);
+      throw denied;
+    });
+    const bump = spyOn(h.taskHost, "bumpWorkspaceStopEpoch");
+    const latch = spyOn(h.taskHost, "latchWorkspaceStopsInProgress");
+    const record = await h.readRecord();
+    const failure = await h.manager.interruptWorkspaceTurn(h.parentId, h.taskId).then(
+      () => null,
+      (error: unknown) => error
+    );
+    expect(failure).toBe(denied);
+    expect(causes).toHaveBeenCalledWith({ kind: "explicit-interrupt" });
+    expect(await h.readRecord()).toEqual(record);
+    expect(h.waiterSettled()).toBe(false);
+    expect(bump).not.toHaveBeenCalled();
+    expect(latch).not.toHaveBeenCalled();
+    expect(h.workspaceMocks.remove).not.toHaveBeenCalled();
+    expect(h.aiMocks.stopStream).not.toHaveBeenCalled();
+    expect(h.notify).not.toHaveBeenCalled();
+  });
+
+  test("explicit interrupt authorizes inside the lock before preserving stop and cleanup ordering", async () => {
+    const h = await startTurn();
+    // A matching mirror must become terminal before waiter delivery and stopStream.
+    await h.manager.updateAgentTaskExecutionState(h.workspaceId, h.taskId, "running");
+    expect(findWorkspaceInConfig(h.config, h.workspaceId)?.taskExecutionStatus).toBe("running");
+    const { internal, causes } = observeCauseInsideLock(h.manager);
+    const order: string[] = [];
+    const validate = causes.getMockImplementation()!;
+    causes.mockImplementation((cause) => {
+      validate(cause);
+      order.push("cause");
+    });
+    const upsert = internal.taskHandleStore.upsertWorkspaceTurn.bind(internal.taskHandleStore);
+    spyOn(internal.taskHandleStore, "upsertWorkspaceTurn").mockImplementation(async (record) => {
+      await upsert(record);
+      order.push("persist");
+    });
+    spyOn(h.taskHost, "bumpWorkspaceStopEpoch").mockImplementation(() => {
+      order.push("epoch");
+    });
+    let stopLatched = false;
+    spyOn(h.taskHost, "latchWorkspaceStopsInProgress").mockImplementation(() => {
+      order.push("latch");
+      stopLatched = true;
+      return () => {
+        order.push("release");
+        stopLatched = false;
+      };
+    });
+    const mirror = h.manager.updateAgentTaskExecutionState.bind(h.manager);
+    spyOn(h.manager, "updateAgentTaskExecutionState").mockImplementation(async (...args) => {
+      await mirror(...args);
+      order.push("mirror");
+    });
+    const settleWaiters = internal.settleWorkspaceTurnWaiters.bind(internal);
+    spyOn(internal, "settleWorkspaceTurnWaiters").mockImplementation((...args) => {
+      expect(findWorkspaceInConfig(h.config, h.workspaceId)?.taskExecutionStatus).toBe(
+        "interrupted"
+      );
+      order.push("waiters");
+      return settleWaiters(...args);
+    });
+    const stopStarted = Promise.withResolvers<void>();
+    const stopFinished = Promise.withResolvers<void>();
+    h.aiMocks.stopStream.mockImplementation(async () => {
+      order.push("stop");
+      stopStarted.resolve();
+      await stopFinished.promise;
+      expect(stopLatched).toBe(true);
+      return Ok(undefined);
+    });
+    const cleanup = internal.cleanupDisposableWorkspaceTurn.bind(internal);
+    spyOn(internal, "cleanupDisposableWorkspaceTurn").mockImplementation(async (record) => {
+      expect(stopLatched).toBe(true);
+      order.push("cleanup");
+      await cleanup(record);
+    });
+    const interrupted = h.manager.interruptWorkspaceTurn(h.parentId, h.taskId);
+    try {
+      await Promise.race([
+        stopStarted.promise,
+        interrupted.then(() => {
+          throw new Error("Interrupt returned without stopping the stream");
+        }),
+      ]);
+      expect(order).toEqual(["cause", "persist", "epoch", "latch", "mirror", "waiters", "stop"]);
+      expect(causes).toHaveBeenCalledWith({ kind: "explicit-interrupt" });
+      expect(await h.readRecord()).toMatchObject({ status: "interrupted" });
+      expect(await h.waiter).toBeInstanceOf(Error);
+      expect(stopLatched).toBe(true);
+      expect(h.manager.getLiveWorkspaceTurnRegistration(h.workspaceId)).toBeUndefined();
+      expect(h.workspaceMocks.remove).not.toHaveBeenCalled();
+    } finally {
+      stopFinished.resolve();
+      await interrupted;
+    }
+    expect(await interrupted).toEqual(Ok({ workspaceId: h.workspaceId }));
+    expect(order.slice(-2)).toEqual(["cleanup", "release"]);
+    expect(stopLatched).toBe(false);
+    expect(h.aiMocks.stopStream).toHaveBeenCalledWith(h.workspaceId, { abandonPartial: false });
+    expect(h.workspaceMocks.remove).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Make workspace-turn terminal transitions name an internal, validated cause, and pin the synthetic-wake false-settlement regression fixed by #3949. **No lifecycle-policy, persisted schema, wire, liveness, or Effect-fiber changes.**

- Cover all 13 central settlement call sites plus the independent explicit-interrupt path with 14 cause kinds. The same synchronous validator runs inside each existing lock before terminal persistence; explicit stop retains its epoch/latch/mirror ordering.
- Carry the actual superseding input ID for manual supersession. Preserve conservative interruption on unreadable history, missing stream-end, missing anchor, or invalid persisted manual-input ID under a separate cause with an explicit reason; no fabricated manual evidence or extra history reads.
- Add 19 real-manager/real-store/real-HistoryService regression cases covering pending waiters, disposable cleanup, terminal attention, continuation, malformed causes, and explicit-stop ordering. Reuse the existing test harness without changing existing assertions.

## Evidence

- **Exact pre-fix main `3937abd4e96ab7475f5f702bd40118016f83e5c4`:** behavior-only reproduction compiles and fails at the `running` assertion: actual `interrupted`, “Workspace turn superseded by an uncorrelated workspace stream-end.” The new cause assertions are not involved.
- **PR2:** 791 tests pass across the manager, TaskService, TaskHandleStore, task tools, and workspace-turn inheritance suites; `make static-check` and a fresh `make build` pass on Bun 1.3.5. Detailed logs, reproduction, and isolated live evidence are in the first comment.

**Live dogfood limitation:** two fresh isolated parent/child monitor attempts failed the requested waiting-through-final scenario: the parent received an early **correlated** `finishReason: "tool-calls"` error. With a retained child, the 60-second script then exited successfully and the child completed with the same turn correlation; the handle self-healed to completed after the parent had already failed. No uncorrelated assistant end or new cause assertion failure occurred. The untouched monitor-withdrawal/queue-cut continuation path is documented with screenshots/video in the first comment; per the addendum, this PR does not broaden into that lifecycle-policy fix. **Live success is not claimed.**

## Scope / risk

The Sep 5 addendum supersedes the original single-chokepoint/manual-only/11-caller assumptions. Production is **+104 net lines** rather than the stale ~40 estimate. The manager owns no AI emitter routing: its regression fixture uses actual creation/admission, the established AI fake with correlated stream state, and the manager's direct event entry point. Existing private-settlement tests receive causes only; all existing assertions remain intact.

The validator is an internal developer contract, not a new authorization or recovery policy. Arbitrary uncorrelated synthetic output is never authoritative completion; readable anchored history without manual supersession stays nonterminal. Unknown-history conservative interruption remains intentional. #3915 remains a soft dependency; the two-week live-host observation and post-wave N20 main-run check remain follow-up signals, not claims established by this PR.

---

<details>
<summary>📋 Accepted implementation plan (including superseding Sep 5 addendum)</summary>

# Effect migration — Wave 4: finish the concurrency/lifecycle core

Bounded wave: **4 PRs (PR 4 optional), explicit STOP criterion, explicit OFF-RAMPs.** Plan only; nothing here is implemented.

> **Review status:** Independently reviewed (adversarial Reviewer sub-agent, advisor unavailable): APPROVE WITH REQUIRED EDITS — both edits applied; verified claims: Effect.promise 0-arity thunk allocates no AbortController (internal/effect.js:741–776); closed-scope forkIn+startImmediately runs onInterrupt (2237–2274, 391–409); forkIn observer removes the scope finalizer on exit (2270–2271); Effect.timeoutOrElse exists (Effect.d.ts:7833); 0 line drift at b87f62729; 11 settleWorkspaceTurn callers confirmed; 'aborted' ∈ NON_RETRYABLE_STREAM_ERRORS. Line references are to `main` @ `b87f62729`.

## 0. Thesis check (coordinator's judgment vs. evidence)

**Thesis:** Effect's payoff in this app is structured concurrency + interruption-safe lifecycles in the orchestration core (still Promise + AbortController).

**Verdict: holds for the stream engine; only half-holds for turn handles.**

- Stream engine — **holds.** `ServiceContainer.dispose()` never stops or awaits in-flight streams (`serviceContainer.ts:478–537` has no `streamManager` step); an in-flight stream dies with the process and is recovered on next load from `partial.json` (≤ 500 ms stale, `PARTIAL_WRITE_THROTTLE_MS`, `streamManager.ts:776`). `AppFiberScope` exists precisely for this and has no occupant. A supervised per-stream fiber is the right tool.
- Turn handles — **half-holds.** The 7× "superseded by an uncorrelated workspace stream-end" false-settle is a _correlation-predicate_ bug (`interruptWorkspaceTurnFromUncorrelatedStreamEnd`, `workspaceTurnManager.ts:4220–4307`: any uncorrelated stream-end after the prompt index settles the handle `interrupted`), not a Promise-vs-fiber structure bug. Turn handles are **persisted records** (`taskHandleStore.upsertWorkspaceTurn`) spanning **multiple streams** (tool-call continuations are deferred via `hasSameTurnContinuation`, `:4491`) and surviving restarts; a fiber/Deferred can only model the in-process waiter and would not fix correlation. Open PR **#3949** fixes the predicate in Promise idiom and is Codex-green. Wave 4's turn-handle PR therefore becomes **"codify the settlement invariant + prove the class is gone"**, not "fiberize handles" (D5 below).

Corrected baseline numbers (measured this workspace): 46/470 `src/node` non-test files import `effect` (coordinator said 35); 113 direct `Effect.run*` sites outside `di/` in 16 files; 226 `Effect.gen`; 9 `TaggedError` classes; effect `4.0.0-rc.112`, `@orpc/*` `1.14.11`; **effect v4 is not GA** (rc line still current).

## 1. Verified current state (evidence the design rests on)

<details>
<summary>Stream engine (streamManager.ts)</summary>

- `startStream` (`:4723–4901`): per-workspace mutex → `new AbortController()` + `linkAbortSignal` (`:4771–4772`) → `resourceScope = Scope.makeUnsafe()` (`:4777`) → temp-dir `Effect.acquireRelease` (`:4802–4824`) → `createStreamAtomically` → `streamText` (`:2244`, `abortSignal: abortController.signal` `:2250`) → registered in `workspaceStreams` (`:2463`) → **`streamInfo.processingPromise = this.processStreamWithCleanup(...)` fire-and-forget (`:4876–4882`)** → returns `Ok({ messageId, completion })`.
- `processStreamWithCleanup` (`:3331–4089`, plain async): `while(true)` retry loop; `for await (part of fullStream)` (`:3358–3837`) with abort check at loop head (`:3361`); post-loop `if (!signal.aborted)` gate (`:3849`) → completion path (`deletePartial` `:3981`, `updateHistory` `:3989`, `recordSessionUsage` `:4001`, `state = COMPLETED` `:4017`, emit `stream-end` `:4023`, `terminalCompletion` `:4024`); error path → `handleStreamFailure` (`:4094–4112`) → `persistStreamError` writes error partial; `finally` (`:4052–4088`): release MCP lease, `Effect.runFork(Scope.close(resourceScope))` (`:4064–4066`), unlink abort, `workspaceStreams.delete`, `eventSpine.emit("stream.end")`, `completionController.settle`.
- Cancellation: `stopStream` (`:5043–5111`) → `cancelStreamSafely` (`:1766–1800`): `if (state === COMPLETED) { await processingPromise; return }` → `state = STOPPING` → `flushPartialWrite` → `abortController.abort()` → `cleanupAbortedStream` (`:1828–1951`): `await processingPromise` → usage → `writePartial` (`:1876–1910`) → `emitStreamAbort` → `settle({status:"aborted"})`. **No completed-guard after the await** (verified `:1838–1951`): a cancel landing between `:3849` and `:4017` re-writes `partial.json` after `deletePartial` and emits `stream-abort` after `stream-end` (pre-existing window; dispose() will widen its exposure). `cancelStreamSafely` is also not idempotent for concurrent callers (only `COMPLETED` is checked).
- AIService on `stream-abort` (`aiService.ts:355–377`): `abandonPartial ? deletePartial : commitPartial → deletePartial` (fire-and-forget listener).
- Crash recovery: `HistoryService.commitPartial` (`historyService.ts:1963–2061`) — strips error metadata, `hasCommitWorthyParts`, stale-epoch check, update-or-append by `historySequence`, delete partial; invoked from `agentSession.init` (`:5002`), `aiService.streamMessage` (`:886`), stream-abort (`:364`), `duplicateWorkspace`.
- `StreamAbortReason = "user" | "startup" | "system"` (`src/common/orpc/schemas/stream.ts:295`).
- Pinned seams: chaos test `Reflect.set(streamManager, "tokenTracker" | "createStreamResult")` (`streamManager.chaos.test.ts:130–134, 238–242`); `streamManager.test.ts` `Reflect.set` on `processStreamWithCleanup` (`:2787`), `createStreamAtomically` (`:2783`), `createTempDirForStream`, `cleanupStreamTempDir`, `Reflect.get` on `workspaceStreams`, `schedulePartialWrite`, …; `modelOnlyNotifications.test.ts` calls `processStreamWithCleanup` directly (`:93, :187`); `aiService.test.ts` spies `startStream`, `generateStreamToken`, `createTempDirForStream`, `isResponseIdLost`. Constructor: `(historyService, sessionUsageService?, getProvidersConfig?, eventSink = noop, runner = defaultEffectRunner)` (`:801–813`); `effectRunner` used at `:1152, :1154, :1169` only.
- Every stream event carries `workspaceId` + `messageId`; `stream-end`/`stream-abort`/`error` carry `metadata.muxMetadata` when the prompt had it.
</details>

<details>
<summary>DI / shutdown / startup</summary>

- `AppFiberScopeLive` is in `CoreLive`'s `runtimeSeams` (`di/layers/core.ts:644`), so both roots have it; `StreamManagerLive` (`core.ts:226–238`, stage S2b) already yields `EffectRunnerTag`. CLI cleanup lists include `appFiberScope.close` (`cli/run.ts:1579`, `cli/workflow.ts:286`).
- Bounds: `APP_FIBER_SCOPE_CLOSE_TIMEOUT_MS = 2000`, `APP_RUNTIME_DISPOSE_TIMEOUT_MS = 2000`; outer budgets are **5000 ms** on both desktop (`desktop/main.ts:1297` `Promise.race` vs `setTimeout(5000)`) and `xum server` (`cli/server.ts:236–243` force-exit). **The scope bound cannot grow** without changing outer budgets.
- rc.112 semantics verified in `node_modules/effect/dist/internal/effect.js:2264`: `forkIn` registers a scope finalizer and **removes it when the fiber completes** (no leak), and **interrupts immediately if the scope is already closed** (streams starting mid-shutdown fail closed). `Effect.promise(evaluate: (signal) => PromiseLike)`, `Effect.onInterrupt`, `Effect.forkIn(_, scope, { startImmediately? })`, `Stream.toAsyncIterableWith(context)`, `Stream.provideContext` all exist.
- `ServiceContainer.initialize()` (`serviceContainer.ts:297–362`): six awaited `initialize()`s wrapped in `recordStep` (durations only, no catch, no timeout) + three sync `start()`s + two fire-and-forget sweeps. Failure handling: desktop `Startup Failed` dialog + `app.quit()` (`desktop/main.ts:1249–1265`); `cli/server.ts:136` uncontained; ACP `serverConnection.ts:205–216` dispose + rethrow; `tests/ipc/setup.ts:85` no catch. No outer timeout anywhere.
- `streamBridge.subscriptionIterable` (`orpc/streamBridge.ts:176`) → `Stream.toAsyncIterable(...)` on the global runtime, 19 call sites in `routerSubscriptions.ts`; heartbeat via `Effect.sleep` in `forkScoped` (`:145–152`). `streamBridge.test.ts` has 11 real-time waits, but only **3 are clock-bound** (`:207` 1 ms initial delay, `:241` heartbeat 10 ms, `:255` 10 ms laziness); 8 are `waitFor(listenerCount…)` readiness polls that TestClock cannot replace.
</details>

<details>
<summary>Turn handles + open PRs</summary>

- Handle record `{ handleId "wst_…", ownerWorkspaceId, workspaceId, turnId, messageId, status, attentionPolicy, disposableWorkspace }`; prompt carries `muxMetadata: { type:"workspace-turn-task", taskHandleId, ownerWorkspaceId, turnId }` (`workspaceTurnManager.ts:1420`). `TaskService` forwards `aiService` `stream-end`/`stream-abort`/`error` to `finalizeWorkspaceTurnFromStreamEnd` (`:4442–4544`): correlated branch matches `record.workspaceId && record.turnId` (`:4472`); **uncorrelated branch** (`metadata == null`, not `agentId === "compact"`) → `interruptWorkspaceTurnFromUncorrelatedStreamEnd` → settles `interrupted` whenever `streamEndIndex >= promptIndex` (`:4293–4305`). Producers of such uncorrelated ends: bash-monitor wake continuations, child terminal-attention deliveries, heartbeat, peer messages, parent auto-resume.
- Cascade: disposable child → `cleanupDisposableWorkspaceTurn` → `workspaceService.remove(…, true)` kills its background processes; persistent child → parent sees `interrupted` → `task_stop` → `backgroundProcessManager.stopMonitor(…, "canceled")`. This is the observed "monitors died afterwards".
- Settlement chokepoint: `settleWorkspaceTurn(params)` (`:2085`), **11 callers**, guarded by `workspaceTurnSettlementLocks.withLock(handleId)`; waiters in `pendingWorkspaceTurnWaitersByHandleId` with `setTimeout` timeouts (`:2425–2496`).
- **#3949** "preserve turns across synthetic wake ends" (coadler): rewrites the uncorrelated branch — walks history from the turn anchor to the stream-end and settles _only if a manual child input intervened_ (`isManualChildWorkspaceInput`); otherwise ignores the end. Touches `:281–295, :4217–4355` + tests (+286/−31). Codex: "Didn't find any major issues" + clean security on `f9baa2fc9`. `mergeable: MERGEABLE`, but `Test / Unit` and `Codex Comments` red, 19 commits behind main.
- **#3915** "correlate workspace-turn liveness" (coadler): creation reservations + `getWorkspaceTurnLiveness`/`getWorkspaceTurnRuntimeActivity` (identity-matches the active stream's `muxMetadata` against the record) for staleness/capacity. Touches `:442–486, :1298, :2573, :3761, :3800–4064` (+494/−60). `BLOCKED`, latest Codex review has open findings, `Test / Unit` red, 19 behind.
- Together they are the identity-correlated model the coordinator wants: #3915 = identity-correlated _liveness_, #3949 = identity-gated _settlement_.
</details>

## 2. Design decisions

**D1 — Fibers WRAP the AbortController; they do not replace it.**
The AI SDK is cancelled only via `AbortSignal`; the `for await` loop, soft-interrupt at step boundaries, retry/fallback re-creation of `streamResult`, and ~30 abort touchpoints (#4032) all key off the signal. Converting the 750-line loop to `Stream.fromAsyncIterable` + fiber interruption would touch hundreds of `WorkspaceStreamInfo` transitions and break the `processStreamWithCleanup`/`createStreamResult` spy seams. Instead: **the fiber is the ownership/supervision unit; the signal stays the cancellation transport.** The dual-cancellation glue #4032 feared is confined to **one** point — the supervisor's `onInterrupt` — which routes through the existing user-stop path (`cancelStreamSafely`), so shutdown ≡ "user pressed stop" semantically (partial flushed with usage, `stream-abort` emitted, `completion` settles `aborted`, AIService commits the partial).

**D2 — Supervisor topology: one supervisor fiber per stream in `AppFiberScope`, wrapping the already-started `processingPromise`.**
`streamInfo.processingPromise = this.processStreamWithCleanup(...)` stays byte-identical (sync-start preserved; `Reflect.set(processStreamWithCleanup)` seam preserved; `cleanupAbortedStream`'s `await processingPromise` unchanged). Immediately after it:

```ts
// startStream, after processingPromise is assigned (unsupervised path unchanged when no scope)
this.superviseEngine(typedWorkspaceId, streamInfo);

private superviseEngine(workspaceId: WorkspaceId, streamInfo: WorkspaceStreamInfo): void {
  if (this.engineScope === undefined) return;               // direct construction / CLI tests: today's behavior
  assert(streamInfo.engineFiber === undefined, "engine already supervised");
  // Zero-arity thunk on purpose: rc.112 allocates an internal AbortController only
  // when `evaluate.length !== 0`; the stream's own controller stays the sole signal.
  const supervisor = Effect.promise(() => streamInfo.processingPromise).pipe(
    Effect.onInterrupt(() =>
      Effect.uninterruptible(   // explicit, per house doctrine (finalizers are already uninterruptible)
        Effect.promise(async () => this.cancelStreamSafely(workspaceId, streamInfo, "system"))
      )
    ),
    Effect.catchDefect((d) => Effect.sync(() => log.warn("[stream] engine supervisor defect", { workspaceId, error: d })))
  );
  streamInfo.engineFiber = this.effectRunner.runSync(
    Effect.forkIn(supervisor, this.engineScope, { startImmediately: true })
  );
}
```

- `Effect.promise` is interruptible while suspended (`internal/effect.js:741–801`, Async op); `onInterrupt` = `onErrorFilter(causeFilterInterruptors, …)` (`:1762`); `forkIn` registers `fiberInterrupt(fiber)` as the scope finalizer (`:2264–2275`), `fiberInterrupt` awaits the fiber (`:635–642`), and parallel `scopeClose` awaits all finalizers via `fiberAwaitAll` (`:1590–1601`) → `closeScopeBounded` at dispose step 2 gives "interrupt **and** await" while `historyService`/`sessionUsage`/`eventSink → AIService → bridge servers` are still alive (bridges stop in step 3, so clients receive `stream-abort`).
- Normal completion: fiber exits → `forkIn`'s observer removes the scope finalizer (verified) → no per-stream residue.
- Stream started after step 2: `forkIn` on a closed scope calls `fiber.interruptUnsafe` synchronously and returns the fiber (`:2272–2274`, `runSync` does not defect). With `startImmediately: true`, `forkUnsafe` runs `child.evaluate` synchronously (`:2233–2247`) up to the `Effect.promise` Async op (`:772–801`), so the fiber is suspended (`_running=false`) when the interrupt lands and `interruptUnsafe` (`:391–409`) unwinds the stack through the `onInterrupt` handler → the stream is aborted as `system` (fail-closed during shutdown). Verified in rc.112 internals (`effect.js:2233–2247, 391–409`); **pin with a test** ("stream started after scope close is aborted") so an RC bump cannot silently change it.
- `"system"` is semantically exact: `"user"`/`"startup"` suppress next-startup recovery (`retryEligibility.ts:114–118, 284–287`), `"system"` marks an involuntary backend interruption (as `taskService.ts:8100, 8223` use it). **No in-session retry loop is possible:** the `stream-abort` handler (`agentSession.ts:6010`) routes `{ type: "aborted" }` to `retryManager.handleStreamFailure`, and `"aborted"` is in `NON_RETRYABLE_STREAM_ERRORS` (`retryEligibility.ts:49–59, 106`) → `retryManager.ts:99–104` abandons immediately, never schedules a fiber. Dogfooding still checks the _restart_ UX (the recovered partial is shown as interrupted; note whether any next-startup recovery re-sends — same class as today's `system` aborts from `taskService`).
- `engineScope` arrives as an **optional 6th constructor parameter** (`engineScope?: Scope.Closeable`), wired from `AppFiberScopeTag` in `StreamManagerLive` (`core.ts:226`). Default `undefined` keeps every direct-construction test and `aiService.ts:174` path identical (I4). `AppFiberScopeLive` already sits beneath S2b in `runtimeSeams`, so no staging change (I6).
- Abort reason: reuse **`"system"`** — no wire/schema change; UI copy for `system` already exists.
- Pending-start window (`pendingStreamStarts`, before registration) is **not** supervised: nothing is persisted for it yet, and `stopStream` already aborts pending controllers. Documented, not fixed.

**D3 — Fix the two adjacent cancel races in the same PR (closely-related bugs, not deferrals).**
(a) `cleanupAbortedStream`: after `await processingPromise`, if `streamInfo.terminalCompletion !== undefined` (completed/failed while the cancel was in flight) → return without abort bookkeeping (prevents `partial.json` resurrection after `deletePartial` and a `stream-abort` after `stream-end`). (b) `cancelStreamSafely` (`:1766`): latch a per-stream `cancelPromise` so concurrent cancellers (user stop racing dispose) join one cleanup → exactly one `stream-abort`, one `settle`. **Zero-suspension requirement:** the latch must be checked and assigned **synchronously at function entry, before any `await`** (the current first await is `flushPartialWrite` at `:1789`) — otherwise racing callers can both enter `cleanupAbortedStream`. Shape:

```ts
if (streamInfo.cancelPromise) return streamInfo.cancelPromise;
streamInfo.cancelPromise = (async () => {
  /* existing body, unchanged */
})();
return streamInfo.cancelPromise;
```

Both are ≤ 10 LoC and get behavioral tests.

**D4 — Shutdown bound stays 2 s; the finalizer must be fast or abandoned.**
Outer budgets are 5 s; 2 s + 2 s already consume 4 s. A flowing stream aborts within one chunk; a wedged provider (no chunks, ignores abort) hits the existing `boundedTeardown` timeout: warning, continue, process exit — identical to today's outcome. Dogfooding measures the actual `[shutdown] AppFiberScope closed { ms }` with a live stream.

**D5 — Turn handles: codify the settlement invariant; do not fiberize.**
Invariant: _a workspace-turn handle settles terminally only by (i) a stream terminal event whose `muxMetadata` correlates `{taskHandleId, ownerWorkspaceId, turnId}` to the record; (ii) an explicit interrupt (`task_stop`/`interruptWorkspaceTurn`); (iii) manual supersession — a manual child input after the turn anchor; (iv) stale-liveness reconciliation._ An uncorrelated stream-end is **never** terminal by itself. #3949 makes (iii) the only uncorrelated outcome; #3915 implements (iv) by identity. Wave 4 adds a `cause` discriminant to `settleWorkspaceTurn` (the single chokepoint) with a runtime assertion, plus the regression harness. Rationale for not converting waiters to `Deferred`/fibers: no behavioral gain, 4.9k-line file, and the coordinator's "settle only on the owning stream's termination" is over-specified — a turn owns _several_ streams.

**D6 — Startup: `initialize()` stays a Promise facade over a runtime-run startup effect; timeout ⇒ same failure path as a thrown step.**
Each step is `Effect.tryPromise({ try: async () => step(), catch: identity }).pipe(Effect.timeoutOrElse({ duration: STARTUP_STEP_TIMEOUT_MS, orElse: () => Effect.fail(new StartupStepTimeoutError(name, ms)) }))` (`timeoutOrElse` exists in rc.112, `Effect.d.ts:7833`; chosen over `timeout` + `catchTag` because the step's error channel is `unknown`, which `catchTag` cannot narrow). No `forkDetach` needed: a Promise step keeps running on its own when the waiting fiber times out (not inside an uninterruptible region, so the timeout interrupts the wait directly). `StartupStepTimeoutError extends Error` with `name = "StartupStepTimeoutError"` set in the constructor and message `"<step> exceeded <ms> ms"` (so the desktop dialog's error formatting shows both the class and the step name) → desktop shows it in the existing `Startup Failed` dialog; CLI/ACP/tests paths unchanged. Step **errors keep their identity** (v4 `runPromise` rejects with the raw failure). Downgrading any step to best-effort is a **policy change, out of scope** (audit of the six implementations: extensionMetadata/telemetry/experiments are local fs, <50 ms; policy has its own 10 s fetch timeout; workspaceService bounds its sync internally; only `taskService.initialize` — config scan + `editConfig` + recovery `sendMessage`s — is potentially unbounded). The three `start()`s stay sync (`Effect.sync`), the two fire-and-forget sweeps stay outside the effect. `stepDurationsMs` is preserved.
**Abandon-and-quit safety:** an abandoned `taskService.initialize` may be mid-`editConfig` when the root exits. Parity requirement for PR 3: after a rejected `initialize()`, every root runs the bounded `dispose()` before exiting. Verified: desktop already does — `services` is assigned before the await (`main.ts:653–656`), the catch calls `app.quit()`, and the `before-quit` listener (`:1271–1305`, guard `if (isDisposing || !services) return`) races `services.dispose()` against 5 s; ACP does (`serverConnection.ts:205–216`); **`cli/server.ts` does not** (`:133–136` awaited at top level, `main().catch` at `:282` only logs) → PR 3 adds a bounded `dispose()` there (≤ 10 LoC, same 5 s budget).

**D7 — streamBridge: thread the runtime context, not a runner.** `subscriptionIterable` gains `context?: Context.Context<never>` → `Stream.toAsyncIterableWith(context)`; `routerSubscriptions` passes the handler's `"effect/context"`. Production behavior identical; heartbeat sleeps on the runtime `Clock`; tests can run the 3 clock-bound waits on `TestClock`. Honest scope: the 8 readiness polls stay.

## 3. PRs (ordered by value ÷ risk; each independently mergeable)

### PR 1 — StreamManager engine core becomes the first `AppFiberScope` occupant

**Value:** high (the only remaining shutdown data-integrity gap; the reason `AppFiberScope` exists). **Risk:** medium → low with D1/D2. **Net product LoC ≈ +55** (`superviseEngine` ~25, ctor param/field ~5, `engineFiber` field ~2, D3 guards ~12, `core.ts` wiring ~2, doc updates in `appRuntime.ts`/`appFiberScope.ts` "occupant" text ~10).

Files: `src/node/services/streamManager.ts`, `src/node/services/di/layers/core.ts`, `src/node/services/di/appRuntime.ts` + `appFiberScope.ts` (docs), tests below.

Pre-work (before writing product code; each yields a note in the PR body):

1. Confirm `processStreamWithCleanup` never rejects (try/catch/finally shape `:3331–4089`); else the supervisor must fold rejections (it already `catchDefect`s).
2. Confirm `Effect.promise` interruption + `onInterrupt` await ordering under `Scope.close` in a 20-line probe test (pattern of `appFiberScope.test.ts:27–47`).
3. Enumerate abort observers that run _after_ the finalizer resolves (AIService `stream-abort` listener → `commitPartial`; agentSession completion continuations) and confirm the durable order (`writePartial` → commit → `deletePartial`) makes a mid-flight `process.exit` recoverable on next load (it is: partial survives until commit completes).
4. Measure: `[shutdown] AppFiberScope closed { ms }` with a live stream in the sandbox (D4).
5. Pin (same probe test): a fiber forked with `startImmediately: true` into an already-closed scope still runs its `onInterrupt` finalizer (reviewer-verified in rc.112 internals; the test guards RC bumps).

Acceptance (behavioral tests only):

- `streamManager.test.ts` (new cases; existing cases untouched): with `engineScope = Scope.makeUnsafe("parallel")` and a fake `createStreamResult` whose `fullStream` yields one `text-delta` then blocks until its `AbortSignal` fires — `closeScopeBounded(engineScope)` resolves; `writePartial` was called with the streamed text; exactly one `stream-abort` (`abortReason: "system"`) and zero `stream-end`; `completion` settles `{status:"aborted"}`; `workspaceStreams` is empty.
- Wedged provider (fullStream never yields, ignores abort): `closeScopeBounded` resolves within the bound, never rejects, warns once (assert the returned promise resolves and no throw; do **not** assert log text).
- No-scope construction: identical event sequence to today (guards existing suites; no new assertions needed beyond the unchanged suites passing).
- D3(a): cancel issued after the loop exits but before `COMPLETED` → history has exactly one final message, `partial.json` absent, event order `stream-end` only.
- D3(b): `stopStream` + `closeScopeBounded` racing on one stream → exactly one `stream-abort`, one settle.
- Fiber residue: after 50 completed streams, `closeScopeBounded(engineScope)` emits zero `stream-abort` and completes in the same tick class as an empty scope (assert no aborts and `workspaceStreams.size === 0`).
- `streamManager.chaos.test.ts` — existing cases byte-identical; **one new fuzz variant** constructs with an engine scope and closes it at a random iteration: every stream settles **exactly once** (count terminal events per `messageId` ≤ 1, all `completion` promises settle).
- `serviceContainer.test.ts`: "dispose() aborts and awaits an in-flight stream before `desktopBridgeServer.stop()`" (extend the ordering harness at `:295–323`); `coreServicesRoot.test.ts`: `xum run` cleanup list does the same via `appFiberScope.close`.

Gate suites: `streamManager.test.ts`, `streamManager.chaos.test.ts`, `streamManager.modelOnlyNotifications.test.ts`, `aiService.test.ts`, `agentSession.disposeRace.test.ts`, `agentSession.sinceReplayContract.test.ts`, `serviceContainer.test.ts`, `coreServicesRoot.test.ts`, `di/*.test.ts`, `taskService.test.ts`, `workspaceService.test.ts`, `turnRequestBuilder.test.ts`; `make static-check`.

House pre-review audits: interruption posture (supervisor's only suspension is the promise; finalizer uninterruptible end-to-end incl. `cancelStreamSafely` → `cleanupAbortedStream`); no defect escapes (`catchDefect` on the supervisor; `Effect.promise` thunks `async`); spy-seam check (`processStreamWithCleanup`, `createStreamResult`, `createStreamAtomically`, `startStream` signatures unchanged; constructor arity unchanged, trailing optional); sync-start (`processingPromise` assigned before fork; `runSync(forkIn)` completes synchronously); no constructor side-effects added; zero-suspension check on D3(b) latch (`cancelPromise` checked-and-assigned synchronously at `cancelStreamSafely` entry, before the first `await` at `:1789`; review the diff for any inserted `await`/lookup ahead of the assignment).

Rollback: revert the `core.ts` wiring line → `engineScope` undefined → today's behavior; D3 guards can stay (independent bug fixes).

### PR 2 — Turn-settlement invariant + false-settle regression harness (gated on #3949)

**Value:** high (7× production race). **Risk:** low. **Net product LoC ≈ +40** (`WorkspaceTurnSettlementCause` union + `cause` on `settleWorkspaceTurn` params + assert ~10; 11 call sites × 1–3 lines).

Relationship to open PRs — explicit:

- **#3949 is the fix and a hard prerequisite.** PR 2 rebases on it, changes none of its logic (`interruptWorkspaceTurnFromUncorrelatedStreamEnd`, `isWorkspaceTurnAnchorForRecord`, `isManualChildWorkspaceInput`), and adds the invariant + proof on top. If #3949 has not merged when PRs 1/3 are done: **do not fork a competing fix**; report to the coordinator, offer the regression test file to #3949's author as a review artifact, and hold PR 2 (it is not on any other PR's critical path).
- **#3915 is a soft prerequisite.** Its diff (`:3800–4064` incl. `settleStaleWorkspaceTurn`, a `settleWorkspaceTurn` caller) overlaps PR 2's one-line-per-caller change. Prefer landing after it; if PR 2 must go first, the conflict is a one-line `cause:` addition per caller. PR 2 never edits liveness/reservation code.
- Wave 4 does not otherwise touch `workspaceTurnManager.ts`.

Design: `type WorkspaceTurnSettlementCause` enumerated from the 11 callers (audited at `main` @ `b87f62729`): `:1373` creation validation failure; `:1476` pre-stream interrupt during launch; `:1500`/`:1518` pre-stream send failure; `:3834`/`:3863` stale-liveness recovery / restart timeout (`settleStaleWorkspaceTurn` — #3915's region); `:4301` **uncorrelated-stream-end manual supersession** (the only uncorrelated settle in the codebase; the path #3949 rewrites); `:4529` correlated terminal; `:4571` stream-abort; `:4675` deferred stream error; `:4736` terminal stream error. `settleWorkspaceTurn` asserts `params.cause` is a member and, for `manual-supersession`, that the superseding input's `messageId` is supplied — turning D5 into an exhaustive `Record<Cause, …>` check rather than prose, so a future "settle on uncorrelated end" cannot be added without naming (and justifying) a cause.

Acceptance:

- New `workspaceTurnManager.uncorrelatedStreamEnd.test.ts` (real `WorkspaceTurnManager` + `TaskHandleStore` + fake `aiService` emitter, following the existing suite's harness): (1) create turn → correlated `stream-start` → **synthetic wake stream** on the same child ends uncorrelated after the anchor → handle stays `running`, waiter unresolved, no disposable cleanup, no terminal attention → correlated `stream-end` → `completed`. (2) same with `finishReason:"tool-calls"` continuation in between. (3) manual child input between anchor and end → `interrupted` with `cause: manual-supersession`. (4) explicit `interruptWorkspaceTurn` → `interrupted`, `cause: explicit-interrupt`. Case (1) is the **scripted reproduction**: it must **fail on the pre-#3949 merge-base** (run the file from a sibling worktree at `git merge-base origin/main <#3949 head>`; record the failing assertion in the PR body) and pass after.
- Existing 113 `workspaceTurnManager.test.ts` cases and `taskService.test.ts` turn cases unchanged.

Gate suites: `workspaceTurnManager.test.ts`, `taskService.test.ts`, `taskHandleStore.test.ts`, `tools/task*.test.ts`; `make static-check`.

Audits: spy-seam (`getWorkspaceTurn`, `listAllWorkspaceTurns`, `enqueueTerminalAttention`, `deliverPersistentChildWorkspaceTurnResult` untouched); settlement lock held across the assert; no new suspension inside `withLock`.

Rollback: revert; the test file stays valid against #3949 alone (drop the `cause` assertions).

### PR 3 — `ServiceContainer.initialize()` as a runtime-run startup effect with per-step timeouts

**Value:** medium (a hung `taskService.initialize()` currently pins the splash screen forever; deterministic TestClock tests of startup). **Risk:** low–medium. **Net product LoC ≈ +80** (step table ~20, timed-step helper ~15, `StartupStepTimeoutError` ~8, constant ~3, facade ~10, root dispose-on-failure parity ≤ 10, doc update ~10).

Files: `serviceContainer.ts`, `src/constants/terminationTimeouts.ts` (keep with the termination constants so the budget doc stays in one place), `cli/server.ts` (dispose in the startup catch if missing), `di/appRuntime.ts` doc ("Deliberately not done" → remove the initialize() line; add startup contract).

Design (D6): `initialize(): Promise<void>` → `this.runtime.managed.runPromise(this.startupEffect())`. `startupEffect = Effect.gen` over an ordered `readonly steps: ReadonlyArray<{ name, run: () => Promise<void> }>` (assert names unique); each step: `recordStep` timing kept, `Effect.tryPromise({ try: async () => run(), catch: identity }).pipe(Effect.timeoutOrElse({ duration: STARTUP_STEP_TIMEOUT_MS, orElse: () => Effect.fail(new StartupStepTimeoutError(name, STARTUP_STEP_TIMEOUT_MS)) }))`. Then `Effect.sync` for the three `start()`s; the sweeps remain after `runPromise`. Constant `STARTUP_STEP_TIMEOUT_MS` — pre-work measures `[startup] <step> { ms }` across sandbox cold starts and picks ≥ 10× the slowest observed (propose 60 s; must be generous — a false timeout turns a slow-but-fine start into a crash). Roots dispose after a rejected `initialize()` (D6 abandon-and-quit safety).

Acceptance (all in `serviceContainer.test.ts`, TestClock via the existing `AppLive` spy at `:355–395`):

- A step that never resolves → `initialize()` rejects with `StartupStepTimeoutError` naming the step after exactly `TestClock.adjust(STARTUP_STEP_TIMEOUT_MS)`; later steps did not run.
- A rejecting step → `initialize()` rejects with **the same error object** (identity), later steps did not run (parity with today).
- Happy path → `stepDurationsMs` has all six keys; `start()`s called once each; second `initialize()` call behavior unchanged from today (verify whether re-entry is guarded today; preserve).
- `tests/ipc` harness and ACP entry still pass unchanged.

Gate suites: `serviceContainer.test.ts`, `coreServicesRoot.test.ts`, `di/*.test.ts`, `src/node/acp/*.test.ts`, `TEST_INTEGRATION=1 bun x jest tests/ipc` (smoke subset); `make static-check`.

Audits: I1 untouched (no layer body changes); I2 (only the composition root touches the runtime); error identity preserved (no wrapping); abandoned-step safety — every root runs bounded `dispose()` after a rejected `initialize()` (D6; `cli/server.ts` gains it in this PR); no sweep moved into the effect; the six-step order and `[startup] <step>` names unchanged.

Rollback: revert; constant removal.

### PR 4 (optional — cut if budget is exhausted) — `streamBridge` on the runtime context

**Value:** low (closes the last documented "global runtime" exception; enables TestClock for the heartbeat). **Risk:** low. **Net product LoC ≈ +30** (`context?` option + `toAsyncIterableWith` ~8; 19 call sites × 1 line via one shared helper in `routerSubscriptions.ts` ~3).

Acceptance: the 3 clock-bound waits (`:207, :241, :255`) run on `TestClock`; the heartbeat test asserts N heartbeats after `TestClock.adjust(N × interval)` with zero real time; existing behavioral assertions unchanged; `tests/ipc` subscription tests pass. Do not rewrite the 8 readiness polls.

Gate suites: `streamBridge.test.ts`, `routerSubscriptions*.test.ts`, `orpc/*.test.ts`, `TEST_INTEGRATION=1 bun x jest tests/ipc` (subscription subset); `make static-check`.

Audits: `Stream.toAsyncIterableWith` preserves double-close safety (pin with the existing test); `Cause.Done` typing unchanged; no `Scope`/`MemoMap`/`Scheduler` captured (pass the oRPC `effect/context`, which the DI layer already strips per `EffectRunnerLive`); `context` stays optional so direct callers/tests without a runtime keep today's global-runtime path.

Rollback: revert; the optional `context` default (`Context.empty()`) is exactly today's `toAsyncIterable`, so a partial revert of call sites is also safe.

### Execution order and size

Net product LoC for the wave ≈ **+205** (PR 1 ≈ +55, PR 2 ≈ +40, PR 3 ≈ +80, PR 4 ≈ +30); tests ≈ +600–800. PR 1 starts immediately. PR 2 starts the moment #3949 merges (parallel with PR 1/3 — disjoint files). PR 3 after PR 1 merges (both touch `appRuntime.ts` docs; PR 3 also touches `serviceContainer.ts`). PR 4 last, only if PRs 1–3 landed and no OFF-RAMP fired. Each PR: Codex dual review, `Codex Comments` minimization, merge queue; commit WIP early (`/tmp` wipes).

## 4. STOP criterion (measurable) and OFF-RAMPs

Wave 4 is **done** — and the Effect migration line **stops** without a new RFC — when all hold:

1. **dispose() awaits in-flight streams:** `serviceContainer.test.ts` ordering test + `coreServicesRoot.test.ts` pass on main; a sandbox `script -f` transcript of `xum server` receiving SIGTERM mid-stream shows `stream-abort` → `[shutdown] AppFiberScope closed { ms }` → `[shutdown] desktopBridgeServer.stop`, and immediately after exit `partial.json` is absent while `chat.jsonl` contains the interrupted assistant message (baseline on `main`: `partial.json` present, message absent until next load). `{ ms }` < 2000 in the flowing-stream case.
2. **False-settle class eliminated:** the scripted reproduction fails on the pre-#3949 merge-base and passes on main after PR 2; `settleWorkspaceTurn` rejects any settlement without an enumerated cause; the coordinator's own Mux sessions show zero "superseded by an uncorrelated workspace stream-end" in the two weeks after PR 2 (soft signal, logged in the wave summary).
3. **Startup:** timeout and error-identity tests pass under TestClock; `[startup]` per-step lines unchanged in the sandbox transcript; a throwaway build with the constant set to 1 ms shows `Startup failed: StartupStepTimeoutError: <step> exceeded 1 ms` and a clean exit.
4. **No new lifecycle flakes:** 0 failures attributable to the touched suites across **N = 20** consecutive _completed_ `Test / Unit` runs on `main` after the last Wave 4 merge — query `gh run list --workflow pr.yml --branch main --limit 60 --json databaseId,status,conclusion,event,headSha` (note: `gh run list --json` serializes these fields in **lowercase**, e.g. `{"status":"completed","conclusion":"success"}`, unlike `statusCheckRollup`), keep `status === "completed"` (pending runs have an empty `conclusion`, not null), take the newest 20, and for any run with `conclusion !== "success"` (case-insensitive normalization acceptable) inspect the failing job's log for the touched suite names (job `timeout`/`cancelled` from the 15-min budget is not a flake); plus green merge-queue runs for each PR. Any attributable flake → fix or revert before declaring done.

**OFF-RAMP (PR 1):** fires if pre-work 1–3 shows (a) routing shutdown through `cancelStreamSafely` cannot preserve crash-recovery semantics without changing `cleanupAbortedStream`'s contract beyond D3, (b) the chaos variant exposes a double-settle not closable by D3(b), or (c) the finalizer cannot fit the 2 s bound for flowing streams. Then: stop PR 1, keep `AppFiberScope` unoccupied, update `appRuntime.ts` "Deliberately not done" with the concrete blocker and the measured evidence, land D3 alone as a bug-fix PR. PRs 2–4 are independent and proceed.
**OFF-RAMP (PR 3):** if error identity or the `tests/ipc`/ACP paths cannot be preserved, keep `initialize()` as is and record why.
**OFF-RAMP (PR 2):** #3949 not merged → hold (see PR 2).

## 5. Risk register

| Risk                                                                                                 | Likelihood                                    | Mitigation                                                                                                                                                                                                            |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Crash-recovery regression: double commit / partial resurrection when shutdown-abort races completion | medium (window widens with dispose())         | D3(a) guard + test; `commitPartial`'s `historySequence` update-or-append is idempotent (`historyService.ts:2036–2041`)                                                                                                |
| Provider abort emits an `error` chunk → error path instead of abort path                             | low                                           | identical to today's user-stop path (parity); chaos variant covers hostile streams                                                                                                                                    |
| Wedged provider pins the 2 s bound → warning every shutdown                                          | low                                           | `boundedTeardown` already bounds; transcript measures; no budget change possible (5 s outer)                                                                                                                          |
| AIService `stream-abort` listener (`commitPartial`) still in flight when `process.exit` runs         | low                                           | durable order writePartial → commit → deletePartial; next-load recovery; PR 1 transcript checks `partial.json` is already gone when `cli/server.ts` logs its final cleanup line before `process.exit(0)` (`:252–266`) |
| Chaos-test seams (`createStreamResult`, `tokenTracker`)                                              | none if scope-less construction stays default | new variant added, old cases untouched                                                                                                                                                                                |
| Collision with #3915/#3949                                                                           | medium                                        | PR 2 gated; no edits to their regions; one-line `cause:` conflicts only                                                                                                                                               |
| RC churn (rc.113+ renames `forkIn`/`onInterrupt`/`toAsyncIterableWith`)                              | low                                           | all Effect imports already in `streamManager.ts`/`streamBridge.ts`; pins fixed; GA upgrade is a separate lockstep PR (§6)                                                                                             |
| Startup false timeout on slow hosts                                                                  | medium if constant too small                  | measure first; ≥ 10× slowest observed; generous default (60 s)                                                                                                                                                        |
| Sync-start assumptions in tests that `Reflect.set(processStreamWithCleanup)`                         | low                                           | promise assigned before fork; forkIn `runSync` synchronous                                                                                                                                                            |
| `shutdown()` (desktop second `before-quit` listener) still does not await streams                    | accepted                                      | contract says `shutdown()` never touches the runtime; desktop's dispose race is the covered path                                                                                                                      |
| Streams starting during shutdown                                                                     | covered                                       | `forkIn` on closed scope interrupts immediately → `system` abort (`startImmediately` semantics verified in rc.112; pinned by test)                                                                                    |
| `system` abort triggers an in-session RetryManager retry during shutdown                             | **unreachable** (verified)                    | `"aborted"` ∈ `NON_RETRYABLE_STREAM_ERRORS` → `retryManager.ts:99–104` abandons; no fiber scheduled                                                                                                                   |
| PR 3: abandoned `taskService.initialize` mid-`editConfig` when the root exits after a timeout        | low                                           | desktop/ACP already dispose on startup failure; PR 3 adds the missing `cli/server.ts` dispose; config writes are lock/journal-protected                                                                               |
| `startImmediately`/`onInterrupt` semantics differ in a later RC                                      | low                                           | pinned by the probe test in `appFiberScope.test.ts` style; RC bumps are a separate lockstep PR                                                                                                                        |

## 6. Standing item — effect v4 GA + `@orpc/experimental-effect` lockstep (analysis only)

v4 is **not GA** (rc.112 is current; v3 `3.x` remains the stable line). No PR this wave. When GA ships: one lockstep PR bumping `effect` + all `@orpc/*` (`1.14.11` today; check the GA-compatible `@orpc/experimental-effect`), canary gates = `di/*.test.ts`, `streamBridge.test.ts`, `streamManager.test.ts`, `serviceContainer.test.ts`, `TEST_INTEGRATION=1 bun x jest tests/ipc`, `make static-check`. The `Context → ServiceMap` rename risk is firewalled: `Context.Service` tags, `Context.omit/get`, `Layer`, `ManagedRuntime`, `TestClock` live only under `di/` + `orpc/effectContext.ts`; `streamManager.ts`/`streamBridge.ts` use `Effect`/`Scope`/`Fiber`/`Exit`/`Stream`/`Queue`/`Cause` only. PR 4 adds one `Context.Context<never>` type reference to `streamBridge.ts` — keep it as a type-only import so a rename is a one-line fix.

## 7. Dogfooding (per PR; evidence attached to the PR with `gh … --attach`)

Common setup: `make dev-server-sandbox DEV_SERVER_SANDBOX_ARGS="--clean-projects"` (or `xum server` on a temp `XUM_ROOT`) with `XUM_LOG_LEVEL=debug`, run under `script -f ~/wave4-scratch/<pr>-<scenario>.log`; scratch under `$HOME/wave4-scratch/` (never `/tmp`). Drive the UI with `agent-browser` (`open` → `snapshot -i` → click the explicit "Send message" ref; re-snapshot after typing). Screenshots are primary evidence; record WebM and finalize with `ffmpeg -c copy`.

- **PR 1:** (1) start a long stream (prompt that streams ~30 s), wait 3–5 s, `kill -TERM <server pid>`; transcript must show the order in STOP #1 and `[shutdown] AppFiberScope closed { ms }`; (2) `ls <XUM_ROOT>/sessions/<ws>/partial.json` (absent) + `tail -n 1 chat.jsonl` (interrupted assistant message); (3) restart, open the workspace in agent-browser, screenshot the persisted interrupted message; (4) same scenario on `main` for the baseline diff; (5) `xum run` Ctrl-C mid-stream transcript (CLI root parity); (6) quality gate between phases: gate suites green before the sandbox run, sandbox evidence before requesting review.
- **PR 2:** primary evidence is the regression file run on both the merge-base worktree (failing output) and the branch (passing). Secondary: sandbox parent workspace delegates via `task` kind=workspace to a child that arms a background bash monitor firing within ~10 s and keeps working ~60 s; screenshot the parent's task result (baseline `main`: `interrupted … uncorrelated workspace stream-end`; after: `completed`) and the child's log lines.
- **PR 3:** `xum server` cold start transcript with `[startup] <step> { ms }` for the six steps (parity); throwaway worktree build with `STARTUP_STEP_TIMEOUT_MS = 1` → transcript of `Startup failed: StartupStepTimeoutError …` and exit code (do not ship); desktop dialog cannot be shown headless — cite the unchanged `desktop/main.ts:1249–1265` catch.
- **PR 4:** agent-browser session left idle 60 s with the connection indicator visible (heartbeats keep it green) + screenshot; `streamBridge.test.ts` on TestClock.

## PR 2 implementation addendum — Sep 5, after #3949 merged

This addendum supersedes stale factual assumptions in D5 / PR 2, not their minimal-change goal. Verified base: #3949 merged as `2f99c6a5b027cd09c7574f7af3eeba1cb804ec6a`; its pre-merge main parent is `3937abd4e96ab7475f5f702bd40118016f83e5c4`. #3915 remains open and is only a soft prerequisite. Proceed with PR 2 without changing its liveness algorithm.

- **Preserve the actual #3949 fallback.** It still conservatively interrupts when history cannot be read or the stream-end/turn anchor cannot be found. Such a transition must have a distinct `uncorrelated-conservative-fallback` cause with a reason (history read failed, missing stream end, or missing turn anchor), never a fabricated manual-input ID. Proven `manual-supersession` requires the actual superseding input's message ID. Change only evidence plumbing through the existing helper; preserve read count, classification, stale-event behavior and outcomes.
- **There are two settlement paths.** `settleWorkspaceTurn` is the central helper, but explicit `interruptWorkspaceTurn` also persists terminal state inside its own lock while establishing stop epoch/latch and mirror ordering. Use one small synchronous cause validator inside both existing lock boundaries. Do not route explicit interrupt through the central helper, nest locks, move stop-latch work, or add async work. Enumerate actual current call sites (including newer creation/admission/recovery failures), not the old count of 11.
- **Internal contract only.** Causes and their evidence are internal parameters/assertions, not persisted task-handle fields, schemas, wire payloads or migrations. Use exhaustive typing plus runtime validation for missing/invalid causes; add behavioral negative coverage. Keep real HistoryService/TaskHandleStore and established test/spy seams.
- **Honest invariant:** an uncorrelated synthetic end is never authoritative completion. With readable, anchored history and no proven manual supersession it remains nonterminal; explicit conservative fallback may interrupt when evidence cannot be established. Keep failure/abort/recovery and explicit-stop semantics unchanged. A concrete missing final-continuation correlation belongs at its dispatch source, not in arbitrary wake-output completion (the fresh #3949 review examined this and accepted the production correlation trace).
- **Reproduction base:** the old `merge-base origin/main <PR head>` recipe is invalid after the prerequisite's additive main sync. Use the exact pre-#3949 main parent above. Run the behavior-only reproduction there (strip only PR2-specific cause assertions if needed); it must compile and fail on the intended premature terminal settlement. The complete harness must pass on the PR2 branch. Add fallback-reason tests and preserve explicit-interrupt side effects/order.
- **Dogfooding:** retain §7 PR2's scripted regression evidence plus a freshly built isolated parent/child monitor-wake scenario, with screenshots/video. Do not assume this coordinator's currently running backend has upgraded just because main merged. Report the two-week live-session observation as a soft signal with version/exposure caveats, not as proof supplied by unit tests.

Acceptance remains regression proof + explicit, validated settlement causes without lifecycle-policy changes. Record this reconciliation in the PR description. Advisor reviewed this approach on Sep 5 and recommended preserving the explicit-interrupt path and conservative fallback as separate named causes rather than forcing the old plan's inaccurate single-chokepoint claim.

## 8. Non-goals (restated; out of this wave)

Typed-error propagation sweep / removing the ~113 facades; converting services to `yield*`-based Effect services; PubSub for the internal EventEmitter bus; Schema at persistence boundaries; Effect observability; converting sync read paths, AI-SDK per-request callbacks, cross-process lock interiors, or deterministic try-lock funnels; replacing `AbortController` as the SDK cancellation transport; converting the `fullStream` loop to `Stream`; fiberizing turn-handle waiters; downgrading startup steps to best-effort; changing outer quit budgets; supervising the pre-registration stream-start window; `shutdown()` semantics; the effect GA bump (standing analysis only).

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `coder:openai/gpt-6-astra` • Thinking: `high` • Cost: `$20.37`_

<!-- mux-attribution: model=coder:openai/gpt-6-astra thinking=high costs=20.37 -->
