### PR TITLE
🤖 fix: preserve subagent execution across parent guidance

### DIFF
--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -68,7 +68,7 @@ import type { AgentAiDefaults, AgentAiSubagentProfile } from "@/common/types/age
 import type { ThinkingLevel } from "@/common/types/thinking";
 import type { SendMessageError } from "@/common/types/errors";
 import type { ErrorEvent, StreamAbortEvent, StreamEndEvent } from "@/common/types/stream";
-import { createMuxMessage, type MuxMessage } from "@/common/types/message";
+import { createMuxMessage, type MuxMessage, type MuxMessageMetadata } from "@/common/types/message";
 import { isDynamicToolPart, type DynamicToolPart } from "@/common/types/toolParts";
 import {
   buildWorkflowRunCardMessage,
@@ -25443,6 +25443,7 @@ describe("TaskService", () => {
       return cfg;
     });
 
+    hasPendingWorkspaceTurnContinuation.mockReturnValue(false);
     await internal.handleStreamEnd({
       type: "stream-end",
       workspaceId: "childworkspace",
@@ -28457,6 +28458,159 @@ describe("TaskService", () => {
       reasoningMode: "pro",
     });
   });
+
+  test.each([
+    ["tool-end", "report"],
+    ["turn-end", "report"],
+    ["tool-end", "canceled"],
+    ["tool-end", "failed"],
+  ] as const)(
+    "parent guidance preserves a reawakened child's execution through %s dispatch (%s)",
+    async (queueDispatchMode, outcome) => {
+      const config = await createTestConfig(rootDir);
+      const { parentId, projectPath } = await saveLocalParentWorkspace(config, rootDir);
+      const childTaskId = "child-parent-guidance";
+      await config.editConfig((cfg) => {
+        const project = cfg.projects.get(projectPath);
+        assert(project);
+        project.workspaces.push(
+          projectWorkspace(projectPath, "child", childTaskId, {
+            parentWorkspaceId: parentId,
+            agentId: "explore",
+            agentType: "explore",
+            taskStatus: "reported",
+            title: "Reviewer",
+          })
+        );
+        return cfg;
+      });
+      type SendArgs = Parameters<WorkspaceHost["sendMessage"]>;
+      let pendingGuidance: SendArgs | undefined;
+      let initialSend: SendArgs | undefined;
+      const sendMessage = mock(async (...args: SendArgs): Promise<Result<void>> => {
+        if (args[0] === childTaskId) {
+          if (initialSend != null) {
+            pendingGuidance = args;
+            return Ok(undefined);
+          }
+          initialSend = args;
+        }
+        await args[3]?.onAccepted?.();
+        return Ok(undefined);
+      });
+      const { workspaceService } = createWorkspaceServiceMocks({
+        sendMessage,
+        hasPendingQueuedOrPreparingTurn: mock(() => pendingGuidance != null),
+        hasPendingWorkspaceTurnContinuation: mock(
+          (_workspaceId: string, metadata: unknown) =>
+            pendingGuidance != null &&
+            JSON.stringify(pendingGuidance[2]?.muxMetadata) === JSON.stringify(metadata)
+        ),
+      });
+      const { taskService, historyService } = createTaskServiceHarness(config, {
+        workspaceService,
+      });
+      const reactivated = await taskService.sendMessageToDescendantAgentTask(
+        parentId,
+        childTaskId,
+        "Review the changes.",
+        "tool-end"
+      );
+      assert(reactivated.success && reactivated.data.delivery === "reactivated");
+      const handleId = reactivated.data.executionTaskId;
+      assert(handleId);
+      assert(initialSend);
+      const initialMetadata = initialSend[2]?.muxMetadata as MuxMessageMetadata | undefined;
+      expect(
+        await taskService.sendMessageToDescendantAgentTask(
+          parentId,
+          childTaskId,
+          "Also check lifecycle behavior.",
+          queueDispatchMode
+        )
+      ).toEqual(Ok({ delivery: "queued", queueDispatchMode }));
+
+      // Drive the real settlement path using correlation captured at the send boundary,
+      // not a hand-authored continuation that would hide a missing metadata regression.
+      await handleTaskServiceStreamEndForTest(taskService, {
+        type: "stream-end",
+        workspaceId: childTaskId,
+        messageId: "before-parent-guidance",
+        metadata: {
+          model: "anthropic:claude-sonnet-4-6",
+          finishReason: queueDispatchMode === "tool-end" ? "tool-calls" : "stop",
+          muxMetadata: initialMetadata,
+        },
+        parts: [{ type: "text", text: "Initial review" }],
+      });
+      await flushTerminalAttentionDrains(taskService);
+      expect(await workspaceTurnSnapshot(taskService, parentId, handleId)).toMatchObject({
+        status: "running",
+      });
+      const parentBeforeReport = await collectFullHistory(historyService, parentId);
+      expect(JSON.stringify(parentBeforeReport)).not.toContain("<mux_subagent_failure>");
+      expect(JSON.stringify(parentBeforeReport)).not.toContain("<mux_subagent_report>");
+
+      assert(pendingGuidance);
+      const guidance = pendingGuidance;
+      pendingGuidance = undefined;
+      if (outcome !== "report") {
+        const reason = "Guidance could not run";
+        if (outcome === "canceled") {
+          assert(guidance[3]?.onCanceled);
+          await guidance[3].onCanceled(reason);
+        } else {
+          assert(guidance[3]?.onAcceptedPreStreamFailure);
+          await guidance[3].onAcceptedPreStreamFailure({ type: "unknown", raw: reason });
+        }
+        expect(findWorkspaceInConfig(config, childTaskId)?.taskPendingGuidance).toBeUndefined();
+        expect(await workspaceTurnSnapshot(taskService, parentId, handleId)).toMatchObject({
+          status: outcome === "canceled" ? "interrupted" : "error",
+          error: reason,
+        });
+        const failure: unknown = await workspaceTurnManagerFor(taskService)
+          .waitForWorkspaceTurn(handleId, {
+            requestingWorkspaceId: parentId,
+            timeoutMs: 100,
+          })
+          .then(
+            () => undefined,
+            (error: unknown) => error
+          );
+        expect(failure).toEqual(new Error(reason));
+        await flushTerminalAttentionDrains(taskService);
+        return;
+      }
+      await guidance[3]?.onAccepted?.();
+      await handleTaskServiceStreamEndForTest(taskService, {
+        type: "stream-end",
+        workspaceId: childTaskId,
+        messageId: "after-parent-guidance",
+        metadata: {
+          model: "anthropic:claude-sonnet-4-6",
+          finishReason: "stop",
+          muxMetadata: guidance[2]?.muxMetadata as MuxMessageMetadata | undefined,
+        },
+        parts: [{ type: "text", text: "Reviewed changes and lifecycle behavior." }],
+      });
+      await flushTerminalAttentionDrains(taskService);
+      const execution = await taskService.getDescendantAgentTaskExecutionSnapshot(
+        parentId,
+        childTaskId
+      );
+      assert(execution);
+      expect(
+        await workspaceTurnManagerFor(taskService).waitForWorkspaceTurn(execution.record.handleId, {
+          requestingWorkspaceId: parentId,
+          ownerWorkspaceId: execution.ownerWorkspaceId,
+          timeoutMs: 100,
+        })
+      ).toMatchObject({ reportMarkdown: "Reviewed changes and lifecycle behavior." });
+      const parentHistory = JSON.stringify(await collectFullHistory(historyService, parentId));
+      expect(parentHistory).not.toContain("<mux_subagent_failure>");
+      expect(parentHistory.match(/<mux_subagent_report>/g)).toHaveLength(1);
+    }
+  );
 
   test("reactivated children can report progress while retaining their completed task status", async () => {
     const config = await createTestConfig(rootDir);

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -4687,6 +4687,12 @@ export class TaskService implements AgentTaskIntegration {
 
         const activeAgentId = resolveTaskAgentIdForResume(entry.workspace);
         const activeAiSettings = this.resolveWorkspaceAISettings(entry.workspace, activeAgentId);
+        // Parent guidance continues the delegated execution, rather than superseding it and
+        // stranding its report. Use the normal continuation guards for earlier manual input.
+        const workspaceTurnMuxMetadata =
+          await this.getWorkspaceTurnManager().getActiveWorkspaceTurnMuxMetadataForWorkspace(
+            taskId
+          );
         let accepted = false;
         const sendResult = await this.workspaceService.sendMessage(
           taskId,
@@ -4703,18 +4709,41 @@ export class TaskService implements AgentTaskIntegration {
             reasoningMode: coerceOpenAIReasoningMode(activeAiSettings?.reasoningMode),
             experiments: entry.workspace.taskExperiments,
             queueDispatchMode,
+            ...(workspaceTurnMuxMetadata != null ? { muxMetadata: workspaceTurnMuxMetadata } : {}),
           },
           {
             synthetic: true,
             agentInitiated: true,
             startStreamInBackground: true,
+            workspaceTurnContinuation: workspaceTurnMuxMetadata != null,
+            ...(workspaceTurnMuxMetadata != null
+              ? {
+                  onCanceled: async (reason: string) => {
+                    await clearGuidanceReservation(true);
+                    await this.getWorkspaceTurnManager().settleWorkspaceTurnContinuationFailure(
+                      taskId,
+                      workspaceTurnMuxMetadata,
+                      "interrupted",
+                      reason
+                    );
+                  },
+                }
+              : {}),
             // Live target: pre-turn rows ride the send through AgentSession
             // turn admission (queued with the trigger when the target is busy).
             preTurnMessages: options?.preTurnMessages,
-            onAcceptedPreStreamFailure: async () => {
+            onAcceptedPreStreamFailure: async (error: SendMessageError) => {
               // If the replacement turn cannot start, remove the settlement reservation and restore
               // an idle child to completion recovery instead of leaving it permanently running.
               await clearGuidanceReservation(true);
+              if (workspaceTurnMuxMetadata != null) {
+                await this.getWorkspaceTurnManager().settleWorkspaceTurnContinuationFailure(
+                  taskId,
+                  workspaceTurnMuxMetadata,
+                  "error",
+                  formatSendMessageError(error).message
+                );
+              }
             },
             onAccepted: async () => {
               await clearGuidanceReservation(false);

--- a/src/node/services/workspaceTurnManager.ts
+++ b/src/node/services/workspaceTurnManager.ts
@@ -4501,9 +4501,6 @@ export class WorkspaceTurnManager {
     ) {
       return true;
     }
-    if (this.workspaceService.hasPendingBashMonitorWakeContinuation(event.workspaceId)) {
-      return true;
-    }
     const activeStream = this.streamManager?.getStreamInfo(event.workspaceId);
     if (activeStream == null || activeStream.messageId === event.messageId) {
       return false;
@@ -4659,16 +4656,17 @@ export class WorkspaceTurnManager {
       return true;
     }
 
-    // A queued continuation can stop the in-flight stream at a tool boundary with
-    // finishReason "tool-calls" and continue the same delegated turn. Report
-    // wake-ups carry the exact correlation explicitly; bash-monitor wakes inherit
-    // it from history. Defer settlement until the continuation's terminal
-    // stream-end instead of reporting a false completion failure to the owner.
-    // Any other queued input (manual message, /compact) supersedes the turn and
-    // must settle the old outcome here.
+    // Parent guidance and report wake-ups continue the exact delegated turn. This includes
+    // turn-end guidance: don't publish an early report before the queued guidance runs.
+    // Uncorrelated bash-monitor wakes inherit only an open tool-boundary continuation;
+    // manual messages and /compact still supersede the old outcome.
     if (
-      event.metadata.finishReason === "tool-calls" &&
-      this.hasSameTurnContinuation(event, metadata)
+      (event.metadata.finishReason === "tool-calls" ||
+        event.metadata.finishReason === "stop" ||
+        event.metadata.finishReason == null) &&
+      (this.hasSameTurnContinuation(event, metadata) ||
+        (event.metadata.finishReason === "tool-calls" &&
+          this.workspaceService.hasPendingBashMonitorWakeContinuation(event.workspaceId)))
     ) {
       await this.markWorkspaceTurnStreamEndDeferred(event);
       return true;

--- a/tests/ipc/tasks/persistentSubagentCompaction.test.ts
+++ b/tests/ipc/tasks/persistentSubagentCompaction.test.ts
@@ -9,6 +9,7 @@ import {
   waitFor,
 } from "../helpers";
 
+import { buildMockStreamStartGateMessage } from "@/node/services/mock/mockAiRouter";
 import type { Workspace as WorkspaceConfigEntry } from "@/node/config";
 import { HistoryService } from "@/node/services/historyService";
 import type { MuxMessage } from "@/common/types/message";
@@ -59,6 +60,115 @@ describe("Persistent sub-agent compaction", () => {
       repoPath = undefined;
     }
   });
+
+  test.each(["tool-end", "turn-end"] as const)(
+    "parent guidance stays attached to a reawakened execution with %s dispatch",
+    async (queueDispatchMode) => {
+      if (!env || !repoPath) throw new Error("Test environment not initialized");
+      const testEnv = env;
+      const parent = await createWorkspace(env, repoPath, generateBranchName("guidance-parent"));
+      if (!parent.success) throw new Error(parent.error);
+      const parentId = parent.metadata.id;
+      workspaceIds.push(parentId);
+      const child = await createWorkspace(env, repoPath, generateBranchName("guidance-child"));
+      if (!child.success) throw new Error(child.error);
+      const childId = child.metadata.id;
+      workspaceIds.push(childId);
+      await env.config.addWorkspace(repoPath, {
+        ...child.metadata,
+        parentWorkspaceId: parentId,
+        agentId: "explore",
+        agentType: "explore",
+        taskStatus: "reported",
+        taskModelString: HAIKU_MODEL,
+        title: "Reviewer",
+      });
+      const historyService = new HistoryService(env.config);
+      const reactivated = await env.services.taskService.sendMessageToDescendantAgentTask(
+        parentId,
+        childId,
+        buildMockStreamStartGateMessage("Review the initial changes."),
+        "tool-end"
+      );
+      if (!reactivated.success || reactivated.data.delivery !== "reactivated") {
+        throw new Error("Expected a reactivated child execution");
+      }
+      const handleId = reactivated.data.executionTaskId;
+      if (!handleId) throw new Error("Expected a reactivated execution task ID");
+      try {
+        // Hold the real session at stream preparation, so guidance deterministically queues.
+        expect(
+          await waitFor(
+            () => testEnv.services.workspaceService.getOrCreateSession(childId).isPreparingTurn(),
+            10_000
+          )
+        ).toBe(true);
+        const guidance = await env.services.taskService.sendMessageToDescendantAgentTask(
+          parentId,
+          childId,
+          "Check lifecycle behavior before reporting.",
+          queueDispatchMode
+        );
+        const correlation =
+          await env.services.workspaceTurnManager.getActiveWorkspaceTurnMuxMetadataForWorkspace(
+            childId
+          );
+        if (!correlation) throw new Error("Missing active correlation");
+        expect(
+          env.services.workspaceService.hasPendingWorkspaceTurnContinuation(childId, correlation)
+        ).toBe(true);
+        expect(guidance).toMatchObject({ success: true, data: { delivery: "queued" } });
+      } finally {
+        env.services.aiService.releaseMockStreamStartGate(childId);
+      }
+
+      expect(
+        await waitFor(async () => {
+          const snapshot =
+            await testEnv.services.taskService.getDescendantAgentTaskExecutionSnapshot(
+              parentId,
+              childId
+            );
+          return (
+            snapshot?.record.status === "completed" ||
+            snapshot?.record.status === "interrupted" ||
+            snapshot?.record.status === "error"
+          );
+        }, 15_000)
+      ).toBe(true);
+      const result = await env.services.workspaceTurnManager.waitForWorkspaceTurn(handleId, {
+        requestingWorkspaceId: parentId,
+        backgroundOnMessageQueued: false,
+        timeoutMs: 10_000,
+      });
+      expect(result.reportMarkdown).toContain("Check lifecycle behavior before reporting.");
+      expect(findWorkspace(env, childId)).toMatchObject({
+        taskExecutionId: handleId,
+        taskExecutionStatus: "completed",
+      });
+      expect(
+        await waitFor(async () => {
+          const history = await historyService.getLastMessages(parentId, 30);
+          return (
+            history.success &&
+            history.data.some((message) => extractText(message).includes("<mux_subagent_report>"))
+          );
+        }, 10_000)
+      ).toBe(true);
+      const parentHistory = await historyService.getLastMessages(parentId, 30);
+      if (!parentHistory.success) throw new Error(parentHistory.error);
+      const reports = parentHistory.data.filter((message) =>
+        extractText(message).includes("<mux_subagent_report>")
+      );
+      expect(reports).toHaveLength(1);
+      expect(extractText(reports[0])).toContain("Check lifecycle behavior before reporting.");
+      expect(
+        parentHistory.data.some((message) =>
+          extractText(message).includes("<mux_subagent_failure>")
+        )
+      ).toBe(false);
+    }
+  );
 
   test("reawakens a compacted child in place and settles its continuation without a live LLM", async () => {
     if (!env || !repoPath) throw new Error("Test environment not initialized");


### PR DESCRIPTION
## Summary

Keep a reactivated sub-agent's execution attached when its parent sends additional `task_send_message` guidance. Previously, a tool-boundary follow-up could falsely terminate the delegated execution with `workspace_turn_superseded`, even while the child continued working.

- Preserve the active execution correlation and normal continuation admission guards.
- Defer settlement until queued guidance finishes, for both `tool-end` and `turn-end` dispatch, rather than publishing an early report.
- Settle canceled or failed-to-start continuations so waiters do not hang.

## Validation

- 659 targeted lifecycle and task-tool tests.
- Three IPC integration cases using the real workspace/session queue and deterministic fake streaming: both guidance dispatch modes deliver one final, post-guidance report; compacted-child reactivation remains supported.
- Regression coverage for canceled guidance and failed starts.
- `make static-check`.

<details>
<summary>Recorded backend verification</summary>

This records the tests running against isolated temporary workspaces, not the user's live app. The video is accelerated.

![Parent-guidance regression and real-queue integration results](https://github.com/user-attachments/assets/803c6f75-e239-4365-94b0-63988f7485f9)

https://github.com/user-attachments/assets/f0f46c36-4e44-40a1-b6c5-ab1bd5889b65

</details>

## Risks

The settlement change also applies to explicitly correlated report continuations. Deferral requires the same execution correlation; unrelated/manual input retains its existing supersede behavior. No persisted schema changes.

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `coder:openai/gpt-6-astra` • Thinking: `high` • Cost: $31.60_

<!-- mux-attribution: model=coder:openai/gpt-6-astra thinking=high costs=31.60 -->
