### PR TITLE
[providers] 🤖 fix: estimate Codex OAuth costs

### DIFF
--- a/src/browser/features/Settings/Sections/ProvidersSection.tsx
+++ b/src/browser/features/Settings/Sections/ProvidersSection.tsx
@@ -2818,8 +2818,9 @@ export function ProvidersSection() {
                                 </ToggleGroup>
 
                                 <p className="text-muted text-xs">
-                                  ChatGPT OAuth uses subscription billing (costs included). API key
-                                  uses OpenAI platform billing.
+                                  ChatGPT OAuth costs use API-equivalent estimates. Your plan may
+                                  include usage or charge credits. API keys use OpenAI platform
+                                  billing.
                                 </p>
 
                                 {!codexOauthDefaultAuthIsEditable && (

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -909,8 +909,8 @@ export interface MuxMetadata {
   routedThroughGateway?: boolean;
   routeProvider?: string;
   /**
-   * True when usage costs are included in a subscription (e.g., ChatGPT subscription routing).
-   * Token counts are still tracked, but the UI should display costs as $0.
+   * Legacy marker for usage that the app classified as subscription-covered.
+   * The UI preserves token counts and $0 costs for these historical records.
    */
   costsIncluded?: boolean;
   // Total usage across all steps (for cost calculation)

--- a/src/common/utils/tokens/displayUsage.test.ts
+++ b/src/common/utils/tokens/displayUsage.test.ts
@@ -388,7 +388,7 @@ describe("createDisplayUsage", () => {
     });
   });
 
-  describe("Subscription-covered usage costs", () => {
+  describe("Legacy subscription-covered usage costs", () => {
     test("returns $0 costs when providerMetadata.mux.costsIncluded is true", () => {
       const usage: LanguageModelV2Usage = {
         inputTokens: 1000, // OpenAI includes cached tokens
@@ -413,7 +413,7 @@ describe("createDisplayUsage", () => {
       expect(result!.reasoning.cost_usd).toBe(0);
     });
 
-    test("gpt-5.3-codex routed through ChatGPT subscription is always zero-cost", () => {
+    test("preserves zero costs for historical Codex usage marked as included", () => {
       const usage: LanguageModelV2Usage = {
         inputTokens: 1500, // includes cached input tokens
         outputTokens: 450,

--- a/src/node/services/agentStatusService.ts
+++ b/src/node/services/agentStatusService.ts
@@ -413,7 +413,6 @@ export class AgentStatusService {
             usage,
             usageOptions.providerMetadata,
             {
-              costsIncluded: usageOptions.costsIncluded,
               analyticsSource: "workspace_status",
               // Creation-time identity from the generator's pinned snapshot.
               metadataModel: usageOptions.metadataModel,

--- a/src/node/services/aiService.test.ts
+++ b/src/node/services/aiService.test.ts
@@ -8,12 +8,13 @@ import * as path from "node:path";
 
 import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
 
+import { resolveModelForMetadata } from "@/common/utils/providers/modelEntries";
 import { AIService, resolveMuxProjectRootForHostFs } from "./aiService";
 import { discoverAvailableSubagentsForToolContext } from "./turnContextAssembler";
 import {
   normalizeAnthropicBaseURL,
   buildAppAttributionHeaders,
-  type ProviderModelFactory,
+  ProviderModelFactory,
 } from "./providerModelFactory";
 import { HistoryService } from "./historyService";
 import { InitStateManager } from "./initStateManager";
@@ -2120,6 +2121,58 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
     });
   });
 
+  it.each([
+    { auth: "oauth", model: KNOWN_MODELS.GPT_53_CODEX.id },
+    { auth: "oauth", model: "openai:team-codex" },
+    { auth: "apiKey", model: KNOWN_MODELS.GPT_53_CODEX.id },
+  ] as const)("keeps $auth chat usage priced for $model", async ({ auth, model }) => {
+    using xumHome = new DisposableTempDir("ai-service-codex-costs");
+    const projectPath = path.join(xumHome.path, "project");
+    await fs.mkdir(projectPath, { recursive: true });
+    const workspaceId = "workspace-codex-costs";
+    const metadata = createLocalWorkspaceMetadata(workspaceId, projectPath);
+    const harness = createHarness(xumHome.path, metadata);
+    const providersConfig = {
+      openai: {
+        ...(auth === "oauth" ? { codexOauth: TEST_CODEX_OAUTH } : { apiKey: "sk-test" }),
+        models: [{ id: "team-codex", mappedToModel: KNOWN_MODELS.GPT_53_CODEX.id }],
+      },
+    };
+    new ProvidersConfigStore(harness.config.rootDir).saveProvidersConfig(providersConfig);
+
+    // Use real model creation so authentication participates in the pricing regression.
+    const factory = Reflect.get(harness.service, "providerModelFactory") as ProviderModelFactory;
+    spyOn(factory, "resolveAndCreateModel").mockImplementation(
+      ProviderModelFactory.prototype.resolveAndCreateModel.bind(factory)
+    );
+    const result = await harness.service.streamMessage({
+      messages: [createMuxMessage("latest-user", "user", "continue")],
+      workspaceId,
+      modelString: model,
+      thinkingLevel: "off",
+    });
+    expect(result.success).toBe(true);
+    expect(harness.startStreamCalls).toHaveLength(1);
+    const stream = harness.startStreamCalls[0];
+    if (!stream) throw new Error("Expected stream options");
+    const initialMetadata = initialMetadataFromStartStreamCall(stream);
+    expect(initialMetadata.costsIncluded).toBeUndefined();
+
+    const usage = createDisplayUsage(
+      { inputTokens: 1500, cachedInputTokens: 500, outputTokens: 450, reasoningTokens: 150 },
+      stream.modelString,
+      { mux: initialMetadata },
+      resolveModelForMetadata(stream.modelString, stream.providersConfigSnapshot ?? null)
+    );
+    expect(usage).toBeDefined();
+    if (!usage) throw new Error("Expected display usage");
+    expect(usage.costsIncluded).toBeUndefined();
+    expect(usage.input.cost_usd).toBeGreaterThan(0);
+    expect(usage.cached.cost_usd).toBeGreaterThan(0);
+    expect(usage.output.cost_usd).toBeGreaterThan(0);
+    expect(usage.reasoning.cost_usd).toBeGreaterThan(0);
+  });
+
   it("passes the resolved routeProvider into initial stream metadata", async () => {
     using xumHome = new DisposableTempDir("ai-service-route-provider-present");
     const projectPath = path.join(xumHome.path, "project");
@@ -2505,13 +2558,13 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
   });
 
   it.each(["advisor", "intuition"] as const)(
-    "zeros %s tool usage costs for costs-included models before persisting",
+    "records API-equivalent costs for %s tool usage through Codex OAuth",
     async (toolName) => {
-      using xumHome = new DisposableTempDir("ai-service-tool-model-usage-costs-included");
+      using xumHome = new DisposableTempDir("ai-service-tool-model-usage-oauth");
       const projectPath = path.join(xumHome.path, "project");
       await fs.mkdir(projectPath, { recursive: true });
 
-      const workspaceId = "workspace-tool-model-usage-costs-included";
+      const workspaceId = "workspace-tool-model-usage-oauth";
       const metadata = createLocalWorkspaceMetadata(workspaceId, projectPath);
       const recordUsage = mock(() => Promise.resolve(undefined));
       const getSessionUsage = mock(() => Promise.resolve(undefined));
@@ -2582,7 +2635,7 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
         agentInitiated: true,
         workspaceId,
       });
-      // A live config refresh must not change the already-created model's billing mode.
+      // Cost estimates must remain available after an authentication change.
       new ProvidersConfigStore(harness.config.rootDir).saveProvidersConfig({
         openai: { apiKey: "new-direct-key" },
       });
@@ -2610,18 +2663,19 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
         },
         timestamp: Date.now(),
       };
-      const expectedDisplayUsage = createDisplayUsage(event.usage, event.model, {
-        ...(event.providerMetadata ?? {}),
-        mux: { costsIncluded: true },
-      });
+      const expectedDisplayUsage = createDisplayUsage(
+        event.usage,
+        event.model,
+        event.providerMetadata
+      );
       expect(expectedDisplayUsage).toBeDefined();
       if (!expectedDisplayUsage) {
         throw new Error("Expected tool usage event to produce display usage");
       }
-      expect(expectedDisplayUsage.costsIncluded).toBe(true);
-      expect(expectedDisplayUsage.input.cost_usd).toBe(0);
-      expect(expectedDisplayUsage.output.cost_usd).toBe(0);
-      expect(expectedDisplayUsage.reasoning.cost_usd).toBe(0);
+      expect(expectedDisplayUsage.costsIncluded).toBeUndefined();
+      expect(expectedDisplayUsage.input.cost_usd).toBeGreaterThan(0);
+      expect(expectedDisplayUsage.output.cost_usd).toBeGreaterThan(0);
+      expect(expectedDisplayUsage.reasoning.cost_usd).toBeGreaterThan(0);
 
       reportModelUsage(event);
       await Promise.resolve();

--- a/src/node/services/branchSummary.ts
+++ b/src/node/services/branchSummary.ts
@@ -45,7 +45,6 @@ import type { AIService } from "./aiService";
 import type { HistoryService } from "./historyService";
 import { runLanguageModelCleanup } from "./languageModelCleanup";
 import { log } from "./log";
-import { modelCostsIncluded } from "./providerModelFactory";
 import type { SessionUsageService } from "./sessionUsageService";
 import { createBranchSummaryMessageId } from "./utils/messageIds";
 
@@ -349,7 +348,6 @@ async function generateAbandonedBranchSummaryText(input: {
     modelString: string,
     usage: LanguageModelV2Usage,
     options: {
-      costsIncluded: boolean;
       providerMetadata?: Record<string, unknown>;
       metadataModel: string;
     }
@@ -565,7 +563,6 @@ async function generateAbandonedBranchSummaryText(input: {
                 input.workspaceId,
                 input
                   .recordUsage(modelString, usage, {
-                    costsIncluded: modelCostsIncluded(modelResult.data.model),
                     ...(providerMetadata !== undefined ? { providerMetadata } : {}),
                     metadataModel: modelResult.data.metadataModel,
                   })
@@ -753,7 +750,6 @@ export async function maybeAppendAbandonedBranchSummary(
               modelString: string,
               usage: LanguageModelV2Usage,
               options: {
-                costsIncluded: boolean;
                 providerMetadata?: Record<string, unknown>;
                 metadataModel: string;
               }
@@ -768,7 +764,6 @@ export async function maybeAppendAbandonedBranchSummary(
                 usage,
                 options.providerMetadata,
                 {
-                  costsIncluded: options.costsIncluded,
                   analyticsSource: "branch_summary",
                   metadataModel: options.metadataModel,
                 }

--- a/src/node/services/continuousCompactionSummary.ts
+++ b/src/node/services/continuousCompactionSummary.ts
@@ -37,7 +37,6 @@ import type { ContinuousCompactionContext } from "./continuousCompactor";
 import { looksLikeRawJsonObject } from "./compactionHandler";
 import { prepareMessagesForProvider } from "./messagePipeline";
 import { runLanguageModelCleanup } from "./languageModelCleanup";
-import { modelCostsIncluded } from "./providerModelFactory";
 import type { SessionUsageService } from "./sessionUsageService";
 
 /** A headless compact-agent call: no workspace stream or compaction request row. */
@@ -208,7 +207,6 @@ export async function summarizeContinuousCompaction(args: {
       providerMetadata,
       {
         metadataModel: created.data.metadataModel,
-        costsIncluded: modelCostsIncluded(created.data.model),
         analyticsSource: "continuous-compaction",
       }
     );

--- a/src/node/services/memoryConsolidationService.ts
+++ b/src/node/services/memoryConsolidationService.ts
@@ -29,7 +29,6 @@ import * as path from "node:path";
 import writeFileAtomic from "write-file-atomic";
 import { z } from "zod";
 import type { LanguageModel } from "ai";
-import { modelCostsIncluded } from "@/node/services/providerModelFactory";
 import type { SessionUsageService } from "@/node/services/sessionUsageService";
 import type { CompactionCompletionMetadata } from "@/common/types/compaction";
 import type { Result } from "@/common/types/result";
@@ -776,7 +775,6 @@ export class MemoryConsolidationService extends EventEmitter {
               usage,
               providerMetadata,
               {
-                costsIncluded: modelCostsIncluded(modelResult.data.model),
                 analyticsSource: "memory_consolidation",
                 // Creation-time identity: a catalog refresh mid-run must not
                 // re-attribute this spend (see ModelFactoryLike).
@@ -1017,7 +1015,6 @@ export class MemoryConsolidationService extends EventEmitter {
                 usage,
                 providerMetadata,
                 {
-                  costsIncluded: modelCostsIncluded(modelResult.data.model),
                   analyticsSource: "memory_harvest",
                   // Creation-time identity (see ModelFactoryLike).
                   metadataModel: modelResult.data.metadataModel,

--- a/src/node/services/providerModelFactory.test.ts
+++ b/src/node/services/providerModelFactory.test.ts
@@ -19,7 +19,6 @@ import {
   buildAIProviderRequestHeaders,
   classifyCopilotInitiator,
   countAnthropicCacheBreakpoints,
-  modelCostsIncluded,
   XUM_AI_PROVIDER_USER_AGENT,
   normalizeCodexResponsesBody,
   markCodexOauthRoutedResponse,
@@ -1333,7 +1332,7 @@ describe("ProviderModelFactory OpenAI WebSocket transport", () => {
         return;
       }
       expect(hasLanguageModelCleanup(result.data)).toBe(false);
-      expect(modelCostsIncluded(result.data)).toBe(true);
+      expect(result.data).toMatchObject({ provider: "openai.responses" });
     });
   });
 
@@ -1433,8 +1432,8 @@ describe("ProviderModelFactory OpenAI WebSocket transport", () => {
   });
 });
 
-describe("ProviderModelFactory modelCostsIncluded", () => {
-  it("marks gpt-5.3-codex as subscription-covered when routed through Codex OAuth", async () => {
+describe("ProviderModelFactory Codex authentication", () => {
+  it("creates a Responses model with only Codex OAuth credentials", async () => {
     await withTempConfig(async (config, factory) => {
       new ProvidersConfigStore(config.rootDir).saveProvidersConfig({
         openai: {
@@ -1454,7 +1453,7 @@ describe("ProviderModelFactory modelCostsIncluded", () => {
         return;
       }
 
-      expect(modelCostsIncluded(result.data)).toBe(true);
+      expect(result.data).toMatchObject({ provider: "openai.responses" });
     });
   });
 
@@ -1479,7 +1478,7 @@ describe("ProviderModelFactory modelCostsIncluded", () => {
         return;
       }
 
-      expect(modelCostsIncluded(result.data)).toBe(true);
+      expect(result.data).toMatchObject({ provider: "openai.responses" });
     });
   });
 
@@ -1525,7 +1524,7 @@ describe("ProviderModelFactory modelCostsIncluded", () => {
     });
   });
 
-  it("does not mark gpt-5.3-codex as subscription-covered when routed through API key", async () => {
+  it("creates a Responses model with only API key credentials", async () => {
     await withTempConfig(async (config, factory) => {
       new ProvidersConfigStore(config.rootDir).saveProvidersConfig({
         openai: {
@@ -1539,7 +1538,7 @@ describe("ProviderModelFactory modelCostsIncluded", () => {
         return;
       }
 
-      expect(modelCostsIncluded(result.data)).toBe(false);
+      expect(result.data).toMatchObject({ provider: "openai.responses" });
     });
   });
 });

--- a/src/node/services/providerModelFactory.ts
+++ b/src/node/services/providerModelFactory.ts
@@ -1837,6 +1837,7 @@ export class ProviderModelFactory {
           if (shouldRouteThroughCodexOauth && effectiveWireFormat !== "chatCompletions") {
             // OAuth can consume paid Business workspace credits. Keep API-equivalent cost estimates;
             // authentication does not prove that usage is free.
+            // Apply this policy to new requests only. Do not migrate historical usage.
 
             // Codex OAuth requires store=false and must override any request-level
             // setting to avoid unresolved item_reference lookups.

--- a/src/node/services/providerModelFactory.ts
+++ b/src/node/services/providerModelFactory.ts
@@ -829,24 +829,6 @@ function parseAnthropicCacheTtl(value: unknown): AnthropicCacheTtl | undefined {
   return undefined;
 }
 
-// ---------------------------------------------------------------------------
-// Model cost tracking
-// ---------------------------------------------------------------------------
-
-const MUX_MODEL_COSTS_INCLUDED = Symbol("mux:modelCostsIncluded");
-
-type LanguageModelWithMuxCostsIncluded = LanguageModel & {
-  [MUX_MODEL_COSTS_INCLUDED]?: true;
-};
-
-function markModelCostsIncluded(model: LanguageModel): void {
-  (model as LanguageModelWithMuxCostsIncluded)[MUX_MODEL_COSTS_INCLUDED] = true;
-}
-
-export function modelCostsIncluded(model: LanguageModel): boolean {
-  return (model as LanguageModelWithMuxCostsIncluded)[MUX_MODEL_COSTS_INCLUDED] === true;
-}
-
 const CODEX_ALLOWED_PARAMS = new Set([
   "model",
   "input",
@@ -1853,7 +1835,8 @@ export class ProviderModelFactory {
           // Skip Codex OAuth routing for chatCompletions — the Codex endpoint
           // only accepts Responses API format, so chat-completions requests would fail.
           if (shouldRouteThroughCodexOauth && effectiveWireFormat !== "chatCompletions") {
-            markModelCostsIncluded(model);
+            // OAuth can consume paid Business workspace credits. Keep API-equivalent cost estimates;
+            // authentication does not prove that usage is free.
 
             // Codex OAuth requires store=false and must override any request-level
             // setting to avoid unresolved item_reference lookups.

--- a/src/node/services/refinement/refineService.ts
+++ b/src/node/services/refinement/refineService.ts
@@ -77,7 +77,6 @@ import {
 } from "@/node/services/memoryConsolidationService";
 import type { MemoryMetaService } from "@/node/services/memoryMeta";
 import type { MemoryScopeContext, MemoryService } from "@/node/services/memoryService";
-import { modelCostsIncluded } from "@/node/services/providerModelFactory";
 import {
   listRefinements,
   type RefinementEvent,
@@ -1061,7 +1060,6 @@ export class RefineService {
             usage,
             providerMetadata,
             {
-              costsIncluded: modelCostsIncluded(modelResult.data.model),
               analyticsSource: "refine",
               metadataModel: modelResult.data.metadataModel,
             }

--- a/src/node/services/sessionUsageService.ts
+++ b/src/node/services/sessionUsageService.ts
@@ -212,9 +212,8 @@ export class SessionUsageService {
     providerMetadata?: Record<string, unknown>,
     options?: {
       /**
-       * Subscription-covered routing (e.g. Codex OAuth). Stamps
-       * providerMetadata.mux.costsIncluded so createDisplayUsage prices the
-       * tokens at $0, mirroring the StreamManager path.
+       * Preserve legacy subscription-covered usage at $0.
+       * New OAuth requests use API-equivalent estimates instead.
        */
       costsIncluded?: boolean;
       /**

--- a/src/node/services/turnRequestBuilder.ts
+++ b/src/node/services/turnRequestBuilder.ts
@@ -54,7 +54,6 @@ import { runLanguageModelCleanup } from "./languageModelCleanup";
 import { log } from "./log";
 import type { StreamManager } from "./streamManager";
 import {
-  markProviderMetadataCostsIncluded,
   type ModelFallbackOptions,
   type StreamTextOnChunk,
   type TurnCompletion,
@@ -171,7 +170,6 @@ import { getAnthropicCacheTtl } from "@/common/utils/ai/cacheStrategy";
 import { getLegacyModeForAgentMetadata, resolveAgentForStream } from "./agentResolution";
 import { DEVTOOLS_RUN_METADATA_ID_HEADER } from "./devToolsHeaderCapture";
 import type { OauthServiceBindings, ProviderModelFactory } from "./providerModelFactory";
-import { modelCostsIncluded } from "./providerModelFactory";
 import {
   assemblePromptPayload,
   buildPlanInstructions,
@@ -1676,10 +1674,6 @@ export class TurnRequestBuilder {
           return;
       }
     };
-    // Tool-side generateText() results do not consistently echo mux.costsIncluded in
-    // providerMetadata, so remember the resolved billing mode from model creation and
-    // re-stamp it before converting usage into display/session costs.
-    const toolModelCostsIncludedByModelString = new Map<string, boolean>();
     // Creation-time pricing identity for tool-created models (advisor and intuition): a
     // Coder catalog refresh can remove/retag the instance while the tool
     // request runs, and resolving the identity from live config at
@@ -1905,7 +1899,6 @@ export class TurnRequestBuilder {
       if (!toolModel.success) {
         throw new Error(`Failed to create tool model: ${getErrorMessage(toolModel.error)}`);
       }
-      toolModelCostsIncludedByModelString.set(toolModelString, modelCostsIncluded(toolModel.data));
       // Same effective-route rule as createModelWithPinnedMetadata:
       // a coder: selection whose gateway is unavailable falls away
       // to a direct provider inside createModel, and identity or
@@ -2088,10 +2081,7 @@ export class TurnRequestBuilder {
           assert(eventModel.length > 0, "tool model usage event model must be non-empty");
           // Persist tool-side model usage under its own model bucket so session costs keep
           // advisor/system-side pricing separate from the parent chat model.
-          const providerMetadata = markProviderMetadataCostsIncluded(
-            event.providerMetadata,
-            toolModelCostsIncludedByModelString.get(eventModel)
-          );
+          const providerMetadata = event.providerMetadata;
           // Prefer the creation-time identity captured when the tool model
           // was created; models not created through the tool runtime fall
           // back to live resolution (their identity is not coder-scoped).
@@ -2831,7 +2821,6 @@ export class TurnRequestBuilder {
                   ...(nextRequest.routeProvider != null
                     ? { routeProvider: nextRequest.routeProvider }
                     : {}),
-                  costsIncluded: modelCostsIncluded(nextRequest.model) ? true : undefined,
                   systemMessageTokens: nextRequest.systemMessageTokens,
                 },
               });
@@ -2902,7 +2891,6 @@ export class TurnRequestBuilder {
         ...(routeProvider != null ? { routeProvider } : {}),
         ...(muxMetadata !== undefined ? { muxMetadata } : {}),
         ...(acpPromptId != null ? { acpPromptId } : {}),
-        ...(modelCostsIncluded(modelResult.data.model) ? { costsIncluded: true } : {}),
       },
       providerOptions: streamProviderOptions,
       maxOutputTokens,

--- a/src/node/services/workspaceStatusGenerator.ts
+++ b/src/node/services/workspaceStatusGenerator.ts
@@ -2,7 +2,6 @@ import { streamText, tool } from "ai";
 import type { LanguageModel } from "ai";
 import type { LanguageModelV2Usage } from "@ai-sdk/provider";
 import { Duration, Effect } from "effect";
-import { modelCostsIncluded } from "./providerModelFactory";
 import type { AIService } from "./aiService";
 import { log } from "./log";
 import { runLanguageModelCleanup } from "./languageModelCleanup";
@@ -125,14 +124,12 @@ export interface GenerateWorkspaceStatusOptions extends BuildWorkspaceStatusProm
   /**
    * Best-effort cost telemetry: status generation bypasses StreamManager,
    * so the caller records the successful candidate's usage into
-   * session-usage.json. costsIncluded reflects subscription-covered routing
-   * (Codex OAuth) so those tokens are priced at $0.
+   * session-usage.json.
    */
   recordUsage?: (
     modelString: string,
     usage: LanguageModelV2Usage,
     options: {
-      costsIncluded: boolean;
       /**
        * Step-accumulated provider metadata. Anthropic reports billed
        * cache-write tokens only here (cacheCreationInputTokens), not in
@@ -317,7 +314,6 @@ function attemptCandidate(
         yield* Effect.tryPromise({
           try: async () =>
             options.recordUsage?.(modelString, usage, {
-              costsIncluded: modelCostsIncluded(created.model),
               providerMetadata: accumulateStepsProviderMetadata(steps),
               metadataModel: created.metadataModel,
             }),


### PR DESCRIPTION
## Summary

Show API-equivalent dollar estimates for new Codex OAuth usage instead of forcing costs to $0.

## Background

OAuth can consume paid Business workspace credits. Authentication alone does not prove that usage is free.

## Implementation

- Remove automatic subscription-covered markers from chat, tool, and background model calls.
- Keep model pricing, cached-token pricing, and reasoning-token pricing in the existing calculation path.
- Update Settings to explain the estimates and possible credit charges.
- Keep existing legacy `costsIncluded` behavior. Do not add historical migrations or backfills.

## Risks

The displayed amounts estimate API-equivalent usage, not exact credit charges. They do not change provider billing.
Dollar-based goal budgets now count new OAuth usage. Historical usage and upgraded-workspace aggregate reconciliation are outside this PR.
Repricing old mixed aggregates can change their displayed totals; this PR does not repair them.

---

_Generated with `xum` • Model: `openai:gpt-6-astra` • Thinking: `high` • Cost: `$27.16`_

<!-- mux-attribution: model=openai:gpt-6-astra thinking=high costs=27.16 -->
