### PR TITLE
🤖 fix: stop sub-agent progress reports from arriving late and stale

### DIFF
--- a/src/constants/agentMessaging.ts
+++ b/src/constants/agentMessaging.ts
@@ -28,6 +28,29 @@ export const MAX_QUEUED_PEER_MESSAGES_PER_TARGET = 10;
 export const AGENT_PEER_MESSAGE_DEDUPE_PREFIX = "agent-msg:";
 
 /**
+ * Queue dedupe-key prefix for incremental `agent_report` updates queued behind a busy parent.
+ * Full key: `agent-report:<child>:<toolCallId>` for a child's original run, or
+ * `agent-report:<child>:<executionId>:<toolCallId>` while a reawakened child runs as a
+ * workspace-turn continuation, so a terminal settlement can drop exactly the updates that
+ * execution superseded (a successor execution's updates keep their own prefix).
+ */
+export const AGENT_REPORT_PROGRESS_DEDUPE_PREFIX = "agent-report:";
+
+/** Prefix matching every queued incremental update from one child (optionally one execution). */
+export function agentReportProgressDedupePrefix(
+  childWorkspaceId: string,
+  executionId?: string
+): string {
+  return executionId == null
+    ? `${AGENT_REPORT_PROGRESS_DEDUPE_PREFIX}${childWorkspaceId}:`
+    : `${AGENT_REPORT_PROGRESS_DEDUPE_PREFIX}${childWorkspaceId}:${executionId}:`;
+}
+
+/** onCanceled reason for queued incremental updates dropped by the child's terminal outcome. */
+export const AGENT_REPORT_PROGRESS_SUPERSEDED_REASON =
+  "Incremental sub-agent update superseded by the terminal report.";
+
+/**
  * Max peer messages admitted for a target without any user-authored input or parent guidance in
  * between; at the cap the target is deemed to need user attention. Charged when a send is
  * admitted (queued or delivered), so dispatch timing cannot exceed the advertised turn count.

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -7069,6 +7069,8 @@ export class AgentSession {
       dedupeKey?: string;
       /** Isolate this keyed message so it can be selectively superseded later. */
       removableDedupeKey?: boolean;
+      /** Queue ahead of hidden turn-end predecessors (see MessageQueue). */
+      promoteAheadOfHiddenTurnEnd?: boolean;
       onAccepted?: () => Promise<void> | void;
       onAcceptedPreStreamFailure?: (error: SendMessageError) => Promise<void> | void;
       onCanceled?: (reason: string) => Promise<void> | void;

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -7156,7 +7156,11 @@ export class AgentSession {
     });
   }
 
-  removeQueuedMessagesByDedupeKeyPrefix(prefix: string, cancelReason: string): number {
+  removeQueuedMessagesByDedupeKeyPrefix(
+    prefix: string,
+    cancelReason: string,
+    options?: { skipCancelCallbacks?: boolean }
+  ): number {
     this.assertNotDisposed("removeQueuedMessagesByDedupeKeyPrefix");
     assert(prefix.length > 0, "removeQueuedMessagesByDedupeKeyPrefix requires prefix");
     const removal = this.messageQueue.removeByDedupeKeyPrefix(prefix);
@@ -7168,8 +7172,15 @@ export class AgentSession {
       this.workspaceId,
       this.messageQueue.getNextDispatchableMode() === "tool-end"
     );
-    for (const callbacks of removal.callbacks) {
-      this.notifyQueuedMessageCleared(callbacks, cancelReason);
+    // Supersession is not withdrawal: a sub-agent progress report dropped because its child's
+    // terminal outcome arrived carries workspace-turn continuation callbacks that would settle
+    // this session's still-active delegated turn as interrupted (see
+    // TaskService.wakeParentWorkspaceWithSyntheticMessage). The terminal delivery is that
+    // turn's next wake, so the caller opts out of the failure notification.
+    if (options?.skipCancelCallbacks !== true) {
+      for (const callbacks of removal.callbacks) {
+        this.notifyQueuedMessageCleared(callbacks, cancelReason);
+      }
     }
     return removal.removedCount;
   }

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -7226,9 +7226,14 @@ export class AgentSession {
    * Whether an earlier queued, dequeued, or direct send supersedes a continuation.
    *
    * A predecessor with the same workspace-turn correlation remains part of the
-   * continuation chain and does not supersede the proposed report.
+   * continuation chain and does not supersede the proposed report. A send that will be
+   * enqueued with promoteAheadOfHiddenTurnEnd (see MessageQueue) never dispatches behind
+   * the trailing hidden turn-end entries, so those are not counted as predecessors.
    */
-  hasQueuedOrDispatchingEntry(continuationMetadata?: WorkspaceTurnMuxMetadata): boolean {
+  hasQueuedOrDispatchingEntry(
+    continuationMetadata?: WorkspaceTurnMuxMetadata,
+    options?: { promoteAheadOfHiddenTurnEnd?: boolean }
+  ): boolean {
     const hasDifferentPreparingSend =
       this.turnPhase === TurnPhase.PREPARING &&
       !hasSameWorkspaceTurnCorrelation(this.preparingWorkspaceTurnMetadata, continuationMetadata);
@@ -7249,11 +7254,17 @@ export class AgentSession {
       if (continuationMetadata == null) {
         return true;
       }
-      return !this.messageQueue.hasAllWorkspaceTurnContinuations(
-        continuationMetadata.taskHandleId,
-        continuationMetadata.ownerWorkspaceId,
-        continuationMetadata.turnId
-      );
+      return options?.promoteAheadOfHiddenTurnEnd === true
+        ? !this.messageQueue.hasAllWorkspaceTurnContinuationsAheadOfPromotedToolEnd(
+            continuationMetadata.taskHandleId,
+            continuationMetadata.ownerWorkspaceId,
+            continuationMetadata.turnId
+          )
+        : !this.messageQueue.hasAllWorkspaceTurnContinuations(
+            continuationMetadata.taskHandleId,
+            continuationMetadata.ownerWorkspaceId,
+            continuationMetadata.turnId
+          );
     }
 
     return false;

--- a/src/node/services/messageQueue.test.ts
+++ b/src/node/services/messageQueue.test.ts
@@ -619,6 +619,41 @@ describe("MessageQueue", () => {
       expect(skipped.options?.muxMetadata).toBeUndefined();
       expect(skipped.internal?.onCanceled).toBeUndefined();
     });
+
+    it("keeps same-turn correlation on skipped entries when the promoted report continues that turn", () => {
+      // Parent runs as a delegated workspace turn: both the child's ancestor-bound peer message
+      // and its later progress report continue the same turn. Promotion must revalidate with the
+      // promoted entry's own metadata populated, or the peer message would be stripped and later
+      // supersede the turn instead of continuing it.
+      const turnMetadata: MuxMessageMetadata = {
+        type: "workspace-turn-task",
+        taskHandleId: "wst_parent",
+        ownerWorkspaceId: "grandparent",
+        turnId: "turn-1",
+      };
+      const peerCanceled = () => undefined;
+      queue.add(
+        "peer message",
+        { ...validOptions, queueDispatchMode: "turn-end", muxMetadata: turnMetadata },
+        { ...hidden, workspaceTurnContinuation: true, onCanceled: peerCanceled }
+      );
+      queue.add(
+        "progress report",
+        { ...validOptions, queueDispatchMode: "tool-end", muxMetadata: turnMetadata },
+        { ...hidden, workspaceTurnContinuation: true, promoteAheadOfHiddenTurnEnd: true }
+      );
+
+      expect(queue.hasAllWorkspaceTurnContinuations("wst_parent", "grandparent", "turn-1")).toBe(
+        true
+      );
+      const promoted = queue.dequeueNext();
+      expect(promoted.message).toBe("progress report");
+      expect(promoted.options?.muxMetadata).toEqual(turnMetadata);
+      const skipped = queue.dequeueNext();
+      expect(skipped.message).toBe("peer message");
+      expect(skipped.options?.muxMetadata).toEqual(turnMetadata);
+      expect(skipped.internal?.onCanceled).toBe(peerCanceled);
+    });
   });
 
   describe("workspace turn metadata", () => {

--- a/src/node/services/messageQueue.test.ts
+++ b/src/node/services/messageQueue.test.ts
@@ -520,6 +520,107 @@ describe("MessageQueue", () => {
     });
   });
 
+  describe("promoteAheadOfHiddenTurnEnd", () => {
+    const validOptions: SendMessageOptions = { model: "gpt-4", agentId: "exec" };
+    const hidden = { synthetic: true, agentInitiated: true, sealed: true };
+
+    it("moves a tool-end progress report ahead of hidden turn-end predecessors so it cuts the turn", () => {
+      queue.addOnce(
+        "peer message",
+        { ...validOptions, queueDispatchMode: "turn-end" },
+        "agent-msg:child:1",
+        hidden
+      );
+      expect(queue.getNextDispatchableMode()).toBe("turn-end");
+
+      expect(
+        queue.addOnce(
+          "progress report",
+          { ...validOptions, queueDispatchMode: "tool-end" },
+          "agent-report:child:call-1",
+          { ...hidden, removableDedupeKey: true, promoteAheadOfHiddenTurnEnd: true }
+        )
+      ).toBe(true);
+
+      expect(queue.getNextDispatchableMode()).toBe("tool-end");
+      expect(queue.getMessages()).toEqual(["progress report", "peer message"]);
+      // The dedupe key follows the promoted entry, not the old tail.
+      expect(queue.removeByDedupeKeyPrefix("agent-report:child:").removedCount).toBe(1);
+      expect(queue.getMessages()).toEqual(["peer message"]);
+    });
+
+    it("never overtakes a user-authored turn-end entry", () => {
+      queue.add("hidden turn-end", { ...validOptions, queueDispatchMode: "turn-end" }, hidden);
+      queue.add("user wait for turn end", { ...validOptions, queueDispatchMode: "turn-end" });
+      queue.add(
+        "later hidden turn-end",
+        { ...validOptions, queueDispatchMode: "turn-end" },
+        hidden
+      );
+
+      queue.add(
+        "progress report",
+        { ...validOptions, queueDispatchMode: "tool-end" },
+        { ...hidden, promoteAheadOfHiddenTurnEnd: true }
+      );
+
+      expect(queue.getMessages()).toEqual([
+        "hidden turn-end",
+        "user wait for turn end",
+        "progress report",
+        "later hidden turn-end",
+      ]);
+      expect(queue.getNextDispatchableMode()).toBe("turn-end");
+    });
+
+    it("keeps FIFO order behind an earlier tool-end entry and without the flag", () => {
+      queue.add("hidden tool-end", { ...validOptions, queueDispatchMode: "tool-end" }, hidden);
+      queue.add("hidden turn-end", { ...validOptions, queueDispatchMode: "turn-end" }, hidden);
+      queue.add(
+        "promoted",
+        { ...validOptions, queueDispatchMode: "tool-end" },
+        { ...hidden, promoteAheadOfHiddenTurnEnd: true }
+      );
+      queue.add("plain tool-end", { ...validOptions, queueDispatchMode: "tool-end" }, hidden);
+
+      expect(queue.getMessages()).toEqual([
+        "hidden tool-end",
+        "promoted",
+        "hidden turn-end",
+        "plain tool-end",
+      ]);
+    });
+
+    it("strips a skipped continuation's correlation, matching other reorders", () => {
+      const onCanceled = () => undefined;
+      queue.add(
+        "continuation report",
+        {
+          ...validOptions,
+          queueDispatchMode: "turn-end",
+          muxMetadata: {
+            type: "workspace-turn-task",
+            taskHandleId: "wst_followup",
+            ownerWorkspaceId: "parent-workspace",
+            turnId: "turn-1",
+          },
+        },
+        { ...hidden, workspaceTurnContinuation: true, onCanceled }
+      );
+      queue.add(
+        "progress report",
+        { ...validOptions, queueDispatchMode: "tool-end" },
+        { ...hidden, promoteAheadOfHiddenTurnEnd: true }
+      );
+
+      expect(queue.dequeueNext().message).toBe("progress report");
+      const skipped = queue.dequeueNext();
+      expect(skipped.message).toBe("continuation report");
+      expect(skipped.options?.muxMetadata).toBeUndefined();
+      expect(skipped.internal?.onCanceled).toBeUndefined();
+    });
+  });
+
   describe("workspace turn metadata", () => {
     const metadata: MuxMessageMetadata = {
       type: "workspace-turn-task",

--- a/src/node/services/messageQueue.test.ts
+++ b/src/node/services/messageQueue.test.ts
@@ -654,6 +654,58 @@ describe("MessageQueue", () => {
       expect(skipped.options?.muxMetadata).toEqual(turnMetadata);
       expect(skipped.internal?.onCanceled).toBe(peerCanceled);
     });
+
+    it("ignores the hidden turn-end entries a promoted report overtakes when judging its correlation", () => {
+      // A queued heartbeat (hidden, turn-end, uncorrelated) would make the plain check report a
+      // superseding predecessor and strip the report's correlation before enqueue — yet the
+      // promoted report dispatches ahead of it, so it must keep continuing the delegated turn.
+      const turnMetadata: MuxMessageMetadata = {
+        type: "workspace-turn-task",
+        taskHandleId: "wst_parent",
+        ownerWorkspaceId: "grandparent",
+        turnId: "turn-1",
+      };
+      const ahead = (): boolean =>
+        queue.hasAllWorkspaceTurnContinuationsAheadOfPromotedToolEnd(
+          "wst_parent",
+          "grandparent",
+          "turn-1"
+        );
+
+      expect(ahead()).toBe(true);
+      queue.add(
+        "same-turn follow-up",
+        { ...validOptions, queueDispatchMode: "tool-end", muxMetadata: turnMetadata },
+        hidden
+      );
+      expect(ahead()).toBe(true);
+
+      queue.addOnce(
+        "heartbeat",
+        { ...validOptions, queueDispatchMode: "turn-end" },
+        "heartbeat-request",
+        hidden
+      );
+      expect(queue.hasAllWorkspaceTurnContinuations("wst_parent", "grandparent", "turn-1")).toBe(
+        false
+      );
+      expect(ahead()).toBe(true);
+
+      // An uncorrelated tool-end tail cannot be overtaken, so it (and everything before it) counts.
+      queue.add("unrelated tool-end", { ...validOptions, queueDispatchMode: "tool-end" }, hidden);
+      expect(ahead()).toBe(false);
+    });
+
+    it("counts a user-authored turn-end tail as a predecessor for a promoted report", () => {
+      queue.add("user wait for turn end", { ...validOptions, queueDispatchMode: "turn-end" });
+      expect(
+        queue.hasAllWorkspaceTurnContinuationsAheadOfPromotedToolEnd(
+          "wst_parent",
+          "grandparent",
+          "turn-1"
+        )
+      ).toBe(false);
+    });
   });
 
   describe("workspace turn metadata", () => {

--- a/src/node/services/messageQueue.ts
+++ b/src/node/services/messageQueue.ts
@@ -1,3 +1,4 @@
+import assert from "@/common/utils/assert";
 import type { FilePart, SendMessageOptions } from "@/common/orpc/types";
 import { AGENT_PEER_MESSAGE_DEDUPE_PREFIX } from "@/constants/agentMessaging";
 import { getValidAgentPeerTriggerMeta } from "@/common/utils/agentMessageEnvelope";
@@ -129,6 +130,14 @@ interface QueuedMessageInternalOptions {
   sealed?: boolean;
   /** Dedupe-keyed maintenance sends are removable by prefix without changing global queue rules. */
   removableDedupeKey?: boolean;
+  /**
+   * Enqueue this tool-end entry ahead of hidden (non-user-authored) turn-end entries queued
+   * before it. Only the FIFO head's mode can cut the active stream, so a background turn-end
+   * predecessor (e.g. a child's ancestor-bound peer message) would otherwise hold a tool-end
+   * sub-agent progress report until the turn ends naturally. A user-authored turn-end entry
+   * still governs: the user's visible "wait for turn end" choice is never pulled forward.
+   */
+  promoteAheadOfHiddenTurnEnd?: boolean;
   onAccepted?: () => Promise<void> | void;
   onAcceptedPreStreamFailure?: (error: SendMessageError) => Promise<void> | void;
   onCanceled?: (reason: string) => Promise<void> | void;
@@ -223,6 +232,9 @@ interface QueueEntry {
  *   so renderer/restoration projections can omit background work precisely.
  * - Compaction entries stay open: a follow-up typed behind a pending /compact
  *   batches under the compaction request (long-standing behavior).
+ * - Only the FIFO head's dispatch mode can cut the active stream. Tool-end sends flagged
+ *   promoteAheadOfHiddenTurnEnd (sub-agent progress reports) therefore enqueue ahead of
+ *   hidden turn-end predecessors, never ahead of a user-authored entry.
  *
  * Display logic:
  * - A single-message compaction or agent-skill entry shows its rawCommand
@@ -451,7 +463,7 @@ export class MessageQueue {
     options?: SendMessageOptions & { fileParts?: FilePart[] },
     internal?: QueuedMessageInternalOptions
   ): boolean {
-    return this.addInternal(message, options, internal);
+    return this.addInternal(message, options, internal) != null;
   }
 
   /**
@@ -489,24 +501,25 @@ export class MessageQueue {
       return false;
     }
 
-    const didAdd = this.addInternal(message, options, internal);
-    if (didAdd && dedupeKey !== undefined) {
-      this.entries[this.entries.length - 1].dedupeKeys.add(dedupeKey);
+    const entry = this.addInternal(message, options, internal);
+    if (entry != null && dedupeKey !== undefined) {
+      entry.dedupeKeys.add(dedupeKey);
     }
-    return didAdd;
+    return entry != null;
   }
 
+  /** Returns the entry the message landed in, or undefined when nothing was queued. */
   private addInternal(
     message: string,
     options?: SendMessageOptions & { fileParts?: FilePart[] },
     internal?: QueuedMessageInternalOptions
-  ): boolean {
+  ): QueueEntry | undefined {
     const trimmedMessage = message.trim();
     const hasFiles = options?.fileParts && options.fileParts.length > 0;
 
     // Reject if both text and file parts are empty
     if (trimmedMessage.length === 0 && !hasFiles) {
-      return false;
+      return undefined;
     }
 
     const incomingHasAcceptedCallbacks =
@@ -572,6 +585,9 @@ export class MessageQueue {
         lastAddedAtMs: 0,
       };
       this.entries.push(entry);
+      if (internal?.promoteAheadOfHiddenTurnEnd === true && incomingMode === "tool-end") {
+        this.promoteAheadOfHiddenTurnEndPredecessors(entry);
+      }
     }
 
     if (internal?.preTurnMessages != null && internal.preTurnMessages.length > 0) {
@@ -650,7 +666,36 @@ export class MessageQueue {
       entry.agentInitiatedCount += 1;
     }
 
-    return true;
+    return entry;
+  }
+
+  /**
+   * Move a freshly pushed tool-end entry ahead of the hidden turn-end entries immediately
+   * before it (see QueuedMessageInternalOptions.promoteAheadOfHiddenTurnEnd). Stops at the
+   * first user-authored or tool-end predecessor, so FIFO order is preserved among entries
+   * that either carry the user's explicit choice or would already cut at a step boundary.
+   */
+  private promoteAheadOfHiddenTurnEndPredecessors(entry: QueueEntry): void {
+    const currentIndex = this.entries.length - 1;
+    assert(
+      this.entries[currentIndex] === entry && entry.dispatchMode === "tool-end",
+      "promoteAheadOfHiddenTurnEndPredecessors requires the tool-end tail entry"
+    );
+    let insertIndex = currentIndex;
+    while (insertIndex > 0) {
+      const predecessor = this.entries[insertIndex - 1];
+      if (predecessor.userAuthored || predecessor.dispatchMode !== "turn-end") {
+        break;
+      }
+      insertIndex -= 1;
+    }
+    if (insertIndex === currentIndex) {
+      return;
+    }
+    this.entries.splice(currentIndex, 1);
+    this.entries.splice(insertIndex, 0, entry);
+    // The skipped entries now follow an unrelated predecessor (same as prioritizeNextUserEntry).
+    this.revalidateWorkspaceTurnCorrelations();
   }
 
   /**

--- a/src/node/services/messageQueue.ts
+++ b/src/node/services/messageQueue.ts
@@ -585,10 +585,8 @@ export class MessageQueue {
         lastAddedAtMs: 0,
       };
       this.entries.push(entry);
-      if (internal?.promoteAheadOfHiddenTurnEnd === true && incomingMode === "tool-end") {
-        this.promoteAheadOfHiddenTurnEndPredecessors(entry);
-      }
     }
+    const createdNewEntry = entry !== tail;
 
     if (internal?.preTurnMessages != null && internal.preTurnMessages.length > 0) {
       entry.preTurnMessages = [...(entry.preTurnMessages ?? []), ...internal.preTurnMessages];
@@ -664,6 +662,17 @@ export class MessageQueue {
     }
     if (internal?.agentInitiated === true) {
       entry.agentInitiatedCount += 1;
+    }
+
+    // Reorder only after muxMetadata/callbacks are populated: correlation revalidation must see
+    // the promoted entry's own workspace-turn metadata, or skipped same-turn continuations would
+    // be stripped as if an unrelated message had overtaken them.
+    if (
+      createdNewEntry &&
+      internal?.promoteAheadOfHiddenTurnEnd === true &&
+      entry.dispatchMode === "tool-end"
+    ) {
+      this.promoteAheadOfHiddenTurnEndPredecessors(entry);
     }
 
     return entry;

--- a/src/node/services/messageQueue.ts
+++ b/src/node/services/messageQueue.ts
@@ -318,6 +318,47 @@ export class MessageQueue {
   }
 
   /**
+   * hasAllWorkspaceTurnContinuations for a tool-end entry about to be enqueued with
+   * promoteAheadOfHiddenTurnEnd: the trailing hidden turn-end entries it will overtake are not
+   * its predecessors, so only the entries that stay ahead of it must share the correlation
+   * (vacuously true when none do). Without this, WorkspaceService would strip the promoted
+   * entry's correlation for an entry it never dispatches behind, and its tool-end cut would
+   * then supersede the delegated turn it was meant to continue.
+   */
+  hasAllWorkspaceTurnContinuationsAheadOfPromotedToolEnd(
+    taskHandleId: string,
+    ownerWorkspaceId: string,
+    turnId: string
+  ): boolean {
+    return this.entries.slice(0, this.trailingHiddenTurnEndRunStart()).every((entry) => {
+      const metadata = entry.muxMetadata;
+      return (
+        isWorkspaceTurnMetadata(metadata) &&
+        metadata.taskHandleId === taskHandleId &&
+        metadata.ownerWorkspaceId === ownerWorkspaceId &&
+        metadata.turnId === turnId
+      );
+    });
+  }
+
+  /**
+   * Index where the trailing run of hidden (non-user-authored) turn-end entries begins — the
+   * entries a promoteAheadOfHiddenTurnEnd add overtakes. Equals entries.length when the tail is
+   * user-authored or tool-end (nothing to overtake).
+   */
+  private trailingHiddenTurnEndRunStart(): number {
+    let start = this.entries.length;
+    while (start > 0) {
+      const predecessor = this.entries[start - 1];
+      if (predecessor.userAuthored || predecessor.dispatchMode !== "turn-end") {
+        break;
+      }
+      start -= 1;
+    }
+    return start;
+  }
+
+  /**
    * Whether the next entry continues the exact workspace turn correlation.
    */
   hasNextWorkspaceTurnContinuation(
@@ -690,19 +731,13 @@ export class MessageQueue {
       this.entries[currentIndex] === entry && entry.dispatchMode === "tool-end",
       "promoteAheadOfHiddenTurnEndPredecessors requires the tool-end tail entry"
     );
-    let insertIndex = currentIndex;
-    while (insertIndex > 0) {
-      const predecessor = this.entries[insertIndex - 1];
-      if (predecessor.userAuthored || predecessor.dispatchMode !== "turn-end") {
-        break;
-      }
-      insertIndex -= 1;
-    }
+    // The new entry is the tail, so the trailing run is measured over its predecessors.
+    this.entries.pop();
+    const insertIndex = this.trailingHiddenTurnEndRunStart();
+    this.entries.splice(insertIndex, 0, entry);
     if (insertIndex === currentIndex) {
       return;
     }
-    this.entries.splice(currentIndex, 1);
-    this.entries.splice(insertIndex, 0, entry);
     // The skipped entries now follow an unrelated predecessor (same as prioritizeNextUserEntry).
     this.revalidateWorkspaceTurnCorrelations();
   }

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -18747,6 +18747,7 @@ describe("TaskService", () => {
         agentInitiated: true,
         startStreamInBackground: true,
         queueDedupeKey: "agent-report:child-progress:progress-1",
+        promoteAheadOfHiddenTurnEnd: true,
       })
     );
     expect(sendMessage.mock.calls[0]?.[1]).toContain('"status": "in_progress"');
@@ -28655,14 +28656,103 @@ describe("TaskService", () => {
     await taskService.reportAgentProgress(childTaskId, "progress-call", {
       reportMarkdown: "The regression is in the effect cleanup path.",
     });
-    expect(
-      sendMessage.mock.calls.some(
-        (call) =>
-          call[0] === parentWorkspaceId &&
-          typeof call[1] === "string" &&
-          call[1].includes("effect cleanup path")
-      )
-    ).toBe(true);
+    const progressSend = sendMessage.mock.calls.find(
+      (call) =>
+        call[0] === parentWorkspaceId &&
+        typeof call[1] === "string" &&
+        call[1].includes("effect cleanup path")
+    );
+    assert(progressSend, "progress report must wake the continuation owner");
+    // Execution-scoped key: this continuation's settlement drops exactly its own queued
+    // updates, and the report may overtake hidden turn-end predecessors in the owner's queue.
+    expect(progressSend[3]).toMatchObject({
+      queueDedupeKey: `agent-report:${childTaskId}:wst_reactivatehandle:progress-call`,
+      removableQueueDedupeKey: true,
+      promoteAheadOfHiddenTurnEnd: true,
+    });
+  });
+
+  test("continuation settlement drops that execution's queued progress before waiters resolve", async () => {
+    const config = await createTestConfig(rootDir);
+    stubStableIds(config, ["settlehandle", "settleturn"]);
+    const projectPath = path.join(rootDir, "repo");
+    const parentWorkspaceId = "parent-settled-progress";
+    const childTaskId = "child-settled-progress";
+    await saveWorkspaces(
+      config,
+      projectPath,
+      [
+        projectWorkspace(projectPath, "parent", parentWorkspaceId),
+        projectWorkspace(projectPath, "child", childTaskId, {
+          parentWorkspaceId,
+          agentId: "exec",
+          agentType: "exec",
+          taskStatus: "reported",
+          reportedAt: "2026-08-10T00:00:00.000Z",
+          title: "Mobile UI Engineer",
+        }),
+      ],
+      testTaskSettings()
+    );
+    const sendMessage = mock(async (...args: unknown[]): Promise<Result<void>> => {
+      const internal = args[3] as { onAccepted?: () => Promise<void> | void } | undefined;
+      await internal?.onAccepted?.();
+      return Ok(undefined);
+    });
+    const removeQueuedMessagesByDedupeKeyPrefix = mock((): Result<number> => Ok(1));
+    const { workspaceService } = createWorkspaceServiceMocks({
+      sendMessage,
+      removeQueuedMessagesByDedupeKeyPrefix,
+    });
+    const { taskService } = createTaskServiceHarness(config, { workspaceService });
+
+    const reactivated = await taskService.sendMessageToDescendantAgentTask(
+      parentWorkspaceId,
+      childTaskId,
+      "Implement the transcript refinements.",
+      "tool-end"
+    );
+    expect(reactivated.success).toBe(true);
+    const handleId = "wst_settlehandle";
+    const taskHandleStore = (taskService as unknown as { taskHandleStore: TaskHandleStore })
+      .taskHandleStore;
+    const activeRecord = await taskHandleStore.getWorkspaceTurn(parentWorkspaceId, handleId);
+    assert(activeRecord, "reactivated workspace-turn record is required");
+
+    let removalsWhenWaiterResolved = -1;
+    const waiter = workspaceTurnManagerFor(taskService)
+      .waitForWorkspaceTurn(handleId, {
+        requestingWorkspaceId: parentWorkspaceId,
+        ownerWorkspaceId: parentWorkspaceId,
+        timeoutMs: 5_000,
+      })
+      .then((result) => {
+        removalsWhenWaiterResolved = removeQueuedMessagesByDedupeKeyPrefix.mock.calls.length;
+        return result;
+      });
+
+    await handleTaskServiceStreamEndForTest(taskService, {
+      type: "stream-end",
+      workspaceId: childTaskId,
+      messageId: "reactivated-final",
+      metadata: {
+        model: "anthropic:claude-sonnet-4-6",
+        finishReason: "stop",
+        muxMetadata: workspaceTurnMuxMetadata(parentWorkspaceId, handleId, activeRecord.turnId),
+      },
+      parts: [{ type: "text", text: "Committed the transcript refinements." }],
+    });
+
+    expect(await waiter).toMatchObject({ reportMarkdown: "Committed the transcript refinements." });
+    expect(removeQueuedMessagesByDedupeKeyPrefix).toHaveBeenCalledWith(
+      parentWorkspaceId,
+      `agent-report:${childTaskId}:${handleId}:`,
+      { cancelReason: "Incremental sub-agent update superseded by the terminal report." }
+    );
+    // A parent whose task_await just returned must not be cut by a now-stale update.
+    expect(removalsWhenWaiterResolved).toBe(
+      removeQueuedMessagesByDedupeKeyPrefix.mock.calls.length
+    );
   });
 
   test("reawakened child stays active through compaction and settles from its correlated follow-up", async () => {

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -18796,7 +18796,10 @@ describe("TaskService", () => {
     expect(removeQueuedMessagesByDedupeKeyPrefix).toHaveBeenCalledWith(
       parentId,
       `agent-report:${childId}:`,
-      { cancelReason: "Incremental sub-agent update superseded by the terminal report." }
+      {
+        cancelReason: "Incremental sub-agent update superseded by the terminal report.",
+        skipCancelCallbacks: true,
+      }
     );
   });
 
@@ -28747,7 +28750,10 @@ describe("TaskService", () => {
     expect(removeQueuedMessagesByDedupeKeyPrefix).toHaveBeenCalledWith(
       parentWorkspaceId,
       `agent-report:${childTaskId}:${handleId}:`,
-      { cancelReason: "Incremental sub-agent update superseded by the terminal report." }
+      {
+        cancelReason: "Incremental sub-agent update superseded by the terminal report.",
+        skipCancelCallbacks: true,
+      }
     );
     // A parent whose task_await just returned must not be cut by a now-stale update.
     expect(removalsWhenWaiterResolved).toBe(

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -18753,6 +18753,21 @@ describe("TaskService", () => {
     expect(sendMessage.mock.calls[0]?.[1]).toContain('"status": "in_progress"');
     expect(sendMessage.mock.calls[1]?.[1]).toContain("Found a second issue.");
     expect(findWorkspaceInConfig(config, childId)?.taskStatus).toBe("running");
+    // The probe re-checked at the parent's admission gates flips once the run is over — for an
+    // original run, on a terminal report or a stop without one.
+    const superseded = (sendMessage.mock.calls[1]?.[3] as { admissionStale?: () => boolean })
+      .admissionStale;
+    assert(superseded, "progress sends must carry a supersession probe");
+    expect(superseded()).toBe(false);
+    await config.editConfig((cfg) => {
+      const workspace = cfg.projects
+        .get(projectPath)
+        ?.workspaces.find((candidate) => candidate.id === childId);
+      assert(workspace, "child workspace must exist");
+      workspace.taskStatus = "interrupted";
+      return cfg;
+    });
+    expect(superseded()).toBe(true);
     expect(
       await readSubagentReportArtifact(path.join(config.sessionsDir, parentId), childId)
     ).toBeNull();
@@ -28796,6 +28811,27 @@ describe("TaskService", () => {
       ?.admissionStale;
     assert(superseded, "progress sends must carry a supersession probe");
     // Live execution: an entry still in PREPARING is admitted.
+    expect(superseded()).toBe(false);
+    // A successor generation that has claimed the execution mirror supersedes it as well.
+    await config.editConfig((cfg) => {
+      const workspace = cfg.projects
+        .get(projectPath)
+        ?.workspaces.find((candidate) => candidate.id === childTaskId);
+      assert(workspace, "child workspace must exist");
+      workspace.taskExecutionId = "wst_successor";
+      workspace.taskExecutionStatus = "running";
+      return cfg;
+    });
+    expect(superseded()).toBe(true);
+    await config.editConfig((cfg) => {
+      const workspace = cfg.projects
+        .get(projectPath)
+        ?.workspaces.find((candidate) => candidate.id === childTaskId);
+      assert(workspace, "child workspace must exist");
+      workspace.taskExecutionId = handleId;
+      workspace.taskExecutionStatus = "running";
+      return cfg;
+    });
     expect(superseded()).toBe(false);
 
     let removalsWhenWaiterResolved = -1;

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -25554,6 +25554,70 @@ describe("TaskService", () => {
     });
   });
 
+  test("superseded nested agent progress is refused without settling the correlated workspace turn", async () => {
+    let progressInternal:
+      | {
+          admissionStale?: () => boolean;
+          onCanceled?: (reason: string) => Promise<void> | void;
+          onAcceptedPreStreamFailure?: (error: SendMessageError) => Promise<void> | void;
+        }
+      | undefined;
+    let sendCount = 0;
+    const sendMessage = mock((...args: unknown[]): Promise<Result<void, SendMessageError>> => {
+      sendCount += 1;
+      if (sendCount === 2) {
+        // Queued behind the busy parent: the session re-checks the probe at dispatch.
+        progressInternal = args[3] as typeof progressInternal;
+      }
+      return Promise.resolve(Ok(undefined));
+    });
+    const { config, parentId, taskService } = await startWorkspaceTurnForTest({ sendMessage });
+
+    await config.editConfig((cfg) => {
+      const project = cfg.projects.get(path.join(rootDir, "repo"));
+      assert(project, "test project must exist");
+      project.workspaces.push({
+        path: path.join(rootDir, "repo", "nested-progress-superseded"),
+        id: "nested-progress-superseded",
+        name: "nested-progress-superseded",
+        createdAt: "2026-06-19T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+        parentWorkspaceId: "childworkspace",
+        taskStatus: "running",
+        agentType: "explore",
+      });
+      return cfg;
+    });
+
+    await taskService.reportAgentProgress("nested-progress-superseded", "progress-call", {
+      reportMarkdown: "Partial findings.",
+    });
+    assert(progressInternal?.admissionStale, "progress sends must carry a supersession probe");
+    expect(progressInternal.admissionStale()).toBe(false);
+
+    // The grandchild's terminal report lands (handleAgentReport persists `reported` first).
+    await config.editConfig((cfg) => {
+      const project = cfg.projects.get(path.join(rootDir, "repo"));
+      assert(project, "test project must exist");
+      const nested = project.workspaces.find(
+        (workspace) => workspace.id === "nested-progress-superseded"
+      );
+      assert(nested, "nested agent must exist");
+      nested.taskStatus = "reported";
+      nested.reportedAt = "2026-06-19T00:00:01.000Z";
+      return cfg;
+    });
+    expect(progressInternal.admissionStale()).toBe(true);
+
+    // The session refuses the stale entry through these hooks; the parent's live delegated turn
+    // must survive because the terminal delivery is its next wake.
+    await progressInternal.onCanceled?.("Send refused: the caller's admission became stale");
+    await progressInternal.onAcceptedPreStreamFailure?.({ type: "unknown", raw: "stale" });
+    expect(await workspaceTurnSnapshot(taskService, parentId)).toMatchObject({
+      status: "running",
+    });
+  });
+
   test("workspace-turn tool-calls stream-end with superseding queued input settles interrupted", async () => {
     // Ordinary queued input (manual message, bare /compact) also cuts the
     // stream at a tool boundary, but it supersedes the delegated turn instead
@@ -28722,6 +28786,18 @@ describe("TaskService", () => {
     const activeRecord = await taskHandleStore.getWorkspaceTurn(parentWorkspaceId, handleId);
     assert(activeRecord, "reactivated workspace-turn record is required");
 
+    await taskService.reportAgentProgress(childTaskId, "progress-call", {
+      reportMarkdown: "Transcript rendering implemented; validating.",
+    });
+    const progressSend = sendMessage.mock.calls.find(
+      (call) => typeof call[1] === "string" && call[1].includes("Transcript rendering implemented")
+    );
+    const superseded = (progressSend?.[3] as { admissionStale?: () => boolean } | undefined)
+      ?.admissionStale;
+    assert(superseded, "progress sends must carry a supersession probe");
+    // Live execution: an entry still in PREPARING is admitted.
+    expect(superseded()).toBe(false);
+
     let removalsWhenWaiterResolved = -1;
     const waiter = workspaceTurnManagerFor(taskService)
       .waitForWorkspaceTurn(handleId, {
@@ -28759,6 +28835,8 @@ describe("TaskService", () => {
     expect(removalsWhenWaiterResolved).toBe(
       removeQueuedMessagesByDedupeKeyPrefix.mock.calls.length
     );
+    // An update that had already left the queue for PREPARING is refused at admission instead.
+    expect(superseded()).toBe(true);
   });
 
   test("reawakened child stays active through compaction and settles from its correlated follow-up", async () => {

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -18773,6 +18773,60 @@ describe("TaskService", () => {
     ).toBeNull();
   });
 
+  test("agent_report refuses an update whose run ended before the wake was sent", async () => {
+    const config = await createTestConfig(rootDir);
+    const projectPath = path.join(rootDir, "repo");
+    const parentId = "parent-late-progress";
+    const childId = "child-late-progress";
+
+    await saveWorkspaces(
+      config,
+      projectPath,
+      [
+        projectWorkspace(projectPath, "parent", parentId),
+        projectWorkspace(projectPath, "child", childId, {
+          name: "agent_explore_child",
+          parentWorkspaceId: parentId,
+          agentType: "explore",
+          taskStatus: "running",
+        }),
+      ],
+      testTaskSettings()
+    );
+
+    // A stop that lands between the entry checks and the probe evaluation (the stop path does not
+    // share the child's event lock) must refuse the update instead of waking the parent with it.
+    const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
+    const { taskService } = createTaskServiceHarness(config, { workspaceService });
+    const realLoad = config.loadConfigOrDefault.bind(config);
+    let loads = 0;
+    const loadSpy = spyOn(config, "loadConfigOrDefault").mockImplementation(() => {
+      loads += 1;
+      const cfg = realLoad();
+      if (loads > 1) {
+        const workspace = cfg.projects
+          .get(projectPath)
+          ?.workspaces.find((candidate) => candidate.id === childId);
+        if (workspace) workspace.taskStatus = "interrupted";
+      }
+      return cfg;
+    });
+    try {
+      const failure: unknown = await taskService
+        .reportAgentProgress(childId, "progress-late", { reportMarkdown: "Obsolete finding." })
+        .then(
+          () => undefined,
+          (error: unknown) => error
+        );
+      expect(failure).toEqual(
+        new Error("agent_report cannot send updates after the sub-agent's run has ended")
+      );
+    } finally {
+      loadSpy.mockRestore();
+    }
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   test("terminal reports supersede queued incremental updates for the same child", async () => {
     const config = await createTestConfig(rootDir);
     const projectPath = path.join(rootDir, "repo");
@@ -18794,11 +18848,26 @@ describe("TaskService", () => {
       testTaskSettings()
     );
 
-    const removeQueuedMessagesByDedupeKeyPrefix = mock((): Result<number> => Ok(1));
+    // Order matters: while a queued update sits at the parent's queue head as a tool-end entry,
+    // the parent's stream stops at its next step boundary for it. Removal must happen with the
+    // terminal status commit, before the report's slower follow-up work (artifacts, patch
+    // generation), and only once the supersession probe would already refuse a dequeued update.
+    const order: string[] = [];
+    const removeQueuedMessagesByDedupeKeyPrefix = mock((): Result<number> => {
+      order.push(`remove:${findWorkspaceInConfig(config, childId)?.taskStatus ?? "missing"}`);
+      return Ok(1);
+    });
     const { workspaceService } = createWorkspaceServiceMocks({
       removeQueuedMessagesByDedupeKeyPrefix,
     });
     const { taskService } = createTaskServiceHarness(config, { workspaceService });
+    spyOn(
+      taskService as unknown as { maybeStartPatchGenerationForReportedTask: () => Promise<void> },
+      "maybeStartPatchGenerationForReportedTask"
+    ).mockImplementation(() => {
+      order.push("patch");
+      return Promise.resolve();
+    });
 
     await handleTaskServiceStreamEndForTest(taskService, {
       type: "stream-end",
@@ -18816,6 +18885,7 @@ describe("TaskService", () => {
         skipCancelCallbacks: true,
       }
     );
+    expect(order).toEqual(["remove:reported", "patch"]);
   });
 
   test("workflow-owned agent_report updates do not wake the parent", async () => {

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -13038,7 +13038,16 @@ describe("TaskService", () => {
     const stopStream = mock((): Promise<Result<void>> => Promise.resolve(Ok(undefined)));
     const { aiService } = createAIServiceMocks(config, { isStreaming, stopStream });
     const remove = mock((): Promise<Result<void>> => Promise.resolve(Ok(undefined)));
-    const { workspaceService } = createWorkspaceServiceMocks({ remove });
+    // The stop supersedes the child's queued incremental updates in the parent's queue; left
+    // there as tool-end entries they would cut the parent's turn before being refused.
+    const removeQueuedMessagesByDedupeKeyPrefix = mock((): Result<number> => {
+      expect(findWorkspaceInConfig(config, childTaskId)?.taskStatus).toBe("interrupted");
+      return Ok(1);
+    });
+    const { workspaceService } = createWorkspaceServiceMocks({
+      remove,
+      removeQueuedMessagesByDedupeKeyPrefix,
+    });
     const { taskService } = createTaskServiceHarness(config, { aiService, workspaceService });
 
     const terminalAttentionStore = new TerminalAttentionStore(config);
@@ -13056,6 +13065,14 @@ describe("TaskService", () => {
     expect(stopStream).toHaveBeenCalledWith(childTaskId, { abandonPartial: false });
     expect(remove).not.toHaveBeenCalled();
     expect(findWorkspaceInConfig(config, childTaskId)?.taskStatus).toBe("interrupted");
+    expect(removeQueuedMessagesByDedupeKeyPrefix).toHaveBeenCalledWith(
+      parentWorkspaceId,
+      `agent-report:${childTaskId}:`,
+      {
+        cancelReason: "Incremental sub-agent update superseded by the terminal report.",
+        skipCancelCallbacks: true,
+      }
+    );
   });
 
   test("removeInactiveDescendantAgentTask enforces scope, leaf order, and idempotency", async () => {

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -56,7 +56,11 @@ import {
 import { BACKGROUND_WORK_WAKE_OPENINGS } from "@/common/utils/machineTurnPrompts";
 import type { AgentPeerMessageMeta } from "@/common/utils/agentMessageEnvelope";
 import type { SendMessageOptions } from "@/common/orpc/types";
-import { AGENT_PEER_MESSAGE_DEDUPE_PREFIX } from "@/constants/agentMessaging";
+import {
+  AGENT_PEER_MESSAGE_DEDUPE_PREFIX,
+  AGENT_REPORT_PROGRESS_SUPERSEDED_REASON,
+  agentReportProgressDedupePrefix,
+} from "@/constants/agentMessaging";
 import { TASK_FAMILY_MESSAGE_MAX_CHARS } from "@/constants/taskMessages";
 import { log } from "@/node/services/log";
 import { eventSpine } from "@/node/services/events/eventSpine";
@@ -8120,11 +8124,21 @@ export class TaskService implements AgentTaskIntegration {
       // A progress report is itself the wake-up message. Unlike terminal attention, it must be
       // allowed through while this child is still active so review findings and other incremental
       // results can immediately background a foreground wait or queue behind a busy parent turn.
+      // The key is scoped to the active continuation execution (when any) so that execution's
+      // terminal settlement drops exactly the updates it superseded.
+      const dedupePrefix = agentReportProgressDedupePrefix(
+        childWorkspaceId,
+        continuationActive ? continuationRecord?.handleId : undefined
+      );
       const wakeResult = await this.wakeParentWorkspaceWithSyntheticMessage({
         parentWorkspaceId,
         parentEntry,
         content: reportContent,
-        queueDedupeKey: `agent-report:${childWorkspaceId}:${toolCallId}`,
+        queueDedupeKey: `${dedupePrefix}${toolCallId}`,
+        // Only the queue head's dispatch mode can cut the parent's stream. A child's earlier
+        // ancestor-bound peer message (turn-end by default) at the head would otherwise hold this
+        // report until the parent's turn ends — observed as 8–40 minute "delayed" updates.
+        promoteAheadOfHiddenTurnEnd: true,
       });
       if (!wakeResult.success) {
         throw new Error(`agent_report failed to wake the parent workspace: ${wakeResult.error}`);
@@ -8151,6 +8165,8 @@ export class TaskService implements AgentTaskIntegration {
     content: string;
     /** Coalesces repeated wakes for the same source (e.g. one agent_report tool call). */
     queueDedupeKey?: string;
+    /** Queue ahead of hidden turn-end predecessors (see SendMessageInternalOptions). */
+    promoteAheadOfHiddenTurnEnd?: boolean;
     queueDispatchMode?: TaskMessageQueueDispatchMode;
     /** Synthetic assistant rows persisted just before the wake's user row (family payloads). */
     preTurnMessages?: MuxMessage[];
@@ -8203,6 +8219,9 @@ export class TaskService implements AgentTaskIntegration {
           : {}),
         ...(params.queueDedupeKey != null
           ? { queueDedupeKey: params.queueDedupeKey, removableQueueDedupeKey: true }
+          : {}),
+        ...(params.promoteAheadOfHiddenTurnEnd === true
+          ? { promoteAheadOfHiddenTurnEnd: true }
           : {}),
         ...(workspaceTurnMuxMetadata != null
           ? {
@@ -12546,8 +12565,8 @@ export class TaskService implements AgentTaskIntegration {
 
     const queuedProgressRemoval = this.workspaceService.removeQueuedMessagesByDedupeKeyPrefix(
       parentWorkspaceId,
-      `agent-report:${childWorkspaceId}:`,
-      { cancelReason: "Incremental sub-agent update superseded by the terminal report." }
+      agentReportProgressDedupePrefix(childWorkspaceId),
+      { cancelReason: AGENT_REPORT_PROGRESS_SUPERSEDED_REASON }
     );
     if (!queuedProgressRemoval.success) {
       log.warn("Failed to remove queued incremental sub-agent reports", {

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -12563,10 +12563,12 @@ export class TaskService implements AgentTaskIntegration {
 
     await this.maybeStartPatchGenerationForReportedTask(childWorkspaceId);
 
+    // skipCancelCallbacks: a parent running as a delegated workspace turn queues each report with
+    // continuation-failure callbacks; superseding the report must not interrupt that live turn.
     const queuedProgressRemoval = this.workspaceService.removeQueuedMessagesByDedupeKeyPrefix(
       parentWorkspaceId,
       agentReportProgressDedupePrefix(childWorkspaceId),
-      { cancelReason: AGENT_REPORT_PROGRESS_SUPERSEDED_REASON }
+      { cancelReason: AGENT_REPORT_PROGRESS_SUPERSEDED_REASON, skipCancelCallbacks: true }
     );
     if (!queuedProgressRemoval.success) {
       log.warn("Failed to remove queued incremental sub-agent reports", {

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -1683,6 +1683,22 @@ export class TaskService implements AgentTaskIntegration {
     if (!parentWorkspaceId) {
       return;
     }
+    // Every interrupted transition lands here right after the status commit. The child's queued
+    // incremental updates are superseded now: left in place as tool-end entries they would still
+    // cut the parent's active turn at its next step boundary before their admission probe refuses
+    // them. (A continuation owned by a different ancestor is cleaned by its settlement instead.)
+    const queuedProgressRemoval = this.workspaceService.removeQueuedMessagesByDedupeKeyPrefix(
+      parentWorkspaceId,
+      agentReportProgressDedupePrefix(taskId),
+      { cancelReason: AGENT_REPORT_PROGRESS_SUPERSEDED_REASON, skipCancelCallbacks: true }
+    );
+    if (!queuedProgressRemoval.success) {
+      log.warn("Failed to remove queued incremental sub-agent reports after interrupt", {
+        parentWorkspaceId,
+        childWorkspaceId: taskId,
+        error: queuedProgressRemoval.error,
+      });
+    }
     this.timelineRecorder.record(parentWorkspaceId, {
       kind: "task.interrupted",
       source: { system: "task" },

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -8086,10 +8086,9 @@ export class TaskService implements AgentTaskIntegration {
       if (childEntry.workspace.taskStatus === "interrupted" && !continuationActive) {
         throw new Error("agent_report cannot send updates from an interrupted sub-agent");
       }
-      const parentWorkspaceId =
-        continuationActive && continuationRecord != null
-          ? continuationRecord.ownerWorkspaceId
-          : directParentWorkspaceId;
+      const activeExecution =
+        continuationActive && continuationRecord != null ? continuationRecord : null;
+      const parentWorkspaceId = activeExecution?.ownerWorkspaceId ?? directParentWorkspaceId;
 
       if (childEntry.workspace.workflowTask != null) {
         // Workflow-owned tasks deliver structured output through WorkflowRunner's journal/result
@@ -8128,8 +8127,28 @@ export class TaskService implements AgentTaskIntegration {
       // terminal settlement drops exactly the updates it superseded.
       const dedupePrefix = agentReportProgressDedupePrefix(
         childWorkspaceId,
-        continuationActive ? continuationRecord?.handleId : undefined
+        activeExecution?.handleId
       );
+      // Superseded once this run's terminal outcome has landed: the settlement paths persist the
+      // child's status mirror (`reported`, or a terminal execution status for a continuation)
+      // BEFORE they remove queued updates, so an entry already dequeued into the parent's
+      // asynchronous PREPARING phase — invisible to that removal — is refused at admission
+      // instead of starting a stale "in progress" turn after the terminal report. Synchronous
+      // reads only: admission probes run inside the session's turn gates. As with peer sends,
+      // a probe-carrying send never resurrects an interrupted parent.
+      const superseded = (): boolean => {
+        const fresh = findWorkspaceEntry(this.config.loadConfigOrDefault(), childWorkspaceId);
+        if (fresh == null) {
+          return true;
+        }
+        if (activeExecution != null) {
+          return (
+            fresh.workspace.taskExecutionId === activeExecution.handleId &&
+            !isActiveWorkspaceTurnTaskStatus(fresh.workspace.taskExecutionStatus)
+          );
+        }
+        return hasCompletedAgentReport(fresh.workspace);
+      };
       const wakeResult = await this.wakeParentWorkspaceWithSyntheticMessage({
         parentWorkspaceId,
         parentEntry,
@@ -8139,6 +8158,7 @@ export class TaskService implements AgentTaskIntegration {
         // ancestor-bound peer message (turn-end by default) at the head would otherwise hold this
         // report until the parent's turn ends — observed as 8–40 minute "delayed" updates.
         promoteAheadOfHiddenTurnEnd: true,
+        admissionStale: superseded,
       });
       if (!wakeResult.success) {
         throw new Error(`agent_report failed to wake the parent workspace: ${wakeResult.error}`);
@@ -8167,6 +8187,12 @@ export class TaskService implements AgentTaskIntegration {
     queueDedupeKey?: string;
     /** Queue ahead of hidden turn-end predecessors (see SendMessageInternalOptions). */
     promoteAheadOfHiddenTurnEnd?: boolean;
+    /**
+     * Synchronous "this wake has been superseded" probe, re-checked at the parent's turn-admission
+     * gates (even after the entry left the queue for PREPARING). A stale wake is refused rather
+     * than dispatched, and never settles the parent's own workspace turn as failed.
+     */
+    admissionStale?: () => boolean;
     queueDispatchMode?: TaskMessageQueueDispatchMode;
     /** Synthetic assistant rows persisted just before the wake's user row (family payloads). */
     preTurnMessages?: MuxMessage[];
@@ -8192,6 +8218,33 @@ export class TaskService implements AgentTaskIntegration {
       await this.getWorkspaceTurnManager().getActiveWorkspaceTurnMuxMetadataForWorkspace(
         parentWorkspaceId
       );
+    // When the parent itself runs as a delegated workspace turn, this wake continues that turn,
+    // so a canceled/failed send normally settles the turn as failed. A wake whose source has been
+    // superseded (params.admissionStale, e.g. a sub-agent progress report outrun by the child's
+    // terminal outcome) is the exception: the parent's live turn is intact and the terminal
+    // delivery is its next wake, so refusing or dropping the stale wake must not interrupt it.
+    const settleContinuationFailure = async (
+      status: "interrupted" | "error",
+      message: string
+    ): Promise<void> => {
+      if (workspaceTurnMuxMetadata == null) {
+        return;
+      }
+      if (params.admissionStale?.() === true) {
+        log.debug("Superseded parent wake dropped without settling the parent's workspace turn", {
+          parentWorkspaceId,
+          status,
+          message,
+        });
+        return;
+      }
+      await this.getWorkspaceTurnManager().settleWorkspaceTurnContinuationFailure(
+        parentWorkspaceId,
+        workspaceTurnMuxMetadata,
+        status,
+        message
+      );
+    };
 
     const sendResult = await this.workspaceService.sendMessage(
       parentWorkspaceId,
@@ -8223,23 +8276,14 @@ export class TaskService implements AgentTaskIntegration {
         ...(params.promoteAheadOfHiddenTurnEnd === true
           ? { promoteAheadOfHiddenTurnEnd: true }
           : {}),
+        ...(params.admissionStale != null ? { admissionStale: params.admissionStale } : {}),
         ...(workspaceTurnMuxMetadata != null
           ? {
               onCanceled: async (reason: string) => {
-                await this.getWorkspaceTurnManager().settleWorkspaceTurnContinuationFailure(
-                  parentWorkspaceId,
-                  workspaceTurnMuxMetadata,
-                  "interrupted",
-                  reason
-                );
+                await settleContinuationFailure("interrupted", reason);
               },
               onAcceptedPreStreamFailure: async (error: SendMessageError) => {
-                await this.getWorkspaceTurnManager().settleWorkspaceTurnContinuationFailure(
-                  parentWorkspaceId,
-                  workspaceTurnMuxMetadata,
-                  "error",
-                  formatSendMessageError(error).message
-                );
+                await settleContinuationFailure("error", formatSendMessageError(error).message);
               },
             }
           : {}),
@@ -8247,14 +8291,7 @@ export class TaskService implements AgentTaskIntegration {
     );
     if (!sendResult.success) {
       const formattedError = formatSendMessageError(sendResult.error);
-      if (workspaceTurnMuxMetadata != null) {
-        await this.getWorkspaceTurnManager().settleWorkspaceTurnContinuationFailure(
-          parentWorkspaceId,
-          workspaceTurnMuxMetadata,
-          "error",
-          formattedError.message
-        );
-      }
+      await settleContinuationFailure("error", formattedError.message);
       return Err(formattedError.message);
     }
     return Ok(undefined);

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -8129,26 +8129,41 @@ export class TaskService implements AgentTaskIntegration {
         childWorkspaceId,
         activeExecution?.handleId
       );
-      // Superseded once this run's terminal outcome has landed: the settlement paths persist the
-      // child's status mirror (`reported`, or a terminal execution status for a continuation)
-      // BEFORE they remove queued updates, so an entry already dequeued into the parent's
-      // asynchronous PREPARING phase — invisible to that removal — is refused at admission
-      // instead of starting a stale "in progress" turn after the terminal report. Synchronous
-      // reads only: admission probes run inside the session's turn gates. As with peer sends,
-      // a probe-carrying send never resurrects an interrupted parent.
+      // Superseded once this run is over: the settlement paths persist the child's status mirror
+      // (`reported`/`interrupted`, or a terminal execution status for a continuation) BEFORE they
+      // remove queued updates, so an entry already dequeued into the parent's asynchronous
+      // PREPARING phase — invisible to that removal — is refused at admission instead of starting
+      // a stale "in progress" turn after the terminal outcome. Synchronous reads only: admission
+      // probes run inside the session's turn gates. As with peer sends, a probe-carrying send
+      // never resurrects an interrupted parent.
       const superseded = (): boolean => {
         const fresh = findWorkspaceEntry(this.config.loadConfigOrDefault(), childWorkspaceId);
         if (fresh == null) {
           return true;
         }
         if (activeExecution != null) {
+          // A successor generation claims the mirror only once this execution stopped being the
+          // live registration, and clearing it is part of this execution's own teardown — either
+          // way the update belongs to a finished generation.
           return (
-            fresh.workspace.taskExecutionId === activeExecution.handleId &&
+            fresh.workspace.taskExecutionId !== activeExecution.handleId ||
             !isActiveWorkspaceTurnTaskStatus(fresh.workspace.taskExecutionStatus)
           );
         }
-        return hasCompletedAgentReport(fresh.workspace);
+        return (
+          hasCompletedAgentReport(fresh.workspace) || fresh.workspace.taskStatus === "interrupted"
+        );
       };
+      // The mirror is written at continuation acceptance, before the child's turn can call
+      // agent_report; if it nevertheless lags the active record here, attaching the probe would
+      // refuse a live update at dispatch. Fall back to removal-only supersession instead.
+      const probeConsistent = !superseded();
+      if (!probeConsistent) {
+        log.debug("agent_report supersession probe unavailable: status mirror lags active run", {
+          childWorkspaceId,
+          executionId: activeExecution?.handleId,
+        });
+      }
       const wakeResult = await this.wakeParentWorkspaceWithSyntheticMessage({
         parentWorkspaceId,
         parentEntry,
@@ -8158,7 +8173,7 @@ export class TaskService implements AgentTaskIntegration {
         // ancestor-bound peer message (turn-end by default) at the head would otherwise hold this
         // report until the parent's turn ends — observed as 8–40 minute "delayed" updates.
         promoteAheadOfHiddenTurnEnd: true,
-        admissionStale: superseded,
+        ...(probeConsistent ? { admissionStale: superseded } : {}),
       });
       if (!wakeResult.success) {
         throw new Error(`agent_report failed to wake the parent workspace: ${wakeResult.error}`);

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -8154,15 +8154,12 @@ export class TaskService implements AgentTaskIntegration {
           hasCompletedAgentReport(fresh.workspace) || fresh.workspace.taskStatus === "interrupted"
         );
       };
-      // The mirror is written at continuation acceptance, before the child's turn can call
-      // agent_report; if it nevertheless lags the active record here, attaching the probe would
-      // refuse a live update at dispatch. Fall back to removal-only supersession instead.
-      const probeConsistent = !superseded();
-      if (!probeConsistent) {
-        log.debug("agent_report supersession probe unavailable: status mirror lags active run", {
-          childWorkspaceId,
-          executionId: activeExecution?.handleId,
-        });
+      // A stop or settlement can land between the status checks above and here (neither shares
+      // this child's event lock), and the mirror is written at continuation acceptance, before
+      // the child's turn can call agent_report — so a probe that is already true means the run
+      // is over. Refuse now rather than wake the parent with an obsolete update.
+      if (superseded()) {
+        throw new Error("agent_report cannot send updates after the sub-agent's run has ended");
       }
       const wakeResult = await this.wakeParentWorkspaceWithSyntheticMessage({
         parentWorkspaceId,
@@ -8173,7 +8170,7 @@ export class TaskService implements AgentTaskIntegration {
         // ancestor-bound peer message (turn-end by default) at the head would otherwise hold this
         // report until the parent's turn ends — observed as 8–40 minute "delayed" updates.
         promoteAheadOfHiddenTurnEnd: true,
-        ...(probeConsistent ? { admissionStale: superseded } : {}),
+        admissionStale: superseded,
       });
       if (!wakeResult.success) {
         throw new Error(`agent_report failed to wake the parent workspace: ${wakeResult.error}`);
@@ -12510,6 +12507,26 @@ export class TaskService implements AgentTaskIntegration {
       },
       { allowMissing: true }
     );
+    // Drop queued incremental updates synchronously with the terminal commit: while they sit at
+    // the parent's queue head as tool-end entries, the parent's stream stops at its next step
+    // boundary for them, and a dispatch refused as superseded cannot restore that cut turn.
+    // skipCancelCallbacks: a parent running as a delegated workspace turn queues each report with
+    // continuation-failure callbacks; superseding the report must not interrupt that live turn.
+    const progressParentWorkspaceId = latestEntryBeforeReport?.workspace.parentWorkspaceId;
+    if (progressParentWorkspaceId) {
+      const queuedProgressRemoval = this.workspaceService.removeQueuedMessagesByDedupeKeyPrefix(
+        progressParentWorkspaceId,
+        agentReportProgressDedupePrefix(childWorkspaceId),
+        { cancelReason: AGENT_REPORT_PROGRESS_SUPERSEDED_REASON, skipCancelCallbacks: true }
+      );
+      if (!queuedProgressRemoval.success) {
+        log.warn("Failed to remove queued incremental sub-agent reports", {
+          parentWorkspaceId: progressParentWorkspaceId,
+          childWorkspaceId,
+          error: queuedProgressRemoval.error,
+        });
+      }
+    }
     eventSpine.emit("task.reported", { workspaceId: childWorkspaceId, taskId: childWorkspaceId });
 
     await this.emitWorkspaceMetadata(childWorkspaceId);
@@ -12614,21 +12631,6 @@ export class TaskService implements AgentTaskIntegration {
     }
 
     await this.maybeStartPatchGenerationForReportedTask(childWorkspaceId);
-
-    // skipCancelCallbacks: a parent running as a delegated workspace turn queues each report with
-    // continuation-failure callbacks; superseding the report must not interrupt that live turn.
-    const queuedProgressRemoval = this.workspaceService.removeQueuedMessagesByDedupeKeyPrefix(
-      parentWorkspaceId,
-      agentReportProgressDedupePrefix(childWorkspaceId),
-      { cancelReason: AGENT_REPORT_PROGRESS_SUPERSEDED_REASON, skipCancelCallbacks: true }
-    );
-    if (!queuedProgressRemoval.success) {
-      log.warn("Failed to remove queued incremental sub-agent reports", {
-        parentWorkspaceId,
-        childWorkspaceId,
-        error: queuedProgressRemoval.error,
-      });
-    }
 
     await this.deliverReportToParent(
       parentWorkspaceId,

--- a/src/node/services/taskWorkspaceSeam.ts
+++ b/src/node/services/taskWorkspaceSeam.ts
@@ -355,6 +355,12 @@ export interface SendMessageInternalOptions {
   /** Keep this dedupe-keyed queue entry isolated so it can be selectively superseded. */
   removableQueueDedupeKey?: boolean;
   /**
+   * For queued tool-end sends: enqueue ahead of hidden (non-user-authored) turn-end entries so
+   * a background turn-end predecessor cannot hold this send until the turn ends naturally.
+   * Never overtakes a user-authored entry. See MessageQueue.promoteAheadOfHiddenTurnEnd.
+   */
+  promoteAheadOfHiddenTurnEnd?: boolean;
+  /**
    * For queued sends: quietly drop the message (success) when other messages are already
    * queued at enqueue time. Scheduled heartbeats use this so a user send racing the awaits
    * in this method keeps queue ownership — MessageQueue dispatches with the latest queued

--- a/src/node/services/taskWorkspaceSeam.ts
+++ b/src/node/services/taskWorkspaceSeam.ts
@@ -421,7 +421,15 @@ export interface TurnAdmissionHost {
   removeQueuedMessagesByDedupeKeyPrefix(
     workspaceId: string,
     prefix: string,
-    options?: { cancelReason?: string }
+    options?: {
+      cancelReason?: string;
+      /**
+       * Drop the entries without invoking their onCanceled/onAcceptedPreStreamFailure callbacks.
+       * For supersession (the entry's source produced a later, authoritative message) rather than
+       * withdrawal: a workspace-turn continuation the entry carried must not be settled as failed.
+       */
+      skipCancelCallbacks?: boolean;
+    }
   ): Result<number>;
   getQueueCutCutter(workspaceId: string): QueueCutCutter | undefined;
   countQueuedAgentPeerMessages(workspaceId: string): number;

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -943,6 +943,64 @@ describe("WorkspaceService bash monitor wake reconciler wiring", () => {
       await cleanup();
     }
   });
+
+  test("superseding queued sub-agent progress skips its continuation-failure callbacks", async () => {
+    const { config, service, cleanup } = await createWakeWiringService();
+    const workspaceId = "superseded-progress-owner";
+    await config.addWorkspace("/tmp/superseded-progress-project", {
+      id: workspaceId,
+      name: workspaceId,
+      projectName: "superseded-progress-project",
+      projectPath: "/tmp/superseded-progress-project",
+      runtimeConfig: { type: "local" },
+    });
+    const session = service.getOrCreateSession(workspaceId);
+    const options: SendMessageOptions = { model: "gpt-4", agentId: "exec" };
+    try {
+      // A progress report queued into an owner that runs as a delegated turn carries callbacks
+      // that settle that turn as interrupted; supersession by the terminal report must not fire them.
+      const progressCanceled = mock(() => undefined);
+      const wakeCanceled = mock(() => undefined);
+      expect(
+        session.queueMessage("progress", options, {
+          synthetic: true,
+          agentInitiated: true,
+          dedupeKey: "agent-report:child:wst_1:call-1",
+          removableDedupeKey: true,
+          onCanceled: progressCanceled,
+        })
+      ).toBe("tool-end");
+      expect(
+        session.queueMessage("wake", options, {
+          synthetic: true,
+          agentInitiated: true,
+          dedupeKey: "bash-monitor-wake:owner:1",
+          removableDedupeKey: true,
+          onCanceled: wakeCanceled,
+        })
+      ).toBe("tool-end");
+
+      expect(
+        service.removeQueuedMessagesByDedupeKeyPrefix(workspaceId, "agent-report:child:wst_1:", {
+          cancelReason: "superseded",
+          skipCancelCallbacks: true,
+        })
+      ).toEqual(Ok(1));
+      // Withdrawal (the default) still notifies, so wake bookkeeping keeps working.
+      expect(
+        service.removeQueuedMessagesByDedupeKeyPrefix(workspaceId, "bash-monitor-wake:", {
+          cancelReason: "withdrawn",
+        })
+      ).toEqual(Ok(1));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(progressCanceled).not.toHaveBeenCalled();
+      expect(wakeCanceled).toHaveBeenCalledWith("withdrawn");
+      expect(session.hasQueuedMessages()).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
 });
 
 async function setWorkspaceGoalOk(

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -9546,6 +9546,44 @@ describe("WorkspaceService sendMessage status clearing", () => {
     );
   });
 
+  test("judges a promoted progress report's correlation against the entries it stays behind", async () => {
+    fakeSession.hasQueuedOrDispatchingEntry.mockReturnValue(false);
+    const onCanceled = mock(() => undefined);
+    const muxMetadata = {
+      type: "workspace-turn-task" as const,
+      taskHandleId: "wst_promoted_progress",
+      ownerWorkspaceId: "owner-workspace",
+      turnId: "turn-promoted-progress",
+    };
+
+    const result = await workspaceService.sendMessage(
+      "test-workspace",
+      "nested progress",
+      { model: "openai:gpt-4o-mini", agentId: "exec", muxMetadata },
+      {
+        synthetic: true,
+        agentInitiated: true,
+        workspaceTurnContinuation: true,
+        queueDedupeKey: "agent-report:child:call-1",
+        removableQueueDedupeKey: true,
+        promoteAheadOfHiddenTurnEnd: true,
+        onCanceled,
+      }
+    );
+
+    expect(result.success).toBe(true);
+    // The session excludes the hidden turn-end entries the promotion will overtake (e.g. a
+    // queued heartbeat) when deciding whether a predecessor supersedes this continuation.
+    expect(fakeSession.hasQueuedOrDispatchingEntry).toHaveBeenCalledWith(muxMetadata, {
+      promoteAheadOfHiddenTurnEnd: true,
+    });
+    expect(fakeSession.queueMessage).toHaveBeenCalledWith(
+      "nested progress",
+      expect.objectContaining({ muxMetadata }),
+      expect.objectContaining({ onCanceled, promoteAheadOfHiddenTurnEnd: true })
+    );
+  });
+
   test("keeps workspace-turn correlation for the next queued continuation", async () => {
     fakeSession.hasQueuedOrDispatchingEntry.mockReturnValue(false);
     const onCanceled = mock(() => undefined);

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -11090,6 +11090,7 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
             workspaceTurnContinuation: internal?.workspaceTurnContinuation,
             dedupeKey: internal?.queueDedupeKey,
             removableDedupeKey: internal?.removableQueueDedupeKey,
+            promoteAheadOfHiddenTurnEnd: internal?.promoteAheadOfHiddenTurnEnd,
             cancelState: internal?.cancelState,
             cancelSignal: internal?.cancelSignal,
             onCanceled: continuationSendState.onCanceled,

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -11902,7 +11902,7 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
   removeQueuedMessagesByDedupeKeyPrefix(
     workspaceId: string,
     prefix: string,
-    options?: { cancelReason?: string }
+    options?: { cancelReason?: string; skipCancelCallbacks?: boolean }
   ): Result<number> {
     try {
       const session = this.sessions.get(workspaceId.trim());
@@ -11912,7 +11912,8 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       return Ok(
         session.removeQueuedMessagesByDedupeKeyPrefix(
           prefix,
-          options?.cancelReason ?? "Queued message superseded before dispatch."
+          options?.cancelReason ?? "Queued message superseded before dispatch.",
+          options?.skipCancelCallbacks === true ? { skipCancelCallbacks: true } : undefined
         )
       );
     } catch (error) {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -10869,10 +10869,18 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
         }
         return withoutCorrelation;
       };
+      // A promoted tool-end send (sub-agent progress) overtakes trailing hidden turn-end entries
+      // such as a queued heartbeat, so they must not count as superseding predecessors here — or
+      // the report would be stripped of the correlation it then dispatches ahead of them with.
+      const promotesAheadOfHiddenTurnEnd =
+        internal?.promoteAheadOfHiddenTurnEnd === true &&
+        (normalizedOptions.queueDispatchMode ?? "tool-end") === "tool-end";
       const getContinuationSendState = () => {
         const preserveCorrelation =
           !isWorkspaceTurnContinuation ||
-          !session.hasQueuedOrDispatchingEntry(workspaceTurnContinuationMetadata);
+          !session.hasQueuedOrDispatchingEntry(workspaceTurnContinuationMetadata, {
+            promoteAheadOfHiddenTurnEnd: promotesAheadOfHiddenTurnEnd,
+          });
         // Dropping callbacks on a superseded correlation protects the delegated-turn OWNER
         // (its onCanceled settles the owner's handle, which the superseded entry no longer
         // represents) — but a peer trigger's onCanceled is the sender's budget refund, tied to

--- a/src/node/services/workspaceTurnManager.ts
+++ b/src/node/services/workspaceTurnManager.ts
@@ -2400,10 +2400,12 @@ export class WorkspaceTurnManager {
         // outcome supersedes them; left queued, each would later dispatch as a stale "in
         // progress" turn. Drop them before waiters resolve so an owner whose task_await just
         // returned cannot be cut at its next step boundary by an update it already outran.
+        // skipCancelCallbacks: when the owner itself runs as a delegated turn, each queued report
+        // carries continuation callbacks that would settle that live turn as interrupted.
         const queuedProgressRemoval = this.workspaceService.removeQueuedMessagesByDedupeKeyPrefix(
           params.record.ownerWorkspaceId,
           agentReportProgressDedupePrefix(params.record.workspaceId, params.record.handleId),
-          { cancelReason: AGENT_REPORT_PROGRESS_SUPERSEDED_REASON }
+          { cancelReason: AGENT_REPORT_PROGRESS_SUPERSEDED_REASON, skipCancelCallbacks: true }
         );
         if (!queuedProgressRemoval.success) {
           log.warn("Failed to remove queued incremental sub-agent reports at settlement", {

--- a/src/node/services/workspaceTurnManager.ts
+++ b/src/node/services/workspaceTurnManager.ts
@@ -26,6 +26,10 @@ import {
   parseSubagentReportEnvelope,
 } from "@/common/utils/subagentReportEnvelope";
 import { WORKSPACE_TURN_TASK_TAGS } from "@/constants/workspaceTags";
+import {
+  AGENT_REPORT_PROGRESS_SUPERSEDED_REASON,
+  agentReportProgressDedupePrefix,
+} from "@/constants/agentMessaging";
 import { log } from "@/node/services/log";
 import {
   readAgentDefinition,
@@ -2390,6 +2394,24 @@ export class WorkspaceTurnManager {
           active.ownerWorkspaceId === params.record.ownerWorkspaceId
         ) {
           this.activeWorkspaceTurnHandleByWorkspaceId.delete(params.record.workspaceId);
+        }
+        // Incremental agent_report updates from this execution were queued behind the owner's
+        // busy turn (reportAgentProgress routes them to the continuation owner). This terminal
+        // outcome supersedes them; left queued, each would later dispatch as a stale "in
+        // progress" turn. Drop them before waiters resolve so an owner whose task_await just
+        // returned cannot be cut at its next step boundary by an update it already outran.
+        const queuedProgressRemoval = this.workspaceService.removeQueuedMessagesByDedupeKeyPrefix(
+          params.record.ownerWorkspaceId,
+          agentReportProgressDedupePrefix(params.record.workspaceId, params.record.handleId),
+          { cancelReason: AGENT_REPORT_PROGRESS_SUPERSEDED_REASON }
+        );
+        if (!queuedProgressRemoval.success) {
+          log.warn("Failed to remove queued incremental sub-agent reports at settlement", {
+            ownerWorkspaceId: params.record.ownerWorkspaceId,
+            childWorkspaceId: params.record.workspaceId,
+            handleId: params.record.handleId,
+            error: queuedProgressRemoval.error,
+          });
         }
         const foregroundWaiterWorkspaceIds = this.settleWorkspaceTurnWaiters(
           params.record.handleId,


### PR DESCRIPTION
## Summary

Sub-agent `agent_report` progress updates could reach the parent 8–40 minutes late, and — for a reawakened (workspace-turn continuation) child — kept arriving *after* the child's terminal report, each burning a full parent turn just to be dismissed as "a delayed interim report". This PR makes progress reports cut the parent's turn promptly even when a hidden turn-end entry sits ahead of them, and drops queued in-progress updates when the continuation that produced them settles.

## Background

Diagnosed from the session shown in the report (`Build React Native Xum mobile app`, child `Mobile UI Engineer`). The child was reawakened via `task_send_message`; timeline (host clock):

| time | event |
| --- | --- |
| 17:33:12 | child → parent `task_send_message` (ancestor target ⇒ default **turn-end**), queued at the parent's FIFO head |
| 17:39:35 / 17:41:53 | child `agent_report` progress ×2 → queued **tool-end** behind the peer message |
| 17:42:21 | continuation completes; terminal report appended via `deliverPersistentChildWorkspaceTurnResultUnlocked` |
| 17:59:15 / 17:59:58 | parent's turn finally ends → peer message refused at admission (sender inactive) → both stale `in_progress` reports dispatch as new parent turns |

Two independent causes:

1. **Head-of-queue gating.** `MessageQueue.getNextDispatchableMode()` (since #3790) only looks at the FIFO head, so the stream's `hasQueuedMessages("tool-end")` stop condition stays false while a hidden turn-end entry is at the head. Every child→ancestor peer message defaults to turn-end, so any progress report queued behind one waits for the parent's natural turn end. (The peer messages themselves were later refused as "sender no longer active" — they never delivered, they only blocked.)
2. **Missing cleanup on continuation settlement.** `handleAgentReport` removes queued `agent-report:<child>:` entries when a child's *original* run reports, but the workspace-turn continuation path (`WorkspaceTurnManager.settleWorkspaceTurn`) never did, so stale updates survived the terminal report.

## Implementation

- `MessageQueue`: new internal option `promoteAheadOfHiddenTurnEnd`. A tool-end entry flagged with it is inserted ahead of the contiguous run of hidden (non-user-authored) turn-end predecessors, stopping at the first user-authored or tool-end entry — the user's visible "wait for turn end" choice is never pulled forward (the #3790 invariant). Reorders re-run `revalidateWorkspaceTurnCorrelations()` exactly like `prioritizeNextUserEntry`. `addInternal` now returns the entry so `addOnce` attaches the dedupe key to the promoted entry rather than the tail.
- `reportAgentProgress`: sets the flag and scopes the dedupe key to the active continuation execution (`agent-report:<child>:<executionId>:<toolCallId>`), so a settlement drops exactly the updates it superseded and never a successor execution's. Prefix/reason literals are centralized in `src/constants/agentMessaging.ts`.
- `WorkspaceTurnManager.settleWorkspaceTurn`: inside the settlement lock, before waiters resolve, removes `agent-report:<child>:<handleId>:` entries from the owner's queue, so a parent whose `task_await` just returned cannot be cut at its next step boundary by an update it already outran.
- Supersession must not fail the parent's own turn (Codex round 1): when the parent itself runs as a delegated workspace turn, each queued report carries continuation-failure callbacks. Both removal sites pass `skipCancelCallbacks: true` (new `TurnAdmissionHost` option), and `wakeParentWorkspaceWithSyntheticMessage` no-ops those callbacks for superseded wakes.
- Entries already dequeued into PREPARING (Codex round 2): progress sends carry a synchronous supersession probe through the existing `admissionStale` mechanism (stale once the child's status mirror shows `reported`/`interrupted`, or — for a continuation — a terminal execution status or a mirror that moved to a successor generation; all persisted before removal runs; a send-time consistency check falls back to removal-only supersession if the mirror ever lags), so `AgentSession`'s turn-admission gates refuse a stale entry that prefix removal could no longer see. A probe already true at send time refuses the update outright.
- Promotion-aware correlation (Codex round 4): a promoted tool-end send judges whether a queued predecessor supersedes its workspace-turn correlation only against the entries it stays behind (`MessageQueue.hasAllWorkspaceTurnContinuationsAheadOfPromotedToolEnd`, sharing the trailing-run helper with the promotion), so a queued heartbeat cannot strip the correlation of a report that dispatches ahead of it. `handleAgentReport` also drops queued updates right after the `reported` commit rather than after artifact/goal/patch work. Interrupted transitions (`recordTaskInterrupted`, the choke point for task_stop and interrupt cascades) drop the child's queued updates the same way.

## Validation

- Replayed the affected session's `chat.jsonl` files to reconstruct the timeline above (per-tool `executionStartedAt` vs. parent delivery timestamps).
- New unit tests: queue promotion (head becomes tool-end; user-authored turn-end barrier; FIFO preserved behind earlier tool-end entries; skipped continuation correlation stripped), execution-scoped key + flag on `reportAgentProgress`, and settlement-time removal ordered before waiter resolution.
- `make static-check` green; `taskService`, `workspaceTurnManager*`, `workspaceService`, `messageQueue` suites: 1142 pass / 0 fail.

## Risks

- **Queue ordering (medium, parent/child orchestration).** Hidden turn-end entries can now dispatch later than a progress report queued after them. This only affects non-user-authored entries; peer messages already tolerate reordering (correlation revalidation is the same path used by "Send now" and the dispatch-mode dropdown). `getQueueCutSupersedeEvidence` still classifies a turn-end queued head as `other_input` (fail-toward-notify).
- **Dropped updates (low).** Removal is execution-scoped and happens only at terminal settlement, mirroring the existing original-run behavior; foreground waiters and the direct-parent envelope still deliver the terminal result.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$18.84`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=18.84 -->




