### PR TITLE
🤖 tests: establish agent loop lifecycle contracts

### DIFF
--- a/src/node/services/agentSession.queueDispatch.test.ts
+++ b/src/node/services/agentSession.queueDispatch.test.ts
@@ -61,6 +61,79 @@ async function waitForCondition(condition: () => boolean, timeoutMs = 500): Prom
 }
 
 describe("AgentSession queued message tool-call dispatch", () => {
+  test.each(["returned error", "rejection"] as const)(
+    "reserves queued startup synchronously and drains after %s cleanup",
+    async (failureKind) => {
+      const workspaceId = `queue-prestart-${failureKind}`;
+      const failureEntered = Promise.withResolvers<void>();
+      const releaseFailure = Promise.withResolvers<void>();
+      const successorStarted = Promise.withResolvers<void>();
+      const streamMessage = mock(() => {
+        successorStarted.resolve();
+        return Promise.resolve(Ok(createStartedTurnHandle()));
+      });
+      const { session, historyService, cleanup } = await createAgentSessionHarness({
+        workspaceId,
+        aiServiceOverrides: { streamMessage },
+      });
+      const append = spyOn(historyService, "appendToHistory");
+      if (failureKind === "returned error") {
+        append.mockResolvedValueOnce(Err("disk unavailable"));
+      } else {
+        append.mockRejectedValueOnce(new Error("disk unavailable"));
+      }
+      const failures: unknown[] = [];
+
+      try {
+        session.queueMessage(
+          "failed head",
+          { model: TEST_MODEL, agentId: "exec" },
+          {
+            synthetic: true,
+            onAcceptedPreStreamFailure: async (error) => {
+              failures.push(error);
+              failureEntered.resolve();
+              await releaseFailure.promise;
+            },
+          }
+        );
+        session.queueMessage("surviving successor", { model: TEST_MODEL, agentId: "exec" });
+        session.sendQueuedMessages();
+
+        // Admission must cover the first await, or another caller can bypass this FIFO head.
+        expect(session.isBusy()).toBe(true);
+        expect(session.isPreparingTurn()).toBe(true);
+        expect(append).not.toHaveBeenCalled();
+
+        await failureEntered.promise;
+        expect(session.isBusy()).toBe(true);
+        expect(session.queuedMessageEntryCount()).toBe(1);
+        expect(streamMessage).not.toHaveBeenCalled();
+        expect(await historyService.getHistoryFromLatestBoundary(workspaceId)).toEqual(Ok([]));
+
+        // No stream-end will arrive for the failed head. Cleanup must finish before its
+        // successor persists, then the queue must make progress without an external nudge.
+        releaseFailure.resolve();
+        await successorStarted.promise;
+        await session.waitForIdle();
+        expect(failures).toHaveLength(1);
+        expect(streamMessage).toHaveBeenCalledTimes(1);
+        expect(session.hasQueuedMessages()).toBe(false);
+        const history = await historyService.getHistoryFromLatestBoundary(workspaceId);
+        expect(history.success).toBe(true);
+        if (!history.success) throw new Error(history.error);
+        expect(history.data).toMatchObject([
+          { role: "user", parts: [{ type: "text", text: "surviving successor" }] },
+        ]);
+      } finally {
+        releaseFailure.resolve();
+        append.mockRestore();
+        session.dispose();
+        await cleanup();
+      }
+    }
+  );
+
   test("counts only a different direct preparing send as a superseding predecessor", async () => {
     const sessionHolder: {
       current?: {

--- a/src/node/services/agentSession.waitForIdle.test.ts
+++ b/src/node/services/agentSession.waitForIdle.test.ts
@@ -58,6 +58,10 @@ describe("AgentSession.waitForIdle", () => {
       const release = session.registerExternalManualFollowUp(controller.signal);
       expect(session.hasQueuedMessages()).toBe(false);
       expect(session.hasPendingManualFollowUp()).toBe(true);
+      // Idle means no active turn phase; it does not promise that all future work is drained.
+      await session.waitForIdle();
+      expect(session.isBusy()).toBe(false);
+      expect(session.hasPendingManualFollowUp()).toBe(true);
 
       controller.abort();
       expect(session.hasPendingManualFollowUp()).toBe(false);
@@ -81,6 +85,8 @@ describe("AgentSession.waitForIdle", () => {
         agentId: "exec",
         queueDispatchMode: "turn-end",
       });
+      await session.waitForIdle();
+      expect(session.isBusy()).toBe(false);
       expect(session.hasQueuedMessages()).toBe(true);
       expect(session.hasQueuedMessages("tool-end")).toBe(false);
 

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -1395,22 +1395,46 @@ describe("StreamManager - engine supervision (AppFiberScope occupant)", () => {
         })(),
       { supervised: false }
     );
-    let stopPromise: Promise<unknown> | undefined;
+    const finalWriteEntered = Promise.withResolvers<void>();
+    const releaseFinalWrite = Promise.withResolvers<void>();
     const realUpdateHistory = historyService.updateHistory.bind(historyService);
     const updateHistorySpy = spyOn(historyService, "updateHistory").mockImplementation(
       async (targetWorkspaceId, message) => {
-        // partial.json is already gone here; state is still STREAMING.
-        stopPromise ??= streamManager.stopStream(targetWorkspaceId);
+        finalWriteEntered.resolve();
+        await releaseFinalWrite.promise;
         return realUpdateHistory(targetWorkspaceId, message);
       }
     );
+    let completionObserved: Promise<void> | undefined;
+    let stopPromise: Promise<unknown> | undefined;
     try {
       const handle = await startSupervisedStreamForTests(streamManager, workspaceId);
+      let settled = false;
+      completionObserved = handle.completion.then(async () => {
+        settled = true;
+        // Dependent turns read immediately on completion, so final history must already exist.
+        const history = await historyService.getHistoryFromLatestBoundary(workspaceId);
+        expect(history.success).toBe(true);
+        if (!history.success) throw new Error(history.error);
+        expect(history.data.filter((message) => message.role === "assistant")).toMatchObject([
+          { parts: [{ type: "text", text: "final answer" }] },
+        ]);
+        expect(history.data[0].metadata?.partial).not.toBe(true);
+      });
 
+      await finalWriteEntered.promise;
+      stopPromise = streamManager.stopStream(workspaceId);
+      const beforeCommit = await historyService.getHistoryFromLatestBoundary(workspaceId);
+      expect(beforeCommit.success).toBe(true);
+      if (!beforeCommit.success) throw new Error(beforeCommit.error);
+      expect(beforeCommit.data[0].parts).toEqual([]);
+      expect(settled).toBe(false);
+      expect(terminalEvents(events)).toEqual([]);
+
+      releaseFinalWrite.resolve();
       expect(await handle.completion).toEqual({ status: "completed" });
-      expect(stopPromise).toBeDefined();
       expect(await stopPromise).toEqual(Ok(undefined));
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      await completionObserved;
 
       expect(terminalEvents(events).map((event) => event.type)).toEqual(["stream-end"]);
       expect(await historyService.readPartial(workspaceId)).toBeNull();
@@ -1425,7 +1449,13 @@ describe("StreamManager - engine supervision (AppFiberScope occupant)", () => {
       ).toBe(true);
       expect(getWorkspaceStreamsForTests(streamManager).size).toBe(0);
     } finally {
-      updateHistorySpy.mockRestore();
+      releaseFinalWrite.resolve();
+      try {
+        await stopPromise;
+        await completionObserved;
+      } finally {
+        updateHistorySpy.mockRestore();
+      }
     }
   });
 
@@ -2841,28 +2871,70 @@ describe("StreamManager - turn completion", () => {
     });
   });
 
-  test("aborted completion waits for asynchronous abort delivery", async () => {
-    let releaseAbortDelivery!: () => void;
-    const abortDelivery = new Promise<void>((resolve) => {
-      releaseAbortDelivery = resolve;
-    });
+  test("aborted completion waits for the sink to commit and remove the partial", async () => {
+    const workspaceId = "completion-abort-workspace";
+    const providerBlocked = Promise.withResolvers<void>();
+    const abortDeliveryEntered = Promise.withResolvers<void>();
+    const releaseAbortDelivery = Promise.withResolvers<void>();
     const { streamManager, handle } = await startWithStreamResult({
-      workspaceId: "completion-abort-workspace",
+      workspaceId,
       messageId: "completion-abort-message",
-      createStreamResult: hangUntilAbort,
-      sink: (event) => (event.type === "stream-abort" ? abortDelivery : undefined),
+      createStreamResult: (_request, controller) =>
+        createStreamResultForTests(
+          (async function* () {
+            yield { type: "text-delta", text: "interrupted answer" };
+            providerBlocked.resolve();
+            await new Promise<void>((resolve) => {
+              if (controller.signal.aborted) return resolve();
+              controller.signal.addEventListener("abort", () => resolve(), { once: true });
+            });
+          })()
+        ),
+      sink: async (event) => {
+        if (event.type !== "stream-abort") return;
+        abortDeliveryEntered.resolve();
+        await releaseAbortDelivery.promise;
+        // The facade owns abort persistence. A completion consumer must see its cleanup,
+        // even though stopStream has already released the engine's streaming registration.
+        await historyService.commitPartial(workspaceId);
+        await historyService.deletePartial(workspaceId);
+      },
     });
 
     let settled = false;
-    void handle.completion.then(() => {
+    const completionObserved = handle.completion.then(async () => {
       settled = true;
+      return {
+        history: await historyService.getHistoryFromLatestBoundary(workspaceId),
+        partial: await historyService.readPartial(workspaceId),
+      };
     });
-    await streamManager.stopStream("completion-abort-workspace", { abortReason: "user" });
-    await Promise.resolve();
-    expect(settled).toBe(false);
+    let stopPromise: Promise<unknown> | undefined;
+    try {
+      await providerBlocked.promise;
+      stopPromise = streamManager.stopStream(workspaceId, { abortReason: "user" });
+      await stopPromise;
+      await abortDeliveryEntered.promise;
+      expect(streamManager.isStreaming(workspaceId)).toBe(false);
+      expect(await historyService.readPartial(workspaceId)).toMatchObject({
+        parts: [{ type: "text", text: "interrupted answer" }],
+      });
+      expect(settled).toBe(false);
 
-    releaseAbortDelivery();
-    expect(await handle.completion).toEqual({ status: "aborted", abortReason: "user" });
+      releaseAbortDelivery.resolve();
+      expect(await handle.completion).toEqual({ status: "aborted", abortReason: "user" });
+      const observed = await completionObserved;
+      expect(observed.partial).toBeNull();
+      expect(observed.history.success).toBe(true);
+      if (!observed.history.success) throw new Error(observed.history.error);
+      expect(observed.history.data).toMatchObject([
+        { id: handle.messageId, parts: [{ type: "text", text: "interrupted answer" }] },
+      ]);
+    } finally {
+      releaseAbortDelivery.resolve();
+      await (stopPromise ?? streamManager.stopStream(workspaceId));
+      await completionObserved;
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
Establish deterministic lifecycle contracts before progressively moving the agent loop onto Effect. Queue tests now prove admission reserves synchronously and successor persistence waits for failed-head cleanup; stream tests prove completion readers observe finalized history and abort partial cleanup. Idle tests distinguish an idle phase from pending work.

Existing stop-versus-success coverage now gates the real final history write instead of using a timer. No production behavior changes.

## Validation
- 349 tests passed across 11 lifecycle, queue, chaos, workspace-turn, and reconnect suites.
- Full local `make static-check` passed with installed tool paths; `git diff --check` passed.
- Local Hadolint used native 2.14.0 because CI-pinned 2.12.0's macOS x86 binary exited 139 on arm64. CI retains its pinned version. Existing formatting target skipped Nix formatting because Nix is unavailable locally.

## Risks
Test-only change. Controlled barriers exercise real HistoryService I/O and preserve existing failure behavior. This is Phase 0 of the approved loop lifecycle refactor.

---

_Generated with `xum` • Model: `unavailable` • Thinking: `unavailable` • Cost: `$unavailable`_

<!-- mux-attribution: model=unavailable thinking=unavailable costs=unavailable -->
