### PR TITLE
🤖 refactor: route agent terminal policy through turn completion

### DIFF
--- a/src/node/services/agentSession.autoCompaction.test.ts
+++ b/src/node/services/agentSession.autoCompaction.test.ts
@@ -1,3 +1,5 @@
+import type { StreamEndEvent } from "@/common/types/stream";
+import { runSessionTerminalPolicy } from "./agentSession.testHarness";
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { EventEmitter } from "events";
 
@@ -823,7 +825,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
         usage,
       });
 
-      aiEmitter.emit("stream-end", {
+      void runSessionTerminalPolicy(session, aiEmitter, {
         type: "stream-end",
         workspaceId,
         messageId: "assistant-providers-config",
@@ -1055,7 +1057,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
     });
 
     const stopStream = mock((_workspaceId: string) => {
-      aiEmitter.emit("stream-abort", {
+      void runSessionTerminalPolicy(session, aiEmitter, {
         type: "stream-abort",
         workspaceId,
         messageId: "assistant-mid-stream",
@@ -1206,7 +1208,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
     });
 
     const stopStream = mock((_workspaceId: string) => {
-      aiEmitter.emit("stream-abort", {
+      void runSessionTerminalPolicy(session, aiEmitter, {
         type: "stream-abort",
         workspaceId,
         messageId: "assistant-mid-stream",
@@ -1369,7 +1371,7 @@ describe("AgentSession on-send auto-compaction for synthetic guidance sends", ()
         outputTokens: 10,
         totalTokens: 52,
       };
-      aiEmitter.emit("stream-end", {
+      const streamEnd: StreamEndEvent = {
         type: "stream-end",
         workspaceId,
         messageId: `assistant-${streamHistories.length}`,
@@ -1379,9 +1381,14 @@ describe("AgentSession on-send auto-compaction for synthetic guidance sends", ()
           usage,
           contextUsage: usage,
         },
-      });
-
-      return Promise.resolve(Ok(createStartedTurnHandle()));
+      };
+      aiEmitter.emit("stream-end", streamEnd);
+      return Promise.resolve(
+        Ok({
+          messageId: streamEnd.messageId,
+          completion: Promise.resolve({ status: "completed" as const, streamEnd }),
+        })
+      );
     });
 
     const harness = await createAgentSessionHarness({

--- a/src/node/services/agentSession.continuousCompaction.test.ts
+++ b/src/node/services/agentSession.continuousCompaction.test.ts
@@ -1,3 +1,4 @@
+import { runSessionTerminalPolicy } from "./agentSession.testHarness";
 import type { CompactionHandler } from "./compactionHandler";
 import assert from "@/common/utils/assert";
 import type { ContinuousPrefixSwap } from "./continuousCompactionJournal";
@@ -340,7 +341,7 @@ describe("AgentSession continuous compaction wiring", () => {
     );
     Reflect.set(h.session, "activeCompactionRequest", { id: "legacy-request", modelString: model });
     const completion = h.session.waitForPendingCompactionCompletionDecision("legacy-summary");
-    h.aiEmitter.emit("stream-end", {
+    void runSessionTerminalPolicy(h.session, h.aiEmitter, {
       type: "stream-end",
       workspaceId,
       messageId: "legacy-summary",
@@ -449,7 +450,7 @@ describe("AgentSession continuous compaction wiring", () => {
   }
 
   function endStream(h: AgentSessionHarness) {
-    h.aiEmitter.emit("stream-end", {
+    void runSessionTerminalPolicy(h.session, h.aiEmitter, {
       type: "stream-end",
       workspaceId,
       messageId: "live-assistant",
@@ -526,7 +527,7 @@ describe("AgentSession continuous compaction wiring", () => {
     const stop = spyOn(h.aiService, "stopStream").mockImplementation((_id, options) => {
       expect(options?.abortReason).toBe("system");
       streaming = false;
-      h.aiEmitter.emit("stream-abort", {
+      void runSessionTerminalPolicy(h.session, h.aiEmitter, {
         type: "stream-abort",
         workspaceId,
         messageId: "live-assistant",
@@ -631,7 +632,7 @@ describe("AgentSession continuous compaction wiring", () => {
           workspaceId,
           createMuxMessage("live-assistant", "assistant", "Committed partial")
         );
-        h.aiEmitter.emit("stream-abort", {
+        void runSessionTerminalPolicy(h.session, h.aiEmitter, {
           type: "stream-abort",
           workspaceId,
           messageId: "live-assistant",
@@ -737,7 +738,7 @@ describe("AgentSession continuous compaction wiring", () => {
           createMuxMessage("live-assistant", "assistant", "Committed partial")
         );
         expect(result.success).toBe(true);
-        h.aiEmitter.emit("stream-abort", {
+        void runSessionTerminalPolicy(h.session, h.aiEmitter, {
           type: "stream-abort",
           workspaceId,
           messageId: "live-assistant",
@@ -842,7 +843,7 @@ describe("AgentSession continuous compaction wiring", () => {
         return Promise.resolve(Ok(createStartedTurnHandle()));
       });
       spyOn(h.aiService, "stopStream").mockImplementation(() => {
-        h.aiEmitter.emit("stream-abort", {
+        void runSessionTerminalPolicy(h.session, h.aiEmitter, {
           type: "stream-abort",
           workspaceId,
           messageId: "live-assistant",
@@ -875,7 +876,7 @@ describe("AgentSession continuous compaction wiring", () => {
       return Promise.resolve(Ok(createStartedTurnHandle()));
     });
     spyOn(h.aiService, "stopStream").mockImplementation((_id, options) => {
-      h.aiEmitter.emit("stream-abort", {
+      void runSessionTerminalPolicy(h.session, h.aiEmitter, {
         type: "stream-abort",
         workspaceId,
         messageId: "live-assistant",
@@ -903,7 +904,7 @@ describe("AgentSession continuous compaction wiring", () => {
       return Promise.resolve(Ok(createStartedTurnHandle()));
     });
     spyOn(h.aiService, "stopStream").mockImplementation((_id, options) => {
-      h.aiEmitter.emit("stream-abort", {
+      void runSessionTerminalPolicy(h.session, h.aiEmitter, {
         type: "stream-abort",
         workspaceId,
         messageId: "live-assistant",

--- a/src/node/services/agentSession.continuousCompaction.test.ts
+++ b/src/node/services/agentSession.continuousCompaction.test.ts
@@ -1,3 +1,4 @@
+import type { TurnCompletion } from "./streamManager";
 import { runSessionTerminalPolicy } from "./agentSession.testHarness";
 import type { CompactionHandler } from "./compactionHandler";
 import assert from "@/common/utils/assert";
@@ -866,52 +867,52 @@ describe("AgentSession continuous compaction wiring", () => {
     }
   );
 
+  // These callbacks interrupt an already-started turn, so model the engine's
+  // completion handle rather than invoking terminal policy without settling it.
+  function mockAbortableStream(h: AgentSessionHarness) {
+    let completion: ReturnType<typeof Promise.withResolvers<TurnCompletion>> | undefined;
+    const streamMessage = spyOn(h.aiService, "streamMessage").mockImplementation(() => {
+      completion = Promise.withResolvers<TurnCompletion>();
+      startStream(h);
+      return Promise.resolve(Ok({ messageId: "live-assistant", completion: completion.promise }));
+    });
+    spyOn(h.aiService, "stopStream").mockImplementation((_id, options) => {
+      const streamAbort = {
+        type: "stream-abort" as const,
+        workspaceId,
+        messageId: completion ? "live-assistant" : "",
+        abortReason: options?.abortReason,
+      };
+      h.aiEmitter.emit("stream-abort", streamAbort);
+      completion?.resolve({
+        status: "aborted",
+        abortReason: options?.abortReason ?? "system",
+        streamAbort,
+      });
+      completion = undefined;
+      return Promise.resolve(Ok(undefined));
+    });
+    return streamMessage;
+  }
+
   test("abandon during fast apply cannot resume the abandoned turn", async () => {
     const h = await setup();
     spyOn(internals(h.session).continuousCompactor, "observe").mockResolvedValue("none");
-    let starts = 0;
-    spyOn(h.aiService, "streamMessage").mockImplementation(() => {
-      starts++;
-      startStream(h);
-      return Promise.resolve(Ok(createStartedTurnHandle()));
-    });
-    spyOn(h.aiService, "stopStream").mockImplementation((_id, options) => {
-      void runSessionTerminalPolicy(h.session, h.aiEmitter, {
-        type: "stream-abort",
-        workspaceId,
-        messageId: "live-assistant",
-        abortReason: options?.abortReason,
-      });
-      return Promise.resolve(Ok(undefined));
-    });
+    const streamMessage = mockAbortableStream(h);
     expect((await h.session.sendMessage("Working", sendOptions)).success).toBe(true);
     const applied = await applyThenFinish(h.session, async () => {
       await h.session.interruptStream({ abandonPartial: true });
       return false;
     });
     expect(applied).toBe(false);
-    expect(starts).toBe(1);
+    expect(streamMessage).toHaveBeenCalledTimes(1);
     mock.restore();
   });
 
   test("abandon after the boundary commit preserves the fold but clears durable resume intent", async () => {
     const h = await setup();
     spyOn(internals(h.session).continuousCompactor, "observe").mockResolvedValue("none");
-    let starts = 0;
-    spyOn(h.aiService, "streamMessage").mockImplementation(() => {
-      starts++;
-      startStream(h);
-      return Promise.resolve(Ok(createStartedTurnHandle()));
-    });
-    spyOn(h.aiService, "stopStream").mockImplementation((_id, options) => {
-      void runSessionTerminalPolicy(h.session, h.aiEmitter, {
-        type: "stream-abort",
-        workspaceId,
-        messageId: "live-assistant",
-        abortReason: options?.abortReason,
-      });
-      return Promise.resolve(Ok(undefined));
-    });
+    const streamMessage = mockAbortableStream(h);
     expect((await h.session.sendMessage("Working", sendOptions)).success).toBe(true);
     const applied = await applyThenFinish(h.session, async (followUp) => {
       await appendBoundary(h, followUp);
@@ -919,7 +920,7 @@ describe("AgentSession continuous compaction wiring", () => {
       return true;
     });
     expect(applied).toBe(true);
-    expect(starts).toBe(1);
+    expect(streamMessage).toHaveBeenCalledTimes(1);
     const history = await rows(h);
     expect(history[0].id).toBe("continuous-boundary");
     expect(history[0].metadata?.muxMetadata).not.toHaveProperty("pendingFollowUp");

--- a/src/node/services/agentSession.goalAutoPause.test.ts
+++ b/src/node/services/agentSession.goalAutoPause.test.ts
@@ -1,3 +1,5 @@
+import type { TurnStreamHandle } from "./streamManager";
+import type { StreamEndEvent } from "@/common/types/stream";
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { EventEmitter } from "events";
 import type { AIService } from "./aiService";
@@ -1155,10 +1157,10 @@ describe("AgentSession goal safety hooks", () => {
     aiService: AIService & EventEmitter,
     workspaceId: string,
     messageId: string,
-    parts: unknown[],
+    parts: StreamEndEvent["parts"],
     options?: { finishReason?: string }
-  ): void {
-    aiService.emit("stream-end", {
+  ): TurnStreamHandle {
+    const payload: StreamEndEvent = {
       type: "stream-end",
       workspaceId,
       messageId,
@@ -1172,7 +1174,16 @@ describe("AgentSession goal safety hooks", () => {
         // exercise truncated / non-stop paths.
         finishReason: options?.finishReason ?? "stop",
       },
+    };
+    aiService.emit("stream-start", {
+      type: "stream-start",
+      workspaceId,
+      messageId,
+      model: "openai:gpt-4o",
+      startTime: Date.now(),
     });
+    aiService.emit("stream-end", payload);
+    return { messageId, completion: Promise.resolve({ status: "completed", streamEnd: payload }) };
   }
 
   test("text-only stream-end during a goal_continuation turn auto-completes the goal", async () => {
@@ -1183,10 +1194,10 @@ describe("AgentSession goal safety hooks", () => {
     await setGoalOk(goalService, { workspaceId, objective: "Wrap things up" });
 
     aiService.streamMessage = mock(() => {
-      emitStreamEnd(aiService, workspaceId, "assistant-silent", [
+      const handle = emitStreamEnd(aiService, workspaceId, "assistant-silent", [
         { type: "text", text: "I believe everything is done already." },
       ]);
-      return Promise.resolve(Ok(createStartedTurnHandle()));
+      return Promise.resolve(Ok(handle));
     }) as unknown as AIService["streamMessage"];
 
     const result = await session.sendMessage("Synthetic continuation", SEND_OPTIONS, {
@@ -1222,7 +1233,7 @@ describe("AgentSession goal safety hooks", () => {
     await setGoalOk(goalService, { workspaceId, objective: "Keep working" });
 
     aiService.streamMessage = mock(() => {
-      emitStreamEnd(aiService, workspaceId, "assistant-acted", [
+      const handle = emitStreamEnd(aiService, workspaceId, "assistant-acted", [
         { type: "text", text: "Let me check the file first." },
         {
           type: "dynamic-tool",
@@ -1233,7 +1244,7 @@ describe("AgentSession goal safety hooks", () => {
           output: { ok: true },
         },
       ]);
-      return Promise.resolve(Ok(createStartedTurnHandle()));
+      return Promise.resolve(Ok(handle));
     }) as unknown as AIService["streamMessage"];
 
     const result = await session.sendMessage("Synthetic continuation", SEND_OPTIONS, {
@@ -1255,10 +1266,10 @@ describe("AgentSession goal safety hooks", () => {
     await setGoalOk(goalService, { workspaceId, objective: "Keep going" });
 
     aiService.streamMessage = mock(() => {
-      emitStreamEnd(aiService, workspaceId, "assistant-text-only", [
+      const handle = emitStreamEnd(aiService, workspaceId, "assistant-text-only", [
         { type: "text", text: "Just thinking out loud." },
       ]);
-      return Promise.resolve(Ok(createStartedTurnHandle()));
+      return Promise.resolve(Ok(handle));
     }) as unknown as AIService["streamMessage"];
 
     // Manual user messages now pause active goals because the goal mode is
@@ -1289,14 +1300,14 @@ describe("AgentSession goal safety hooks", () => {
     await setGoalOk(goalService, { workspaceId, objective: "Keep working" });
 
     aiService.streamMessage = mock(() => {
-      emitStreamEnd(
+      const handle = emitStreamEnd(
         aiService,
         workspaceId,
         "assistant-truncated",
         [{ type: "text", text: "Mid-sentence, then cut off by the token limit" }],
         { finishReason: "length" }
       );
-      return Promise.resolve(Ok(createStartedTurnHandle()));
+      return Promise.resolve(Ok(handle));
     }) as unknown as AIService["streamMessage"];
 
     const result = await session.sendMessage("Synthetic continuation", SEND_OPTIONS, {
@@ -1325,10 +1336,10 @@ describe("AgentSession goal safety hooks", () => {
     });
 
     aiService.streamMessage = mock(() => {
-      emitStreamEnd(aiService, workspaceId, "assistant-paused-silent", [
+      const handle = emitStreamEnd(aiService, workspaceId, "assistant-paused-silent", [
         { type: "text", text: "All wrapped up." },
       ]);
-      return Promise.resolve(Ok(createStartedTurnHandle()));
+      return Promise.resolve(Ok(handle));
     }) as unknown as AIService["streamMessage"];
 
     const result = await session.sendMessage("Synthetic continuation", SEND_OPTIONS, {

--- a/src/node/services/agentSession.postCompactionRefresh.test.ts
+++ b/src/node/services/agentSession.postCompactionRefresh.test.ts
@@ -1,3 +1,4 @@
+import { runSessionTerminalPolicy } from "./agentSession.testHarness";
 import { describe, expect, test, mock, afterEach } from "bun:test";
 import { AgentSession } from "./agentSession";
 import type { Config } from "@/node/config";
@@ -85,7 +86,7 @@ describe("AgentSession post-compaction refresh trigger", () => {
       },
     };
 
-    aiEmitter.emit("stream-end", streamEnd);
+    void runSessionTerminalPolicy(session, aiEmitter, streamEnd);
 
     await waitForCondition(() => {
       expect(onCompactionComplete).toHaveBeenCalledTimes(1);
@@ -109,7 +110,7 @@ describe("AgentSession post-compaction refresh trigger", () => {
       text: "The user prefers concise tests.",
     });
 
-    aiEmitter.emit("stream-end", streamEnd);
+    void runSessionTerminalPolicy(session, aiEmitter, streamEnd);
     await new Promise((resolve) => setTimeout(resolve, 25));
     expect(onCompactionComplete).toHaveBeenCalledTimes(1);
 
@@ -156,7 +157,7 @@ describe("AgentSession post-compaction refresh trigger", () => {
     );
     const decision = session.waitForPendingCompactionCompletionDecision("failed-follow-up-summary");
 
-    aiEmitter.emit("stream-end", {
+    void runSessionTerminalPolicy(session, aiEmitter, {
       type: "stream-end",
       workspaceId,
       messageId: "failed-follow-up-summary",

--- a/src/node/services/agentSession.queueDispatch.test.ts
+++ b/src/node/services/agentSession.queueDispatch.test.ts
@@ -1,3 +1,5 @@
+import type { StreamAbortEvent } from "@/common/types/stream";
+import { runSessionTerminalPolicy } from "./agentSession.testHarness";
 import { describe, expect, mock, spyOn, test } from "bun:test";
 
 import type { MuxMessageMetadata } from "@/common/types/message";
@@ -36,10 +38,7 @@ function streamStartEvent(workspaceId: string): Record<string, unknown> {
   };
 }
 
-function streamAbortEvent(
-  workspaceId: string,
-  abortReason: "system" | "user"
-): Record<string, unknown> {
+function streamAbortEvent(workspaceId: string, abortReason: "system" | "user"): StreamAbortEvent {
   return {
     type: "stream-abort",
     workspaceId,
@@ -384,7 +383,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
       expect(stopStream).not.toHaveBeenCalled();
       expect(sendQueuedMessages).not.toHaveBeenCalled();
 
-      aiEmitter.emit("stream-end", {
+      void runSessionTerminalPolicy(session, aiEmitter, {
         type: "stream-end",
         workspaceId,
         messageId: "assistant-1",
@@ -433,7 +432,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
         abortReason: "system",
       });
 
-      aiEmitter.emit("stream-abort", streamAbortEvent(workspaceId, "system"));
+      void runSessionTerminalPolicy(session, aiEmitter, streamAbortEvent(workspaceId, "system"));
       const didDispatch = await waitForCondition(() => sendQueuedMessages.mock.calls.length > 0);
       expect(didDispatch).toBe(true);
       expect(sendQueuedMessages).toHaveBeenCalledTimes(1);
@@ -610,7 +609,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
 
       // The next turn (e.g. a descendant-task terminal wake) starts and ends.
       aiEmitter.emit("stream-start", streamStartEvent(workspaceId));
-      aiEmitter.emit("stream-end", {
+      void runSessionTerminalPolicy(session, aiEmitter, {
         type: "stream-end",
         workspaceId,
         messageId: "assistant-1",
@@ -1254,7 +1253,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
       const interruptResult = await session.interruptStream();
       expect(interruptResult.success).toBe(true);
       // The native soft-stop can still win the event race after the hard user interrupt.
-      aiEmitter.emit("stream-abort", streamAbortEvent(workspaceId, "system"));
+      void runSessionTerminalPolicy(session, aiEmitter, streamAbortEvent(workspaceId, "system"));
 
       await new Promise((resolve) => setTimeout(resolve, 25));
       expect(sendQueuedMessages).not.toHaveBeenCalled();

--- a/src/node/services/agentSession.startupAutoRetry.test.ts
+++ b/src/node/services/agentSession.startupAutoRetry.test.ts
@@ -1,3 +1,4 @@
+import { runSessionTerminalPolicy } from "./agentSession.testHarness";
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { EventEmitter } from "events";
 import {
@@ -719,7 +720,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(scheduleCalls).toBe(1);
 
     aiStreaming = false;
-    aiEmitter.emit("stream-abort", {
+    void runSessionTerminalPolicy(session, aiEmitter, {
       type: "stream-abort",
       workspaceId,
       messageId: "assistant-1",
@@ -1757,7 +1758,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     privateSession.activeStreamUserMessageId = "user-1";
     privateSession.setTurnPhase("preparing");
 
-    aiEmitter.emit("stream-abort", {
+    void runSessionTerminalPolicy(session, aiEmitter, {
       type: "stream-abort",
       workspaceId,
       messageId: "assistant-1",

--- a/src/node/services/agentSession.testHarness.ts
+++ b/src/node/services/agentSession.testHarness.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from "events";
 import type { WorkspaceChatMessage } from "@/common/orpc/types";
 import { Err, Ok } from "@/common/types/result";
 import type { Config } from "@/node/config";
+import type { StreamEndEvent, StreamAbortEvent } from "@/common/types/stream";
 import type { TurnStreamHandle } from "@/node/services/streamManager";
 import { AgentSession, type AgentSessionAIService } from "@/node/services/agentSession";
 import type { CompactionCompletionMetadata } from "@/common/types/compaction";
@@ -30,6 +31,32 @@ export function createFailedTurnHandle(
       streamError: { messageId, ...failure },
     }),
   };
+}
+
+/**
+ * Isolated terminal-policy tests with no engine. Lifecycle tests must instead
+ * return controllable handles through streamMessage (see turnCompletion.test.ts).
+ */
+export function runSessionTerminalPolicy(
+  session: AgentSession,
+  emitter: EventEmitter,
+  payload: StreamEndEvent | StreamAbortEvent
+): Promise<void> {
+  const policy = session as unknown as {
+    handleTurnSuccess(payload: StreamEndEvent): Promise<void>;
+    handleTurnAbort(payload: StreamAbortEvent, systemMessageTokens?: number): Promise<void>;
+    streamManager: {
+      getStreamInfo(
+        workspaceId: string
+      ): { initialMetadata?: { systemMessageTokens?: number } } | undefined;
+    };
+  };
+  const systemMessageTokens = policy.streamManager.getStreamInfo(payload.workspaceId)
+    ?.initialMetadata?.systemMessageTokens;
+  emitter.emit(payload.type, payload);
+  return payload.type === "stream-end"
+    ? policy.handleTurnSuccess(payload)
+    : policy.handleTurnAbort(payload, systemMessageTokens);
 }
 
 function createAgentSessionTestConfig(sessionDir = "/tmp"): Config {

--- a/src/node/services/agentSession.testHarness.ts
+++ b/src/node/services/agentSession.testHarness.ts
@@ -6,7 +6,11 @@ import { Err, Ok } from "@/common/types/result";
 import type { Config } from "@/node/config";
 import type { StreamEndEvent, StreamAbortEvent } from "@/common/types/stream";
 import type { TurnStreamHandle } from "@/node/services/streamManager";
-import { AgentSession, type AgentSessionAIService } from "@/node/services/agentSession";
+import {
+  AgentSession,
+  type AgentSessionAIService,
+  type AgentSessionStreamManager,
+} from "@/node/services/agentSession";
 import type { CompactionCompletionMetadata } from "@/common/types/compaction";
 import type { BackgroundProcessManager } from "@/node/services/backgroundProcessManager";
 import type { WorkspaceGoalService } from "@/node/services/workspaceGoalService";
@@ -128,6 +132,7 @@ export interface AgentSessionHarnessOptions {
   config?: Config;
   historyService?: HistoryService;
   aiService?: AgentSessionAIService;
+  streamManager?: AgentSessionStreamManager;
   aiEmitter?: EventEmitter;
   aiServiceOverrides?: Partial<AgentSessionAIService>;
   initStateManager?: InitStateManager;
@@ -176,6 +181,7 @@ export async function createAgentSessionHarness(
     config,
     historyService,
     aiService,
+    streamManager: options.streamManager,
     mcpServerManager: options.mcpServerManager,
     initStateManager,
     workspaceGoalService: options.workspaceGoalService,

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -4284,7 +4284,7 @@ export class AgentSession {
           return Ok(undefined);
         }
 
-        // Terminal turn-phase transitions are driven by handle completion.
+        // Raw terminals reserve COMPLETING; delivered completion runs terminal policy.
         const streamResult = await this.streamWithHistory(
           modelForStream,
           optionsForStream,
@@ -5468,14 +5468,19 @@ export class AgentSession {
               break;
             case "aborted":
               if (outcome.streamAbort) {
-                await this.handleTurnAbort(
-                  {
-                    ...outcome.streamAbort,
-                    messageId: handle.messageId,
-                    abortReason: outcome.abortReason,
-                  },
-                  outcome.systemMessageTokens
-                );
+                const payload = {
+                  ...outcome.streamAbort,
+                  messageId: handle.messageId,
+                  abortReason: outcome.abortReason,
+                };
+                if (operation.started) {
+                  await this.handleTurnAbort(payload, outcome.systemMessageTokens);
+                } else if (!operation.startupAbortNotified) {
+                  // A registered engine can abort during envelope preparation, before
+                  // provider startup. Preserve startup policy: no accounting or compaction.
+                  operation.startupAbortNotified = true;
+                  await this.handleStartupAbort(payload);
+                }
               }
               break;
           }
@@ -6357,6 +6362,21 @@ export class AgentSession {
     this.emitChatEvent(payload);
   }
 
+  private markStartedTurnCompleting(messageId: string): void {
+    const operation = this.activeTurnOperation;
+    if (
+      operation?.started &&
+      operation.messageId === messageId &&
+      !operation.consumed &&
+      this.isCurrentTurnOperation(operation) &&
+      this.turnPhase === TurnPhase.STREAMING
+    ) {
+      // Raw terminal observers can initiate edits before engine cleanup settles.
+      // Make those edits wait for completion instead of stopping an already-ended stream.
+      this.setTurnPhase(TurnPhase.COMPLETING);
+    }
+  }
+
   private async handleTurnAbort(
     payload: StreamAbortEvent,
     systemMessageTokens?: number
@@ -6883,6 +6903,7 @@ export class AgentSession {
         if (operation) operation.startupAbortNotified = true;
         return this.handleStartupAbort(payload);
       }
+      this.markStartedTurnCompleting(payload.messageId);
     });
     forward("runtime-status", (payload) => {
       if (payload.type === "runtime-status") {
@@ -6903,6 +6924,8 @@ export class AgentSession {
       ) {
         this.beginCompactionCompletionDecision(payload.messageId);
       }
+      // Register the decision before this transition emits a reentrant lifecycle event.
+      this.markStartedTurnCompleting(payload.messageId);
     });
 
     const errorHandler = (...args: unknown[]) => {

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -123,6 +123,7 @@ import {
   type RuntimeStatusEvent,
   type StreamAbortReason,
   type StreamEndEvent,
+  type StreamAbortEvent,
   type StreamLifecycleSnapshot,
 } from "@/common/types/stream";
 import type { GoalStreamOriginKind, WorkspaceGoalService } from "./workspaceGoalService";
@@ -871,6 +872,15 @@ export class AgentSession {
   /** Tracks whether the current stream included post-compaction attachments. */
   private activeStreamHadPostCompactionInjection = false;
 
+  // Registered before streamMessage: mock/simulation terminals can arrive before its handle.
+  private activeTurnOperation?: {
+    messageId?: string;
+    consumed: boolean;
+    startupMessageId?: string;
+    startupAbortNotified: boolean;
+    compaction: boolean;
+  };
+
   /**
    * muxMetadata of the queued entry currently being dispatched, held from
    * dequeue until its sendMessage settles (the stream has started or failed).
@@ -1079,6 +1089,12 @@ export class AgentSession {
       return;
     }
     this.disposed = true;
+    for (const messageId of this.compactionCompletionDecisions.keys()) {
+      this.resolveCompactionCompletionDecision(messageId, false);
+    }
+    for (const messageId of this.streamErrorRecoveryDecisions.keys()) {
+      this.resolveStreamErrorRecoveryDecision(messageId, "terminal");
+    }
     this.continuousCompactor.reset("dispose");
 
     this.activePreparedTurnAbortController?.abort();
@@ -3551,6 +3567,8 @@ export class AgentSession {
           const abortController = this.activePreparedTurnAbortController;
           this.activePreparedTurnAbortController = null;
           abortController.abort();
+          // Editing now owns history, even before its replacement reaches PREPARING.
+          this.activeTurnOperation = undefined;
           this.setTurnPhase(TurnPhase.IDLE);
           preemptedPreparing = true;
         }
@@ -4263,7 +4281,7 @@ export class AgentSession {
           return Ok(undefined);
         }
 
-        // Turn-phase transitions for success are driven by stream events.
+        // Terminal turn-phase transitions are driven by handle completion.
         const streamResult = await this.streamWithHistory(
           modelForStream,
           optionsForStream,
@@ -5404,16 +5422,45 @@ export class AgentSession {
     return { success: false, error, failureHandled: true };
   }
 
-  private consumeTurnCompletion(handle: TurnStreamHandle): void {
-    void handle.completion
-      .then(async (outcome) => {
-        // A disposed session must not persist retry/goal state post-teardown.
-        if (outcome.status !== "failed" || this.disposed) return;
+  private isCurrentTurnOperation(operation: AgentSession["activeTurnOperation"]): boolean {
+    return !this.disposed && this.activeTurnOperation === operation;
+  }
 
+  private consumeTurnCompletion(
+    handle: TurnStreamHandle,
+    operation: NonNullable<AgentSession["activeTurnOperation"]>
+  ): Promise<void> {
+    // Never join terminal policy from the engine sink: a follow-up may await the
+    // old processingPromise. Completion is delivered only after engine cleanup.
+    return handle.completion
+      .then(async (outcome) => {
+        if (operation.consumed) return;
+        operation.consumed = true;
         try {
-          await this.handleStreamError(outcome.streamError);
+          if (!this.isCurrentTurnOperation(operation)) return;
+          switch (outcome.status) {
+            case "failed":
+              await this.handleStreamError({ ...outcome.streamError, messageId: handle.messageId });
+              break;
+            case "completed":
+              await this.handleTurnSuccess({ ...outcome.streamEnd, messageId: handle.messageId });
+              break;
+            case "aborted":
+              if (outcome.streamAbort) {
+                await this.handleTurnAbort(
+                  {
+                    ...outcome.streamAbort,
+                    messageId: handle.messageId,
+                    abortReason: outcome.abortReason,
+                  },
+                  outcome.systemMessageTokens
+                );
+              }
+              break;
+          }
         } finally {
-          this.resolveStreamErrorRecoveryDecision(outcome.streamError.messageId, "terminal");
+          this.resolveStreamErrorRecoveryDecision(handle.messageId, "terminal");
+          this.resolveCompactionCompletionDecision(handle.messageId, false);
         }
       })
       .catch((error: unknown) => {
@@ -5447,6 +5494,13 @@ export class AgentSession {
     if (isStreamStartAborted()) {
       return Ok(undefined);
     }
+
+    const operation: NonNullable<AgentSession["activeTurnOperation"]> = {
+      consumed: false,
+      startupAbortNotified: false,
+      compaction: false,
+    };
+    this.activeTurnOperation = operation;
 
     // Reset per-stream flags (used for retries / crash-safe bookkeeping).
     this.compactionMonitor.resetForNewStream();
@@ -5642,6 +5696,7 @@ export class AgentSession {
     // emit an error event for fire-and-forget senders and then return Err;
     // collect them so the Err path resolves each exactly once.
     const preStartErrors: StreamErrorPayload[] = [];
+    operation.compaction = this.activeCompactionRequest != null;
     const streamResult = await this.aiService.streamMessage({
       messages: requestMessages,
       workspaceId: this.workspaceId,
@@ -5680,9 +5735,18 @@ export class AgentSession {
       minThinkingLevel,
       activeTurnThinkingOverride,
       onPreStartError: ({ workspaceId: _workspaceId, ...payload }) => preStartErrors.push(payload),
+      onStreamStarting: (messageId) => {
+        operation.startupMessageId = messageId;
+      },
     });
 
     if (!streamResult.success) {
+      if (!this.isCurrentTurnOperation(operation)) {
+        for (const payload of preStartErrors) {
+          this.resolveStreamErrorRecoveryDecision(payload.messageId, "terminal");
+        }
+        return { success: false, error: streamResult.error, failureHandled: true };
+      }
       return await this.handleStreamWithHistoryFailure(
         streamResult.error,
         acpPromptId,
@@ -5690,7 +5754,8 @@ export class AgentSession {
       );
     }
 
-    this.consumeTurnCompletion(streamResult.data);
+    operation.messageId = streamResult.data.messageId;
+    void this.consumeTurnCompletion(streamResult.data, operation);
     return Ok(undefined);
   }
 
@@ -6180,6 +6245,7 @@ export class AgentSession {
   }
 
   private async handleStreamError(data: StreamErrorPayload): Promise<void> {
+    const operation = this.activeTurnOperation;
     this.setTurnPhase(TurnPhase.COMPLETING);
 
     this.queuedProviderToolEndAbortInFlight = false;
@@ -6210,6 +6276,7 @@ export class AgentSession {
     this.setTerminalStreamLifecycle("failed");
     this.terminalStreamError = streamErrorMessage;
     await this.restoreGoalAccountingSnapshot();
+    if (!this.isCurrentTurnOperation(operation)) return;
     this.activeCompactionRequest = undefined;
     this.resetActiveStreamState();
 
@@ -6221,11 +6288,319 @@ export class AgentSession {
       type: failureType,
       message: data.error,
     });
+    if (!this.isCurrentTurnOperation(operation)) return;
     await this.updateStartupAutoRetryAbandonFromFailure(failureType, failedUserMessageId);
+    if (!this.isCurrentTurnOperation(operation)) return;
     this.resolveStreamErrorRecoveryDecision(data.messageId, "terminal");
 
     this.emitChatEvent(streamErrorMessage);
     this.setTurnPhase(TurnPhase.IDLE);
+  }
+
+  private async handleStartupAbort(payload: StreamAbortEvent): Promise<void> {
+    const operation = this.activeTurnOperation;
+    log.debug("Forwarding stream-abort without phase transition (not in STREAMING)", {
+      workspaceId: this.workspaceId,
+      turnPhase: this.turnPhase,
+    });
+
+    const preStreamAbortReason = "abortReason" in payload ? payload.abortReason : undefined;
+    if (this.turnPhase === TurnPhase.PREPARING) {
+      this.clearPreparingRuntimeStatus();
+      this.setTerminalStreamLifecycle("interrupted", {
+        abortReason: preStreamAbortReason,
+        hadAnyOutput: false,
+      });
+    }
+    if (preStreamAbortReason === "user") {
+      await this.workspaceGoalService?.recordUserStoppedStream(this.workspaceId);
+      if (!this.isCurrentTurnOperation(operation)) return;
+    }
+    await this.updateStartupAutoRetryAbandonFromAbort(
+      preStreamAbortReason,
+      this.activeStreamUserMessageId
+    );
+    if (!this.isCurrentTurnOperation(operation)) return;
+
+    this.queuedProviderToolEndAbortInFlight = false;
+    this.activeToolCallIds.clear();
+    this.emitChatEvent(payload);
+  }
+
+  private async handleTurnAbort(
+    payload: StreamAbortEvent,
+    systemMessageTokens?: number
+  ): Promise<void> {
+    const operation = this.activeTurnOperation;
+    this.setTurnPhase(TurnPhase.COMPLETING);
+    const activeModelForAbort = this.activeStreamContext?.modelString;
+    const activeOptionsForAbort = this.activeStreamContext?.options;
+    this.lastSystemMessageTokens = systemMessageTokens ?? this.lastSystemMessageTokens;
+    if (activeModelForAbort) {
+      this.updateUsageStateFromModelUsage({
+        model: activeModelForAbort,
+        usage: payload.metadata?.contextUsage,
+        providerMetadata:
+          payload.metadata?.contextProviderMetadata ?? payload.metadata?.providerMetadata,
+        live: false,
+      });
+    }
+    this.clearLiveUsageState();
+
+    const failedUserMessageId = this.activeStreamUserMessageId;
+    const hadCompactionRequest = this.activeCompactionRequest !== undefined;
+    const abortReason = "abortReason" in payload ? payload.abortReason : undefined;
+    const isQueuedProviderToolEndAbort =
+      this.queuedProviderToolEndAbortInFlight && abortReason !== "user";
+    if (abortReason === "user") {
+      await this.workspaceGoalService?.recordUserStoppedStream(this.workspaceId);
+      if (!this.isCurrentTurnOperation(operation)) return;
+    }
+    if (activeModelForAbort) {
+      // Forward goalKind / agentInitiated from the active stream context so
+      // an interrupted continuation/wrap stream is correctly classified
+      // as `goal_continuation` / `goal_budget_limit` and counts toward
+      // the turn cap. Without this, getGoalStreamOriginKind falls back to
+      // `"user"` and the interrupted synthetic turn would not consume a
+      // turn, under-enforcing limits (Codex P2 PRRT_kwDOPxxmWM5_t9Bu).
+      await this.recordGoalAccountingFromUsage({
+        model: activeModelForAbort,
+        usage: payload.metadata?.usage,
+        providerMetadata: payload.metadata?.providerMetadata,
+        goalKind: this.activeStreamContext?.goalKind,
+        agentInitiated: this.activeStreamContext?.agentInitiated,
+        isCompaction: hadCompactionRequest,
+      });
+      if (!this.isCurrentTurnOperation(operation)) return;
+    }
+    if (abortReason !== "user") {
+      await this.workspaceGoalService?.applyPendingAfterStreamEnd(this.workspaceId);
+      if (!this.isCurrentTurnOperation(operation)) return;
+    }
+    this.setTerminalStreamLifecycle("interrupted", { abortReason });
+    this.activeCompactionRequest = undefined;
+    this.resetActiveStreamState();
+    if (!hadCompactionRequest && activeModelForAbort && !this.continuousCompactionAbandoned) {
+      await this.observeContinuousCompactionAtStreamEnd(activeModelForAbort, activeOptionsForAbort);
+      if (!this.isCurrentTurnOperation(operation)) return;
+    }
+    if (hadCompactionRequest && !this.disposed) {
+      this.clearQueue();
+    }
+    if (!isQueuedProviderToolEndAbort) {
+      await this.handleStreamFailureForAutoRetry({
+        type: "aborted",
+        message: abortReason,
+      });
+      if (!this.isCurrentTurnOperation(operation)) return;
+    }
+    await this.updateStartupAutoRetryAbandonFromAbort(abortReason, failedUserMessageId);
+    if (!this.isCurrentTurnOperation(operation)) return;
+    this.emitChatEvent(payload);
+    const dispatchedQueuedMessage =
+      !this.midStreamCompactionPending &&
+      !this.continuousCompactor.isApplying() &&
+      this.dispatchQueuedProviderToolEndMessageAfterAbort(abortReason);
+    if (!dispatchedQueuedMessage) {
+      this.setTurnPhase(TurnPhase.IDLE);
+    }
+  }
+
+  private async handleTurnSuccess(payload: StreamEndEvent): Promise<void> {
+    const operation = this.activeTurnOperation;
+    this.setTurnPhase(TurnPhase.COMPLETING);
+    this.retryManager.handleStreamSuccess();
+    await this.clearStartupAutoRetryAbandon();
+    if (!this.isCurrentTurnOperation(operation)) return;
+
+    const streamEndPayload = payload;
+    const activeStreamGoalKind = this.activeStreamContext?.goalKind;
+    const activeStreamOptions = this.activeStreamContext?.options;
+
+    let goalContinuationRequest: {
+      sendOptions: SendMessageOptions;
+      streamEndedAtMs: number;
+    } | null = null;
+    let emittedStreamEnd = false;
+    const completedCompactionRequest = this.activeCompactionRequest;
+    let continuedAfterCompaction = false;
+
+    try {
+      this.activeCompactionRequest = undefined;
+      this.lastSystemMessageTokens =
+        streamEndPayload.metadata.systemMessageTokens ?? this.lastSystemMessageTokens;
+      this.updateUsageStateFromModelUsage({
+        model: streamEndPayload.metadata.model,
+        usage: streamEndPayload.metadata.contextUsage,
+        providerMetadata:
+          streamEndPayload.metadata.contextProviderMetadata ??
+          streamEndPayload.metadata.providerMetadata,
+        live: false,
+      });
+      this.clearLiveUsageState();
+
+      const handled = await this.compactionHandler.handleCompletion(
+        streamEndPayload,
+        completedCompactionRequest?.id
+      );
+      if (!this.isCurrentTurnOperation(operation)) return;
+
+      await this.recordGoalAccountingFromUsage({
+        model: streamEndPayload.metadata.model,
+        usage: streamEndPayload.metadata.usage,
+        providerMetadata: streamEndPayload.metadata.providerMetadata,
+        metadataModel: streamEndPayload.metadata.metadataModel,
+        goalKind: this.activeStreamContext?.goalKind,
+        agentInitiated: this.activeStreamContext?.agentInitiated,
+        isCompaction: handled,
+      });
+      if (!this.isCurrentTurnOperation(operation)) return;
+      await this.workspaceGoalService?.applyPendingAfterStreamEnd(this.workspaceId);
+      if (!this.isCurrentTurnOperation(operation)) return;
+
+      if (!handled) {
+        this.emitChatEvent(payload);
+        emittedStreamEnd = true;
+
+        if (this.ackPendingPostCompactionStateOnStreamEnd) {
+          this.ackPendingPostCompactionStateOnStreamEnd = false;
+          try {
+            await this.compactionHandler.ackPendingStateConsumed();
+            if (!this.isCurrentTurnOperation(operation)) return;
+          } catch (error) {
+            log.warn("Failed to ack pending post-compaction state", {
+              workspaceId: this.workspaceId,
+              error: getErrorMessage(error),
+            });
+          }
+          this.onPostCompactionStateChange?.();
+        }
+      } else {
+        // CompactionHandler emits its own sanitized stream-end; mark as handled
+        // so the catch block doesn't re-emit the unsanitized original payload.
+        emittedStreamEnd = true;
+
+        // Compaction collapses history to a boundary summary, so prior context-usage snapshots
+        // are stale. Clear them to prevent immediate re-trigger loops on the follow-up turn.
+        this.clearUsageState();
+
+        if (completedCompactionRequest?.source === "auto-compaction") {
+          this.emitChatEvent({
+            type: "auto-compaction-completed",
+            newUsagePercent: 0,
+          });
+        }
+      }
+
+      // IMPORTANT: reset BEFORE anything that can start a new stream,
+      // so the next turn doesn't get its state clobbered by our cleanup.
+      this.resetActiveStreamState();
+      if (!handled && !completedCompactionRequest) {
+        await this.observeContinuousCompactionAtStreamEnd(
+          streamEndPayload.metadata.model,
+          activeStreamOptions
+        );
+        if (!this.isCurrentTurnOperation(operation)) return;
+      }
+
+      if (handled) {
+        // Dispatch follow-up AFTER reset so it can set its own stream state. Child lifecycle
+        // settlement defers only when this durable continuation was actually accepted.
+        // RLM keep-recent floor: when tail copies were appended the summary is
+        // not the last row, so target it by ID (stashed in onCompactionComplete).
+        const rlmSummaryId = this.pendingCompactionFollowUpSummaryId;
+        this.pendingCompactionFollowUpSummaryId = null;
+        continuedAfterCompaction = await this.dispatchPendingFollowUp(rlmSummaryId ?? undefined);
+        if (!this.isCurrentTurnOperation(operation)) return;
+      }
+
+      // Stream end: auto-send queued messages (for user messages typed during streaming)
+      // and suppress goal continuations for external slash workflow follow-ups waiting on idle.
+      // P2: if an edit is waiting, skip the queue flush so the edit truncates first.
+      const hadQueuedMessages = this.hasPendingManualFollowUp();
+      const continuousApplyPending =
+        this.midStreamCompactionPending || this.continuousCompactor.isApplying();
+      if (this.deferQueuedFlushUntilAfterEdit || continuousApplyPending) {
+        this.queuedProviderToolEndAbortInFlight = false;
+        // Clear the queued-message signal while the edit flow owns the next dispatch.
+        this.backgroundProcessManager.setMessageQueued(this.workspaceId, false);
+        // Do not dispatch stream-end follow-ups while the edit flow is waiting
+        // for IDLE; truncation must run before any synthetic turn resumes.
+      } else {
+        this.sendQueuedMessages();
+      }
+
+      if (
+        !handled &&
+        !this.deferQueuedFlushUntilAfterEdit &&
+        !continuousApplyPending &&
+        !hadQueuedMessages
+      ) {
+        const sendOptions = activeStreamOptions ?? {
+          model: streamEndPayload.metadata.model,
+          agentId: WORKSPACE_DEFAULTS.agentId,
+        };
+        if (sendOptions.agentId !== "plan" && sendOptions.agentId !== "compact") {
+          // If a `goal_continuation` turn ended without any tool calls,
+          // interpret the text-only finish as an implicit `complete_goal`.
+          // The continuation prompt asks the agent to call `complete_goal`
+          // explicitly, but real models sometimes finish with a plain
+          // "looks done" reply instead — without this fallback the
+          // continuation loop would re-fire on the same idle output until
+          // budget/cooldown gates intervene. We restrict to continuation
+          // turns (not user messages, not budget-limit wrap-ups) so a
+          // user's first manual turn answered with text is never
+          // mistaken for completion. `requestContinuationAfterStreamEnd`
+          // below safely no-ops once the goal flips to `complete`.
+          if (activeStreamGoalKind === GOAL_CONTINUATION_KIND) {
+            await this.maybeAutoCompleteGoalFromSilentContinuation(streamEndPayload);
+            if (!this.isCurrentTurnOperation(operation)) return;
+          }
+
+          goalContinuationRequest = {
+            sendOptions,
+            streamEndedAtMs: Date.now(),
+          };
+        }
+      }
+    } catch (error) {
+      const streamEndCleanupError = getErrorMessage(error);
+      log.error("stream-end cleanup failed", {
+        workspaceId: this.workspaceId,
+        error: streamEndCleanupError,
+      });
+
+      // Defense-in-depth: unblock renderer if compaction handler threw before we emitted.
+      if (this.isCurrentTurnOperation(operation) && !emittedStreamEnd) {
+        try {
+          this.emitChatEvent(payload);
+        } catch {
+          // Best-effort; don't mask the original error.
+        }
+      }
+    } finally {
+      if (completedCompactionRequest != null) {
+        this.resolveCompactionCompletionDecision(
+          streamEndPayload.messageId,
+          continuedAfterCompaction
+        );
+      }
+
+      // Only clean up if we're still in COMPLETING — a new turn started by
+      // dispatchPendingFollowUp() or sendQueuedMessages()
+      // owns the stream state now.
+      if (this.isCurrentTurnOperation(operation) && this.turnPhase === TurnPhase.COMPLETING) {
+        this.resetActiveStreamState();
+        this.setTurnPhase(TurnPhase.IDLE);
+        if (goalContinuationRequest != null) {
+          await this.workspaceGoalService?.requestContinuationAfterStreamEnd({
+            workspaceId: this.workspaceId,
+            sendOptions: goalContinuationRequest.sendOptions,
+            streamEndedAtMs: goalContinuationRequest.streamEndedAtMs,
+          });
+        }
+      }
+    }
   }
 
   private attachAiListeners(): void {
@@ -6251,6 +6626,9 @@ export class AgentSession {
 
     forward("stream-start", (payload) => {
       if (payload.type === "stream-start") {
+        if (this.activeTurnOperation && !this.activeTurnOperation.consumed) {
+          this.activeTurnOperation.messageId = payload.messageId;
+        }
         this.continuousCompactionAbandoned = false;
         this.dispatchingQueuedEntry = false;
         this.dispatchingQueuedEntryMuxMetadata = undefined;
@@ -6461,117 +6839,18 @@ export class AgentSession {
         await this.interruptForCompaction();
       }
     });
-    forward("stream-abort", async (payload) => {
-      if (payload.type !== "stream-abort") {
-        this.emitChatEvent(payload);
-        return;
-      }
-
-      // stopStream() emits synthetic aborts even when no real stream is active
-      // (e.g., during PREPARING or after COMPLETING). We must still forward the
-      // event to the renderer so it clears "starting…" / "interrupting…" UI, but
-      // we must NOT clobber the turn phase or reset stream state — the originating
-      // code path handles its own transition back to IDLE:
-      //   PREPARING → sendMessage error handler / sendQueuedMessages .then() handler
-      //   COMPLETING → stream-end finally block
-      if (this.turnPhase !== TurnPhase.STREAMING) {
-        log.debug("Forwarding stream-abort without phase transition (not in STREAMING)", {
-          workspaceId: this.workspaceId,
-          turnPhase: this.turnPhase,
-        });
-
-        const preStreamAbortReason = "abortReason" in payload ? payload.abortReason : undefined;
-        if (this.turnPhase === TurnPhase.PREPARING) {
-          this.clearPreparingRuntimeStatus();
-          this.setTerminalStreamLifecycle("interrupted", {
-            abortReason: preStreamAbortReason,
-            hadAnyOutput: false,
-          });
-        }
-        if (preStreamAbortReason === "user") {
-          await this.workspaceGoalService?.recordUserStoppedStream(this.workspaceId);
-        }
-        await this.updateStartupAutoRetryAbandonFromAbort(
-          preStreamAbortReason,
-          this.activeStreamUserMessageId
-        );
-
-        this.queuedProviderToolEndAbortInFlight = false;
-        this.activeToolCallIds.clear();
-        this.emitChatEvent(payload);
-        return;
-      }
-
-      this.setTurnPhase(TurnPhase.COMPLETING);
-      const activeModelForAbort = this.activeStreamContext?.modelString;
-      const activeOptionsForAbort = this.activeStreamContext?.options;
-      this.lastSystemMessageTokens =
-        this.streamManager.getStreamInfo(this.workspaceId)?.initialMetadata?.systemMessageTokens ??
-        this.lastSystemMessageTokens;
-      if (activeModelForAbort) {
-        this.updateUsageStateFromModelUsage({
-          model: activeModelForAbort,
-          usage: payload.metadata?.contextUsage,
-          providerMetadata:
-            payload.metadata?.contextProviderMetadata ?? payload.metadata?.providerMetadata,
-          live: false,
-        });
-      }
-      this.clearLiveUsageState();
-
-      const failedUserMessageId = this.activeStreamUserMessageId;
-      const hadCompactionRequest = this.activeCompactionRequest !== undefined;
-      const abortReason = "abortReason" in payload ? payload.abortReason : undefined;
-      const isQueuedProviderToolEndAbort =
-        this.queuedProviderToolEndAbortInFlight && abortReason !== "user";
-      if (abortReason === "user") {
-        await this.workspaceGoalService?.recordUserStoppedStream(this.workspaceId);
-      }
-      if (activeModelForAbort) {
-        // Forward goalKind / agentInitiated from the active stream context so
-        // an interrupted continuation/wrap stream is correctly classified
-        // as `goal_continuation` / `goal_budget_limit` and counts toward
-        // the turn cap. Without this, getGoalStreamOriginKind falls back to
-        // `"user"` and the interrupted synthetic turn would not consume a
-        // turn, under-enforcing limits (Codex P2 PRRT_kwDOPxxmWM5_t9Bu).
-        await this.recordGoalAccountingFromUsage({
-          model: activeModelForAbort,
-          usage: payload.metadata?.usage,
-          providerMetadata: payload.metadata?.providerMetadata,
-          goalKind: this.activeStreamContext?.goalKind,
-          agentInitiated: this.activeStreamContext?.agentInitiated,
-          isCompaction: hadCompactionRequest,
-        });
-      }
-      if (abortReason !== "user") {
-        await this.workspaceGoalService?.applyPendingAfterStreamEnd(this.workspaceId);
-      }
-      this.setTerminalStreamLifecycle("interrupted", { abortReason });
-      this.activeCompactionRequest = undefined;
-      this.resetActiveStreamState();
-      if (!hadCompactionRequest && activeModelForAbort && !this.continuousCompactionAbandoned) {
-        await this.observeContinuousCompactionAtStreamEnd(
-          activeModelForAbort,
-          activeOptionsForAbort
-        );
-      }
-      if (hadCompactionRequest && !this.disposed) {
-        this.clearQueue();
-      }
-      if (!isQueuedProviderToolEndAbort) {
-        await this.handleStreamFailureForAutoRetry({
-          type: "aborted",
-          message: abortReason,
-        });
-      }
-      await this.updateStartupAutoRetryAbandonFromAbort(abortReason, failedUserMessageId);
-      this.emitChatEvent(payload);
-      const dispatchedQueuedMessage =
-        !this.midStreamCompactionPending &&
-        !this.continuousCompactor.isApplying() &&
-        this.dispatchQueuedProviderToolEndMessageAfterAbort(abortReason);
-      if (!dispatchedQueuedMessage) {
-        this.setTurnPhase(TurnPhase.IDLE);
+    forward("stream-abort", (payload) => {
+      if (payload.type !== "stream-abort") return;
+      const operation = this.activeTurnOperation;
+      // Only the facade's synthetic startup identity (or an empty no-stream ID)
+      // is handleless. A registered STARTING engine may abort before stream-start;
+      // its assistant-ID event still belongs exclusively to delivered completion.
+      if (
+        !payload.messageId ||
+        (operation?.startupMessageId === payload.messageId && !operation.startupAbortNotified)
+      ) {
+        if (operation) operation.startupAbortNotified = true;
+        return this.handleStartupAbort(payload);
       }
     });
     forward("runtime-status", (payload) => {
@@ -6581,199 +6860,17 @@ export class AgentSession {
       this.emitChatEvent(payload);
     });
 
-    forward("stream-end", async (payload) => {
-      if (payload.type !== "stream-end") {
-        this.emitChatEvent(payload);
-        return;
-      }
-
-      this.setTurnPhase(TurnPhase.COMPLETING);
-      this.retryManager.handleStreamSuccess();
-      await this.clearStartupAutoRetryAbandon();
-
-      const streamEndPayload = payload;
-      const activeStreamGoalKind = this.activeStreamContext?.goalKind;
-      const activeStreamOptions = this.activeStreamContext?.options;
-
-      let goalContinuationRequest: {
-        sendOptions: SendMessageOptions;
-        streamEndedAtMs: number;
-      } | null = null;
-      let emittedStreamEnd = false;
-      const completedCompactionRequest = this.activeCompactionRequest;
-      let continuedAfterCompaction = false;
-
-      try {
-        this.activeCompactionRequest = undefined;
-        if (completedCompactionRequest != null) {
-          this.beginCompactionCompletionDecision(streamEndPayload.messageId);
-        }
-        this.lastSystemMessageTokens =
-          streamEndPayload.metadata.systemMessageTokens ?? this.lastSystemMessageTokens;
-        this.updateUsageStateFromModelUsage({
-          model: streamEndPayload.metadata.model,
-          usage: streamEndPayload.metadata.contextUsage,
-          providerMetadata:
-            streamEndPayload.metadata.contextProviderMetadata ??
-            streamEndPayload.metadata.providerMetadata,
-          live: false,
-        });
-        this.clearLiveUsageState();
-
-        const handled = await this.compactionHandler.handleCompletion(
-          streamEndPayload,
-          completedCompactionRequest?.id
-        );
-
-        await this.recordGoalAccountingFromUsage({
-          model: streamEndPayload.metadata.model,
-          usage: streamEndPayload.metadata.usage,
-          providerMetadata: streamEndPayload.metadata.providerMetadata,
-          metadataModel: streamEndPayload.metadata.metadataModel,
-          goalKind: this.activeStreamContext?.goalKind,
-          agentInitiated: this.activeStreamContext?.agentInitiated,
-          isCompaction: handled,
-        });
-        await this.workspaceGoalService?.applyPendingAfterStreamEnd(this.workspaceId);
-
-        if (!handled) {
-          this.emitChatEvent(payload);
-          emittedStreamEnd = true;
-
-          if (this.ackPendingPostCompactionStateOnStreamEnd) {
-            this.ackPendingPostCompactionStateOnStreamEnd = false;
-            try {
-              await this.compactionHandler.ackPendingStateConsumed();
-            } catch (error) {
-              log.warn("Failed to ack pending post-compaction state", {
-                workspaceId: this.workspaceId,
-                error: getErrorMessage(error),
-              });
-            }
-            this.onPostCompactionStateChange?.();
-          }
-        } else {
-          // CompactionHandler emits its own sanitized stream-end; mark as handled
-          // so the catch block doesn't re-emit the unsanitized original payload.
-          emittedStreamEnd = true;
-
-          // Compaction collapses history to a boundary summary, so prior context-usage snapshots
-          // are stale. Clear them to prevent immediate re-trigger loops on the follow-up turn.
-          this.clearUsageState();
-
-          if (completedCompactionRequest?.source === "auto-compaction") {
-            this.emitChatEvent({
-              type: "auto-compaction-completed",
-              newUsagePercent: 0,
-            });
-          }
-        }
-
-        // IMPORTANT: reset BEFORE anything that can start a new stream,
-        // so the next turn doesn't get its state clobbered by our cleanup.
-        this.resetActiveStreamState();
-        if (!handled && !completedCompactionRequest) {
-          await this.observeContinuousCompactionAtStreamEnd(
-            streamEndPayload.metadata.model,
-            activeStreamOptions
-          );
-        }
-
-        if (handled) {
-          // Dispatch follow-up AFTER reset so it can set its own stream state. Child lifecycle
-          // settlement defers only when this durable continuation was actually accepted.
-          // RLM keep-recent floor: when tail copies were appended the summary is
-          // not the last row, so target it by ID (stashed in onCompactionComplete).
-          const rlmSummaryId = this.pendingCompactionFollowUpSummaryId;
-          this.pendingCompactionFollowUpSummaryId = null;
-          continuedAfterCompaction = await this.dispatchPendingFollowUp(rlmSummaryId ?? undefined);
-        }
-
-        // Stream end: auto-send queued messages (for user messages typed during streaming)
-        // and suppress goal continuations for external slash workflow follow-ups waiting on idle.
-        // P2: if an edit is waiting, skip the queue flush so the edit truncates first.
-        const hadQueuedMessages = this.hasPendingManualFollowUp();
-        const continuousApplyPending =
-          this.midStreamCompactionPending || this.continuousCompactor.isApplying();
-        if (this.deferQueuedFlushUntilAfterEdit || continuousApplyPending) {
-          this.queuedProviderToolEndAbortInFlight = false;
-          // Clear the queued-message signal while the edit flow owns the next dispatch.
-          this.backgroundProcessManager.setMessageQueued(this.workspaceId, false);
-          // Do not dispatch stream-end follow-ups while the edit flow is waiting
-          // for IDLE; truncation must run before any synthetic turn resumes.
-        } else {
-          this.sendQueuedMessages();
-        }
-
-        if (
-          !handled &&
-          !this.deferQueuedFlushUntilAfterEdit &&
-          !continuousApplyPending &&
-          !hadQueuedMessages
-        ) {
-          const sendOptions = activeStreamOptions ?? {
-            model: streamEndPayload.metadata.model,
-            agentId: WORKSPACE_DEFAULTS.agentId,
-          };
-          if (sendOptions.agentId !== "plan" && sendOptions.agentId !== "compact") {
-            // If a `goal_continuation` turn ended without any tool calls,
-            // interpret the text-only finish as an implicit `complete_goal`.
-            // The continuation prompt asks the agent to call `complete_goal`
-            // explicitly, but real models sometimes finish with a plain
-            // "looks done" reply instead — without this fallback the
-            // continuation loop would re-fire on the same idle output until
-            // budget/cooldown gates intervene. We restrict to continuation
-            // turns (not user messages, not budget-limit wrap-ups) so a
-            // user's first manual turn answered with text is never
-            // mistaken for completion. `requestContinuationAfterStreamEnd`
-            // below safely no-ops once the goal flips to `complete`.
-            if (activeStreamGoalKind === GOAL_CONTINUATION_KIND) {
-              await this.maybeAutoCompleteGoalFromSilentContinuation(streamEndPayload);
-            }
-
-            goalContinuationRequest = {
-              sendOptions,
-              streamEndedAtMs: Date.now(),
-            };
-          }
-        }
-      } catch (error) {
-        const streamEndCleanupError = getErrorMessage(error);
-        log.error("stream-end cleanup failed", {
-          workspaceId: this.workspaceId,
-          error: streamEndCleanupError,
-        });
-
-        // Defense-in-depth: unblock renderer if compaction handler threw before we emitted.
-        if (!emittedStreamEnd) {
-          try {
-            this.emitChatEvent(payload);
-          } catch {
-            // Best-effort; don't mask the original error.
-          }
-        }
-      } finally {
-        if (completedCompactionRequest != null) {
-          this.resolveCompactionCompletionDecision(
-            streamEndPayload.messageId,
-            continuedAfterCompaction
-          );
-        }
-
-        // Only clean up if we're still in COMPLETING — a new turn started by
-        // dispatchPendingFollowUp() or sendQueuedMessages()
-        // owns the stream state now.
-        if (this.turnPhase === TurnPhase.COMPLETING) {
-          this.resetActiveStreamState();
-          this.setTurnPhase(TurnPhase.IDLE);
-          if (goalContinuationRequest != null) {
-            await this.workspaceGoalService?.requestContinuationAfterStreamEnd({
-              workspaceId: this.workspaceId,
-              sendOptions: goalContinuationRequest.sendOptions,
-              streamEndedAtMs: goalContinuationRequest.streamEndedAtMs,
-            });
-          }
-        }
+    forward("stream-end", (payload) => {
+      if (payload.type !== "stream-end") return;
+      const operation = this.activeTurnOperation;
+      // TaskService observes raw events before acquiring its workspace lock. Publish
+      // the decision now, while compaction context and queue attribution still exist.
+      if (
+        operation?.messageId === payload.messageId &&
+        operation.compaction &&
+        !operation.consumed
+      ) {
+        this.beginCompactionCompletionDecision(payload.messageId);
       }
     });
 
@@ -6840,6 +6937,7 @@ export class AgentSession {
 
   private setTurnPhase(next: TurnPhase): void {
     this.turnPhase = next;
+    if (next === TurnPhase.PREPARING) this.activeTurnOperation = undefined;
     this.clearPreparingRuntimeStatus();
 
     if (next !== TurnPhase.IDLE) {
@@ -7411,7 +7509,7 @@ export class AgentSession {
 
   async waitForPendingCompactionCompletionDecision(messageId: string): Promise<boolean> {
     if (!this.compactionCompletionDecisions.has(messageId)) {
-      if (this.activeCompactionRequest == null) return false;
+      if (this.disposed || this.activeCompactionRequest == null) return false;
       this.beginCompactionCompletionDecision(messageId);
     }
     const decision = this.compactionCompletionDecisions.get(messageId);

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -879,6 +879,8 @@ export class AgentSession {
     startupMessageId?: string;
     startupAbortNotified: boolean;
     compaction: boolean;
+    started: boolean;
+    policySettlement: { promise: Promise<void>; resolve: () => void };
   };
 
   /**
@@ -1089,6 +1091,7 @@ export class AgentSession {
       return;
     }
     this.disposed = true;
+    this.activeTurnOperation?.policySettlement.resolve();
     for (const messageId of this.compactionCompletionDecisions.keys()) {
       this.resolveCompactionCompletionDecision(messageId, false);
     }
@@ -3568,7 +3571,7 @@ export class AgentSession {
           this.activePreparedTurnAbortController = null;
           abortController.abort();
           // Editing now owns history, even before its replacement reaches PREPARING.
-          this.activeTurnOperation = undefined;
+          this.clearActiveTurnOperation();
           this.setTurnPhase(TurnPhase.IDLE);
           preemptedPreparing = true;
         }
@@ -5338,6 +5341,16 @@ export class AgentSession {
     abandonPartial?: boolean;
   }): Promise<Result<void>> {
     this.assertNotDisposed("interruptStream");
+    // Send-now callers may replace the turn immediately after this returns. Capture
+    // its settlement before any await so the old abort reaches accounting and the
+    // renderer before replacement PREPARING invalidates its operation identity.
+    // Startup edits must still preempt a blocked envelope; soft stop only requests
+    // a future boundary, so neither joins policy here.
+    const interruptedOperation = this.activeTurnOperation;
+    const interruptedPolicy =
+      options?.soft !== true && interruptedOperation?.started
+        ? interruptedOperation.policySettlement.promise
+        : undefined;
     if (options?.abandonPartial || this.midStreamCompactionPending) {
       this.continuousCompactionAbandoned = true;
       this.continuousCompactor.reset("user-interrupt");
@@ -5369,6 +5382,7 @@ export class AgentSession {
       return Err(stopResult.error);
     }
 
+    await interruptedPolicy;
     return Ok(undefined);
   }
 
@@ -5422,6 +5436,13 @@ export class AgentSession {
     return { success: false, error, failureHandled: true };
   }
 
+  private clearActiveTurnOperation(): void {
+    // A replaced operation may never get a handle back (startup cancellation).
+    // Release any explicit interrupt waiter when ownership is relinquished.
+    this.activeTurnOperation?.policySettlement.resolve();
+    this.activeTurnOperation = undefined;
+  }
+
   private isCurrentTurnOperation(operation: AgentSession["activeTurnOperation"]): boolean {
     return !this.disposed && this.activeTurnOperation === operation;
   }
@@ -5461,9 +5482,11 @@ export class AgentSession {
         } finally {
           this.resolveStreamErrorRecoveryDecision(handle.messageId, "terminal");
           this.resolveCompactionCompletionDecision(handle.messageId, false);
+          operation.policySettlement.resolve();
         }
       })
       .catch((error: unknown) => {
+        operation.policySettlement.resolve();
         log.error("Failed to consume turn completion", {
           workspaceId: this.workspaceId,
           error: getErrorMessage(error),
@@ -5499,7 +5522,10 @@ export class AgentSession {
       consumed: false,
       startupAbortNotified: false,
       compaction: false,
+      started: false,
+      policySettlement: Promise.withResolvers<void>(),
     };
+    this.clearActiveTurnOperation();
     this.activeTurnOperation = operation;
 
     // Reset per-stream flags (used for retries / crash-safe bookkeeping).
@@ -5741,17 +5767,21 @@ export class AgentSession {
     });
 
     if (!streamResult.success) {
-      if (!this.isCurrentTurnOperation(operation)) {
-        for (const payload of preStartErrors) {
-          this.resolveStreamErrorRecoveryDecision(payload.messageId, "terminal");
+      try {
+        if (!this.isCurrentTurnOperation(operation)) {
+          for (const payload of preStartErrors) {
+            this.resolveStreamErrorRecoveryDecision(payload.messageId, "terminal");
+          }
+          return { success: false, error: streamResult.error, failureHandled: true };
         }
-        return { success: false, error: streamResult.error, failureHandled: true };
+        return await this.handleStreamWithHistoryFailure(
+          streamResult.error,
+          acpPromptId,
+          preStartErrors
+        );
+      } finally {
+        operation.policySettlement.resolve();
       }
-      return await this.handleStreamWithHistoryFailure(
-        streamResult.error,
-        acpPromptId,
-        preStartErrors
-      );
     }
 
     operation.messageId = streamResult.data.messageId;
@@ -6628,6 +6658,7 @@ export class AgentSession {
       if (payload.type === "stream-start") {
         if (this.activeTurnOperation && !this.activeTurnOperation.consumed) {
           this.activeTurnOperation.messageId = payload.messageId;
+          this.activeTurnOperation.started = true;
         }
         this.continuousCompactionAbandoned = false;
         this.dispatchingQueuedEntry = false;
@@ -6937,7 +6968,7 @@ export class AgentSession {
 
   private setTurnPhase(next: TurnPhase): void {
     this.turnPhase = next;
-    if (next === TurnPhase.PREPARING) this.activeTurnOperation = undefined;
+    if (next === TurnPhase.PREPARING) this.clearActiveTurnOperation();
     this.clearPreparingRuntimeStatus();
 
     if (next !== TurnPhase.IDLE) {

--- a/src/node/services/agentSession.turnCompletion.test.ts
+++ b/src/node/services/agentSession.turnCompletion.test.ts
@@ -27,6 +27,7 @@ interface InternalSession {
   consumeTurnCompletion(handle: TurnStreamHandle, operation: Operation): Promise<void>;
   clearStartupAutoRetryAbandon(): Promise<void>;
   recordGoalAccountingFromUsage(input: unknown): Promise<void>;
+  observeContinuousCompactionAtStreamEnd(...args: unknown[]): Promise<void>;
   setTurnPhase(phase: "preparing" | "streaming" | "idle"): void;
   getEditTruncateTargetId(messageId: string): Promise<string>;
 }
@@ -65,7 +66,7 @@ function observePolicy(session: AgentSession) {
 }
 
 describe("AgentSession turn completion", () => {
-  test("raw success is observational; completion uses handle identity and runs policy once", async () => {
+  test("raw success defers policy; completion uses handle identity and runs policy once", async () => {
     const completion = Promise.withResolvers<TurnCompletion>();
     const emitter = new EventEmitter();
     const handle = { messageId: "assistant-1", completion: completion.promise };
@@ -102,56 +103,152 @@ describe("AgentSession turn completion", () => {
     }
   });
 
-  test("delivered abort before stream-start runs once and retains precleanup token context", async () => {
-    const envelopeEntered = Promise.withResolvers<void>();
-    const releaseEnvelope = Promise.withResolvers<void>();
-    const completion = Promise.withResolvers<TurnCompletion>();
-    const emitter = new EventEmitter();
-    const recordUserStoppedStream = mock(() => Promise.resolve());
-    const h = await createAgentSessionHarness({
-      workspaceId,
-      aiEmitter: emitter,
-      captureEvents: true,
-      aiServiceOverrides: {
-        streamMessage: mock(async (opts: StreamMessageOptions) => {
-          opts.onStreamStarting?.("starting-1");
-          envelopeEntered.resolve();
-          await releaseEnvelope.promise;
-          return Ok({ messageId: "assistant-1", completion: completion.promise });
-        }),
-      },
-    });
-    const consumer = observePolicy(h.session);
-    const send = h.session.sendMessage("hello", sendOptions);
-    try {
-      await envelopeEntered.promise;
-      Reflect.set(h.session, "workspaceGoalService", {
-        recordUserStoppedStream,
-        recordStreamAccounting: mock(() => Promise.resolve(null)),
-      } satisfies Partial<WorkspaceGoalService>);
-      emitter.emit("stream-abort", abort());
-      expect(recordUserStoppedStream).not.toHaveBeenCalled();
-      expect(h.events.filter((event) => event.type === "stream-abort")).toHaveLength(0);
-      completion.resolve({
-        status: "aborted",
-        abortReason: "user",
-        streamAbort: abort(),
-        systemMessageTokens: 417,
+  test.each([false, true])(
+    "delivered abort with started=%s applies the matching policy once",
+    async (started) => {
+      const envelopeEntered = Promise.withResolvers<void>();
+      const releaseEnvelope = Promise.withResolvers<void>();
+      const completion = Promise.withResolvers<TurnCompletion>();
+      const emitter = new EventEmitter();
+      const recordUserStoppedStream = mock(() => Promise.resolve());
+      const h = await createAgentSessionHarness({
+        workspaceId,
+        aiEmitter: emitter,
+        captureEvents: true,
+        aiServiceOverrides: {
+          streamMessage: mock(async (opts: StreamMessageOptions) => {
+            opts.onStreamStarting?.("starting-1");
+            if (started) start(emitter);
+            envelopeEntered.resolve();
+            await releaseEnvelope.promise;
+            return Ok({ messageId: "assistant-1", completion: completion.promise });
+          }),
+        },
       });
-      releaseEnvelope.resolve();
-      await send;
-      await policyPromise(consumer);
-      expect(recordUserStoppedStream).toHaveBeenCalledTimes(1);
-      expect(internal(h.session).lastSystemMessageTokens).toBe(417);
-      expect(h.events.filter((event) => event.type === "stream-abort")).toHaveLength(1);
-      expect(h.session.isBusy()).toBe(false);
-    } finally {
-      releaseEnvelope.resolve();
-      await send;
-      h.session.dispose();
-      await h.cleanup();
+      const consumer = observePolicy(h.session);
+      const accounting = spyOn(internal(h.session), "recordGoalAccountingFromUsage");
+      const compaction = spyOn(internal(h.session), "observeContinuousCompactionAtStreamEnd");
+      const send = h.session.sendMessage("hello", sendOptions);
+      try {
+        await envelopeEntered.promise;
+        Reflect.set(h.session, "workspaceGoalService", {
+          recordUserStoppedStream,
+          recordStreamAccounting: mock(() => Promise.resolve(null)),
+        } satisfies Partial<WorkspaceGoalService>);
+        emitter.emit("stream-abort", abort());
+        expect(recordUserStoppedStream).not.toHaveBeenCalled();
+        expect(h.events.filter((event) => event.type === "stream-abort")).toHaveLength(0);
+        completion.resolve({
+          status: "aborted",
+          abortReason: "user",
+          streamAbort: abort(),
+          systemMessageTokens: 417,
+        });
+        releaseEnvelope.resolve();
+        await send;
+        await policyPromise(consumer);
+        expect(recordUserStoppedStream).toHaveBeenCalledTimes(1);
+        expect(accounting).toHaveBeenCalledTimes(started ? 1 : 0);
+        expect(compaction).toHaveBeenCalledTimes(started ? 1 : 0);
+        expect(internal(h.session).lastSystemMessageTokens).toBe(started ? 417 : undefined);
+        expect(h.events.filter((event) => event.type === "stream-abort")).toHaveLength(1);
+        expect(h.session.isBusy()).toBe(false);
+      } finally {
+        releaseEnvelope.resolve();
+        await send;
+        h.session.dispose();
+        await h.cleanup();
+      }
     }
-  });
+  );
+
+  test.each(["stream-end", "stream-abort"] as const)(
+    "edit from raw %s waits for delivered completion without interrupting again",
+    async (terminal) => {
+      const completion = Promise.withResolvers<TurnCompletion>();
+      const replacementStarted = Promise.withResolvers<void>();
+      const emitter = new EventEmitter();
+      let calls = 0;
+      const stopStream = mock(() => {
+        // The engine registry has already been cleared by the raw terminal.
+        emitter.emit("stream-abort", abort(""));
+        return Promise.resolve(Ok(undefined));
+      });
+      const h = await createAgentSessionHarness({
+        workspaceId,
+        aiEmitter: emitter,
+        captureEvents: true,
+        aiServiceOverrides: {
+          stopStream,
+          streamMessage: mock(() => {
+            const messageId = `assistant-${++calls}`;
+            start(emitter, messageId);
+            if (calls === 2) replacementStarted.resolve();
+            return Promise.resolve(
+              Ok({
+                messageId,
+                completion:
+                  calls === 1 ? completion.promise : new Promise<TurnCompletion>(() => undefined),
+              })
+            );
+          }),
+        },
+      });
+      const consumer = observePolicy(h.session);
+      const accounting = spyOn(internal(h.session), "recordGoalAccountingFromUsage");
+      const editAdmissionEntered = Promise.withResolvers<void>();
+      const interruptStream = h.session.interruptStream.bind(h.session);
+      const interrupt = spyOn(h.session, "interruptStream").mockImplementation((options) => {
+        editAdmissionEntered.resolve();
+        return interruptStream(options);
+      });
+      const waitForIdle = h.session.waitForIdle.bind(h.session);
+      spyOn(h.session, "waitForIdle").mockImplementation((signal) => {
+        editAdmissionEntered.resolve();
+        return waitForIdle(signal);
+      });
+      const payload = { ...abort(), abortReason: "system" as const };
+      const outcome: TurnCompletion =
+        terminal === "stream-end"
+          ? { status: "completed", streamEnd: end() }
+          : { status: "aborted", abortReason: "system", streamAbort: payload };
+      let edit: ReturnType<AgentSession["sendMessage"]> | undefined;
+      try {
+        await h.session.sendMessage("original", sendOptions);
+        const firstPolicy = policyPromise(consumer);
+        const history = await h.historyService.getHistoryFromLatestBoundary(workspaceId);
+        if (!history.success) throw new Error(history.error);
+        const userId = history.data.find((message) => message.role === "user")!.id;
+        emitter.once(terminal, () => {
+          edit = h.session.sendMessage("edited", { ...sendOptions, editMessageId: userId });
+        });
+        emitter.emit(terminal, terminal === "stream-end" ? end() : payload);
+        // Observe the actual edit admission branch after its asynchronous history reads.
+        await editAdmissionEntered.promise;
+        expect(edit).toBeDefined();
+        expect(interrupt).not.toHaveBeenCalled();
+        expect(stopStream).not.toHaveBeenCalled();
+        expect(accounting).not.toHaveBeenCalled();
+        expect(calls).toBe(1);
+        expect(h.session.isBusy()).toBe(true);
+        completion.resolve(outcome);
+        await firstPolicy;
+        expect((await edit)?.success).toBe(true);
+        await replacementStarted.promise;
+        expect(calls).toBe(2);
+        expect(h.session.isBusy()).toBe(true);
+        expect(h.events.filter((event) => event.type === terminal)).toHaveLength(1);
+        expect(
+          h.events.filter((event) => event.type === "stream-abort" && event.abortReason === "user")
+        ).toHaveLength(0);
+      } finally {
+        completion.resolve(outcome);
+        await edit;
+        h.session.dispose();
+        await h.cleanup();
+      }
+    }
+  );
 
   test.each(["user", "system"] as const)(
     "startup %s cancellation handle does not duplicate its delayed notification",
@@ -238,6 +335,10 @@ describe("AgentSession turn completion", () => {
         });
         replacement = h.session.sendMessage("replacement", sendOptions);
         await historyEntered.promise;
+        // Old raw terminals must not mark the replacement as completing either.
+        if (status === "completed") emitter.emit("stream-end", end());
+        if (status === "aborted") emitter.emit("stream-abort", abort());
+        expect(h.session.isPreparingTurn()).toBe(true);
         completion.resolve(
           status === "completed"
             ? { status, streamEnd: end() }
@@ -351,6 +452,12 @@ describe("AgentSession turn completion", () => {
         }),
       },
     });
+    let lifecycleDecision: Promise<boolean> | undefined;
+    h.session.onChatEvent(({ message }) => {
+      if (message.type === "stream-lifecycle" && message.phase === "completing") {
+        lifecycleDecision = h.session.waitForPendingCompactionCompletionDecision("assistant-1");
+      }
+    });
     let decision: Promise<boolean> | undefined;
     // Raw terminal observation must happen before the handle is returned to sendMessage.
     emitter.on("stream-end", () => {
@@ -383,6 +490,8 @@ describe("AgentSession turn completion", () => {
       await firstPolicy.value;
       expect(decision).toBeDefined();
       expect(await decision).toBe(true);
+      expect(lifecycleDecision).toBeDefined();
+      expect(await lifecycleDecision).toBe(true);
       expect(calls).toBe(2);
       expect(h.session.isBusy()).toBe(true);
       const rendererEnds = h.events.filter((event) => event.type === "stream-end");

--- a/src/node/services/agentSession.turnCompletion.test.ts
+++ b/src/node/services/agentSession.turnCompletion.test.ts
@@ -576,4 +576,66 @@ describe("AgentSession turn completion", () => {
       await h.cleanup();
     }
   });
+  test.each(["hard", "soft", "dispose"] as const)(
+    "%s interruption handles stream-start before the handle is returned",
+    async (mode) => {
+      const emitter = new EventEmitter();
+      const started = Promise.withResolvers<void>();
+      const releaseHandle = Promise.withResolvers<void>();
+      const stopped = Promise.withResolvers<void>();
+      const completion = Promise.withResolvers<TurnCompletion>();
+      const h = await createAgentSessionHarness({
+        workspaceId,
+        aiEmitter: emitter,
+        captureEvents: true,
+        aiServiceOverrides: {
+          streamMessage: mock(async () => {
+            start(emitter);
+            started.resolve();
+            await releaseHandle.promise;
+            return Ok({ messageId: "assistant-1", completion: completion.promise });
+          }),
+          stopStream: mock(() => {
+            emitter.emit("stream-abort", abort());
+            completion.resolve({ status: "aborted", abortReason: "user", streamAbort: abort() });
+            stopped.resolve();
+            return Promise.resolve(Ok(undefined));
+          }),
+        },
+      });
+      const consumer = observePolicy(h.session);
+      const sending = h.session.sendMessage("hello", sendOptions);
+      let interrupt: Promise<unknown> | undefined;
+      try {
+        await started.promise;
+        let returned = false;
+        interrupt = h.session.interruptStream({ soft: mode === "soft" }).then((result) => {
+          returned = true;
+          return result;
+        });
+        await stopped.promise;
+        if (mode === "dispose") h.session.dispose();
+        if (mode === "hard") {
+          await new Promise<void>((resolve) => setImmediate(resolve));
+          expect(returned).toBe(false);
+        } else {
+          await interrupt;
+          expect(returned).toBe(true);
+        }
+        releaseHandle.resolve();
+        await sending;
+        await interrupt;
+        await policyPromise(consumer);
+        expect(h.events.filter((event) => event.type === "stream-abort")).toHaveLength(
+          mode === "dispose" ? 0 : 1
+        );
+      } finally {
+        releaseHandle.resolve();
+        h.session.dispose();
+        await sending;
+        await interrupt;
+        await h.cleanup();
+      }
+    }
+  );
 });

--- a/src/node/services/agentSession.turnCompletion.test.ts
+++ b/src/node/services/agentSession.turnCompletion.test.ts
@@ -1,0 +1,579 @@
+import { createMuxMessage } from "@/common/types/message";
+import { describe, expect, mock, spyOn, test } from "bun:test";
+import { EventEmitter } from "events";
+import type { StreamAbortEvent, StreamEndEvent } from "@/common/types/stream";
+import { Ok } from "@/common/types/result";
+import type { StreamMessageOptions } from "./turnRequestBuilder";
+import type { TurnCompletion, TurnStreamHandle } from "./streamManager";
+import type { WorkspaceGoalService } from "./workspaceGoalService";
+import type { AgentSession } from "./agentSession";
+import { createAgentSessionHarness } from "./agentSession.testHarness";
+
+const workspaceId = "session-completion";
+const model = "openai:gpt-4o";
+const sendOptions = { model, agentId: "exec" };
+
+interface Operation {
+  messageId?: string;
+  consumed: boolean;
+  startupMessageId?: string;
+  startupAbortNotified: boolean;
+  compaction: boolean;
+}
+interface InternalSession {
+  activeTurnOperation?: Operation;
+  lastSystemMessageTokens?: number;
+  activeCompactionRequest?: { id: string; modelString: string };
+  consumeTurnCompletion(handle: TurnStreamHandle, operation: Operation): Promise<void>;
+  clearStartupAutoRetryAbandon(): Promise<void>;
+  recordGoalAccountingFromUsage(input: unknown): Promise<void>;
+  setTurnPhase(phase: "preparing" | "streaming" | "idle"): void;
+  getEditTruncateTargetId(messageId: string): Promise<string>;
+}
+const internal = (session: AgentSession) => session as unknown as InternalSession;
+const end = (messageId = "assistant-1"): StreamEndEvent => ({
+  type: "stream-end",
+  workspaceId,
+  messageId,
+  metadata: { model },
+  parts: [{ type: "text", text: "Finished answer" }],
+});
+const abort = (messageId = "assistant-1"): StreamAbortEvent => ({
+  type: "stream-abort",
+  workspaceId,
+  messageId,
+  abortReason: "user",
+});
+function start(emitter: EventEmitter, messageId = "assistant-1") {
+  emitter.emit("stream-start", {
+    type: "stream-start",
+    workspaceId,
+    messageId,
+    model,
+    startTime: Date.now(),
+  });
+}
+
+// Observe the already-detached consumer promise without introducing a second policy path.
+function policyPromise(spy: ReturnType<typeof observePolicy>): Promise<void> {
+  const result = spy.mock.results.at(-1);
+  if (result?.type !== "return") throw new Error("No completion consumer registered");
+  return result.value;
+}
+function observePolicy(session: AgentSession) {
+  return spyOn(internal(session), "consumeTurnCompletion");
+}
+
+describe("AgentSession turn completion", () => {
+  test("raw success is observational; completion uses handle identity and runs policy once", async () => {
+    const completion = Promise.withResolvers<TurnCompletion>();
+    const emitter = new EventEmitter();
+    const handle = { messageId: "assistant-1", completion: completion.promise };
+    const h = await createAgentSessionHarness({
+      workspaceId,
+      aiEmitter: emitter,
+      captureEvents: true,
+      aiServiceOverrides: {
+        streamMessage: mock(() => {
+          start(emitter);
+          return Promise.resolve(Ok(handle));
+        }),
+      },
+    });
+    const consumer = observePolicy(h.session);
+    try {
+      expect((await h.session.sendMessage("hello", sendOptions)).success).toBe(true);
+      emitter.emit("stream-end", end());
+      expect(h.session.isBusy()).toBe(true);
+      expect(h.events.filter((event) => event.type === "stream-end")).toHaveLength(0);
+      const operation = internal(h.session).activeTurnOperation!;
+      // Even a malformed producer's redundant event ID cannot override handle identity.
+      completion.resolve({ status: "completed", streamEnd: end("wrong-id") });
+      await policyPromise(consumer);
+      await internal(h.session).consumeTurnCompletion(handle, operation);
+      emitter.emit("stream-end", end());
+      expect(h.events.filter((event) => event.type === "stream-end")).toMatchObject([
+        { messageId: handle.messageId },
+      ]);
+      expect(h.session.isBusy()).toBe(false);
+    } finally {
+      h.session.dispose();
+      await h.cleanup();
+    }
+  });
+
+  test("delivered abort before stream-start runs once and retains precleanup token context", async () => {
+    const envelopeEntered = Promise.withResolvers<void>();
+    const releaseEnvelope = Promise.withResolvers<void>();
+    const completion = Promise.withResolvers<TurnCompletion>();
+    const emitter = new EventEmitter();
+    const recordUserStoppedStream = mock(() => Promise.resolve());
+    const h = await createAgentSessionHarness({
+      workspaceId,
+      aiEmitter: emitter,
+      captureEvents: true,
+      aiServiceOverrides: {
+        streamMessage: mock(async (opts: StreamMessageOptions) => {
+          opts.onStreamStarting?.("starting-1");
+          envelopeEntered.resolve();
+          await releaseEnvelope.promise;
+          return Ok({ messageId: "assistant-1", completion: completion.promise });
+        }),
+      },
+    });
+    const consumer = observePolicy(h.session);
+    const send = h.session.sendMessage("hello", sendOptions);
+    try {
+      await envelopeEntered.promise;
+      Reflect.set(h.session, "workspaceGoalService", {
+        recordUserStoppedStream,
+        recordStreamAccounting: mock(() => Promise.resolve(null)),
+      } satisfies Partial<WorkspaceGoalService>);
+      emitter.emit("stream-abort", abort());
+      expect(recordUserStoppedStream).not.toHaveBeenCalled();
+      expect(h.events.filter((event) => event.type === "stream-abort")).toHaveLength(0);
+      completion.resolve({
+        status: "aborted",
+        abortReason: "user",
+        streamAbort: abort(),
+        systemMessageTokens: 417,
+      });
+      releaseEnvelope.resolve();
+      await send;
+      await policyPromise(consumer);
+      expect(recordUserStoppedStream).toHaveBeenCalledTimes(1);
+      expect(internal(h.session).lastSystemMessageTokens).toBe(417);
+      expect(h.events.filter((event) => event.type === "stream-abort")).toHaveLength(1);
+      expect(h.session.isBusy()).toBe(false);
+    } finally {
+      releaseEnvelope.resolve();
+      await send;
+      h.session.dispose();
+      await h.cleanup();
+    }
+  });
+
+  test.each(["user", "system"] as const)(
+    "startup %s cancellation handle does not duplicate its delayed notification",
+    async (reason) => {
+      const emitter = new EventEmitter();
+      const h = await createAgentSessionHarness({
+        workspaceId,
+        aiEmitter: emitter,
+        captureEvents: true,
+        aiServiceOverrides: {
+          streamMessage: mock((opts: StreamMessageOptions) => {
+            opts.onStreamStarting?.("starting-1");
+            return Promise.resolve(
+              Ok({
+                messageId: "starting-1",
+                completion: Promise.resolve<TurnCompletion>({
+                  status: "aborted",
+                  abortReason: reason,
+                }),
+              })
+            );
+          }),
+        },
+      });
+      const consumer = observePolicy(h.session);
+      try {
+        await h.session.sendMessage("hello", sendOptions);
+        await policyPromise(consumer);
+        const received = Promise.withResolvers<void>();
+        h.session.onChatEvent(({ message }) => {
+          if (message.type === "stream-abort") received.resolve();
+        });
+        const payload = { ...abort("starting-1"), abortReason: reason };
+        emitter.emit("stream-abort", payload);
+        await received.promise;
+        emitter.emit("stream-abort", payload);
+        expect(h.events.filter((event) => event.type === "stream-abort")).toMatchObject([
+          { abortReason: reason },
+        ]);
+      } finally {
+        h.session.dispose();
+        await h.cleanup();
+      }
+    }
+  );
+
+  test.each(["completed", "aborted", "failed"] as const)(
+    "late %s completion cannot change a replacement paused in history preparation",
+    async (status) => {
+      const completion = Promise.withResolvers<TurnCompletion>();
+      const emitter = new EventEmitter();
+      let calls = 0;
+      const h = await createAgentSessionHarness({
+        workspaceId,
+        aiEmitter: emitter,
+        captureEvents: true,
+        aiServiceOverrides: {
+          streamMessage: mock(() => {
+            const messageId = `assistant-${++calls}`;
+            start(emitter, messageId);
+            return Promise.resolve(
+              Ok({
+                messageId,
+                completion:
+                  calls === 1 ? completion.promise : new Promise<TurnCompletion>(() => undefined),
+              })
+            );
+          }),
+        },
+      });
+      const consumer = observePolicy(h.session);
+      const historyEntered = Promise.withResolvers<void>();
+      const releaseHistory = Promise.withResolvers<void>();
+      let replacement: Promise<unknown> | undefined;
+      try {
+        await h.session.sendMessage("hello", sendOptions);
+        const oldPolicy = policyPromise(consumer);
+        internal(h.session).setTurnPhase("idle");
+        const commit = h.historyService.commitPartial.bind(h.historyService);
+        spyOn(h.historyService, "commitPartial").mockImplementationOnce(async (id) => {
+          historyEntered.resolve();
+          await releaseHistory.promise;
+          return commit(id);
+        });
+        replacement = h.session.sendMessage("replacement", sendOptions);
+        await historyEntered.promise;
+        completion.resolve(
+          status === "completed"
+            ? { status, streamEnd: end() }
+            : status === "aborted"
+              ? { status, abortReason: "user", streamAbort: abort() }
+              : {
+                  status,
+                  streamError: { messageId: "assistant-1", error: "old failure", errorType: "api" },
+                }
+        );
+        await oldPolicy;
+        expect(h.session.isPreparingTurn()).toBe(true);
+        expect(
+          h.events.filter((event) =>
+            ["stream-end", "stream-abort", "stream-error"].includes(event.type)
+          )
+        ).toHaveLength(0);
+        releaseHistory.resolve();
+        await replacement;
+        expect(calls).toBe(2);
+      } finally {
+        releaseHistory.resolve();
+        await replacement;
+        h.session.dispose();
+        await h.cleanup();
+      }
+    }
+  );
+
+  test("disposal during success policy resolves compaction waiters and skips further accounting", async () => {
+    const completion = Promise.withResolvers<TurnCompletion>();
+    const emitter = new EventEmitter();
+    const h = await createAgentSessionHarness({
+      workspaceId,
+      aiEmitter: emitter,
+      aiServiceOverrides: {
+        streamMessage: mock(() => {
+          start(emitter);
+          return Promise.resolve(Ok({ messageId: "assistant-1", completion: completion.promise }));
+        }),
+      },
+    });
+    const consumer = observePolicy(h.session);
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    try {
+      await h.session.sendMessage("hello", sendOptions);
+      internal(h.session).activeCompactionRequest = { id: "compact", modelString: model };
+      internal(h.session).activeTurnOperation!.compaction = true;
+      spyOn(internal(h.session), "clearStartupAutoRetryAbandon").mockImplementation(async () => {
+        entered.resolve();
+        await release.promise;
+      });
+      const accounting = spyOn(internal(h.session), "recordGoalAccountingFromUsage");
+      emitter.emit("stream-end", end());
+      const decision = h.session.waitForPendingCompactionCompletionDecision("assistant-1");
+      completion.resolve({ status: "completed", streamEnd: end() });
+      await entered.promise;
+      h.session.dispose();
+      expect(await decision).toBe(false);
+      expect(await h.session.waitForPendingCompactionCompletionDecision("late-observer")).toBe(
+        false
+      );
+      release.resolve();
+      await policyPromise(consumer);
+      expect(accounting).not.toHaveBeenCalled();
+      expect(h.session.isBusy()).toBe(false);
+    } finally {
+      release.resolve();
+      h.session.dispose();
+      await h.cleanup();
+    }
+  });
+  test("synchronous compaction completion publishes its decision, sanitizes the renderer and starts its follow-up", async () => {
+    const emitter = new EventEmitter();
+    let calls = 0;
+    const rawEnd = {
+      ...end(),
+      metadata: {
+        model,
+        providerMetadata: { openai: { responseId: "stale" } },
+        contextProviderMetadata: { openai: { responseId: "stale" } },
+      },
+      parts: [
+        { type: "reasoning" as const, text: "Private compaction reasoning" },
+        { type: "text" as const, text: "Durable summary" },
+      ],
+    };
+    const h = await createAgentSessionHarness({
+      workspaceId,
+      aiEmitter: emitter,
+      captureEvents: true,
+      aiServiceOverrides: {
+        streamMessage: mock(() => {
+          const messageId = `assistant-${++calls}`;
+          start(emitter, messageId);
+          if (calls > 1)
+            return Promise.resolve(
+              Ok({ messageId, completion: new Promise<TurnCompletion>(() => undefined) })
+            );
+          emitter.emit("stream-end", rawEnd);
+          return Promise.resolve(
+            Ok({
+              messageId,
+              completion: Promise.resolve<TurnCompletion>({
+                status: "completed",
+                streamEnd: rawEnd,
+              }),
+            })
+          );
+        }),
+      },
+    });
+    let decision: Promise<boolean> | undefined;
+    // Raw terminal observation must happen before the handle is returned to sendMessage.
+    emitter.on("stream-end", () => {
+      decision = h.session.waitForPendingCompactionCompletionDecision("assistant-1");
+    });
+    const consumer = observePolicy(h.session);
+    try {
+      await h.historyService.appendToHistory(
+        workspaceId,
+        createMuxMessage("prior", "user", "Keep this context")
+      );
+      const result = await h.session.sendMessage(
+        "Please compact",
+        {
+          model,
+          agentId: "compact",
+          muxMetadata: {
+            type: "compaction-request",
+            rawCommand: "/compact",
+            parsed: {
+              followUpContent: { text: "Continue after summary", model, agentId: "exec" },
+            },
+          },
+        },
+        { synthetic: true }
+      );
+      expect(result.success).toBe(true);
+      const firstPolicy = consumer.mock.results[0];
+      if (firstPolicy?.type !== "return") throw new Error("Missing first policy");
+      await firstPolicy.value;
+      expect(decision).toBeDefined();
+      expect(await decision).toBe(true);
+      expect(calls).toBe(2);
+      expect(h.session.isBusy()).toBe(true);
+      const rendererEnds = h.events.filter((event) => event.type === "stream-end");
+      expect(rendererEnds).toHaveLength(1);
+      expect(rendererEnds[0].parts).toEqual(rawEnd.parts);
+      expect(rendererEnds[0].metadata).not.toHaveProperty("providerMetadata");
+      expect(rendererEnds[0].metadata).not.toHaveProperty("contextProviderMetadata");
+      const history = await h.historyService.getHistoryFromLatestBoundary(workspaceId);
+      if (!history.success) throw new Error(history.error);
+      expect(history.data[0].metadata?.compactionBoundary).toBe(true);
+      expect(history.data.at(-1)?.parts).toMatchObject([
+        { type: "text", text: "Continue after summary" },
+      ]);
+    } finally {
+      h.session.dispose();
+      await h.cleanup();
+    }
+  });
+
+  test("edit preemption drops the old completion while truncation lookup is paused", async () => {
+    const envelopeEntered = Promise.withResolvers<void>();
+    const releaseEnvelope = Promise.withResolvers<void>();
+    const lookupEntered = Promise.withResolvers<void>();
+    const releaseLookup = Promise.withResolvers<void>();
+    const completion = Promise.withResolvers<TurnCompletion>();
+    let calls = 0;
+    const replacementStarted = Promise.withResolvers<void>();
+    const h = await createAgentSessionHarness({
+      workspaceId,
+      captureEvents: true,
+      aiServiceOverrides: {
+        streamMessage: mock(async () => {
+          const messageId = `assistant-${++calls}`;
+          if (calls === 1) {
+            envelopeEntered.resolve();
+            await releaseEnvelope.promise;
+          }
+          if (calls === 2) replacementStarted.resolve();
+          return Ok({
+            messageId,
+            completion:
+              calls === 1 ? completion.promise : new Promise<TurnCompletion>(() => undefined),
+          });
+        }),
+      },
+    });
+    const consumer = observePolicy(h.session);
+    let edit: Promise<unknown> | undefined;
+    const original = h.session.sendMessage("original", sendOptions);
+    try {
+      await envelopeEntered.promise;
+      const history = await h.historyService.getHistoryFromLatestBoundary(workspaceId);
+      if (!history.success) throw new Error(history.error);
+      const userId = history.data.find((message) => message.role === "user")!.id;
+      const lookup = internal(h.session).getEditTruncateTargetId.bind(h.session);
+      spyOn(internal(h.session), "getEditTruncateTargetId").mockImplementation(async (id) => {
+        lookupEntered.resolve();
+        await releaseLookup.promise;
+        return lookup(id);
+      });
+      edit = h.session.sendMessage("edited", { ...sendOptions, editMessageId: userId });
+      await lookupEntered.promise;
+      completion.resolve({ status: "completed", streamEnd: end() });
+      releaseEnvelope.resolve();
+      await original;
+      await policyPromise(consumer);
+      expect(h.events.filter((event) => event.type === "stream-end")).toHaveLength(0);
+      expect(h.session.isBusy()).toBe(true);
+      releaseLookup.resolve();
+      await edit;
+      await replacementStarted.promise;
+      expect(calls).toBe(2);
+    } finally {
+      releaseEnvelope.resolve();
+      releaseLookup.resolve();
+      await original;
+      await edit;
+      h.session.dispose();
+      await h.cleanup();
+    }
+  });
+  test("provider-tool-end abort dispatches the queued turn only after delivered completion", async () => {
+    const completion = Promise.withResolvers<TurnCompletion>();
+    const emitter = new EventEmitter();
+    const nextStarted = Promise.withResolvers<void>();
+    let calls = 0;
+    const stopStream = mock(() => Promise.resolve(Ok(undefined)));
+    const h = await createAgentSessionHarness({
+      workspaceId,
+      aiEmitter: emitter,
+      captureEvents: true,
+      aiServiceOverrides: {
+        stopStream,
+        streamMessage: mock(() => {
+          const messageId = `assistant-${++calls}`;
+          start(emitter, messageId);
+          if (calls === 2) nextStarted.resolve();
+          return Promise.resolve(
+            Ok({
+              messageId,
+              completion:
+                calls === 1 ? completion.promise : new Promise<TurnCompletion>(() => undefined),
+            })
+          );
+        }),
+      },
+    });
+    const consumer = observePolicy(h.session);
+    try {
+      await h.session.sendMessage("hello", sendOptions);
+      const firstPolicy = policyPromise(consumer);
+      h.session.queueMessage("queued follow-up", sendOptions);
+      emitter.emit("tool-call-end", {
+        type: "tool-call-end",
+        workspaceId,
+        messageId: "assistant-1",
+        toolCallId: "search-1",
+        toolName: "web_search",
+        providerExecuted: true,
+        result: { success: true },
+        timestamp: Date.now(),
+      });
+      expect(stopStream).toHaveBeenCalledWith(workspaceId, { soft: true, abortReason: "system" });
+      const payload = { ...abort(), abortReason: "system" as const };
+      emitter.emit("stream-abort", payload);
+      expect(calls).toBe(1);
+      expect(h.session.hasQueuedMessages()).toBe(true);
+      completion.resolve({ status: "aborted", abortReason: "system", streamAbort: payload });
+      await firstPolicy;
+      await nextStarted.promise;
+      expect(calls).toBe(2);
+      expect(h.session.hasQueuedMessages()).toBe(false);
+      expect(h.events.filter((event) => event.type === "stream-abort")).toHaveLength(1);
+      expect(h.session.isBusy()).toBe(true);
+    } finally {
+      h.session.dispose();
+      await h.cleanup();
+    }
+  });
+
+  test("a duplicate compaction terminal cannot create a second pending decision", async () => {
+    const emitter = new EventEmitter();
+    const h = await createAgentSessionHarness({
+      workspaceId,
+      aiEmitter: emitter,
+      aiServiceOverrides: {
+        streamMessage: mock(() => {
+          start(emitter);
+          emitter.emit("stream-end", end());
+          return Promise.resolve(
+            Ok({
+              messageId: "assistant-1",
+              completion: Promise.resolve<TurnCompletion>({
+                status: "completed",
+                streamEnd: end(),
+              }),
+            })
+          );
+        }),
+      },
+    });
+    const consumer = observePolicy(h.session);
+    let decision: Promise<boolean> | undefined;
+    emitter.once("stream-end", () => {
+      decision = h.session.waitForPendingCompactionCompletionDecision("assistant-1");
+    });
+    try {
+      await h.historyService.appendToHistory(
+        workspaceId,
+        createMuxMessage("prior", "user", "context")
+      );
+      await h.session.sendMessage(
+        "compact",
+        {
+          model,
+          agentId: "compact",
+          muxMetadata: {
+            type: "compaction-request",
+            rawCommand: "/compact",
+            parsed: {},
+          },
+        },
+        { synthetic: true }
+      );
+      await policyPromise(consumer);
+      expect(await decision).toBe(false);
+      emitter.emit("stream-end", end());
+      expect(await h.session.waitForPendingCompactionCompletionDecision("assistant-1")).toBe(false);
+    } finally {
+      h.session.dispose();
+      await h.cleanup();
+    }
+  });
+});

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -203,7 +203,8 @@ export class AIService extends EventEmitter {
       lastLlmRequestByWorkspace: this.lastLlmRequestByWorkspace,
       bindings: this.turnRequestBuilderBindings,
       emit: (event, ...args) => this.emit(event, ...args),
-      createAbortedTurnHandle: (messageId) => this.createAbortedTurnHandle(messageId),
+      createAbortedTurnHandle: (messageId, signal) =>
+        this.createAbortedTurnHandle(messageId, signal),
       createSettledTurnHandle: (messageId, completion) =>
         this.createSettledTurnHandle(messageId, completion),
       getWorkspaceMetadata: (workspaceId) => this.getWorkspaceMetadata(workspaceId),
@@ -383,8 +384,11 @@ export class AIService extends EventEmitter {
     return { messageId, completion: Promise.resolve(completion) };
   }
 
-  private createAbortedTurnHandle(messageId: string): TurnStreamHandle {
-    return this.createSettledTurnHandle(messageId, { status: "aborted", abortReason: "startup" });
+  private createAbortedTurnHandle(messageId: string, signal?: AbortSignal): TurnStreamHandle {
+    return this.createSettledTurnHandle(messageId, {
+      status: "aborted",
+      abortReason: this.streamManager.getStartupAbortReason(signal),
+    });
   }
 
   private trackPendingDevToolsRunMetadata(
@@ -843,6 +847,7 @@ export class AIService extends EventEmitter {
     });
     const startTime = Date.now();
     const syntheticMessageId = pendingStart.syntheticMessageId;
+    opts.onStreamStarting?.(syntheticMessageId);
     const combinedAbortSignal = pendingStart.abortSignal;
     const startupPhaseTimingsMs: Record<string, number> = {};
     const recordStartupPhaseTiming = (phase: string, phaseStartedAt: number): void => {
@@ -857,7 +862,7 @@ export class AIService extends EventEmitter {
       if (this.mockModeEnabled && this.mockAiStreamPlayer) {
         await this.initStateManager.waitForInit(workspaceId, combinedAbortSignal);
         if (combinedAbortSignal.aborted) {
-          return Ok(this.createAbortedTurnHandle(syntheticMessageId));
+          return Ok(this.createAbortedTurnHandle(syntheticMessageId, combinedAbortSignal));
         }
         const result = await this.mockAiStreamPlayer.play(messages, workspaceId, {
           model: modelString,
@@ -869,7 +874,9 @@ export class AIService extends EventEmitter {
         if (!result.success) {
           return result;
         }
-        return Ok(result.data ?? this.createAbortedTurnHandle(syntheticMessageId));
+        return Ok(
+          result.data ?? this.createAbortedTurnHandle(syntheticMessageId, combinedAbortSignal)
+        );
       }
 
       const lastMessage = messages[messages.length - 1];

--- a/src/node/services/aiService.turnCompletion.test.ts
+++ b/src/node/services/aiService.turnCompletion.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { AIService } from "./aiService";
+import { InitStateManager } from "./initStateManager";
+import { ProviderService } from "./providerService";
+import { createTestHistoryService } from "./testHistoryService";
+import { createMuxMessage } from "@/common/types/message";
+import type { StreamAbortEvent } from "@/common/types/stream";
+
+// Exercise the real facade's pending-start registration and cancellation handle,
+// including the mock-mode shortcut that returns before a player handle exists.
+describe("AIService startup completion", () => {
+  test.each(["user", "system"] as const)(
+    "preserves %s cancellation reason without inventing a delivered abort",
+    async (abortReason) => {
+      const { config, historyService, cleanup } = await createTestHistoryService();
+      const init = new InitStateManager(config);
+      const service = new AIService(config, historyService, init, new ProviderService(config));
+      service.enableMockMode();
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      spyOn(init, "waitForInit").mockImplementation(async () => {
+        entered.resolve();
+        await release.promise;
+      });
+      const aborts: StreamAbortEvent[] = [];
+      service.on("stream-abort", (event) => {
+        aborts.push(event as StreamAbortEvent);
+      });
+      let registeredId: string | undefined;
+      const started = service.streamMessage({
+        workspaceId: "startup",
+        modelString: "openai:gpt-4o",
+        messages: [createMuxMessage("user", "user", "hello")],
+        onStreamStarting: (messageId) => {
+          registeredId = messageId;
+        },
+      });
+      try {
+        // Registration must be synchronous even when init has not run yet.
+        expect(registeredId).toBeDefined();
+        await entered.promise;
+        await service.stopStream("startup", { abortReason });
+        release.resolve();
+        const result = await started;
+        if (!result.success) throw new Error(JSON.stringify(result.error));
+        expect(result.data.messageId).toBe(registeredId!);
+        expect(await result.data.completion).toEqual({ status: "aborted", abortReason });
+        expect(aborts).toMatchObject([{ messageId: registeredId, abortReason }]);
+      } finally {
+        release.resolve();
+        await started;
+        await cleanup();
+      }
+    }
+  );
+});

--- a/src/node/services/coreServicesRoot.test.ts
+++ b/src/node/services/coreServicesRoot.test.ts
@@ -234,7 +234,10 @@ describe("createCoreServices", () => {
     await closeScopeBounded(root.appFiberScope);
 
     expect(abortReasons).toEqual(["system"]);
-    expect(await started.data.completion).toEqual({ status: "aborted", abortReason: "system" });
+    expect(await started.data.completion).toMatchObject({
+      status: "aborted",
+      abortReason: "system",
+    });
     expect(root.streamManager.isStreaming(workspaceId)).toBe(false);
     expect(await root.historyService.readPartial(workspaceId)).toBeNull();
     const history = await root.historyService.getHistoryFromLatestBoundary(workspaceId);

--- a/src/node/services/mock/mockAiStreamPlayer.test.ts
+++ b/src/node/services/mock/mockAiStreamPlayer.test.ts
@@ -733,7 +733,10 @@ describe("MockAiStreamPlayer", () => {
       muxMetadata,
     });
     expect(playResult.success).toBe(true);
-    await waitForCondition(() => !player.isStreaming(workspaceId), 2000);
+    if (!playResult.success || !playResult.data) throw new Error("Expected mock handle");
+    const completion = await playResult.data.completion;
+    expect(completion).toMatchObject({ status: "completed", streamEnd });
+    expect(player.isStreaming(workspaceId)).toBe(false);
 
     expect(streamStart).toMatchObject({ agentId: "explore", thinkingLevel: "high" });
     expect(streamEnd?.metadata).toMatchObject({
@@ -809,4 +812,59 @@ describe("MockAiStreamPlayer", () => {
     if (!playResult.success || !playResult.data) throw new Error("expected a stream handle");
     expect(await playResult.data.completion).toMatchObject({ status: "aborted" });
   });
+  test.each([false, true])(
+    "abort completion waits for partial deletion (reject=%s)",
+    async (rejectDelete) => {
+      const emitter = new EventEmitter();
+      const player = new MockAiStreamPlayer({
+        historyService,
+        aiService: emitter as unknown as AIService,
+      });
+      const workspaceId = "mock-abort-completion-barrier";
+      const delta = Promise.withResolvers<void>();
+      emitter.once("stream-delta", () => delta.resolve());
+      const played = await player.play(
+        [createMuxMessage("user", "user", "[force] keep streaming")],
+        workspaceId
+      );
+      if (!played.success || !played.data) throw new Error("Expected mock handle");
+      await delta.promise;
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const deletePartial = historyService.deletePartial.bind(historyService);
+      const deletion = spyOn(historyService, "deletePartial").mockImplementationOnce(async (id) => {
+        entered.resolve();
+        await release.promise;
+        if (rejectDelete) throw new Error("partial delete failed");
+        return deletePartial(id);
+      });
+      let settled = false;
+      const observed = played.data.completion.then(() => {
+        settled = true;
+      });
+      let terminal: unknown;
+      emitter.once("stream-abort", (payload) => {
+        terminal = payload;
+      });
+      const stop = player.stop(workspaceId).catch((error) => error as unknown);
+      try {
+        await entered.promise;
+        expect(player.isStreaming(workspaceId)).toBe(false);
+        expect(settled).toBe(false);
+        expect(terminal).toBeDefined();
+        release.resolve();
+        await stop;
+        expect(await played.data.completion).toMatchObject({
+          status: "aborted",
+          streamAbort: terminal,
+        });
+        await observed;
+        if (!rejectDelete) expect(await historyService.readPartial(workspaceId)).toBeNull();
+      } finally {
+        release.resolve();
+        await stop;
+        deletion.mockRestore();
+      }
+    }
+  );
 });

--- a/src/node/services/mock/mockAiStreamPlayer.ts
+++ b/src/node/services/mock/mockAiStreamPlayer.ts
@@ -25,6 +25,7 @@ import type {
   StreamStartEvent,
   StreamDeltaEvent,
   StreamEndEvent,
+  StreamAbortEvent,
   UsageDeltaEvent,
 } from "@/common/types/stream";
 import type { ToolCallStartEvent, ToolCallEndEvent } from "@/common/types/stream";
@@ -242,21 +243,26 @@ export class MockAiStreamPlayer {
     active.cancelled = true;
 
     // Emit stream-abort event to mirror real streaming behavior before we await disk cleanup.
-    this.deps.aiService.emit("stream-abort", {
+    const streamAbort: StreamAbortEvent = {
       type: "stream-abort",
       workspaceId,
       messageId: active.messageId,
       abortReason: "user",
-    });
+    };
+    this.deps.aiService.emit("stream-abort", streamAbort);
 
     this.cleanup(workspaceId);
 
     // User-initiated mock interrupts should not leave behind resumable partial state.
-    const deletePartialResult = await this.deps.historyService.deletePartial(workspaceId);
-    if (!deletePartialResult.success) {
-      log.error(
-        `Failed to clear mock partial on stop for ${active.messageId}: ${deletePartialResult.error}`
-      );
+    try {
+      const deletePartialResult = await this.deps.historyService.deletePartial(workspaceId);
+      if (!deletePartialResult.success) {
+        log.error(
+          `Failed to clear mock partial on stop for ${active.messageId}: ${deletePartialResult.error}`
+        );
+      }
+    } finally {
+      active.settleCompletion({ status: "aborted", abortReason: "user", streamAbort });
     }
   }
 
@@ -883,8 +889,8 @@ export class MockAiStreamPlayer {
         if (!this.isCurrentActiveStream(workspaceId, active)) return;
 
         this.deps.aiService.emit("stream-end", payload);
-        active.settleCompletion({ status: "completed" });
         this.cleanup(workspaceId);
+        active.settleCompletion({ status: "completed", streamEnd: payload });
         break;
       }
     }
@@ -895,8 +901,6 @@ export class MockAiStreamPlayer {
     if (!active) return;
 
     active.cancelled = true;
-    // Settle-once backstop: terminal events settled above; cancels settle here.
-    active.settleCompletion({ status: "aborted", abortReason: "user" });
 
     if (active.partialWriteTimer) {
       clearTimeout(active.partialWriteTimer);

--- a/src/node/services/serviceContainer.test.ts
+++ b/src/node/services/serviceContainer.test.ts
@@ -683,7 +683,10 @@ describe("ServiceContainer", () => {
 
     expect(bridgeStopSpy).toHaveBeenCalledTimes(1);
     expect(steps).toEqual(["stream-abort:system", "bridge-stop"]);
-    expect(await started.data.completion).toEqual({ status: "aborted", abortReason: "system" });
+    expect(await started.data.completion).toMatchObject({
+      status: "aborted",
+      abortReason: "system",
+    });
     expect(services.streamManager.isStreaming(workspaceId)).toBe(false);
     // Durable outcome at the moment the bridge stopped: partial.json gone, the
     // interrupted assistant message (still flagged partial, as every

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -22,6 +22,7 @@ import {
   StreamManager,
   type ModelFallbackPrepareOptions,
   type TurnEngineEvent,
+  type TurnCompletion,
   type TurnExecutionOptions,
 } from "./streamManager";
 import type {
@@ -49,6 +50,7 @@ import { closeScopeBounded } from "./di/appRuntime";
 import { Scope } from "effect";
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { countTokens } from "@/node/utils/main/tokenizer";
+import * as tokenizer from "@/node/utils/main/tokenizer";
 import { shouldRunIntegrationTests, validateApiKeys } from "../../../tests/testUtils";
 import { DisposableTempDir } from "@/node/services/tempDir";
 import type { ExecOptions, ExecStream, Runtime } from "@/node/runtime/Runtime";
@@ -56,6 +58,10 @@ import { createRuntime } from "@/node/runtime/runtimeFactory";
 import { attachLanguageModelCleanup } from "./languageModelCleanup";
 import { shellQuote } from "@/common/utils/shell";
 import { onTurnEngineEvent } from "./streamManager.testHarness";
+import { AIService } from "./aiService";
+import { InitStateManager } from "./initStateManager";
+import { ProviderService } from "./providerService";
+import { createAgentSessionHarness } from "./agentSession.testHarness";
 
 function createTestLanguageModel(modelId = "cleanup-model"): LanguageModel {
   return {
@@ -77,10 +83,15 @@ if (shouldRunIntegrationTests()) {
 
 // Real HistoryService backed by a temp directory (created fresh per test)
 let historyService: HistoryService;
+let historyConfig: Awaited<ReturnType<typeof createTestHistoryService>>["config"];
 let historyCleanup: () => Promise<void>;
 
 beforeEach(async () => {
-  ({ historyService, cleanup: historyCleanup } = await createTestHistoryService());
+  ({
+    historyService,
+    config: historyConfig,
+    cleanup: historyCleanup,
+  } = await createTestHistoryService());
 });
 
 afterEach(async () => {
@@ -1347,6 +1358,217 @@ describe("StreamManager - engine supervision (AppFiberScope occupant)", () => {
     expect(getWorkspaceStreamsForTests(streamManager).size).toBe(0);
     expect(streamManager.isStreaming(workspaceId)).toBe(false);
   });
+
+  test.each([
+    "tokenization",
+    "sink-sync",
+    "sink-async",
+    "preflush",
+    "processing",
+    "usage",
+    "soft-tokenization",
+    "soft-preflush",
+    "soft-usage",
+  ] as const)("abort completion survives %s failure", async (failure) => {
+    const workspaceId = `abort-failure-${failure}`;
+    const soft = failure.startsWith("soft-");
+    const failureKind = failure.replace("soft-", "");
+    const releaseBoundary = Promise.withResolvers<void>();
+    const providerEntered = Promise.withResolvers<void>();
+    const { streamManager, events } = createSupervisedStreamManagerForTests(
+      (signal) =>
+        (async function* () {
+          yield { type: "reasoning-delta", text: "unfinished reasoning" };
+          providerEntered.resolve();
+          if (soft) {
+            await releaseBoundary.promise;
+            yield { type: "text-end" };
+          }
+          if (!signal.aborted) {
+            await new Promise<void>((resolve) =>
+              signal.addEventListener("abort", () => resolve(), { once: true })
+            );
+          }
+        })(),
+      { supervised: false }
+    );
+    const handle = await startSupervisedStreamForTests(streamManager, workspaceId);
+    await providerEntered.promise;
+    const streamInfo = getWorkspaceStreamsForTests(streamManager).get(workspaceId) as Record<
+      string,
+      unknown
+    >;
+    const usage = { inputTokens: 120, outputTokens: 30, totalTokens: 150 };
+    streamInfo.cumulativeUsage = usage;
+    const processingPromise = streamInfo.processingPromise as Promise<void>;
+    const abortController = streamInfo.abortController as AbortController;
+    const countTokensSpy = spyOn(tokenizer, "countTokens");
+    const flush = getPrivateMethodForTests<(...args: never[]) => Promise<void>>(
+      streamManager,
+      "flushPartialWrite"
+    );
+    let outcome: TurnCompletion | undefined;
+    const observed = handle.completion.then((value) => {
+      outcome = value;
+    });
+    try {
+      if (failureKind === "tokenization") {
+        countTokensSpy.mockRejectedValueOnce(new Error("tokenizer unavailable"));
+      } else if (failureKind === "sink-sync" || failureKind === "sink-async") {
+        streamManager.setEventSink((event) => {
+          events.push(event);
+          if (event.type !== "stream-abort") return;
+          if (failureKind === "sink-sync") throw new Error("synchronous sink failure");
+          return Promise.reject(new Error("asynchronous sink failure"));
+        });
+      } else if (failureKind === "preflush") {
+        Reflect.set(streamManager, "flushPartialWrite", () => {
+          Reflect.set(streamManager, "flushPartialWrite", flush);
+          return Promise.reject(new Error("pre-cancel flush failure"));
+        });
+      } else if (failureKind === "usage") {
+        Reflect.set(streamManager, "recordSessionUsage", () =>
+          Promise.reject(new Error("usage attribution unavailable"))
+        );
+      } else {
+        // A teardown failure after the provider exits rejects the processing join.
+        streamInfo.processingPromise = processingPromise.then(() => {
+          throw new Error("processing teardown failure");
+        });
+      }
+      expect(
+        (await streamManager.stopStream(workspaceId, { abortReason: "user", soft })).success
+      ).toBe(true);
+      if (soft) {
+        releaseBoundary.resolve();
+        await processingPromise;
+        await streamInfo.cancelPromise;
+      }
+      // stop intentionally does not await sink delivery; drain its settlement microtasks.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(outcome).toMatchObject({
+        status: "aborted",
+        abortReason: "user",
+        streamAbort: {
+          messageId: handle.messageId,
+          metadata: { usage },
+        },
+      });
+      await observed;
+      expect(abortController.signal.aborted).toBe(true);
+      expect(terminalEvents(events).map((event) => event.type)).toEqual(["stream-abort"]);
+      expect(getWorkspaceStreamsForTests(streamManager).size).toBe(0);
+    } finally {
+      countTokensSpy.mockRestore();
+      Reflect.set(streamManager, "flushPartialWrite", flush);
+      abortController.abort();
+      releaseBoundary.resolve();
+      await processingPromise;
+    }
+  });
+
+  test.each(["interrupt", "edit", "raw-listener", "partial-commit"] as const)(
+    "%s finishes and publishes its abort despite cancellation bookkeeping failure",
+    async (scenario) => {
+      const workspaceId = `session-abort-failure-${scenario}`;
+      const providerEntered = Promise.withResolvers<void>();
+      const replacementEntered = Promise.withResolvers<void>();
+      let providerCalls = 0;
+      const { streamManager } = createSupervisedStreamManagerForTests(
+        (signal) =>
+          (async function* () {
+            yield { type: "text-delta", text: "retained partial" };
+            yield { type: "reasoning-delta", text: "unfinished reasoning" };
+            if (++providerCalls === 1) providerEntered.resolve();
+            else replacementEntered.resolve();
+            if (!signal.aborted)
+              await new Promise<void>((resolve) =>
+                signal.addEventListener("abort", () => resolve(), { once: true })
+              );
+          })(),
+        { supervised: false }
+      );
+      const service = new AIService(
+        historyConfig,
+        historyService,
+        new InitStateManager(historyConfig),
+        new ProviderService(historyConfig),
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        streamManager
+      );
+      let turns = 0;
+      spyOn(service, "streamMessage").mockImplementation(async () =>
+        Ok(await startSupervisedStreamForTests(streamManager, workspaceId, ++turns * 2 - 1))
+      );
+      const h = await createAgentSessionHarness({
+        workspaceId,
+        config: historyConfig,
+        historyService,
+        aiService: service,
+        streamManager,
+        captureEvents: true,
+      });
+      const countTokensSpy = spyOn(tokenizer, "countTokens");
+      const commitSpy = spyOn(historyService, "commitPartial");
+      const throwFromRawListener = () => {
+        throw new Error("raw abort subscriber failure");
+      };
+      const options = { model: "openai:gpt-4.1-mini", agentId: "exec" };
+      try {
+        await h.session.sendMessage("original", options);
+        await providerEntered.promise;
+        const streamInfo = getWorkspaceStreamsForTests(streamManager).get(workspaceId) as Record<
+          string,
+          unknown
+        >;
+        streamInfo.cumulativeUsage = { inputTokens: 120, outputTokens: 30, totalTokens: 150 };
+        if (scenario === "raw-listener") service.on("stream-abort", throwFromRawListener);
+        else if (scenario === "partial-commit")
+          commitSpy.mockRejectedValueOnce(new Error("disk unavailable"));
+        else countTokensSpy.mockRejectedValueOnce(new Error("tokenizer unavailable"));
+        const history = await historyService.getHistoryFromLatestBoundary(workspaceId);
+        if (!history.success) throw new Error(history.error);
+        const userId = history.data.find((message) => message.role === "user")!.id;
+        const result =
+          scenario === "edit"
+            ? await h.session.sendMessage("edited", { ...options, editMessageId: userId })
+            : await h.session.interruptStream();
+        expect(result.success).toBe(true);
+        expect(h.events.filter((event) => event.type === "stream-abort")).toMatchObject([
+          { abortReason: "user", messageId: `${workspaceId}-msg-1` },
+        ]);
+        if (scenario !== "edit") {
+          expect(h.session.isBusy()).toBe(false);
+          const partial = await historyService.readPartial(workspaceId);
+          if (scenario === "partial-commit") expect(partial).not.toBeNull();
+          else expect(partial).toBeNull();
+          if (scenario !== "partial-commit") {
+            const committed = await historyService.getHistoryFromLatestBoundary(workspaceId);
+            if (!committed.success) throw new Error(committed.error);
+            expect(
+              committed.data.find((message) => message.role === "assistant")?.metadata?.usage
+            ).toMatchObject({ inputTokens: 120, outputTokens: 30 });
+          }
+          expect((await h.session.sendMessage("next", options)).success).toBe(true);
+        }
+        await replacementEntered.promise;
+        expect(providerCalls).toBe(2);
+        expect(h.session.isBusy()).toBe(true);
+      } finally {
+        service.off("stream-abort", throwFromRawListener);
+        countTokensSpy.mockRestore();
+        commitSpy.mockRestore();
+        h.session.dispose();
+        await streamManager.stopStream(workspaceId, { abortReason: "system" });
+      }
+    }
+  );
 
   test("a wedged provider (never yields, ignores abort) cannot pin the bounded close", async () => {
     const workspaceId = "supervised-wedged-workspace";

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -1343,7 +1343,7 @@ describe("StreamManager - engine supervision (AppFiberScope occupant)", () => {
     expect(terminal.map((event) => event.type)).toEqual(["stream-abort"]);
     expect((terminal[0] as StreamAbortEvent).abortReason).toBe("system");
     // ... and the turn handle plus the registry were settled before the close resolved.
-    expect(await handle.completion).toEqual({ status: "aborted", abortReason: "system" });
+    expect(await handle.completion).toMatchObject({ status: "aborted", abortReason: "system" });
     expect(getWorkspaceStreamsForTests(streamManager).size).toBe(0);
     expect(streamManager.isStreaming(workspaceId)).toBe(false);
   });
@@ -1374,7 +1374,7 @@ describe("StreamManager - engine supervision (AppFiberScope occupant)", () => {
 
     const handle = await startSupervisedStreamForTests(streamManager, workspaceId);
 
-    expect(await handle.completion).toEqual({ status: "aborted", abortReason: "system" });
+    expect(await handle.completion).toMatchObject({ status: "aborted", abortReason: "system" });
     expect(terminalEvents(events).map((event) => event.type)).toEqual(["stream-abort"]);
     expect(getWorkspaceStreamsForTests(streamManager).size).toBe(0);
   });
@@ -1432,7 +1432,7 @@ describe("StreamManager - engine supervision (AppFiberScope occupant)", () => {
       expect(terminalEvents(events)).toEqual([]);
 
       releaseFinalWrite.resolve();
-      expect(await handle.completion).toEqual({ status: "completed" });
+      expect(await handle.completion).toMatchObject({ status: "completed" });
       expect(await stopPromise).toEqual(Ok(undefined));
       await completionObserved;
 
@@ -1485,7 +1485,7 @@ describe("StreamManager - engine supervision (AppFiberScope occupant)", () => {
     expect(aborts[0].abortReason).toBe("user");
     expect(terminalEvents(events)).toHaveLength(1);
     expect(settleCount).toBe(1);
-    expect(await handle.completion).toEqual({ status: "aborted", abortReason: "user" });
+    expect(await handle.completion).toMatchObject({ status: "aborted", abortReason: "user" });
     expect(getWorkspaceStreamsForTests(streamManager).size).toBe(0);
   });
 
@@ -1533,7 +1533,10 @@ describe("StreamManager - engine supervision (AppFiberScope occupant)", () => {
     const result = await startPromise;
     expect(result.success).toBe(true);
     if (!result.success) throw new Error("expected Ok");
-    expect(await result.data.completion).toEqual({ status: "aborted", abortReason: "system" });
+    expect(await result.data.completion).toMatchObject({
+      status: "aborted",
+      abortReason: "system",
+    });
     expect(events.filter((event) => event.type === "stream-start")).toHaveLength(0);
     expect(terminalEvents(events)).toHaveLength(1);
     expect(streamManager.isStreaming(workspaceId)).toBe(false);
@@ -1564,7 +1567,7 @@ describe("StreamManager - engine supervision (AppFiberScope occupant)", () => {
       Ok(undefined)
     );
 
-    expect(await handle.completion).toEqual({ status: "aborted", abortReason: "user" });
+    expect(await handle.completion).toMatchObject({ status: "aborted", abortReason: "user" });
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(terminalEvents(events).map((event) => event.type)).toEqual(["stream-abort"]);
     expect(getWorkspaceStreamsForTests(streamManager).size).toBe(0);
@@ -1581,7 +1584,7 @@ describe("StreamManager - engine supervision (AppFiberScope occupant)", () => {
     );
     for (let i = 1; i <= 50; i++) {
       const handle = await startSupervisedStreamForTests(streamManager, workspaceId, i);
-      expect(await handle.completion).toEqual({ status: "completed" });
+      expect(await handle.completion).toMatchObject({ status: "completed" });
     }
     expect(getWorkspaceStreamsForTests(streamManager).size).toBe(0);
     expect(events.filter((event) => event.type === "stream-end")).toHaveLength(50);
@@ -2751,6 +2754,7 @@ describe("StreamManager - turn completion", () => {
     createStreamResult?: (request: unknown, abortController: AbortController) => unknown;
     sink?: (event: TurnEngineEvent) => void | Promise<void>;
     events?: TurnEngineEvent[];
+    systemMessageTokens?: number;
   }) {
     const streamManager = new StreamManager(
       historyService,
@@ -2775,6 +2779,7 @@ describe("StreamManager - turn completion", () => {
         messageId: input.messageId,
         model: createTestLanguageModel(),
         providedRuntimeTempDir: "",
+        initialMetadata: { systemMessageTokens: input.systemMessageTokens },
       })
     );
     expect(result.success).toBe(true);
@@ -2807,7 +2812,10 @@ describe("StreamManager - turn completion", () => {
     );
     expect(aborted.success).toBe(true);
     if (!aborted.success) throw new Error("Expected aborted startup handle");
-    expect(await aborted.data.completion).toEqual({ status: "aborted", abortReason: "startup" });
+    expect(await aborted.data.completion).toMatchObject({
+      status: "aborted",
+      abortReason: "startup",
+    });
   });
 
   test("completed, failed, and debug-injected turns settle once after their terminal event", async () => {
@@ -2826,7 +2834,7 @@ describe("StreamManager - turn completion", () => {
     void completed.handle.completion.then(() => {
       completedSettlements += 1;
     });
-    expect(await completed.handle.completion).toEqual({ status: "completed" });
+    expect(await completed.handle.completion).toMatchObject({ status: "completed" });
     await Promise.resolve();
     expect(completedEvents.at(-1)?.type).toBe("stream-end");
     expect(completedSettlements).toBe(1);
@@ -2879,6 +2887,7 @@ describe("StreamManager - turn completion", () => {
     const { streamManager, handle } = await startWithStreamResult({
       workspaceId,
       messageId: "completion-abort-message",
+      systemMessageTokens: 733,
       createStreamResult: (_request, controller) =>
         createStreamResultForTests(
           (async function* () {
@@ -2922,7 +2931,13 @@ describe("StreamManager - turn completion", () => {
       expect(settled).toBe(false);
 
       releaseAbortDelivery.resolve();
-      expect(await handle.completion).toEqual({ status: "aborted", abortReason: "user" });
+      expect(await handle.completion).toMatchObject({
+        status: "aborted",
+        abortReason: "user",
+        systemMessageTokens: 733,
+        streamAbort: { type: "stream-abort", workspaceId, messageId: handle.messageId },
+      });
+      expect(streamManager.getStreamInfo(workspaceId)).toBeUndefined();
       const observed = await completionObserved;
       expect(observed.partial).toBeNull();
       expect(observed.history.success).toBe(true);
@@ -3223,7 +3238,10 @@ describe("StreamManager - Concurrent Stream Prevention", () => {
     const result = await startPromise;
     expect(result.success).toBe(true);
     if (!result.success) throw new Error("Expected aborted startup handle");
-    expect(await result.data.completion).toEqual({ status: "aborted", abortReason: "startup" });
+    expect(await result.data.completion).toMatchObject({
+      status: "aborted",
+      abortReason: "startup",
+    });
     expect(createCalled).toBe(false);
     expect(cleanupCalled).toBe(true);
     expect(processCalled).toBe(false);

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -210,8 +210,14 @@ export type TurnEngineEventSink = (event: TurnEngineEvent) => void | Promise<voi
 
 // Turn identity lives on TurnStreamHandle.messageId; completions cannot diverge from it.
 export type TurnCompletion =
-  | { status: "completed" }
-  | { status: "aborted"; abortReason: StreamAbortReason }
+  | { status: "completed"; streamEnd: Omit<StreamEndEvent, "messageId"> }
+  | {
+      status: "aborted";
+      abortReason: StreamAbortReason;
+      // Absent for startup cancellation / cleanup without a delivered terminal event.
+      streamAbort?: Omit<StreamAbortEvent, "messageId" | "abortReason">;
+      systemMessageTokens?: number;
+    }
   | { status: "failed"; streamError: StreamErrorPayload & { errorType: StreamErrorType } };
 
 export interface TurnStreamHandle {
@@ -903,6 +909,11 @@ export class StreamManager {
 
   setMockStreamLifecycle(lifecycle: MockStreamLifecycle | undefined): void {
     this.mockStreamLifecycle = lifecycle;
+  }
+
+  getStartupAbortReason(signal?: AbortSignal): StreamAbortReason {
+    const reason: unknown = signal?.reason;
+    return reason === "user" || reason === "system" || reason === "startup" ? reason : "startup";
   }
 
   beginStreamStart(input: {
@@ -2008,14 +2019,16 @@ export class StreamManager {
 
     // Emit abort asynchronously as before; completion settles only after the facade's
     // partial cleanup and external stream-abort emission have finished.
-    const abortDelivery = this.emitStreamAbort(
+    const streamAbort: StreamAbortEvent = {
+      type: "stream-abort",
       workspaceId,
-      streamInfo.messageId,
-      { usage, contextUsage, duration, providerMetadata, contextProviderMetadata },
+      messageId: streamInfo.messageId,
+      metadata: { usage, contextUsage, duration, providerMetadata, contextProviderMetadata },
       abortReason,
       abandonPartial,
-      streamInfo.initialMetadata?.acpPromptId
-    );
+      acpPromptId: streamInfo.initialMetadata?.acpPromptId,
+    };
+    const abortDelivery = Promise.resolve(this.eventSink(streamAbort));
 
     // Clean up immediately
     this.workspaceStreams.delete(workspaceId);
@@ -2026,7 +2039,12 @@ export class StreamManager {
         log.error("Stream-abort delivery failed", { error: getErrorMessage(error) });
       })
       .finally(() => {
-        streamInfo.completionController?.settle({ status: "aborted", abortReason });
+        streamInfo.completionController?.settle({
+          status: "aborted",
+          abortReason,
+          streamAbort,
+          systemMessageTokens: streamInfo.initialMetadata?.systemMessageTokens,
+        });
       });
   }
 
@@ -4308,7 +4326,7 @@ export class StreamManager {
             // before updateHistory completes, compaction can clear the file and then
             // updateHistory writes stale data back.
             this.emitTurnEvent(streamEndEvent);
-            streamInfo.terminalCompletion = { status: "completed" };
+            streamInfo.terminalCompletion = { status: "completed", streamEnd: streamEndEvent };
           }
           break;
         } catch (error) {
@@ -5050,7 +5068,10 @@ export class StreamManager {
     const completionController = createTurnCompletionController();
     const handle: TurnStreamHandle = { messageId, completion: completionController.promise };
     const settleStartupAbort = (): Result<TurnStreamHandle, SendMessageError> => {
-      completionController.settle({ status: "aborted", abortReason: "startup" });
+      completionController.settle({
+        status: "aborted",
+        abortReason: this.getStartupAbortReason(abortSignal),
+      });
       return Ok(handle);
     };
 
@@ -5214,7 +5235,10 @@ export class StreamManager {
       // No handle is handed out on this path, so the completion is observed only
       // by a supervisor forked at registration: settle it so that fiber exits
       // instead of cancelling this never-started stream at shutdown.
-      completionController.settle({ status: "aborted", abortReason: "startup" });
+      completionController.settle({
+        status: "aborted",
+        abortReason: this.getStartupAbortReason(abortSignal),
+      });
       // Convert to strongly-typed error
       return Err(this.convertToSendMessageError(error));
     }
@@ -5441,7 +5465,7 @@ export class StreamManager {
       : this.isStreaming(workspaceId);
 
     if (pending) {
-      pending.abortController.abort();
+      pending.abortController.abort(options?.abortReason ?? "startup");
       if (!isActuallyStreaming) {
         await this.emitStreamAbort(
           typedWorkspaceId,

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -1853,19 +1853,16 @@ export class StreamManager {
       return streamInfo.cancelPromise;
     }
     streamInfo.cancelPromise = (async () => {
+      streamInfo.state = StreamState.STOPPING;
       try {
-        streamInfo.state = StreamState.STOPPING;
-        // Flush any pending partial write immediately (preserves work on interruption)
+        // A failed best-effort flush must not prevent the provider from being stopped.
         await this.flushPartialWrite(workspaceId, streamInfo);
-
-        streamInfo.abortController.abort();
-
-        // Unlike checkSoftCancelStream, await cleanup (blocking)
-        await this.cleanupAbortedStream(workspaceId, streamInfo, abortReason, abandonPartial);
       } catch (error) {
-        log.error("Error during stream cancellation:", error);
-        // Force cleanup even if cancellation fails
-        this.workspaceStreams.delete(workspaceId);
+        log.error("Failed to flush partial before cancellation", { error });
+      } finally {
+        streamInfo.abortController.abort();
+        // Unlike checkSoftCancelStream, await cleanup (blocking).
+        await this.cleanupAbortedStream(workspaceId, streamInfo, abortReason, abandonPartial);
       }
     })();
     return streamInfo.cancelPromise;
@@ -1883,7 +1880,9 @@ export class StreamManager {
 
       // Flush any pending partial write immediately (preserves work on interruption)
       await this.flushPartialWrite(workspaceId, streamInfo);
-
+    } catch (error) {
+      log.error("Failed to flush partial before soft cancellation", { error });
+    } finally {
       streamInfo.abortController.abort();
 
       // Return back to the stream loop so we can wait for it to finish before
@@ -1899,10 +1898,6 @@ export class StreamManager {
         abortReason,
         abandonPartial
       );
-    } catch (error) {
-      log.error("Error during stream cancellation:", error);
-      // Force cleanup even if cancellation fails
-      this.workspaceStreams.delete(workspaceId);
     }
   }
 
@@ -1915,7 +1910,13 @@ export class StreamManager {
     // CRITICAL: Wait for processing to fully complete before cleanup
     // This prevents race conditions where the old stream is still running
     // while a new stream starts (e.g., old stream writing to partial.json)
-    await streamInfo.processingPromise;
+    try {
+      await streamInfo.processingPromise;
+    } catch (error) {
+      // The provider has exited even when teardown failed. Cancellation still owns
+      // an aborted terminal unless the loop already published another outcome.
+      log.error("Stream processing failed during cancellation", { error });
+    }
 
     // The cancel lost the race: the loop had already left the fullStream and
     // finished as completed/failed (terminalCompletion set, stream-end/error
@@ -1935,7 +1936,6 @@ export class StreamManager {
     const usage = hasTokenUsage(streamInfo.cumulativeUsage)
       ? streamInfo.cumulativeUsage
       : undefined;
-    await this.backfillReasoningTokensFromParts(streamInfo, usage);
 
     // For context window display, use last step's usage (inputTokens = current context size)
     const contextUsage = streamInfo.lastStepUsage;
@@ -1947,78 +1947,6 @@ export class StreamManager {
       streamInfo.initialMetadata?.costsIncluded
     );
 
-    // Record session usage for aborted streams (mirrors stream-end path)
-    // This ensures tokens consumed before abort are tracked for cost display
-    await this.recordSessionUsage(
-      workspaceId,
-      streamInfo.model,
-      usage,
-      providerMetadata,
-      "Failed to record session usage on abort",
-      "error",
-      streamInfo
-    );
-
-    // Stamp the aborted turn's usage onto the partial message BEFORE emitting
-    // stream-abort (whose handler commits the partial to chat.jsonl). Analytics
-    // prices history rows from metadata.usage, so without this every
-    // interrupted turn — user Esc, queued tool-end preemption, monitor wakes —
-    // would ingest as $0 even though the provider billed all completed steps.
-    if (!abandonPartial && (usage !== undefined || streamInfo.toolModelUsages.length > 0)) {
-      try {
-        await this.awaitPendingPartialWrite(streamInfo);
-        const partialMessage = this.buildPartialAssistantMessage(streamInfo, {
-          metadata: {
-            ...(usage !== undefined ? { usage: cloneUsage(usage) } : {}),
-            ...(providerMetadata !== undefined ? { providerMetadata } : {}),
-            ...(contextUsage !== undefined ? { contextUsage } : {}),
-            ...(contextProviderMetadata !== undefined ? { contextProviderMetadata } : {}),
-            duration,
-            ...(streamInfo.toolModelUsages.length > 0
-              ? { toolModelUsages: streamInfo.toolModelUsages.map(clonePersistedToolModelUsage) }
-              : {}),
-          },
-        });
-        await this.historyService.writePartial(workspaceId as string, partialMessage);
-
-        // Tool-only aborts (Esc while a tool is still running): commitPartial
-        // refuses to commit partials whose only parts are input-available tool
-        // calls, so the usage stamped above would die with the deleted
-        // partial. Route that spend through the headless-usage sidecar
-        // instead. Same predicate commitPartial applies, so exactly one of
-        // {chat row, sidecar row} carries this turn's usage.
-        if (!hasCommitWorthyParts(partialMessage.parts)) {
-          await this.recordDroppedPartialUsageInSidecar(
-            workspaceId,
-            streamInfo,
-            usage,
-            providerMetadata,
-            "aborted_stream"
-          );
-        }
-      } catch (error) {
-        log.error("Failed to persist aborted-stream usage on partial message", { error });
-      }
-    } else if (abandonPartial && (usage !== undefined || streamInfo.toolModelUsages.length > 0)) {
-      // Abandoned aborts (edit/discard of the streaming turn): the partial is
-      // deliberately dropped and its content never reaches chat.jsonl, but
-      // the provider still billed every completed step. The sidecar is the
-      // only route to the events table for this spend.
-      try {
-        await this.recordDroppedPartialUsageInSidecar(
-          workspaceId,
-          streamInfo,
-          usage,
-          providerMetadata,
-          "aborted_stream"
-        );
-      } catch (error) {
-        log.error("Failed to record abandoned-abort usage in headless sidecar", { error });
-      }
-    }
-
-    // Emit abort asynchronously as before; completion settles only after the facade's
-    // partial cleanup and external stream-abort emission have finished.
     const streamAbort: StreamAbortEvent = {
       type: "stream-abort",
       workspaceId,
@@ -2028,24 +1956,109 @@ export class StreamManager {
       abandonPartial,
       acpPromptId: streamInfo.initialMetadata?.acpPromptId,
     };
-    const abortDelivery = Promise.resolve(this.eventSink(streamAbort));
+    try {
+      try {
+        await this.backfillReasoningTokensFromParts(streamInfo, usage);
+      } catch (error) {
+        // Estimation is optional: preserve provider usage and the user's abort reason.
+        log.error("Failed to estimate reasoning usage on abort", { error });
+      }
 
-    // Clean up immediately
-    this.workspaceStreams.delete(workspaceId);
-    void abortDelivery
-      .catch((error) => {
-        // Contain sink rejections: .finally alone would re-propagate them as
-        // an unhandled rejection after completion settles.
-        log.error("Stream-abort delivery failed", { error: getErrorMessage(error) });
-      })
-      .finally(() => {
-        streamInfo.completionController?.settle({
-          status: "aborted",
-          abortReason,
-          streamAbort,
-          systemMessageTokens: streamInfo.initialMetadata?.systemMessageTokens,
+      // Record session usage for aborted streams (mirrors stream-end path)
+      // This ensures tokens consumed before abort are tracked for cost display
+      await this.recordSessionUsage(
+        workspaceId,
+        streamInfo.model,
+        usage,
+        providerMetadata,
+        "Failed to record session usage on abort",
+        "error",
+        streamInfo
+      );
+
+      // Stamp the aborted turn's usage onto the partial message BEFORE emitting
+      // stream-abort (whose handler commits the partial to chat.jsonl). Analytics
+      // prices history rows from metadata.usage, so without this every
+      // interrupted turn — user Esc, queued tool-end preemption, monitor wakes —
+      // would ingest as $0 even though the provider billed all completed steps.
+      if (!abandonPartial && (usage !== undefined || streamInfo.toolModelUsages.length > 0)) {
+        try {
+          await this.awaitPendingPartialWrite(streamInfo);
+          const partialMessage = this.buildPartialAssistantMessage(streamInfo, {
+            metadata: {
+              ...(usage !== undefined ? { usage: cloneUsage(usage) } : {}),
+              ...(providerMetadata !== undefined ? { providerMetadata } : {}),
+              ...(contextUsage !== undefined ? { contextUsage } : {}),
+              ...(contextProviderMetadata !== undefined ? { contextProviderMetadata } : {}),
+              duration,
+              ...(streamInfo.toolModelUsages.length > 0
+                ? { toolModelUsages: streamInfo.toolModelUsages.map(clonePersistedToolModelUsage) }
+                : {}),
+            },
+          });
+          await this.historyService.writePartial(workspaceId as string, partialMessage);
+
+          // Tool-only aborts (Esc while a tool is still running): commitPartial
+          // refuses to commit partials whose only parts are input-available tool
+          // calls, so the usage stamped above would die with the deleted
+          // partial. Route that spend through the headless-usage sidecar
+          // instead. Same predicate commitPartial applies, so exactly one of
+          // {chat row, sidecar row} carries this turn's usage.
+          if (!hasCommitWorthyParts(partialMessage.parts)) {
+            await this.recordDroppedPartialUsageInSidecar(
+              workspaceId,
+              streamInfo,
+              usage,
+              providerMetadata,
+              "aborted_stream"
+            );
+          }
+        } catch (error) {
+          log.error("Failed to persist aborted-stream usage on partial message", { error });
+        }
+      } else if (abandonPartial && (usage !== undefined || streamInfo.toolModelUsages.length > 0)) {
+        // Abandoned aborts (edit/discard of the streaming turn): the partial is
+        // deliberately dropped and its content never reaches chat.jsonl, but
+        // the provider still billed every completed step. The sidecar is the
+        // only route to the events table for this spend.
+        try {
+          await this.recordDroppedPartialUsageInSidecar(
+            workspaceId,
+            streamInfo,
+            usage,
+            providerMetadata,
+            "aborted_stream"
+          );
+        } catch (error) {
+          log.error("Failed to record abandoned-abort usage in headless sidecar", { error });
+        }
+      }
+    } catch (error) {
+      log.error("Failed abort bookkeeping; delivering preserved terminal metadata", { error });
+    } finally {
+      // Emit abort asynchronously as before; completion settles only after the facade's
+      // partial cleanup and external stream-abort emission have finished.
+      const abortDelivery = (async () => this.eventSink(streamAbort))();
+
+      // Clean up immediately
+      if (this.workspaceStreams.get(workspaceId) === streamInfo) {
+        this.workspaceStreams.delete(workspaceId);
+      }
+      void abortDelivery
+        .catch((error) => {
+          // Contain sink rejections: .finally alone would re-propagate them as
+          // an unhandled rejection after completion settles.
+          log.error("Stream-abort delivery failed", { error: getErrorMessage(error) });
+        })
+        .finally(() => {
+          streamInfo.completionController?.settle({
+            status: "aborted",
+            abortReason,
+            streamAbort,
+            systemMessageTokens: streamInfo.initialMetadata?.systemMessageTokens,
+          });
         });
-      });
+    }
   }
 
   /**

--- a/src/node/services/streamSimulation.test.ts
+++ b/src/node/services/streamSimulation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, spyOn } from "bun:test";
 
 import { StreamEndEventSchema } from "@/common/orpc/schemas/stream";
 import { createMuxMessage, type MuxMetadata } from "@/common/types/message";
@@ -90,6 +90,51 @@ describe("streamSimulation", () => {
       expect(historyResult.data[0]?.metadata?.agentId).toBe("exec");
       expect(historyResult.data[0]?.metadata?.mode).toBe("exec");
     } finally {
+      await cleanup();
+    }
+  });
+  test("returns its terminal payload only after final history while preserving raw emission order", async () => {
+    const { historyService, cleanup } = await createTestHistoryService();
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const events: CapturedEvent[] = [];
+    const ctx = createSimulationContext(events);
+    let run: Promise<StreamEndEvent> | undefined;
+    try {
+      await historyService.appendToHistory(
+        ctx.workspaceId,
+        createMuxMessage(ctx.assistantMessageId, "assistant", "", {
+          historySequence: ctx.historySequence,
+        })
+      );
+      const update = historyService.updateHistory.bind(historyService);
+      spyOn(historyService, "updateHistory").mockImplementationOnce(async (id, message) => {
+        entered.resolve();
+        await release.promise;
+        return update(id, message);
+      });
+      let finished = false;
+      run = simulateToolPolicyNoop(ctx, undefined, historyService);
+      const observed = run.then(() => {
+        finished = true;
+      });
+      await entered.promise;
+      expect(events.map((event) => event.event)).toEqual([
+        "stream-start",
+        "stream-delta",
+        "stream-end",
+      ]);
+      expect(finished).toBe(false);
+      release.resolve();
+      const terminal = await run;
+      await observed;
+      expect(terminal).toBe(getCapturedEvent<StreamEndEvent>(events, "stream-end"));
+      const history = await historyService.getHistoryFromLatestBoundary(ctx.workspaceId);
+      if (!history.success) throw new Error(history.error);
+      expect(history.data[0].parts).toEqual(terminal.parts);
+    } finally {
+      release.resolve();
+      await run;
       await cleanup();
     }
   });

--- a/src/node/services/streamSimulation.ts
+++ b/src/node/services/streamSimulation.ts
@@ -119,7 +119,7 @@ export async function simulateToolPolicyNoop(
   ctx: SimulationContext,
   effectiveToolPolicy: ToolPolicy | undefined,
   historyService: HistoryService
-): Promise<void> {
+): Promise<StreamEndEvent> {
   const noopMessage = createMuxMessage(ctx.assistantMessageId, "assistant", "", {
     timestamp: Date.now(),
     model: ctx.canonicalModelString,
@@ -190,4 +190,5 @@ export async function simulateToolPolicyNoop(
 
   await historyService.deletePartial(ctx.workspaceId);
   await historyService.updateHistory(ctx.workspaceId, finalAssistantMessage);
+  return streamEndEvent;
 }

--- a/src/node/services/turnRequestBuilder.ts
+++ b/src/node/services/turnRequestBuilder.ts
@@ -255,6 +255,8 @@ export interface StreamMessageOptions {
   acpPromptId?: string;
   /** Invoked with each fatal pre-start error event this call emits before returning Err. */
   onPreStartError?: (event: ErrorEvent) => void;
+  /** Synchronous registration of the facade's handleless startup notification identity. */
+  onStreamStarting?: (messageId: string) => void;
   /** Tool names that should be delegated back to ACP clients for this request. */
   delegatedToolNames?: string[];
   recordFileState?: (filePath: string, state: FileState) => Promise<void>;
@@ -488,7 +490,7 @@ interface TurnRequestBuilderDependencies {
   lastLlmRequestByWorkspace: Map<string, DebugLlmRequestSnapshot>;
   bindings: TurnRequestBuilderBindings;
   emit: (event: string, ...args: unknown[]) => boolean;
-  createAbortedTurnHandle: (messageId: string) => TurnStreamHandle;
+  createAbortedTurnHandle: (messageId: string, signal?: AbortSignal) => TurnStreamHandle;
   createSettledTurnHandle: (messageId: string, completion: TurnCompletion) => TurnStreamHandle;
   getWorkspaceMetadata: (workspaceId: string) => Promise<Result<WorkspaceMetadata>>;
   createWorkspaceRuntimeContext: (
@@ -1131,7 +1133,9 @@ export class TurnRequestBuilder {
     if (combinedAbortSignal.aborted) {
       return {
         type: "finished",
-        result: Ok(this.dependencies.createAbortedTurnHandle(syntheticMessageId)),
+        result: Ok(
+          this.dependencies.createAbortedTurnHandle(syntheticMessageId, combinedAbortSignal)
+        ),
       };
     }
 
@@ -2576,7 +2580,9 @@ export class TurnRequestBuilder {
     if (combinedAbortSignal.aborted) {
       return {
         type: "finished",
-        result: Ok(this.dependencies.createAbortedTurnHandle(assistantMessageId)),
+        result: Ok(
+          this.dependencies.createAbortedTurnHandle(assistantMessageId, combinedAbortSignal)
+        ),
       };
     }
 
@@ -2641,7 +2647,7 @@ export class TurnRequestBuilder {
           ),
         };
       }
-      await simulateToolPolicyNoop(
+      const streamEnd = await simulateToolPolicyNoop(
         simulationCtx,
         effectiveToolPolicy,
         this.dependencies.historyService
@@ -2649,7 +2655,10 @@ export class TurnRequestBuilder {
       return {
         type: "finished",
         result: Ok(
-          this.dependencies.createSettledTurnHandle(assistantMessageId, { status: "completed" })
+          this.dependencies.createSettledTurnHandle(assistantMessageId, {
+            status: "completed",
+            streamEnd,
+          })
         ),
       };
     }
@@ -2700,7 +2709,9 @@ export class TurnRequestBuilder {
       await deleteAbortedPlaceholder(assistantMessageId);
       return {
         type: "finished",
-        result: Ok(this.dependencies.createAbortedTurnHandle(assistantMessageId)),
+        result: Ok(
+          this.dependencies.createAbortedTurnHandle(assistantMessageId, combinedAbortSignal)
+        ),
       };
     }
 

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -1,3 +1,4 @@
+import type { TurnCompletion } from "./streamManager";
 import { describe, expect, test, mock, beforeEach, afterEach, spyOn, type Mock } from "bun:test";
 import { WorkspaceService, generateForkBranchName, generateForkTitle } from "./workspaceService";
 import { registerInProcessWorkflowRun } from "@/node/services/workflows/workflowArchiveAdmission";
@@ -18385,6 +18386,100 @@ describe("WorkspaceService interruptStream", () => {
 
   afterEach(async () => {
     await cleanupHistory();
+  });
+
+  test("sendQueuedImmediately waits for interrupted accounting and terminal publication", async () => {
+    const workspaceId = "ws-interrupt-policy-barrier";
+    const completion = Promise.withResolvers<TurnCompletion>();
+    const accountingEntered = Promise.withResolvers<void>();
+    const releaseAccounting = Promise.withResolvers<void>();
+    const replacementStarted = Promise.withResolvers<void>();
+    const emitter = new EventEmitter();
+    const terminalOrder: string[] = [];
+    let streamCount = 0;
+    const h = await createAgentSessionHarness({
+      workspaceId,
+      aiEmitter: emitter,
+      captureEvents: true,
+      aiServiceOverrides: {
+        streamMessage: mock(() => {
+          const messageId = `assistant-${++streamCount}`;
+          emitter.emit("stream-start", {
+            type: "stream-start",
+            workspaceId,
+            messageId,
+            model: "openai:gpt-4o",
+            startTime: Date.now(),
+          });
+          if (streamCount === 2) replacementStarted.resolve();
+          return Promise.resolve(
+            Ok({
+              messageId,
+              completion:
+                streamCount === 1
+                  ? completion.promise
+                  : new Promise<TurnCompletion>(() => undefined),
+            })
+          );
+        }),
+        stopStream: mock(() => {
+          const streamAbort = {
+            type: "stream-abort" as const,
+            workspaceId,
+            messageId: "assistant-1",
+            abortReason: "user" as const,
+          };
+          emitter.emit("stream-abort", streamAbort);
+          completion.resolve({ status: "aborted", abortReason: "user", streamAbort });
+          return Promise.resolve(Ok(undefined));
+        }),
+      },
+    });
+    const workspaceService = createWorkspaceServiceForTest({
+      config: h.config,
+      historyService: h.historyService,
+      aiService: h.aiService as AIService,
+      initStateManager: h.initStateManager,
+      backgroundProcessManager: h.backgroundProcessManager,
+    });
+    spyOn(workspaceService, "getOrCreateSession").mockReturnValue(h.session);
+    const policy = h.session as unknown as {
+      recordGoalAccountingFromUsage(input: unknown): Promise<void>;
+    };
+    spyOn(policy, "recordGoalAccountingFromUsage").mockImplementation(async () => {
+      accountingEntered.resolve();
+      await releaseAccounting.promise;
+    });
+    const dispatch = spyOn(h.session, "sendNextUserQueuedMessage");
+    h.session.onChatEvent(({ message }) => {
+      if (message.type === "stream-start" || message.type === "stream-abort")
+        terminalOrder.push(`${message.type}:${message.messageId}`);
+    });
+    let interrupt: Promise<unknown> | undefined;
+    try {
+      await h.session.sendMessage("source", { model: "openai:gpt-4o", agentId: "exec" });
+      h.session.queueMessage("queued replacement", { model: "openai:gpt-4o", agentId: "exec" });
+      interrupt = workspaceService.interruptStream(workspaceId, { sendQueuedImmediately: true });
+      await accountingEntered.promise;
+      // Drain the facade's Promise-only bookkeeping while terminal accounting is
+      // held by the explicit barrier; no elapsed-time assumption or timer is needed.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(dispatch).not.toHaveBeenCalled();
+      releaseAccounting.resolve();
+      await interrupt;
+      await replacementStarted.promise;
+      expect(terminalOrder).toEqual([
+        "stream-start:assistant-1",
+        "stream-abort:assistant-1",
+        "stream-start:assistant-2",
+      ]);
+      expect(h.session.isBusy()).toBe(true);
+    } finally {
+      releaseAccounting.resolve();
+      await interrupt;
+      h.session.dispose();
+      await h.cleanup();
+    }
   });
 
   test("sendQueuedImmediately clears hard-interrupt suppression before queued resend", async () => {


### PR DESCRIPTION
AgentSession currently runs success and abort policy from raw engine events, while failure policy uses the stream completion handle. This unifies asynchronous terminal policy on handle completion after attempt cleanup, so late terminals cannot mutate replacement turns.

Raw observers synchronously mark a correlated started turn as completing, preventing reentrant edits from interrupting an already-ended stream. Completions carry terminal metadata across real, mock, simulation, and startup paths. Aborts before stream-start retain startup policy without goal accounting or compaction. Compaction decisions are registered before lifecycle publication and settle after continuation acceptance.

A hard interrupt of an already-started turn awaits session accounting and terminal publication before returning to a send-now caller. This prevents a queued replacement from suppressing the old abort and leaving the renderer stuck streaming. Engine completion remains independent of session settlement; soft interruption and startup preemption remain nonblocking.

Cancellation preserves the original abort outcome even when partial flushing, token estimation, usage bookkeeping, processing teardown, or event delivery fails. Terminal delivery and handle settlement remain guaranteed, allowing interruption and editing to finish.

Validation: 964 affected backend tests and make static-check passed on the latest revision. All 5 send-mode UI integration tests passed before the cancellation failure-hardening change; CI reruns them on the current head. Thirteen new failure-injection cases verify hard/soft cancellation and real engine/facade/session interruption, editing, renderer termination, and replacement sends. Deterministic regressions cover pre-start cancellation, raw-terminal reentrant edits, compaction decision ordering, stale/duplicate completion, disposal, and send-now accounting barriers. Existing mock-stream setup and monitor polling timing flakes passed unchanged reruns. Local Nix formatting was skipped because Nix is unavailable; canonical macOS TMPDIR avoids existing path assertions.

Regression risk centers on interruption, queued replacement, and compaction ordering. Raw event timing and engine-versus-session settlement remain separate, with deterministic interleaving tests covering these boundaries.

---

_Generated with `xum` • Model: `unavailable` • Thinking: `unavailable` • Cost: `$unavailable`_

<!-- mux-attribution: model=unavailable thinking=unavailable costs=unavailable -->
