### PR TITLE
🤖 refactor: centralize agent turn lifecycle ownership

### DIFF
--- a/src/node/services/agentSession.continueMessageAgentId.test.ts
+++ b/src/node/services/agentSession.continueMessageAgentId.test.ts
@@ -1,3 +1,4 @@
+import type { TurnCoordinator } from "./turnCoordinator";
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { createMuxMessage } from "@/common/types/message";
 import type { CompactionFollowUpRequest, MuxMessage } from "@/common/types/message";
@@ -449,9 +450,9 @@ describe("AgentSession continue-message agentId fallback", () => {
     const { internals } = await createSession([
       compactionSummaryMessage("summary-completing-turn", idleFollowUp()),
     ]);
-    const completingInternals = internals as SessionInternals & { turnPhase: string };
+    const completingInternals = internals as SessionInternals & { coordinator: TurnCoordinator };
     completingInternals.sendMessage = mock(() => Promise.resolve({ success: true as const }));
-    completingInternals.turnPhase = "completing";
+    completingInternals.coordinator.beginPolicy(completingInternals.coordinator.turnId);
 
     const dispatched = await completingInternals.dispatchPendingFollowUp();
 

--- a/src/node/services/agentSession.drainQueuedMessagesIfIdle.test.ts
+++ b/src/node/services/agentSession.drainQueuedMessagesIfIdle.test.ts
@@ -1,3 +1,4 @@
+import type { TurnCoordinator } from "./turnCoordinator";
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { EventEmitter } from "events";
 import * as path from "node:path";
@@ -22,7 +23,7 @@ const WORKSPACE_ID = "workspace-drain-if-idle-test";
 
 interface PrivateSessionAccess {
   midStreamCompactionPending: boolean;
-  autoRetryStarting: boolean;
+  coordinator: TurnCoordinator;
   activeStreamContext?: { modelString: string; options?: unknown; providersConfig: null };
   interruptForCompaction: () => Promise<void>;
 }
@@ -101,7 +102,7 @@ describe("AgentSession.drainQueuedMessagesIfIdle", () => {
     [
       "a scheduled auto-retry does not hold the queue",
       (s) => {
-        s.autoRetryStarting = true;
+        s.coordinator.beginRetry();
       },
       1,
     ],

--- a/src/node/services/agentSession.postCompactionRetry.test.ts
+++ b/src/node/services/agentSession.postCompactionRetry.test.ts
@@ -168,12 +168,8 @@ describe("AgentSession post-compaction context retry", () => {
       agentId: "exec",
     } as unknown as SendMessageOptions;
 
-    // Call streamWithHistory directly (private) to avoid needing a full user send pipeline.
-    await (
-      session as unknown as {
-        streamWithHistory: (m: string, o: SendMessageOptions) => Promise<unknown>;
-      }
-    ).streamWithHistory(options.model, options);
+    // Exercise the public resume facade so retry preparation has a real admitted owner.
+    await session.resumeStream(options);
 
     // Wait for the retry call to happen.
     await Promise.race([
@@ -325,11 +321,7 @@ describe("AgentSession post-compaction context retry", () => {
       agentId: "exec",
     } as unknown as SendMessageOptions;
 
-    await (
-      session as unknown as {
-        streamWithHistory: (m: string, o: SendMessageOptions) => Promise<unknown>;
-      }
-    ).streamWithHistory(options.model, options);
+    await session.resumeStream(options);
 
     // The error event began a recovery decision and kicked off the retry.
     await Promise.race([
@@ -472,11 +464,7 @@ describe("AgentSession post-compaction context retry", () => {
       agentId: "exec",
     } as unknown as SendMessageOptions;
 
-    await (
-      session as unknown as {
-        streamWithHistory: (m: string, o: SendMessageOptions) => Promise<unknown>;
-      }
-    ).streamWithHistory(options.model, options);
+    await session.resumeStream(options);
 
     const withTimeout = <T>(promise: Promise<T>, label: string): Promise<T> =>
       Promise.race([

--- a/src/node/services/agentSession.preStreamError.test.ts
+++ b/src/node/services/agentSession.preStreamError.test.ts
@@ -1,3 +1,4 @@
+import type { TurnCoordinator } from "./turnCoordinator";
 import { describe, expect, it, mock, afterEach } from "bun:test";
 import { EventEmitter } from "events";
 import { PROVIDER_DISPLAY_NAMES } from "@/common/constants/providers";
@@ -133,7 +134,7 @@ describe("AgentSession pre-stream errors", () => {
     let finishStartup: (() => void) | undefined;
     const privateSession = session as unknown as {
       streamWithHistory: () => Promise<Result<void, SendMessageError>>;
-      activePreparedTurnAbortController: AbortController | null;
+      coordinator: TurnCoordinator;
     };
     privateSession.streamWithHistory = async () => {
       await new Promise<void>((resolve) => {
@@ -153,10 +154,10 @@ describe("AgentSession pre-stream errors", () => {
       );
     });
 
-    while (privateSession.activePreparedTurnAbortController == null || finishStartup == null) {
+    while (finishStartup == null) {
       await new Promise((resolve) => setTimeout(resolve, 0));
     }
-    privateSession.activePreparedTurnAbortController.abort();
+    expect(privateSession.coordinator.preemptPreparation()).toBe(true);
     finishStartup();
 
     expect(await failure).toEqual({
@@ -292,10 +293,10 @@ describe("AgentSession pre-stream errors", () => {
     historyCleanup = cleanup;
 
     const privateSession = session as unknown as {
-      setTurnPhase(next: "idle" | "preparing" | "streaming" | "completing"): void;
+      coordinator: TurnCoordinator;
     };
 
-    privateSession.setTurnPhase("preparing");
+    privateSession.coordinator.prepare();
     aiEmitter.emit("runtime-status", {
       type: "runtime-status",
       workspaceId,

--- a/src/node/services/agentSession.queueDispatch.test.ts
+++ b/src/node/services/agentSession.queueDispatch.test.ts
@@ -60,6 +60,39 @@ async function waitForCondition(condition: () => boolean, timeoutMs = 500): Prom
 }
 
 describe("AgentSession queued message tool-call dispatch", () => {
+  test("a queued provider startup failure drains its successor after accepted-turn cleanup", async () => {
+    const successor = Promise.withResolvers<void>();
+    let calls = 0;
+    const streamMessage = mock(() => {
+      if (++calls === 1)
+        return Promise.resolve(
+          Err({ type: "api_key_not_found" as const, provider: "anthropic" as const })
+        );
+      successor.resolve();
+      return Promise.resolve(Ok(createStartedTurnHandle()));
+    });
+    const { session, cleanup } = await createAgentSessionHarness({
+      workspaceId: "queue-provider-startup-failure",
+      aiServiceOverrides: { streamMessage },
+    });
+    try {
+      session.queueMessage(
+        "failed startup",
+        { model: TEST_MODEL, agentId: "exec" },
+        { synthetic: true }
+      );
+      session.queueMessage("successor", { model: TEST_MODEL, agentId: "exec" });
+      session.sendQueuedMessages();
+      await successor.promise;
+      await session.waitForIdle();
+      expect(calls).toBe(2);
+      expect(session.hasQueuedMessages()).toBe(false);
+    } finally {
+      session.dispose();
+      await cleanup();
+    }
+  });
+
   test.each(["returned error", "rejection"] as const)(
     "reserves queued startup synchronously and drains after %s cleanup",
     async (failureKind) => {

--- a/src/node/services/agentSession.startupAutoRetry.test.ts
+++ b/src/node/services/agentSession.startupAutoRetry.test.ts
@@ -1,3 +1,4 @@
+import type { TurnCoordinator } from "./turnCoordinator";
 import { runSessionTerminalPolicy } from "./agentSession.testHarness";
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { EventEmitter } from "events";
@@ -514,12 +515,12 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(appendResult.success).toBe(true);
 
     const privateSession = session as unknown as {
-      setTurnPhase: (phase: "idle" | "preparing" | "streaming" | "completing") => void;
+      coordinator: TurnCoordinator;
       startupAutoRetryCheckPromise: Promise<void> | null;
       startupAutoRetryCheckScheduled: boolean;
     };
 
-    privateSession.setTurnPhase("preparing");
+    privateSession.coordinator.prepare();
     session.ensureStartupAutoRetryCheck();
 
     const firstCheckPromise = privateSession.startupAutoRetryCheckPromise;
@@ -528,7 +529,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(privateSession.startupAutoRetryCheckScheduled).toBe(false);
     expect(events.some((event) => event.type === "auto-retry-scheduled")).toBe(false);
 
-    privateSession.setTurnPhase("idle");
+    privateSession.coordinator.finishTurn(privateSession.coordinator.turnId);
 
     const deadline = Date.now() + 1500;
     while (
@@ -1749,14 +1750,14 @@ describe("AgentSession startup auto-retry recovery", () => {
     });
 
     const privateSession = session as unknown as {
-      setTurnPhase: (phase: "idle" | "preparing" | "streaming" | "completing") => void;
+      coordinator: TurnCoordinator;
       activeStreamUserMessageId?: string;
       getAutoRetryPreferencePath: () => string;
       startupAutoRetryAbandon: { reason: string; userMessageId?: string } | null;
     };
 
     privateSession.activeStreamUserMessageId = "user-1";
-    privateSession.setTurnPhase("preparing");
+    privateSession.coordinator.prepare();
 
     void runSessionTerminalPolicy(session, aiEmitter, {
       type: "stream-abort",

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -1,3 +1,4 @@
+import type { TurnStreamHandle } from "./streamManager";
 import type { StreamManager } from "./streamManager";
 import * as path from "path";
 import assert from "@/common/utils/assert";
@@ -9,7 +10,14 @@ import { PlatformPaths } from "@/common/utils/paths";
 import { log } from "@/node/services/log";
 import { eventSpine } from "@/node/services/events/eventSpine";
 import { ProvidersConfigStore, type Config } from "@/node/config";
-import type { TurnStreamHandle } from "@/node/services/streamManager";
+import {
+  TurnCoordinator,
+  type TurnPhase,
+  type TurnId,
+  type OperationId,
+  type StreamErrorRecoveryOutcome,
+} from "./turnCoordinator";
+export type { StreamErrorRecoveryOutcome } from "./turnCoordinator";
 import type { StreamMessageOptions } from "@/node/services/turnRequestBuilder";
 import type { HistoryService } from "@/node/services/historyService";
 import type { SessionUsageService } from "@/node/services/sessionUsageService";
@@ -648,23 +656,6 @@ interface AgentSessionOptions {
   hasExternalSendPreflight?: () => boolean;
 }
 
-enum TurnPhase {
-  IDLE = "idle",
-  PREPARING = "preparing",
-  STREAMING = "streaming",
-  COMPLETING = "completing",
-}
-
-/**
- * Recorded outcome of handleStreamError for the current recovery episode.
- * "retry-started" means an in-session recovery retry completed stream startup
- * (isStreaming was true at resolution); "terminal" means the error settled
- * with no retry. Waiters (task/workspace-turn stream-error settlement) act on
- * this recorded outcome instead of sampling transient phase flags, which a
- * fast retry could outrun.
- */
-export type StreamErrorRecoveryOutcome = "retry-started" | "terminal";
-
 type StartupAutoRetryCheckOutcome = "completed" | "deferred";
 
 interface CachedMemoryContext {
@@ -692,26 +683,50 @@ export class AgentSession {
     [];
   private readonly initListeners: Array<{ event: string; handler: (...args: unknown[]) => void }> =
     [];
-  private disposed = false;
-  private shuttingDown = false;
-  private turnPhase: TurnPhase = TurnPhase.IDLE;
-  /** Edit-flow admission reservations currently holding busy-ness (see isBusy, r32). */
-  private editAdmissionDepth = 0;
-  /**
-   * Context-discarding history mutations currently blocking turn admission
-   * (see holdTurnAdmission, r40). Deliberately NOT part of isBusy(): the
-   * holder itself requires an idle session.
-   */
-  private turnAdmissionBlocks = 0;
-  private activePreparedTurnAbortController: AbortController | null = null;
-  /**
-   * Per-turn holder for mid-turn thinking-level overrides. Created when a turn
-   * is durably accepted (before any await that could let the renderer's slider
-   * route race in), threaded by reference into StreamManager, and cleared when
-   * the turn ends (setTurnPhase → IDLE). Null while idle: the slider route then
-   * reports accepted:false and persisted settings cover the next turn.
-   */
-  private activeTurnThinkingOverride: ActiveTurnThinkingOverride | null = null;
+  private readonly coordinator = new TurnCoordinator({
+    streamStarted: (payload) => {
+      this.continuousCompactionAbandoned = false;
+      this.dispatchingQueuedEntry = false;
+      this.dispatchingQueuedEntryMuxMetadata = undefined;
+      this.preparingWorkspaceTurnMetadata = undefined;
+      this.activeStreamStartedAtMs = payload.startTime;
+      // Codex P1 (PRRT_kwDOPxxmWM6cClKS): a new live stream makes mid-stream
+      // setGoal deferral meaningful again — clear the goal service's settled
+      // fast-path synchronously so a model set_goal in THIS stream queues
+      // for its stream-end drain instead of writing goal.json mid-stream.
+      this.workspaceGoalService?.recordStreamStarted(this.workspaceId);
+      this.queuedProviderToolEndAbortInFlight = false;
+      this.activeToolCallIds.clear();
+    },
+    phaseChanged: (phase, isCurrent) => this.publishTurnPhase(phase, isCurrent),
+    drainQueue: () => {
+      if (!this.messageQueue.isEmpty()) this.sendQueuedMessages();
+    },
+    policy: async (operation, messageId, outcome, started, notifyStartup) => {
+      if (!this.coordinator.isCurrentOperation(operation)) return;
+      switch (outcome.status) {
+        case "completed":
+          await this.handleTurnSuccess({ ...outcome.streamEnd, messageId }, operation);
+          break;
+        case "failed":
+          await this.handleStreamError({ ...outcome.streamError, messageId }, operation);
+          break;
+        case "aborted":
+          if (outcome.streamAbort) {
+            const payload = { ...outcome.streamAbort, messageId, abortReason: outcome.abortReason };
+            if (started)
+              await this.handleTurnAbort(payload, outcome.systemMessageTokens, operation);
+            else if (notifyStartup) await this.handleStartupAbort(payload, operation);
+          }
+          break;
+      }
+    },
+    policyError: (error) =>
+      log.error("Failed to consume turn completion", {
+        workspaceId: this.workspaceId,
+        error: getErrorMessage(error),
+      }),
+  });
   // When true, stream-end skips auto-flushing queued messages so an edit can truncate first.
   private deferQueuedFlushUntilAfterEdit = false;
   // Provider-executed tools (for example native web_search/web_fetch) complete inside one
@@ -720,14 +735,11 @@ export class AgentSession {
   private queuedProviderToolEndAbortInFlight = false;
   private readonly activeToolCallIds = new Set<string>();
 
-  private idleWaiters: Array<() => void> = [];
-  private pendingExternalManualFollowUps = 0;
   private readonly messageQueue = new MessageQueue();
   private readonly compactionHandler: CompactionHandler;
   private readonly compactionMonitor: CompactionMonitor;
   private readonly continuousCompactor: ContinuousCompactor;
 
-  private autoRetryStarting = false;
   private readonly retryManager: RetryManager;
   private lastAutoRetryResumeRequest?: AutoRetryResumeRequest;
   /** Startup recovery should run once per session to avoid duplicate retry timers on reconnect. */
@@ -845,43 +857,8 @@ export class AgentSession {
   /** Last lifecycle snapshot emitted to live subscribers (used for change detection only). */
   private lastEmittedStreamLifecycle: StreamLifecycleSnapshot | null = null;
 
-  /**
-   * Stream-error recovery decisions keyed by the failed assistant messageId.
-   * Per-attempt tracking (not a single shared decision) because recovery
-   * episodes can overlap: a retry stream can emit its own error before the
-   * original retry path resumes, and folding both into one decision would let
-   * one episode's "retry-started" mask the other's "terminal". Resolved
-   * outcomes are retained so waiters queued behind workspace event locks can
-   * read the decision after the fact.
-   */
-  private readonly streamErrorRecoveryDecisions = new Map<
-    string,
-    {
-      promise: Promise<StreamErrorRecoveryOutcome>;
-      resolve: (outcome: StreamErrorRecoveryOutcome) => void;
-      outcome?: StreamErrorRecoveryOutcome;
-    }
-  >();
-
-  /** Compaction persistence outcomes keyed by the compact assistant message. */
-  private readonly compactionCompletionDecisions = new Map<
-    string,
-    { promise: Promise<boolean>; resolve: (handled: boolean) => void; outcome?: boolean }
-  >();
-
   /** Tracks whether the current stream included post-compaction attachments. */
   private activeStreamHadPostCompactionInjection = false;
-
-  // Registered before streamMessage: mock/simulation terminals can arrive before its handle.
-  private activeTurnOperation?: {
-    messageId?: string;
-    consumed: boolean;
-    startupMessageId?: string;
-    startupAbortNotified: boolean;
-    compaction: boolean;
-    started: boolean;
-    policySettlement: { promise: Promise<void>; resolve: () => void };
-  };
 
   /**
    * muxMetadata of the queued entry currently being dispatched, held from
@@ -1081,30 +1058,17 @@ export class AgentSession {
    * Stops the retry timer and makes every internal dispatch boundary below bail like `disposed`.
    */
   beginShutdown(): void {
-    this.shuttingDown = true;
+    this.coordinator.beginShutdown();
     this.continuousCompactor.reset("shutdown");
     this.retryManager.cancel();
   }
 
   dispose(): void {
-    if (this.disposed) {
+    if (this.coordinator.disposed) {
       return;
     }
-    this.disposed = true;
-    this.activeTurnOperation?.policySettlement.resolve();
-    for (const messageId of this.compactionCompletionDecisions.keys()) {
-      this.resolveCompactionCompletionDecision(messageId, false);
-    }
-    for (const messageId of this.streamErrorRecoveryDecisions.keys()) {
-      this.resolveStreamErrorRecoveryDecision(messageId, "terminal");
-    }
+    this.coordinator.dispose();
     this.continuousCompactor.reset("dispose");
-
-    this.activePreparedTurnAbortController?.abort();
-    this.activePreparedTurnAbortController = null;
-
-    // Ensure any callers blocked on waitForIdle() can continue during teardown.
-    this.setTurnPhase(TurnPhase.IDLE);
 
     this.retryManager.dispose();
 
@@ -1217,18 +1181,18 @@ export class AgentSession {
   }
 
   private getCurrentStreamLifecycleSnapshot(): StreamLifecycleSnapshot {
-    if (this.turnPhase === TurnPhase.PREPARING) {
+    if (this.coordinator.phase === "preparing") {
       return { phase: "preparing", hadAnyOutput: false };
     }
 
-    if (this.turnPhase === TurnPhase.STREAMING) {
+    if (this.coordinator.phase === "streaming") {
       return {
         phase: "streaming",
         hadAnyOutput: this.activeStreamHadAnyDelta,
       };
     }
 
-    if (this.turnPhase === TurnPhase.COMPLETING) {
+    if (this.coordinator.phase === "completing") {
       return {
         phase: "completing",
         hadAnyOutput: this.activeStreamHadAnyDelta,
@@ -1264,7 +1228,7 @@ export class AgentSession {
   }
 
   private emitStreamLifecycleIfChanged(): void {
-    if (this.disposed) {
+    if (this.coordinator.disposed) {
       return;
     }
 
@@ -1316,75 +1280,18 @@ export class AgentSession {
 
   private handleRetryStatusChange(event: RetryStatusEvent): void {
     if (event.type === "auto-retry-starting") {
-      this.autoRetryStarting = true;
+      this.coordinator.beginRetry();
     } else if (event.type === "auto-retry-scheduled" || event.type === "auto-retry-abandoned") {
-      this.autoRetryStarting = false;
+      this.coordinator.clearRetryStarting();
     }
     this.emitRetryEvent(event);
   }
 
   private emitRetryEvent(event: RetryStatusEvent): void {
-    if (this.disposed) {
+    if (this.coordinator.disposed) {
       return;
     }
     this.emitChatEvent(event);
-  }
-
-  private beginCompactionCompletionDecision(messageId: string): void {
-    if (this.compactionCompletionDecisions.has(messageId)) return;
-    let resolveDecision!: (handled: boolean) => void;
-    const promise = new Promise<boolean>((resolve) => {
-      resolveDecision = resolve;
-    });
-    this.compactionCompletionDecisions.set(messageId, { promise, resolve: resolveDecision });
-  }
-
-  private resolveCompactionCompletionDecision(messageId: string, handled: boolean): void {
-    const decision = this.compactionCompletionDecisions.get(messageId);
-    if (decision == null || decision.outcome != null) return;
-    decision.outcome = handled;
-    decision.resolve(handled);
-  }
-
-  private beginStreamErrorRecoveryDecision(messageId: string): void {
-    // Duplicate error events for the same attempt share one decision.
-    if (this.streamErrorRecoveryDecisions.has(messageId)) {
-      return;
-    }
-
-    // Bound retention: evict oldest resolved decisions (insertion order),
-    // never pending ones — deleting a pending decision would orphan waiters.
-    const maxRetainedDecisions = 8;
-    for (const [key, entry] of this.streamErrorRecoveryDecisions) {
-      if (this.streamErrorRecoveryDecisions.size < maxRetainedDecisions) {
-        break;
-      }
-      if (entry.outcome != null) {
-        this.streamErrorRecoveryDecisions.delete(key);
-      }
-    }
-
-    let resolveDecision!: (outcome: StreamErrorRecoveryOutcome) => void;
-    const promise = new Promise<StreamErrorRecoveryOutcome>((resolve) => {
-      resolveDecision = resolve;
-    });
-    this.streamErrorRecoveryDecisions.set(messageId, { promise, resolve: resolveDecision });
-  }
-
-  private resolveStreamErrorRecoveryDecision(
-    messageId: string,
-    outcome: StreamErrorRecoveryOutcome
-  ): void {
-    const decision = this.streamErrorRecoveryDecisions.get(messageId);
-    // First resolution per attempt wins: the errorHandler's terminal safety
-    // net must not overwrite a "retry-started" already recorded for the same
-    // attempt.
-    if (decision == null || decision.outcome != null) {
-      return;
-    }
-
-    decision.outcome = outcome;
-    decision.resolve(outcome);
   }
 
   private async handleStreamFailureForAutoRetry(error: RetryFailureError): Promise<void> {
@@ -1392,13 +1299,15 @@ export class AgentSession {
       typeof error.type === "string" && error.type.length > 0,
       "handleStreamFailureForAutoRetry requires a non-empty error.type"
     );
-    if (this.shuttingDown) {
+    if (this.coordinator.closing) {
       return;
     }
 
     // Load persisted preference before scheduling retries so an on-disk opt-out is
     // honored even when the first failure happens before startup recovery runs.
+    const turn = this.coordinator.turnId;
     await this.loadAutoRetryEnabledPreference();
+    if (this.coordinator.closing || !this.coordinator.isCurrentTurn(turn)) return;
     this.retryManager.handleStreamFailure(error);
   }
 
@@ -1434,7 +1343,7 @@ export class AgentSession {
   }
 
   private async retryActiveStream(): Promise<void> {
-    this.autoRetryStarting = true;
+    const retry = this.coordinator.beginRetry();
     try {
       const request = this.lastAutoRetryResumeRequest;
       if (!request) {
@@ -1487,7 +1396,7 @@ export class AgentSession {
         this.activeStreamUserMessageId
       );
     } finally {
-      this.autoRetryStarting = false;
+      this.coordinator.finishRetry(retry);
     }
   }
 
@@ -2350,7 +2259,7 @@ export class AgentSession {
   }
 
   private async scheduleStartupAutoRetryIfNeeded(): Promise<StartupAutoRetryCheckOutcome> {
-    if (this.disposed || this.isBusy() || this.isAiStreaming()) {
+    if (this.coordinator.disposed || this.isBusy() || this.isAiStreaming()) {
       // Busy/streaming deferrals are state-driven; do not carry history-error backoff.
       this.startupAutoRetryDeferredRetryDelayMs = 0;
       return "deferred";
@@ -2442,7 +2351,7 @@ export class AgentSession {
 
     // Disk reads above may race with user actions; retry once the current work settles
     // instead of permanently suppressing startup auto-retry for this session.
-    if (this.disposed || this.isBusy() || this.isAiStreaming()) {
+    if (this.coordinator.disposed || this.isBusy() || this.isAiStreaming()) {
       this.startupAutoRetryDeferredRetryDelayMs = 0;
       return "deferred";
     }
@@ -2463,12 +2372,12 @@ export class AgentSession {
     const delayMs = Math.max(0, Math.trunc(retryDelayMs));
     if (delayMs > 0) {
       await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
-      if (this.disposed) {
+      if (this.coordinator.disposed) {
         return;
       }
     }
 
-    while (!this.disposed) {
+    while (!this.coordinator.disposed) {
       await this.waitForIdle();
       if (!this.isAiStreaming()) {
         return;
@@ -2486,7 +2395,7 @@ export class AgentSession {
             return;
           }
 
-          if (this.disposed || !this.isAiStreaming()) {
+          if (this.coordinator.disposed || !this.isAiStreaming()) {
             cleanup();
             resolve();
           }
@@ -2509,7 +2418,11 @@ export class AgentSession {
   }
 
   ensureStartupAutoRetryCheck(): void {
-    if (this.disposed || this.startupAutoRetryCheckScheduled || this.startupAutoRetryCheckPromise) {
+    if (
+      this.coordinator.disposed ||
+      this.startupAutoRetryCheckScheduled ||
+      this.startupAutoRetryCheckPromise
+    ) {
       return;
     }
 
@@ -2535,7 +2448,7 @@ export class AgentSession {
       .finally(() => {
         this.startupAutoRetryCheckPromise = null;
 
-        if (!rerunWhenIdle || this.disposed) {
+        if (!rerunWhenIdle || this.coordinator.disposed) {
           return;
         }
 
@@ -2543,7 +2456,7 @@ export class AgentSession {
         this.startupAutoRetryDeferredRetryDelayMs = 0;
 
         void this.waitForStartupAutoRetryRerunWindow(rerunDelayMs).then(() => {
-          if (!this.disposed) {
+          if (!this.coordinator.disposed) {
             this.ensureStartupAutoRetryCheck();
           }
         });
@@ -2551,7 +2464,7 @@ export class AgentSession {
   }
 
   async runStartupRecovery(): Promise<void> {
-    if (this.disposed || this.shuttingDown) {
+    if (this.coordinator.disposed || this.coordinator.closing) {
       return;
     }
 
@@ -2591,7 +2504,7 @@ export class AgentSession {
     }
 
     let deferredAttempts = 0;
-    while (!this.disposed && !this.shuttingDown) {
+    while (!this.coordinator.disposed && !this.coordinator.closing) {
       let outcome: StartupAutoRetryCheckOutcome;
       try {
         outcome = await this.scheduleStartupAutoRetryIfNeeded();
@@ -2645,7 +2558,7 @@ export class AgentSession {
   }
 
   scheduleStartupRecovery(): void {
-    if (this.disposed || this.startupRecoveryScheduled || this.startupRecoveryPromise) {
+    if (this.coordinator.disposed || this.startupRecoveryScheduled || this.startupRecoveryPromise) {
       return;
     }
 
@@ -3155,6 +3068,8 @@ export class AgentSession {
     message: string,
     options?: SendMessageOptions & { fileParts?: FilePart[] },
     internal?: {
+      /** A dequeued send keeps its admission owner through acceptance and startup failure. */
+      turnReservation?: TurnId;
       synthetic?: boolean;
       agentInitiated?: boolean;
       goalContinuation?: boolean;
@@ -3210,7 +3125,7 @@ export class AgentSession {
        * r41: staleness probe for this send's admission epoch, captured
        * synchronously with WorkspaceService's entry checks. Returns true when
        * a context-discarding mutation COMPLETED after the send entered — the
-       * level-triggered turnAdmissionBlocks check cannot catch a mutation
+       * level-triggered admission block check cannot catch a mutation
        * that started and finished while the send sat in pre-admission
        * awaits. Not threaded through queued entries: those dispatch into the
        * post-mutation context by design.
@@ -3502,7 +3417,7 @@ export class AgentSession {
     // directory removal is about to delete. Bail exactly like that check
     // (nothing durable has been persisted for this turn yet, so a plain Ok is
     // safe — no monitor wake can be past its point of no return here).
-    if (this.disposed) {
+    if (this.coordinator.disposed) {
       return Ok(undefined);
     }
     if (pendingBranchSummary) {
@@ -3518,23 +3433,12 @@ export class AgentSession {
     // phase has taken over busy-ness by then; on a pre-PREPARING failure the
     // session returns to idle, so drain anything queued behind the
     // reservation (mirrors the queued-dispatch failure contract).
+    let editReservation: Disposable | undefined;
     const editAdmission = {
-      armed: false,
       arm: () => {
-        if (!editAdmission.armed) {
-          editAdmission.armed = true;
-          this.editAdmissionDepth += 1;
-        }
+        editReservation ??= this.coordinator.reserve("edit");
       },
-      [Symbol.dispose]: () => {
-        if (!editAdmission.armed) return;
-        editAdmission.armed = false;
-        this.editAdmissionDepth -= 1;
-        assert(this.editAdmissionDepth >= 0, "editAdmissionDepth must not go negative");
-        if (this.editAdmissionDepth === 0 && this.turnPhase === TurnPhase.IDLE) {
-          this.sendQueuedMessages();
-        }
-      },
+      [Symbol.dispose]: () => editReservation?.[Symbol.dispose](),
     };
     using _editAdmission = editAdmission;
 
@@ -3550,7 +3454,7 @@ export class AgentSession {
         // If we're already COMPLETING, do NOT call stopStream(): StreamManager will emit a
         // synthetic stream-abort when no stream is active, which can incorrectly transition us to
         // IDLE while completion cleanup is still in-flight.
-        if (this.turnPhase !== TurnPhase.COMPLETING) {
+        if (this.coordinator.phase !== "completing") {
           // MUST use abandonPartial=true to prevent handleAbort from performing partial compaction
           // with mismatched history (since we're about to truncate it).
           const stopResult = await this.interruptStream({ abandonPartial: true });
@@ -3564,17 +3468,9 @@ export class AgentSession {
           }
         }
 
-        if (this.turnPhase === TurnPhase.PREPARING && this.activePreparedTurnAbortController) {
-          // Last-message edits can arrive while the previous turn is still in startup.
-          // Abort it and mark idle so the edit can truncate immediately.
-          const abortController = this.activePreparedTurnAbortController;
-          this.activePreparedTurnAbortController = null;
-          abortController.abort();
-          // Editing now owns history, even before its replacement reaches PREPARING.
-          this.clearActiveTurnOperation();
-          this.setTurnPhase(TurnPhase.IDLE);
-          preemptedPreparing = true;
-        }
+        // Editing owns history before its replacement reaches PREPARING. The coordinator
+        // invalidates startup synchronously so late completion cannot write across truncation.
+        preemptedPreparing = this.coordinator.preemptPreparation();
 
         // Tell stream-end to skip sendQueuedMessages() so the edit truncates first.
         this.deferQueuedFlushUntilAfterEdit = true;
@@ -3585,7 +3481,7 @@ export class AgentSession {
 
           // Workspace teardown does not await in-flight async work; bail out if the session was
           // disposed while waiting for completion cleanup.
-          if (this.disposed) {
+          if (this.coordinator.disposed) {
             return Ok(undefined);
           }
         } finally {
@@ -3600,10 +3496,10 @@ export class AgentSession {
       // claims busy-ness), so whichever side runs first is observed by the
       // other. The epoch probe (r41) also refuses edits whose target rows a
       // completed mutation already discarded.
-      if (this.turnAdmissionBlocks > 0 || isAdmissionStale()) {
+      if (this.coordinator.admissionBlocked || isAdmissionStale()) {
         return Err(createUnknownSendMessageError(CONTEXT_MUTATION_SEND_BLOCKED_MESSAGE));
       }
-      if (this.shuttingDown) {
+      if (this.coordinator.closing) {
         return Err(createUnknownSendMessageError(SESSION_SHUTDOWN_SEND_BLOCKED_MESSAGE));
       }
 
@@ -3952,12 +3848,12 @@ export class AgentSession {
     // refuse while sends are in preflight (r42), so rows can no longer land
     // after a mutation commits; this check and the PREPARING gate remain
     // backstops for entry-accounting bypasses.
-    if (this.turnAdmissionBlocks > 0 || isAdmissionStale()) {
+    if (this.coordinator.admissionBlocked || isAdmissionStale()) {
       return Err(createUnknownSendMessageError(CONTEXT_MUTATION_SEND_BLOCKED_MESSAGE));
     }
     // Still pre-persist: a row appended now would read as a dispatched turn on the next startup
     // while streamWithHistory's own latch check keeps its stream from ever running.
-    if (this.shuttingDown) {
+    if (this.coordinator.closing) {
       return Err(createUnknownSendMessageError(SESSION_SHUTDOWN_SEND_BLOCKED_MESSAGE));
     }
 
@@ -4145,7 +4041,7 @@ export class AgentSession {
     // Workspace may be tearing down while we await filesystem IO.
     // If so, skip event emission + streaming to avoid races with dispose(). A cancelable monitor
     // wake past the point of no return is already durable, so finalize it before leaving.
-    if (this.disposed) {
+    if (this.coordinator.disposed) {
       if (cancelSignal != null && cancellationDisabled) {
         await internal?.onAccepted?.();
       }
@@ -4157,7 +4053,7 @@ export class AgentSession {
     // await, so a slider change during PREPARING (runtime warmup, model
     // creation) lands in the holder the stream's prepareStep will read.
     const turnThinkingOverride: ActiveTurnThinkingOverride = {};
-    this.activeTurnThinkingOverride = turnThinkingOverride;
+    this.coordinator.acceptThinkingOverride(turnThinkingOverride, this.coordinator.turnId);
 
     // Emit snapshots only for immediately-sent turns. On on-send compaction paths,
     // snapshots are deferred with the follow-up message to avoid duplicate ephemeral
@@ -4216,8 +4112,8 @@ export class AgentSession {
     } catch (error) {
       // Pre-stream failure: identity-guarded so a replacement turn's holder
       // (created while this one unwound) is never cleared by mistake.
-      if (this.activeTurnThinkingOverride === turnThinkingOverride) {
-        this.activeTurnThinkingOverride = null;
+      if (this.coordinator.thinkingOverride === turnThinkingOverride) {
+        this.coordinator.releaseThinkingOverride(turnThinkingOverride);
       }
       return Err(createUnknownSendMessageError(getErrorMessage(error)));
     }
@@ -4244,7 +4140,7 @@ export class AgentSession {
     // normally impossible since mutations refuse while sends are in
     // preflight (r42), but kept for paths that bypass WorkspaceService
     // entry accounting.
-    if (this.turnAdmissionBlocks > 0 || isAdmissionStale()) {
+    if (this.coordinator.admissionBlocked || isAdmissionStale()) {
       const error = createUnknownSendMessageError(CONTEXT_MUTATION_SEND_BLOCKED_MESSAGE);
       // The turn was already accepted (rows durable, onAccepted ran):
       // internal callers like the terminal-attention outbox mark state
@@ -4256,16 +4152,21 @@ export class AgentSession {
     }
 
     const preparedTurnAbortController = new AbortController();
-    this.activePreparedTurnAbortController = preparedTurnAbortController;
     this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(optionsForStream.muxMetadata);
-    this.setTurnPhase(TurnPhase.PREPARING);
+    const preparedTurn = this.coordinator.prepare(
+      preparedTurnAbortController,
+      internal?.turnReservation
+    );
     // From this synchronous point isBusy() reports the turn — release the
     // service-side preflight reservation (see onTurnAdmissionCommitted doc).
     internal?.onTurnAdmissionCommitted?.();
 
     const startPreparedStream = async (): Promise<AgentSessionResult<void>> => {
       try {
-        if (preparedTurnAbortController.signal.aborted) {
+        if (
+          !this.coordinator.isCurrentTurn(preparedTurn) ||
+          preparedTurnAbortController.signal.aborted
+        ) {
           await notifyAcceptedPreStreamFailure(
             createUnknownSendMessageError("Accepted stream startup was canceled before it began.")
           );
@@ -4277,7 +4178,7 @@ export class AgentSession {
         // and dispatched via dispatchPendingFollowUp() after compaction completes.
         // This provides crash safety - the follow-up survives app restarts.
 
-        if (this.disposed || preparedTurnAbortController.signal.aborted) {
+        if (this.coordinator.disposed || preparedTurnAbortController.signal.aborted) {
           await notifyAcceptedPreStreamFailure(
             createUnknownSendMessageError("Accepted stream startup was canceled before streaming.")
           );
@@ -4286,6 +4187,7 @@ export class AgentSession {
 
         // Raw terminals reserve COMPLETING; delivered completion runs terminal policy.
         const streamResult = await this.streamWithHistory(
+          preparedTurn,
           modelForStream,
           optionsForStream,
           undefined,
@@ -4308,12 +4210,7 @@ export class AgentSession {
         // Success should advance via stream events; if startup never emitted any, don't leave the
         // session stuck in PREPARING. Guard by controller identity so an aborted startup cannot
         // mark the replacement edit's new PREPARING turn idle when it unwinds later.
-        if (this.activePreparedTurnAbortController === preparedTurnAbortController) {
-          this.activePreparedTurnAbortController = null;
-          if (this.turnPhase === TurnPhase.PREPARING) {
-            this.setTurnPhase(TurnPhase.IDLE);
-          }
-        }
+        this.coordinator.finishPreparation(preparedTurn);
       }
     };
 
@@ -4323,7 +4220,11 @@ export class AgentSession {
       // Resume, that makes chat history the durable source of truth for the
       // running goal before runtime warmup or streaming can race/fail.
       const drainQueuedMessagesAfterFailedStartup = (): void => {
-        if (this.turnPhase === TurnPhase.IDLE && !this.messageQueue.isEmpty()) {
+        if (
+          this.coordinator.isCurrentTurn(preparedTurn) &&
+          this.coordinator.phase === "idle" &&
+          !this.messageQueue.isEmpty()
+        ) {
           this.sendQueuedMessages();
         }
       };
@@ -4398,7 +4299,7 @@ export class AgentSession {
     // clears the resume request (discardAutoRetryForContextMutation, r41),
     // so a straggler reschedule self-abandons instead of replaying the
     // discarded context.
-    if (this.turnAdmissionBlocks > 0) {
+    if (this.coordinator.admissionBlocked) {
       return Ok({ started: false });
     }
 
@@ -4411,15 +4312,16 @@ export class AgentSession {
       internal?.goalId
     );
     this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(optionsForStream.muxMetadata);
-    this.setTurnPhase(TurnPhase.PREPARING);
+    const preparedTurn = this.coordinator.prepare();
     // Open the mid-turn thinking override window for the resumed turn (after
-    // setTurnPhase(PREPARING), which clears the holder on the IDLE transition).
+    // preparation publication; the coordinator expires the holder when the turn becomes idle).
     const turnThinkingOverride: ActiveTurnThinkingOverride = {};
-    this.activeTurnThinkingOverride = turnThinkingOverride;
+    this.coordinator.acceptThinkingOverride(turnThinkingOverride, preparedTurn);
     try {
       // Must await here so the finally block runs after streaming completes,
       // not immediately when the Promise is returned.
       const result = await this.streamWithHistory(
+        preparedTurn,
         modelForStream,
         optionsForStream,
         undefined,
@@ -4436,8 +4338,8 @@ export class AgentSession {
 
       return Ok({ started: true });
     } finally {
-      if (this.turnPhase === TurnPhase.PREPARING) {
-        this.setTurnPhase(TurnPhase.IDLE);
+      if (this.coordinator.isCurrentTurn(preparedTurn)) {
+        this.coordinator.finishPreparation(preparedTurn);
       }
     }
   }
@@ -4580,7 +4482,7 @@ export class AgentSession {
     rejection: SendMessageError,
     enqueuedAtMs?: number
   ): Promise<boolean> {
-    if (this.disposed) {
+    if (this.coordinator.disposed) {
       return false;
     }
     const trimmed = message.trim();
@@ -4620,7 +4522,7 @@ export class AgentSession {
           workspaceId: this.workspaceId,
           error: appendResult.error,
         });
-      } else if (!this.disposed) {
+      } else if (!this.coordinator.disposed) {
         this.emitChatEvent({ ...userMessage, type: "message" });
       }
     } catch (error) {
@@ -4629,7 +4531,7 @@ export class AgentSession {
         error: getErrorMessage(error),
       });
     }
-    if (!this.disposed) {
+    if (!this.coordinator.disposed) {
       const streamError = buildStreamErrorEventData(rejection);
       this.emitChatEvent(createStreamErrorMessage(streamError));
     }
@@ -4971,11 +4873,11 @@ export class AgentSession {
       enabled:
         enabled &&
         this.compactionMonitor.getThreshold() < 1 &&
-        !this.disposed &&
-        !this.shuttingDown &&
+        !this.coordinator.disposed &&
+        !this.coordinator.closing &&
         !this.continuousCompactionAbandoned &&
-        this.turnAdmissionBlocks === 0 &&
-        this.editAdmissionDepth === 0 &&
+        !this.coordinator.admissionBlocked &&
+        !this.coordinator.editReserved &&
         !this.isWorkspaceArchivedOnDisk(),
       model,
       contextWindowTokens:
@@ -5103,8 +5005,8 @@ export class AgentSession {
     if (
       this.midStreamCompactionPending ||
       !context?.options ||
-      this.disposed ||
-      this.shuttingDown
+      this.coordinator.disposed ||
+      this.coordinator.closing
     ) {
       return false;
     }
@@ -5116,8 +5018,8 @@ export class AgentSession {
     this.continuousCompactionStopped = true;
     await this.waitForIdle();
     if (
-      this.disposed ||
-      this.shuttingDown ||
+      this.coordinator.disposed ||
+      this.coordinator.closing ||
       this.continuousCompactionAbandoned ||
       this.isWorkspaceArchivedOnDisk()
     )
@@ -5164,10 +5066,10 @@ export class AgentSession {
       // rather than relying on activeStreamContext (cleared by stream-abort).
       if (
         this.continuousCompactionAbandoned ||
-        this.disposed ||
-        this.shuttingDown ||
+        this.coordinator.disposed ||
+        this.coordinator.closing ||
         this.isWorkspaceArchivedOnDisk() ||
-        this.turnAdmissionBlocks > 0
+        this.coordinator.admissionBlocked
       )
         return;
       const pressure = this.compactionMonitor.checkBeforeSend({
@@ -5221,7 +5123,7 @@ export class AgentSession {
   }
 
   private async interruptForCompaction(): Promise<void> {
-    if (this.midStreamCompactionPending || this.disposed) {
+    if (this.midStreamCompactionPending || this.coordinator.disposed) {
       return;
     }
 
@@ -5247,7 +5149,7 @@ export class AgentSession {
       }
 
       await this.waitForIdle();
-      if (this.disposed) {
+      if (this.coordinator.disposed) {
         return;
       }
 
@@ -5346,11 +5248,7 @@ export class AgentSession {
     // renderer before replacement PREPARING invalidates its operation identity.
     // Startup edits must still preempt a blocked envelope; soft stop only requests
     // a future boundary, so neither joins policy here.
-    const interruptedOperation = this.activeTurnOperation;
-    const interruptedPolicy =
-      options?.soft !== true && interruptedOperation?.started
-        ? interruptedOperation.policySettlement.promise
-        : undefined;
+    const interruptedPolicy = this.coordinator.captureInterruptSettlement(options?.soft);
     if (options?.abandonPartial || this.midStreamCompactionPending) {
       this.continuousCompactionAbandoned = true;
       this.continuousCompactor.reset("user-interrupt");
@@ -5387,17 +5285,19 @@ export class AgentSession {
   }
 
   private async handleStreamWithHistoryFailure(
+    turn: TurnId,
+    operation: OperationId,
     error: SendMessageError,
     acpPromptId?: string,
     preStartErrors?: StreamErrorPayload[] | null
   ): Promise<AgentSessionResult<void>> {
     // A disposed session must not persist retry/goal state or error rows
-    // post-teardown (mirrors consumeTurnCompletion). Settle collected recovery
+    // post-teardown (mirrors delivered completion). Settle collected recovery
     // decisions in memory so waiters cannot hang, then skip all recovery
     // bookkeeping; failureHandled keeps callers from running theirs.
-    if (this.disposed) {
+    if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation)) {
       for (const payload of preStartErrors ?? []) {
-        this.resolveStreamErrorRecoveryDecision(payload.messageId, "terminal");
+        this.coordinator.resolveErrorDecision(payload.messageId, "terminal");
       }
       return { success: false, error, failureHandled: true };
     }
@@ -5407,12 +5307,15 @@ export class AgentSession {
     if (preStartErrors != null && preStartErrors.length > 0) {
       for (const payload of preStartErrors) {
         try {
-          await this.handleStreamError({
-            ...payload,
-            acpPromptId: payload.acpPromptId ?? acpPromptId,
-          });
+          await this.handleStreamError(
+            {
+              ...payload,
+              acpPromptId: payload.acpPromptId ?? acpPromptId,
+            },
+            operation
+          );
         } finally {
-          this.resolveStreamErrorRecoveryDecision(payload.messageId, "terminal");
+          this.coordinator.resolveErrorDecision(payload.messageId, "terminal");
         }
       }
       return { success: false, error, failureHandled: true };
@@ -5428,78 +5331,18 @@ export class AgentSession {
         type: failureType,
         message: this.extractRetryFailureMessage(error),
       });
+      if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
+        return { success: false, error, failureHandled: true };
       await this.updateStartupAutoRetryAbandonFromFailure(failureType, failedUserMessageId);
     } else {
-      await this.handleStreamError(buildStreamErrorEventData(error, { acpPromptId }));
+      await this.handleStreamError(buildStreamErrorEventData(error, { acpPromptId }), operation);
     }
 
     return { success: false, error, failureHandled: true };
   }
 
-  private clearActiveTurnOperation(): void {
-    // A replaced operation may never get a handle back (startup cancellation).
-    // Release any explicit interrupt waiter when ownership is relinquished.
-    this.activeTurnOperation?.policySettlement.resolve();
-    this.activeTurnOperation = undefined;
-  }
-
-  private isCurrentTurnOperation(operation: AgentSession["activeTurnOperation"]): boolean {
-    return !this.disposed && this.activeTurnOperation === operation;
-  }
-
-  private consumeTurnCompletion(
-    handle: TurnStreamHandle,
-    operation: NonNullable<AgentSession["activeTurnOperation"]>
-  ): Promise<void> {
-    // Never join terminal policy from the engine sink: a follow-up may await the
-    // old processingPromise. Completion is delivered only after engine cleanup.
-    return handle.completion
-      .then(async (outcome) => {
-        if (operation.consumed) return;
-        operation.consumed = true;
-        try {
-          if (!this.isCurrentTurnOperation(operation)) return;
-          switch (outcome.status) {
-            case "failed":
-              await this.handleStreamError({ ...outcome.streamError, messageId: handle.messageId });
-              break;
-            case "completed":
-              await this.handleTurnSuccess({ ...outcome.streamEnd, messageId: handle.messageId });
-              break;
-            case "aborted":
-              if (outcome.streamAbort) {
-                const payload = {
-                  ...outcome.streamAbort,
-                  messageId: handle.messageId,
-                  abortReason: outcome.abortReason,
-                };
-                if (operation.started) {
-                  await this.handleTurnAbort(payload, outcome.systemMessageTokens);
-                } else if (!operation.startupAbortNotified) {
-                  // A registered engine can abort during envelope preparation, before
-                  // provider startup. Preserve startup policy: no accounting or compaction.
-                  operation.startupAbortNotified = true;
-                  await this.handleStartupAbort(payload);
-                }
-              }
-              break;
-          }
-        } finally {
-          this.resolveStreamErrorRecoveryDecision(handle.messageId, "terminal");
-          this.resolveCompactionCompletionDecision(handle.messageId, false);
-          operation.policySettlement.resolve();
-        }
-      })
-      .catch((error: unknown) => {
-        operation.policySettlement.resolve();
-        log.error("Failed to consume turn completion", {
-          workspaceId: this.workspaceId,
-          error: getErrorMessage(error),
-        });
-      });
-  }
-
   private async streamWithHistory(
+    turn: TurnId,
     modelString: string,
     options?: SendMessageOptions,
     openaiTruncationModeOverride?: "auto" | "disabled",
@@ -5517,21 +5360,15 @@ export class AgentSession {
     // recovery-initiated stream (which carries no abortSignal) awaits commitPartial, file-change
     // detection, or history reads, and must not reach the provider afterwards.
     const isStreamStartAborted = (): boolean =>
-      this.disposed || this.shuttingDown || abortSignal?.aborted === true;
+      !this.coordinator.isCurrentTurn(turn) ||
+      this.coordinator.closing ||
+      abortSignal?.aborted === true;
 
     if (isStreamStartAborted()) {
       return Ok(undefined);
     }
 
-    const operation: NonNullable<AgentSession["activeTurnOperation"]> = {
-      consumed: false,
-      startupAbortNotified: false,
-      compaction: false,
-      started: false,
-      policySettlement: Promise.withResolvers<void>(),
-    };
-    this.clearActiveTurnOperation();
-    this.activeTurnOperation = operation;
+    const operation = this.coordinator.registerOperation(turn);
 
     // Reset per-stream flags (used for retries / crash-safe bookkeeping).
     this.compactionMonitor.resetForNewStream();
@@ -5554,6 +5391,8 @@ export class AgentSession {
     const commitResult = await this.historyService.commitPartial(this.workspaceId);
     if (!commitResult.success) {
       return await this.handleStreamWithHistoryFailure(
+        turn,
+        operation,
         createUnknownSendMessageError(commitResult.error)
       );
     }
@@ -5581,6 +5420,8 @@ export class AgentSession {
       );
       if (!notificationAppendResult.success) {
         return await this.handleStreamWithHistoryFailure(
+          turn,
+          operation,
           createUnknownSendMessageError(notificationAppendResult.error)
         );
       }
@@ -5594,6 +5435,8 @@ export class AgentSession {
 
     if (!historyResult.success) {
       return await this.handleStreamWithHistoryFailure(
+        turn,
+        operation,
         createUnknownSendMessageError(historyResult.error)
       );
     }
@@ -5604,6 +5447,8 @@ export class AgentSession {
 
     if (requestMessages.length === 0) {
       return await this.handleStreamWithHistoryFailure(
+        turn,
+        operation,
         createUnknownSendMessageError(
           "Cannot resume stream: workspace history is empty. Send a new message instead."
         )
@@ -5727,7 +5572,7 @@ export class AgentSession {
     // emit an error event for fire-and-forget senders and then return Err;
     // collect them so the Err path resolves each exactly once.
     const preStartErrors: StreamErrorPayload[] = [];
-    operation.compaction = this.activeCompactionRequest != null;
+    this.coordinator.configureOperation(operation, this.activeCompactionRequest != null);
     const streamResult = await this.aiService.streamMessage({
       messages: requestMessages,
       workspaceId: this.workspaceId,
@@ -5767,30 +5612,33 @@ export class AgentSession {
       activeTurnThinkingOverride,
       onPreStartError: ({ workspaceId: _workspaceId, ...payload }) => preStartErrors.push(payload),
       onStreamStarting: (messageId) => {
-        operation.startupMessageId = messageId;
+        this.coordinator.streamStarting(operation, messageId);
       },
     });
 
     if (!streamResult.success) {
       try {
-        if (!this.isCurrentTurnOperation(operation)) {
+        if (!this.coordinator.isCurrentOperation(operation)) {
           for (const payload of preStartErrors) {
-            this.resolveStreamErrorRecoveryDecision(payload.messageId, "terminal");
+            this.coordinator.resolveErrorDecision(payload.messageId, "terminal");
           }
           return { success: false, error: streamResult.error, failureHandled: true };
         }
         return await this.handleStreamWithHistoryFailure(
+          turn,
+          operation,
           streamResult.error,
           acpPromptId,
           preStartErrors
         );
       } finally {
-        operation.policySettlement.resolve();
+        this.coordinator.finishStartup(operation);
       }
     }
 
-    operation.messageId = streamResult.data.messageId;
-    void this.consumeTurnCompletion(streamResult.data, operation);
+    this.coordinator.consumeCompletion(operation, streamResult.data).catch((error: unknown) => {
+      log.error("Failed to consume turn completion", { error: getErrorMessage(error) });
+    });
     return Ok(undefined);
   }
 
@@ -6010,7 +5858,7 @@ export class AgentSession {
     // retry stream (it would snapshot the transcript the mutation discards).
     // Skipping leaves the recovery decision to the terminal path, exactly
     // like a retry that failed to start.
-    if (this.turnAdmissionBlocks > 0) {
+    if (this.coordinator.admissionBlocked) {
       log.info("Skipping compaction retry: a context-discarding history mutation is in progress", {
         workspaceId: this.workspaceId,
       });
@@ -6026,10 +5874,11 @@ export class AgentSession {
     this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(
       retryOptionsForResume.muxMetadata
     );
-    this.setTurnPhase(TurnPhase.PREPARING);
+    const preparedTurn = this.coordinator.prepare();
     let retryResult: Result<void, SendMessageError>;
     try {
       retryResult = await this.streamWithHistory(
+        preparedTurn,
         context.modelString,
         retryOptions,
         isGptClass ? "auto" : undefined,
@@ -6040,8 +5889,8 @@ export class AgentSession {
         retryGoalId
       );
     } finally {
-      if (this.turnPhase === TurnPhase.PREPARING) {
-        this.setTurnPhase(TurnPhase.IDLE);
+      if (this.coordinator.isCurrentTurn(preparedTurn)) {
+        this.coordinator.finishPreparation(preparedTurn);
       }
     }
     if (!retryResult.success) {
@@ -6059,7 +5908,7 @@ export class AgentSession {
     // streamWithHistory resolves once stream startup completed (the stream is
     // registered, so isStreaming is true); resolve the recovery decision only
     // now so waiters observe the actual retry outcome, not a pre-stream state.
-    this.resolveStreamErrorRecoveryDecision(data.messageId, "retry-started");
+    this.coordinator.resolveErrorDecision(data.messageId, "retry-started");
     return true;
   }
 
@@ -6123,7 +5972,7 @@ export class AgentSession {
 
     // r40: same admission gate as the compaction retry above — this path also
     // crosses a transient idle gap before re-entering PREPARING.
-    if (this.turnAdmissionBlocks > 0) {
+    if (this.coordinator.admissionBlocked) {
       log.info(
         "Skipping post-compaction retry: a context-discarding history mutation is in progress",
         { workspaceId: this.workspaceId }
@@ -6133,10 +5982,11 @@ export class AgentSession {
 
     // Retry the same request, but without post-compaction injection.
     this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(context.options?.muxMetadata);
-    this.setTurnPhase(TurnPhase.PREPARING);
+    const preparedTurn = this.coordinator.prepare();
     let retryResult: Result<void, SendMessageError>;
     try {
       retryResult = await this.streamWithHistory(
+        preparedTurn,
         context.modelString,
         context.options,
         context.openaiTruncationModeOverride,
@@ -6147,8 +5997,8 @@ export class AgentSession {
         context.goalId
       );
     } finally {
-      if (this.turnPhase === TurnPhase.PREPARING) {
-        this.setTurnPhase(TurnPhase.IDLE);
+      if (this.coordinator.isCurrentTurn(preparedTurn)) {
+        this.coordinator.finishPreparation(preparedTurn);
       }
     }
 
@@ -6165,7 +6015,7 @@ export class AgentSession {
 
     // Resolve only after startup completed so waiters observe the actual
     // retry outcome (see maybeRetryCompactionOnContextExceeded).
-    this.resolveStreamErrorRecoveryDecision(data.messageId, "retry-started");
+    this.coordinator.resolveErrorDecision(data.messageId, "retry-started");
     return true;
   }
 
@@ -6279,9 +6129,14 @@ export class AgentSession {
     this.ackPendingPostCompactionStateOnStreamEnd = false;
   }
 
-  private async handleStreamError(data: StreamErrorPayload): Promise<void> {
-    const operation = this.activeTurnOperation;
-    this.setTurnPhase(TurnPhase.COMPLETING);
+  private async handleStreamError(
+    data: StreamErrorPayload,
+    operation = this.coordinator.operationId
+  ): Promise<void> {
+    const turn = this.coordinator.turnId;
+    this.coordinator.beginPolicy(turn);
+    if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
+      return;
 
     this.queuedProviderToolEndAbortInFlight = false;
     this.clearLiveUsageState();
@@ -6304,6 +6159,8 @@ export class AgentSession {
       return; // retry set PREPARING
     }
 
+    if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
+      return;
     // Terminal error — no retry succeeded
     const failedUserMessageId = this.activeStreamUserMessageId;
     const failureType = data.errorType ?? "unknown";
@@ -6311,11 +6168,12 @@ export class AgentSession {
     this.setTerminalStreamLifecycle("failed");
     this.terminalStreamError = streamErrorMessage;
     await this.restoreGoalAccountingSnapshot();
-    if (!this.isCurrentTurnOperation(operation)) return;
+    if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
+      return;
     this.activeCompactionRequest = undefined;
     this.resetActiveStreamState();
 
-    if (hadCompactionRequest && !this.disposed) {
+    if (hadCompactionRequest && !this.coordinator.disposed) {
       this.clearQueue();
     }
 
@@ -6323,24 +6181,29 @@ export class AgentSession {
       type: failureType,
       message: data.error,
     });
-    if (!this.isCurrentTurnOperation(operation)) return;
+    if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
+      return;
     await this.updateStartupAutoRetryAbandonFromFailure(failureType, failedUserMessageId);
-    if (!this.isCurrentTurnOperation(operation)) return;
-    this.resolveStreamErrorRecoveryDecision(data.messageId, "terminal");
+    if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
+      return;
+    this.coordinator.resolveErrorDecision(data.messageId, "terminal");
 
     this.emitChatEvent(streamErrorMessage);
-    this.setTurnPhase(TurnPhase.IDLE);
+    this.coordinator.finishTurn(turn);
   }
 
-  private async handleStartupAbort(payload: StreamAbortEvent): Promise<void> {
-    const operation = this.activeTurnOperation;
+  private async handleStartupAbort(
+    payload: StreamAbortEvent,
+    operation = this.coordinator.operationId
+  ): Promise<void> {
+    const turn = this.coordinator.turnId;
     log.debug("Forwarding stream-abort without phase transition (not in STREAMING)", {
       workspaceId: this.workspaceId,
-      turnPhase: this.turnPhase,
+      turnPhase: this.coordinator.phase,
     });
 
     const preStreamAbortReason = "abortReason" in payload ? payload.abortReason : undefined;
-    if (this.turnPhase === TurnPhase.PREPARING) {
+    if (this.coordinator.phase === "preparing") {
       this.clearPreparingRuntimeStatus();
       this.setTerminalStreamLifecycle("interrupted", {
         abortReason: preStreamAbortReason,
@@ -6349,40 +6212,30 @@ export class AgentSession {
     }
     if (preStreamAbortReason === "user") {
       await this.workspaceGoalService?.recordUserStoppedStream(this.workspaceId);
-      if (!this.isCurrentTurnOperation(operation)) return;
+      if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
+        return;
     }
     await this.updateStartupAutoRetryAbandonFromAbort(
       preStreamAbortReason,
       this.activeStreamUserMessageId
     );
-    if (!this.isCurrentTurnOperation(operation)) return;
+    if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
+      return;
 
     this.queuedProviderToolEndAbortInFlight = false;
     this.activeToolCallIds.clear();
     this.emitChatEvent(payload);
   }
 
-  private markStartedTurnCompleting(messageId: string): void {
-    const operation = this.activeTurnOperation;
-    if (
-      operation?.started &&
-      operation.messageId === messageId &&
-      !operation.consumed &&
-      this.isCurrentTurnOperation(operation) &&
-      this.turnPhase === TurnPhase.STREAMING
-    ) {
-      // Raw terminal observers can initiate edits before engine cleanup settles.
-      // Make those edits wait for completion instead of stopping an already-ended stream.
-      this.setTurnPhase(TurnPhase.COMPLETING);
-    }
-  }
-
   private async handleTurnAbort(
     payload: StreamAbortEvent,
-    systemMessageTokens?: number
+    systemMessageTokens?: number,
+    operation = this.coordinator.operationId
   ): Promise<void> {
-    const operation = this.activeTurnOperation;
-    this.setTurnPhase(TurnPhase.COMPLETING);
+    const turn = this.coordinator.turnId;
+    this.coordinator.beginPolicy(turn);
+    if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
+      return;
     const activeModelForAbort = this.activeStreamContext?.modelString;
     const activeOptionsForAbort = this.activeStreamContext?.options;
     this.lastSystemMessageTokens = systemMessageTokens ?? this.lastSystemMessageTokens;
@@ -6404,7 +6257,8 @@ export class AgentSession {
       this.queuedProviderToolEndAbortInFlight && abortReason !== "user";
     if (abortReason === "user") {
       await this.workspaceGoalService?.recordUserStoppedStream(this.workspaceId);
-      if (!this.isCurrentTurnOperation(operation)) return;
+      if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
+        return;
     }
     if (activeModelForAbort) {
       // Forward goalKind / agentInitiated from the active stream context so
@@ -6421,20 +6275,23 @@ export class AgentSession {
         agentInitiated: this.activeStreamContext?.agentInitiated,
         isCompaction: hadCompactionRequest,
       });
-      if (!this.isCurrentTurnOperation(operation)) return;
+      if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
+        return;
     }
     if (abortReason !== "user") {
       await this.workspaceGoalService?.applyPendingAfterStreamEnd(this.workspaceId);
-      if (!this.isCurrentTurnOperation(operation)) return;
+      if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
+        return;
     }
     this.setTerminalStreamLifecycle("interrupted", { abortReason });
     this.activeCompactionRequest = undefined;
     this.resetActiveStreamState();
     if (!hadCompactionRequest && activeModelForAbort && !this.continuousCompactionAbandoned) {
       await this.observeContinuousCompactionAtStreamEnd(activeModelForAbort, activeOptionsForAbort);
-      if (!this.isCurrentTurnOperation(operation)) return;
+      if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
+        return;
     }
-    if (hadCompactionRequest && !this.disposed) {
+    if (hadCompactionRequest && !this.coordinator.disposed) {
       this.clearQueue();
     }
     if (!isQueuedProviderToolEndAbort) {
@@ -6442,26 +6299,34 @@ export class AgentSession {
         type: "aborted",
         message: abortReason,
       });
-      if (!this.isCurrentTurnOperation(operation)) return;
+      if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
+        return;
     }
     await this.updateStartupAutoRetryAbandonFromAbort(abortReason, failedUserMessageId);
-    if (!this.isCurrentTurnOperation(operation)) return;
+    if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
+      return;
     this.emitChatEvent(payload);
     const dispatchedQueuedMessage =
       !this.midStreamCompactionPending &&
       !this.continuousCompactor.isApplying() &&
       this.dispatchQueuedProviderToolEndMessageAfterAbort(abortReason);
     if (!dispatchedQueuedMessage) {
-      this.setTurnPhase(TurnPhase.IDLE);
+      this.coordinator.finishTurn(turn);
     }
   }
 
-  private async handleTurnSuccess(payload: StreamEndEvent): Promise<void> {
-    const operation = this.activeTurnOperation;
-    this.setTurnPhase(TurnPhase.COMPLETING);
+  private async handleTurnSuccess(
+    payload: StreamEndEvent,
+    operation = this.coordinator.operationId
+  ): Promise<void> {
+    const turn = this.coordinator.turnId;
+    this.coordinator.beginPolicy(turn);
+    if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
+      return;
     this.retryManager.handleStreamSuccess();
     await this.clearStartupAutoRetryAbandon();
-    if (!this.isCurrentTurnOperation(operation)) return;
+    if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
+      return;
 
     const streamEndPayload = payload;
     const activeStreamGoalKind = this.activeStreamContext?.goalKind;
@@ -6493,7 +6358,8 @@ export class AgentSession {
         streamEndPayload,
         completedCompactionRequest?.id
       );
-      if (!this.isCurrentTurnOperation(operation)) return;
+      if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
+        return;
 
       await this.recordGoalAccountingFromUsage({
         model: streamEndPayload.metadata.model,
@@ -6504,9 +6370,11 @@ export class AgentSession {
         agentInitiated: this.activeStreamContext?.agentInitiated,
         isCompaction: handled,
       });
-      if (!this.isCurrentTurnOperation(operation)) return;
+      if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
+        return;
       await this.workspaceGoalService?.applyPendingAfterStreamEnd(this.workspaceId);
-      if (!this.isCurrentTurnOperation(operation)) return;
+      if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
+        return;
 
       if (!handled) {
         this.emitChatEvent(payload);
@@ -6516,7 +6384,11 @@ export class AgentSession {
           this.ackPendingPostCompactionStateOnStreamEnd = false;
           try {
             await this.compactionHandler.ackPendingStateConsumed();
-            if (!this.isCurrentTurnOperation(operation)) return;
+            if (
+              !this.coordinator.isCurrentTurn(turn) ||
+              !this.coordinator.isCurrentOperation(operation)
+            )
+              return;
           } catch (error) {
             log.warn("Failed to ack pending post-compaction state", {
               workspaceId: this.workspaceId,
@@ -6550,7 +6422,11 @@ export class AgentSession {
           streamEndPayload.metadata.model,
           activeStreamOptions
         );
-        if (!this.isCurrentTurnOperation(operation)) return;
+        if (
+          !this.coordinator.isCurrentTurn(turn) ||
+          !this.coordinator.isCurrentOperation(operation)
+        )
+          return;
       }
 
       if (handled) {
@@ -6561,7 +6437,11 @@ export class AgentSession {
         const rlmSummaryId = this.pendingCompactionFollowUpSummaryId;
         this.pendingCompactionFollowUpSummaryId = null;
         continuedAfterCompaction = await this.dispatchPendingFollowUp(rlmSummaryId ?? undefined);
-        if (!this.isCurrentTurnOperation(operation)) return;
+        if (
+          !this.coordinator.isCurrentTurn(turn) ||
+          !this.coordinator.isCurrentOperation(operation)
+        )
+          return;
       }
 
       // Stream end: auto-send queued messages (for user messages typed during streaming)
@@ -6604,7 +6484,11 @@ export class AgentSession {
           // below safely no-ops once the goal flips to `complete`.
           if (activeStreamGoalKind === GOAL_CONTINUATION_KIND) {
             await this.maybeAutoCompleteGoalFromSilentContinuation(streamEndPayload);
-            if (!this.isCurrentTurnOperation(operation)) return;
+            if (
+              !this.coordinator.isCurrentTurn(turn) ||
+              !this.coordinator.isCurrentOperation(operation)
+            )
+              return;
           }
 
           goalContinuationRequest = {
@@ -6621,7 +6505,7 @@ export class AgentSession {
       });
 
       // Defense-in-depth: unblock renderer if compaction handler threw before we emitted.
-      if (this.isCurrentTurnOperation(operation) && !emittedStreamEnd) {
+      if (this.coordinator.isCurrentOperation(operation) && !emittedStreamEnd) {
         try {
           this.emitChatEvent(payload);
         } catch {
@@ -6630,7 +6514,7 @@ export class AgentSession {
       }
     } finally {
       if (completedCompactionRequest != null) {
-        this.resolveCompactionCompletionDecision(
+        this.coordinator.resolveCompactionDecision(
           streamEndPayload.messageId,
           continuedAfterCompaction
         );
@@ -6639,9 +6523,12 @@ export class AgentSession {
       // Only clean up if we're still in COMPLETING — a new turn started by
       // dispatchPendingFollowUp() or sendQueuedMessages()
       // owns the stream state now.
-      if (this.isCurrentTurnOperation(operation) && this.turnPhase === TurnPhase.COMPLETING) {
+      if (
+        this.coordinator.isCurrentOperation(operation) &&
+        this.coordinator.phase === "completing"
+      ) {
         this.resetActiveStreamState();
-        this.setTurnPhase(TurnPhase.IDLE);
+        this.coordinator.finishTurn(turn);
         if (goalContinuationRequest != null) {
           await this.workspaceGoalService?.requestContinuationAfterStreamEnd({
             workspaceId: this.workspaceId,
@@ -6675,26 +6562,9 @@ export class AgentSession {
     };
 
     forward("stream-start", (payload) => {
-      if (payload.type === "stream-start") {
-        if (this.activeTurnOperation && !this.activeTurnOperation.consumed) {
-          this.activeTurnOperation.messageId = payload.messageId;
-          this.activeTurnOperation.started = true;
-        }
-        this.continuousCompactionAbandoned = false;
-        this.dispatchingQueuedEntry = false;
-        this.dispatchingQueuedEntryMuxMetadata = undefined;
-        this.preparingWorkspaceTurnMetadata = undefined;
-        this.activeStreamStartedAtMs = payload.startTime;
-        // Codex P1 (PRRT_kwDOPxxmWM6cClKS): a new live stream makes mid-stream
-        // setGoal deferral meaningful again — clear the goal service's settled
-        // fast-path synchronously so a model set_goal in THIS stream queues
-        // for its stream-end drain instead of writing goal.json mid-stream.
-        this.workspaceGoalService?.recordStreamStarted(this.workspaceId);
-        this.queuedProviderToolEndAbortInFlight = false;
-        this.activeToolCallIds.clear();
+      if (payload.type === "stream-start" && this.coordinator.streamStarted(payload)) {
+        this.emitChatEvent(payload);
       }
-      this.setTurnPhase(TurnPhase.STREAMING);
-      this.emitChatEvent(payload);
     });
     forward("stream-delta", (payload) => {
       this.markActiveStreamHadAnyOutput();
@@ -6892,18 +6762,8 @@ export class AgentSession {
     });
     forward("stream-abort", (payload) => {
       if (payload.type !== "stream-abort") return;
-      const operation = this.activeTurnOperation;
-      // Only the facade's synthetic startup identity (or an empty no-stream ID)
-      // is handleless. A registered STARTING engine may abort before stream-start;
-      // its assistant-ID event still belongs exclusively to delivered completion.
-      if (
-        !payload.messageId ||
-        (operation?.startupMessageId === payload.messageId && !operation.startupAbortNotified)
-      ) {
-        if (operation) operation.startupAbortNotified = true;
-        return this.handleStartupAbort(payload);
-      }
-      this.markStartedTurnCompleting(payload.messageId);
+      if (this.coordinator.observeStartupAbort(payload)) return this.handleStartupAbort(payload);
+      this.coordinator.rawTerminal("aborted", payload.messageId);
     });
     forward("runtime-status", (payload) => {
       if (payload.type === "runtime-status") {
@@ -6914,18 +6774,7 @@ export class AgentSession {
 
     forward("stream-end", (payload) => {
       if (payload.type !== "stream-end") return;
-      const operation = this.activeTurnOperation;
-      // TaskService observes raw events before acquiring its workspace lock. Publish
-      // the decision now, while compaction context and queue attribution still exist.
-      if (
-        operation?.messageId === payload.messageId &&
-        operation.compaction &&
-        !operation.consumed
-      ) {
-        this.beginCompactionCompletionDecision(payload.messageId);
-      }
-      // Register the decision before this transition emits a reentrant lifecycle event.
-      this.markStartedTurnCompleting(payload.messageId);
+      this.coordinator.rawTerminal("completed", payload.messageId);
     });
 
     const errorHandler = (...args: unknown[]) => {
@@ -6941,7 +6790,7 @@ export class AgentSession {
       const data = raw as StreamErrorPayload & { workspaceId: string };
       // Begin synchronously at event emission so completion waiters always find
       // this attempt's decision before they run.
-      this.beginStreamErrorRecoveryDecision(data.messageId);
+      this.coordinator.beginErrorDecision(data.messageId);
     };
 
     this.aiListeners.push({ event: "error", handler: errorHandler });
@@ -6979,7 +6828,7 @@ export class AgentSession {
   emitChatEvent(message: WorkspaceChatMessage): void {
     // NOTE: Workspace teardown does not await in-flight async work (sendMessage(), stopStream(), etc).
     // Those code paths can still try to emit events after dispose; drop them rather than crashing.
-    if (this.disposed) {
+    if (this.coordinator.disposed) {
       return;
     }
 
@@ -6989,41 +6838,29 @@ export class AgentSession {
     } satisfies AgentSessionChatEvent);
   }
 
-  private setTurnPhase(next: TurnPhase): void {
-    this.turnPhase = next;
-    if (next === TurnPhase.PREPARING) this.clearActiveTurnOperation();
+  private publishTurnPhase(next: TurnPhase, isCurrent: () => boolean): void {
     this.clearPreparingRuntimeStatus();
-
-    if (next !== TurnPhase.IDLE) {
+    if (next !== "idle") {
       this.terminalStreamLifecycle = null;
       this.terminalStreamError = null;
     }
-
     this.emitStreamLifecycleIfChanged();
-
-    if (next === TurnPhase.IDLE) {
+    // A lifecycle observer may already have admitted a replacement. Its queue attribution
+    // belongs to that turn; the coordinator has separately detached the old resources/waiters.
+    if (next === "idle" && isCurrent()) {
       this.dispatchingQueuedEntry = false;
       this.dispatchingQueuedEntryMuxMetadata = undefined;
       this.preparingWorkspaceTurnMetadata = undefined;
-      // Turn ended: expire any mid-turn thinking override. Safe unconditionally
-      // because a replacement turn (e.g. an edit) only creates its holder after
-      // the preempted turn has already been transitioned to IDLE.
-      this.activeTurnThinkingOverride = null;
-      const waiters = this.idleWaiters;
-      this.idleWaiters = [];
-      for (const resolve of waiters) {
-        resolve();
-      }
     }
   }
 
   isBusy(): boolean {
-    // editAdmissionDepth covers the edit flow's pre-PREPARING window (r32):
+    // An edit reservation covers the edit flow's pre-PREPARING window (r32):
     // truncation + abandoned-branch summary can take seconds before the edit
     // turn reaches PREPARING, and a concurrent ordinary send observing an
     // idle session would interleave its rows with the edit's against moved
     // history.
-    return this.turnPhase !== TurnPhase.IDLE || this.editAdmissionDepth > 0;
+    return this.coordinator.isBusy();
   }
 
   /**
@@ -7072,7 +6909,7 @@ export class AgentSession {
   /**
    * Block new turn admission while a context-discarding history mutation
    * (reset, full clear, destructive replace) runs (r40). Unlike
-   * editAdmissionDepth this does NOT claim busy-ness — the holder requires an
+   * edit reservations this does NOT claim busy-ness — the holder requires an
    * idle session — it refuses turn starts during the mutation's awaits
    * (refine drain + cross-process lock, up to seconds) that would otherwise
    * snapshot the about-to-be-discarded transcript and stream across the
@@ -7087,30 +6924,7 @@ export class AgentSession {
    */
   holdTurnAdmission(): Disposable {
     this.continuousCompactor.reset("context-mutation");
-    this.turnAdmissionBlocks += 1;
-    let released = false;
-    return {
-      [Symbol.dispose]: () => {
-        if (released) {
-          return;
-        }
-        released = true;
-        this.turnAdmissionBlocks -= 1;
-        assert(this.turnAdmissionBlocks >= 0, "turnAdmissionBlocks must not go negative");
-        // Entries left queued while the block was held have no stream-end
-        // drain to dispatch them (the session stayed idle throughout) —
-        // drain now, mirroring the edit-admission release. Only when entries
-        // exist: releases from a session that never queued must stay
-        // side-effect free.
-        if (
-          this.turnAdmissionBlocks === 0 &&
-          this.turnPhase === TurnPhase.IDLE &&
-          !this.messageQueue.isEmpty()
-        ) {
-          this.sendQueuedMessages();
-        }
-      },
-    };
+    return this.coordinator.reserve("admission");
   }
 
   /**
@@ -7122,7 +6936,7 @@ export class AgentSession {
    */
   setActiveTurnThinkingLevel(level: ThinkingLevel): { accepted: boolean } {
     this.assertNotDisposed("setActiveTurnThinkingLevel");
-    const holder = this.activeTurnThinkingOverride;
+    const holder = this.coordinator.thinkingOverride;
     if (!holder) {
       return { accepted: false };
     }
@@ -7131,7 +6945,7 @@ export class AgentSession {
   }
 
   isPreparingTurn(): boolean {
-    return this.turnPhase === TurnPhase.PREPARING;
+    return this.coordinator.phase === "preparing";
   }
 
   // Back-compat alias; prefer isPreparingTurn() + isBusy().
@@ -7140,39 +6954,7 @@ export class AgentSession {
   }
 
   async waitForIdle(signal?: AbortSignal): Promise<void> {
-    assert(
-      signal == null || typeof signal.aborted === "boolean",
-      "waitForIdle signal must be an AbortSignal"
-    );
-    if (signal?.aborted === true) {
-      throw new Error("Waiting for session idle canceled.");
-    }
-    if (this.turnPhase === TurnPhase.IDLE) {
-      return;
-    }
-
-    await new Promise<void>((resolve, reject) => {
-      let settled = false;
-      const settle = (callback: () => void) => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        signal?.removeEventListener("abort", abort);
-        callback();
-      };
-      const waiter = () => settle(resolve);
-      const abort = () => {
-        const waiterIndex = this.idleWaiters.indexOf(waiter);
-        if (waiterIndex !== -1) {
-          this.idleWaiters.splice(waiterIndex, 1);
-        }
-        settle(() => reject(new Error("Waiting for session idle canceled.")));
-      };
-
-      this.idleWaiters.push(waiter);
-      signal?.addEventListener("abort", abort, { once: true });
-    });
+    await this.coordinator.waitForIdle(signal);
   }
 
   /**
@@ -7180,31 +6962,7 @@ export class AgentSession {
    * Reserve a manual slot while they wait so goal continuations do not outrun them at stream end.
    */
   registerExternalManualFollowUp(signal?: AbortSignal): () => void {
-    assert(
-      signal == null || typeof signal.aborted === "boolean",
-      "registerExternalManualFollowUp signal must be an AbortSignal"
-    );
-    if (signal?.aborted === true) {
-      throw new Error("External manual follow-up canceled.");
-    }
-
-    let released = false;
-    const release = () => {
-      if (released) {
-        return;
-      }
-      released = true;
-      signal?.removeEventListener("abort", release);
-      assert(
-        this.pendingExternalManualFollowUps > 0,
-        "pending external manual follow-up count underflowed"
-      );
-      this.pendingExternalManualFollowUps -= 1;
-    };
-
-    this.pendingExternalManualFollowUps += 1;
-    signal?.addEventListener("abort", release, { once: true });
-    return release;
+    return this.coordinator.registerManualFollowUp(signal);
   }
 
   queueMessage(
@@ -7387,7 +7145,7 @@ export class AgentSession {
     options?: { promoteAheadOfHiddenTurnEnd?: boolean }
   ): boolean {
     const hasDifferentPreparingSend =
-      this.turnPhase === TurnPhase.PREPARING &&
+      this.coordinator.phase === "preparing" &&
       !hasSameWorkspaceTurnCorrelation(this.preparingWorkspaceTurnMetadata, continuationMetadata);
     if (hasDifferentPreparingSend) {
       return true;
@@ -7477,10 +7235,10 @@ export class AgentSession {
    */
   getQueueCutCutter(): QueueCutCutter | undefined {
     // PREPARING covers both direct sends (preparingWorkspaceTurnMetadata set
-    // alongside setTurnPhase(PREPARING)) and dequeued entries (set at dequeue in
+    // alongside preparation publication) and dequeued entries (set at dequeue in
     // sendQueuedMessages). The metadata is already parsed workspace-turn
     // correlation or undefined for any other input.
-    if (this.turnPhase === TurnPhase.PREPARING) {
+    if (this.coordinator.phase === "preparing") {
       return { stage: "preparing", muxMetadata: this.preparingWorkspaceTurnMetadata };
     }
     // Dequeue-to-stream-start window after PREPARING released (e.g. a
@@ -7517,7 +7275,7 @@ export class AgentSession {
 
   private async requestQueuedProviderToolEndDispatch(): Promise<void> {
     if (
-      this.turnPhase !== TurnPhase.STREAMING ||
+      this.coordinator.phase !== "streaming" ||
       this.queuedProviderToolEndAbortInFlight ||
       this.activeToolCallIds.size > 0 ||
       !this.hasQueuedMessages("tool-end")
@@ -7562,39 +7320,25 @@ export class AgentSession {
   }
 
   async waitForPendingCompactionCompletionDecision(messageId: string): Promise<boolean> {
-    if (!this.compactionCompletionDecisions.has(messageId)) {
-      if (this.disposed || this.activeCompactionRequest == null) return false;
-      this.beginCompactionCompletionDecision(messageId);
-    }
-    const decision = this.compactionCompletionDecisions.get(messageId);
-    assert(decision, "compaction completion decision must exist");
-    const handled = await (decision.outcome ?? decision.promise);
-    this.compactionCompletionDecisions.delete(messageId);
-    return handled;
+    return this.coordinator.waitForCompactionDecision(
+      messageId,
+      this.activeCompactionRequest != null
+    );
   }
 
-  /**
-   * Waits for the stream-error recovery decision of one failed attempt
-   * (keyed by the error event's assistant messageId) and returns its outcome.
-   * Late callers receive the retained outcome; undefined means no decision
-   * was recorded for that attempt (e.g. the session was recreated).
-   */
+  /** Late callers receive the retained decision for their attempt, never a sampled phase. */
   async waitForPendingStreamErrorRecoveryDecision(
     messageId: string
   ): Promise<StreamErrorRecoveryOutcome | undefined> {
-    const decision = this.streamErrorRecoveryDecisions.get(messageId);
-    if (decision == null) {
-      return undefined;
-    }
-    return decision.outcome ?? decision.promise;
+    return this.coordinator.waitForErrorDecision(messageId);
   }
 
   hasPendingAutoRetry(): boolean {
-    return this.retryManager.isRetryPending || this.autoRetryStarting;
+    return this.retryManager.isRetryPending || this.coordinator.retryStarting;
   }
 
   hasPendingManualFollowUp(): boolean {
-    return !this.messageQueue.isEmpty() || this.pendingExternalManualFollowUps > 0;
+    return !this.messageQueue.isEmpty() || this.coordinator.manualFollowUpPending;
   }
 
   /**
@@ -7687,14 +7431,14 @@ export class AgentSession {
     // sendQueuedMessages can race with teardown (e.g. workspace.remove) because we
     // trigger it off stream/tool events and disposal does not await stopStream().
     // If the session is already disposed, do nothing.
-    if (this.disposed) {
+    if (this.coordinator.disposed) {
       return;
     }
 
     // r40: leave entries queued while a context-discarding mutation blocks
     // turn admission — dispatching would set PREPARING and stream across the
     // mutation. The block's release drains the queue (holdTurnAdmission).
-    if (this.turnAdmissionBlocks > 0) {
+    if (this.coordinator.admissionBlocked) {
       return;
     }
 
@@ -7721,9 +7465,13 @@ export class AgentSession {
       // Set PREPARING synchronously before the async sendMessage to prevent
       // incoming messages from bypassing the queue during the await gap.
       this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(options?.muxMetadata);
-      this.setTurnPhase(TurnPhase.PREPARING);
+      const preparedTurn = this.coordinator.prepare();
 
-      void this.sendMessage(message, options, { ...internal, enqueuedAtMs })
+      void this.sendMessage(message, options, {
+        ...internal,
+        enqueuedAtMs,
+        turnReservation: preparedTurn,
+      })
         .then(async (result) => {
           // Keep the dispatch marker through the dequeue-to-stream-start window. A background
           // send can resolve before startup emits stream-start, and later reports must not claim
@@ -7732,22 +7480,22 @@ export class AgentSession {
           // leave the session stuck in PREPARING and notify correlated internal callers.
           if (!result.success) {
             await internal?.onAcceptedPreStreamFailure?.(result.error);
-            if (this.turnPhase === TurnPhase.PREPARING) {
-              this.setTurnPhase(TurnPhase.IDLE);
+            if (this.coordinator.isCurrentTurn(preparedTurn)) {
+              this.coordinator.finishPreparation(preparedTurn);
             }
             // No stream started, so no stream-end drain will fire for the
             // remaining entries — try the next one now (each attempt pops an
             // entry, so this terminates).
-            this.sendQueuedMessages();
+            if (this.coordinator.isCurrentTurn(preparedTurn)) this.drainQueuedMessagesIfIdle();
             return;
           }
           if (internal?.cancelState?.canceledBeforeAcceptance === true) {
             // Cancellation can arrive after dequeue while sendMessage is validating or writing
             // history. No stream will start, so release PREPARING and continue with later entries.
-            if (this.turnPhase === TurnPhase.PREPARING) {
-              this.setTurnPhase(TurnPhase.IDLE);
+            if (this.coordinator.isCurrentTurn(preparedTurn)) {
+              this.coordinator.finishPreparation(preparedTurn);
             }
-            this.sendQueuedMessages();
+            if (this.coordinator.isCurrentTurn(preparedTurn)) this.drainQueuedMessagesIfIdle();
           }
         })
         .catch(async (error: unknown) => {
@@ -7766,12 +7514,13 @@ export class AgentSession {
               hookError,
             });
           }
+          if (!this.coordinator.isCurrentTurn(preparedTurn)) return;
           this.dispatchingQueuedEntry = false;
           this.dispatchingQueuedEntryMuxMetadata = undefined;
-          if (this.turnPhase === TurnPhase.PREPARING) {
-            this.setTurnPhase(TurnPhase.IDLE);
+          if (this.coordinator.isCurrentTurn(preparedTurn)) {
+            this.coordinator.finishPreparation(preparedTurn);
           }
-          this.sendQueuedMessages();
+          this.drainQueuedMessagesIfIdle();
         });
     }
   }
@@ -7851,7 +7600,7 @@ export class AgentSession {
     summaryMessageId?: string,
     cancelResume?: () => boolean
   ): Promise<boolean> {
-    if (this.disposed || this.shuttingDown) {
+    if (this.coordinator.disposed || this.coordinator.closing) {
       return false;
     }
 
@@ -7989,7 +7738,7 @@ export class AgentSession {
     const enforceIdleRule =
       followUp.dispatchOptions?.requireIdle === true || persistedGoalKind != null;
     const hasQueuedMessages = this.hasPendingManualFollowUp();
-    const hasActiveNonCompletingTurn = this.isBusy() && this.turnPhase !== TurnPhase.COMPLETING;
+    const hasActiveNonCompletingTurn = this.isBusy() && this.coordinator.phase !== "completing";
     // Codex P1 (PRRT_kwDOPxxmWM6cRJD-): a manual service-level send can sit
     // in its preflight (awaiting pricing/settings) without queueing or
     // holding the turn phase — it must win over the synthetic follow-up too.
@@ -8002,7 +7751,7 @@ export class AgentSession {
         workspaceId: this.workspaceId,
         summaryMessageId: lastMessage.id,
         hasQueuedMessages,
-        turnPhase: this.turnPhase,
+        turnPhase: this.coordinator.phase,
       });
       await this.skipIdleRuleFollowUp(
         lastMessage,
@@ -8058,7 +7807,7 @@ export class AgentSession {
       ? () =>
           this.hasPendingManualFollowUp() ||
           this.hasExternalSendPreflight?.() === true ||
-          (this.isBusy() && this.turnPhase !== TurnPhase.COMPLETING)
+          (this.isBusy() && this.coordinator.phase !== "completing")
       : undefined;
     const followUpAdmissionStale =
       idleRuleStale != null || goalAdmissionStale != null || cancelResume != null
@@ -8195,7 +7944,7 @@ export class AgentSession {
         await this.skipIdleRuleFollowUp(
           lastMessage,
           this.hasPendingManualFollowUp() || this.hasExternalSendPreflight?.() === true,
-          this.isBusy() && this.turnPhase !== TurnPhase.COMPLETING
+          this.isBusy() && this.coordinator.phase !== "completing"
         );
         return false;
       }
@@ -9036,6 +8785,6 @@ export class AgentSession {
   }
 
   private assertNotDisposed(operation: string): void {
-    assert(!this.disposed, `AgentSession.${operation} called after dispose`);
+    assert(!this.coordinator.disposed, `AgentSession.${operation} called after dispose`);
   }
 }

--- a/src/node/services/agentSession.turnCompletion.test.ts
+++ b/src/node/services/agentSession.turnCompletion.test.ts
@@ -1,10 +1,11 @@
+import type { TurnCoordinator } from "./turnCoordinator";
 import { createMuxMessage } from "@/common/types/message";
 import { describe, expect, mock, spyOn, test } from "bun:test";
 import { EventEmitter } from "events";
 import type { StreamAbortEvent, StreamEndEvent } from "@/common/types/stream";
-import { Ok } from "@/common/types/result";
+import { Err, Ok } from "@/common/types/result";
 import type { StreamMessageOptions } from "./turnRequestBuilder";
-import type { TurnCompletion, TurnStreamHandle } from "./streamManager";
+import type { TurnCompletion } from "./streamManager";
 import type { WorkspaceGoalService } from "./workspaceGoalService";
 import type { AgentSession } from "./agentSession";
 import { createAgentSessionHarness } from "./agentSession.testHarness";
@@ -13,22 +14,13 @@ const workspaceId = "session-completion";
 const model = "openai:gpt-4o";
 const sendOptions = { model, agentId: "exec" };
 
-interface Operation {
-  messageId?: string;
-  consumed: boolean;
-  startupMessageId?: string;
-  startupAbortNotified: boolean;
-  compaction: boolean;
-}
 interface InternalSession {
-  activeTurnOperation?: Operation;
   lastSystemMessageTokens?: number;
   activeCompactionRequest?: { id: string; modelString: string };
-  consumeTurnCompletion(handle: TurnStreamHandle, operation: Operation): Promise<void>;
   clearStartupAutoRetryAbandon(): Promise<void>;
   recordGoalAccountingFromUsage(input: unknown): Promise<void>;
   observeContinuousCompactionAtStreamEnd(...args: unknown[]): Promise<void>;
-  setTurnPhase(phase: "preparing" | "streaming" | "idle"): void;
+  coordinator: TurnCoordinator;
   getEditTruncateTargetId(messageId: string): Promise<string>;
 }
 const internal = (session: AgentSession) => session as unknown as InternalSession;
@@ -62,7 +54,7 @@ function policyPromise(spy: ReturnType<typeof observePolicy>): Promise<void> {
   return result.value;
 }
 function observePolicy(session: AgentSession) {
-  return spyOn(internal(session), "consumeTurnCompletion");
+  return spyOn(internal(session).coordinator, "consumeCompletion");
 }
 
 describe("AgentSession turn completion", () => {
@@ -87,11 +79,11 @@ describe("AgentSession turn completion", () => {
       emitter.emit("stream-end", end());
       expect(h.session.isBusy()).toBe(true);
       expect(h.events.filter((event) => event.type === "stream-end")).toHaveLength(0);
-      const operation = internal(h.session).activeTurnOperation!;
+      const operation = internal(h.session).coordinator.operationId!;
       // Even a malformed producer's redundant event ID cannot override handle identity.
       completion.resolve({ status: "completed", streamEnd: end("wrong-id") });
       await policyPromise(consumer);
-      await internal(h.session).consumeTurnCompletion(handle, operation);
+      await internal(h.session).coordinator.consumeCompletion(operation, handle);
       emitter.emit("stream-end", end());
       expect(h.events.filter((event) => event.type === "stream-end")).toMatchObject([
         { messageId: handle.messageId },
@@ -326,7 +318,7 @@ describe("AgentSession turn completion", () => {
       try {
         await h.session.sendMessage("hello", sendOptions);
         const oldPolicy = policyPromise(consumer);
-        internal(h.session).setTurnPhase("idle");
+        internal(h.session).coordinator.finishTurn(internal(h.session).coordinator.turnId);
         const commit = h.historyService.commitPartial.bind(h.historyService);
         spyOn(h.historyService, "commitPartial").mockImplementationOnce(async (id) => {
           historyEntered.resolve();
@@ -387,7 +379,10 @@ describe("AgentSession turn completion", () => {
     try {
       await h.session.sendMessage("hello", sendOptions);
       internal(h.session).activeCompactionRequest = { id: "compact", modelString: model };
-      internal(h.session).activeTurnOperation!.compaction = true;
+      internal(h.session).coordinator.configureOperation(
+        internal(h.session).coordinator.operationId!,
+        true
+      );
       spyOn(internal(h.session), "clearStartupAutoRetryAbandon").mockImplementation(async () => {
         entered.resolve();
         await release.promise;
@@ -747,4 +742,105 @@ describe("AgentSession turn completion", () => {
       }
     }
   );
+  test.each(["error", "rejection"] as const)(
+    "a preempted preparation's delayed history %s cannot apply failure policy to its replacement",
+    async (failure) => {
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const emitter = new EventEmitter();
+      const h = await createAgentSessionHarness({
+        workspaceId,
+        aiEmitter: emitter,
+        captureEvents: true,
+        aiServiceOverrides: {
+          streamMessage: mock(() => {
+            start(emitter, "replacement");
+            return Promise.resolve(
+              Ok({
+                messageId: "replacement",
+                completion: new Promise<TurnCompletion>(() => undefined),
+              })
+            );
+          }),
+        },
+      });
+      try {
+        spyOn(h.historyService, "commitPartial").mockImplementationOnce(async () => {
+          entered.resolve();
+          await release.promise;
+          if (failure === "rejection") throw new Error("retired startup history failure");
+          return Err("retired startup history failure");
+        });
+        const original = h.session
+          .sendMessage("original", sendOptions)
+          .catch((error: unknown) => error);
+        await entered.promise;
+        const history = await h.historyService.getHistoryFromLatestBoundary(workspaceId);
+        if (!history.success) throw new Error(history.error);
+        const messageId = history.data.find((message) => message.role === "user")!.id;
+        const replacementStarted = Promise.withResolvers<void>();
+        const unsubscribe = h.session.onChatEvent(({ message: event }) => {
+          if (event.type === "stream-start" && event.messageId === "replacement")
+            replacementStarted.resolve();
+        });
+        await h.session.sendMessage("replacement", { ...sendOptions, editMessageId: messageId });
+        await replacementStarted.promise;
+        unsubscribe();
+        release.resolve();
+        await original;
+        expect(h.session.isBusy()).toBe(true);
+        expect(h.session.isPreparingTurn()).toBe(false);
+        expect(h.events.some((event) => event.type === "stream-error")).toBe(false);
+        expect(h.session.hasPendingAutoRetry()).toBe(false);
+        expect(h.session.setActiveTurnThinkingLevel("high")).toEqual({ accepted: true });
+      } finally {
+        release.resolve();
+        h.session.dispose();
+        await h.cleanup();
+      }
+    }
+  );
+  test("shutdown followed by disposal cannot reopen retry after a suspended preference read", async () => {
+    const completion = Promise.withResolvers<TurnCompletion>();
+    const preferenceEntered = Promise.withResolvers<void>();
+    const preference = Promise.withResolvers<boolean>();
+    const emitter = new EventEmitter();
+    const h = await createAgentSessionHarness({
+      workspaceId,
+      aiEmitter: emitter,
+      captureEvents: true,
+      aiServiceOverrides: {
+        streamMessage: mock(() => {
+          start(emitter);
+          return Promise.resolve(Ok({ messageId: "assistant-1", completion: completion.promise }));
+        }),
+      },
+    });
+    const consumer = observePolicy(h.session);
+    try {
+      await h.session.sendMessage("hello", sendOptions);
+      const retryPolicy = h.session as unknown as {
+        loadAutoRetryEnabledPreference(): Promise<boolean>;
+      };
+      spyOn(retryPolicy, "loadAutoRetryEnabledPreference").mockImplementationOnce(() => {
+        preferenceEntered.resolve();
+        return preference.promise;
+      });
+      completion.resolve({
+        status: "failed",
+        streamError: { messageId: "assistant-1", error: "provider failed", errorType: "api" },
+      });
+      await preferenceEntered.promise;
+      h.session.beginShutdown();
+      h.session.dispose();
+      preference.resolve(true);
+      await policyPromise(consumer);
+      expect(h.session.hasPendingAutoRetry()).toBe(false);
+      expect(h.events.some((event) => event.type === "auto-retry-scheduled")).toBe(false);
+    } finally {
+      preference.resolve(true);
+      h.session.dispose();
+      await h.cleanup();
+    }
+  });
 });

--- a/src/node/services/agentSession.waitForIdle.test.ts
+++ b/src/node/services/agentSession.waitForIdle.test.ts
@@ -1,10 +1,10 @@
+import type { TurnCoordinator } from "./turnCoordinator";
 import { describe, expect, test } from "bun:test";
 
 import { createAgentSessionHarness } from "./agentSession.testHarness";
 
 interface IdleWaiterTestSession {
-  setTurnPhase(next: "idle" | "preparing"): void;
-  idleWaiters: Array<() => void>;
+  coordinator: TurnCoordinator;
 }
 
 const WAIT_FOR_IDLE_CANCELED_MESSAGE = "Waiting for session idle canceled.";
@@ -24,12 +24,11 @@ describe("AgentSession.waitForIdle", () => {
     const internalSession = session as unknown as IdleWaiterTestSession;
 
     try {
-      internalSession.setTurnPhase("preparing");
+      internalSession.coordinator.prepare();
       const controller = new AbortController();
       const waitResult = captureWaitForIdleResult(session.waitForIdle(controller.signal));
 
       expect(session.isBusy()).toBe(true);
-      expect(internalSession.idleWaiters).toHaveLength(1);
 
       controller.abort();
 
@@ -37,9 +36,8 @@ describe("AgentSession.waitForIdle", () => {
       expect(error).toBeInstanceOf(Error);
       expect((error as Error).message).toBe(WAIT_FOR_IDLE_CANCELED_MESSAGE);
       expect(session.isBusy()).toBe(true);
-      expect(internalSession.idleWaiters).toHaveLength(0);
     } finally {
-      internalSession.setTurnPhase("idle");
+      internalSession.coordinator.finishTurn(internalSession.coordinator.turnId);
       session.dispose();
       await cleanup();
     }
@@ -106,7 +104,7 @@ describe("AgentSession.waitForIdle", () => {
     const internalSession = session as unknown as IdleWaiterTestSession;
 
     try {
-      internalSession.setTurnPhase("preparing");
+      internalSession.coordinator.prepare();
       const waits = Array.from({ length: 3 }, () => {
         const controller = new AbortController();
         return {
@@ -114,8 +112,6 @@ describe("AgentSession.waitForIdle", () => {
           result: captureWaitForIdleResult(session.waitForIdle(controller.signal)),
         };
       });
-
-      expect(internalSession.idleWaiters).toHaveLength(waits.length);
 
       for (const wait of waits) {
         wait.controller.abort();
@@ -127,9 +123,8 @@ describe("AgentSession.waitForIdle", () => {
         expect((error as Error).message).toBe(WAIT_FOR_IDLE_CANCELED_MESSAGE);
       }
       expect(session.isBusy()).toBe(true);
-      expect(internalSession.idleWaiters).toHaveLength(0);
     } finally {
-      internalSession.setTurnPhase("idle");
+      internalSession.coordinator.finishTurn(internalSession.coordinator.turnId);
       session.dispose();
       await cleanup();
     }

--- a/src/node/services/turnCoordinator.test.ts
+++ b/src/node/services/turnCoordinator.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  TurnCoordinator,
+  initialCoordinatorState,
+  transition,
+  type CoordinatorEvent,
+  type TurnId,
+} from "./turnCoordinator";
+import type { StreamStartEvent } from "@/common/types/stream";
+import type { TurnCompletion } from "./streamManager";
+import type { ActiveTurnThinkingOverride } from "./thinkingOverride";
+
+const completed: TurnCompletion = {
+  status: "completed",
+  streamEnd: {
+    type: "stream-end",
+    workspaceId: "test",
+    metadata: { model: "openai:gpt-4o" },
+    parts: [],
+  },
+};
+
+function startEvent(messageId: string): StreamStartEvent {
+  return {
+    type: "stream-start",
+    workspaceId: "test",
+    messageId,
+    model: "openai:gpt-4o",
+    startTime: 1,
+    historySequence: 1,
+  };
+}
+
+function setup(overrides: Partial<ConstructorParameters<typeof TurnCoordinator>[0]> = {}) {
+  const callbacks = {
+    phaseChanged: mock(() => undefined),
+    drainQueue: mock(() => undefined),
+    policy: mock(() => Promise.resolve()),
+    policyError: mock(() => undefined),
+    ...overrides,
+  };
+  return { coordinator: new TurnCoordinator(callbacks), callbacks };
+}
+
+// Commands are observable work, so a stale event must not merely leave the phase looking right.
+function reduce(events: CoordinatorEvent[]) {
+  let state = initialCoordinatorState(Symbol("idle"));
+  for (const event of events) state = transition(state, event).state;
+  return state;
+}
+
+describe("TurnCoordinator", () => {
+  test("retired preparation, operation, reservation and retry events cannot affect their replacements", () => {
+    const a = Symbol("A"),
+      b = Symbol("B"),
+      op = Symbol("operation"),
+      retryA = Symbol("retry A"),
+      retryB = Symbol("retry B");
+    const state = reduce([
+      { type: "prepare", id: a },
+      { type: "register", id: op, turnId: a },
+      { type: "prepare", id: b },
+      { type: "retry-start", id: retryA },
+      { type: "retry-start", id: retryB },
+    ]);
+    for (const event of [
+      { type: "finish", id: a, preparingOnly: false },
+      { type: "register", id: Symbol("late operation"), turnId: a },
+      { type: "completion", id: op, messageId: "A", outcome: completed },
+      { type: "retry-finish", id: retryA },
+      { type: "release", id: Symbol("released"), kind: "edit" },
+    ] satisfies CoordinatorEvent[]) {
+      expect(transition(state, event)).toEqual({ state, commands: [] });
+    }
+  });
+
+  test("idle publication detaches A's resources and waiters before reentrant B admission", async () => {
+    let replacement: TurnId | undefined;
+    let replacementWait: Promise<void> | undefined;
+    let bIdle = false;
+    const thinkingA: ActiveTurnThinkingOverride = {};
+    const thinkingB: ActiveTurnThinkingOverride = {};
+    const { coordinator } = setup({
+      phaseChanged: (phase) => {
+        if (phase !== "idle" || replacement) return;
+        replacement = coordinator.prepare();
+        coordinator.acceptThinkingOverride(thinkingB, replacement);
+        replacementWait = coordinator.waitForIdle().then(() => {
+          bIdle = true;
+        });
+      },
+    });
+    const a = coordinator.prepare();
+    coordinator.acceptThinkingOverride(thinkingA, a);
+    const aWait = coordinator.waitForIdle();
+    coordinator.finishTurn(a);
+    await aWait;
+    expect(bIdle).toBe(false);
+    expect(coordinator.thinkingOverride).toBe(thinkingB);
+    coordinator.finishTurn(a);
+    await Promise.resolve();
+    expect(bIdle).toBe(false);
+    expect(coordinator.isBusy()).toBe(true);
+    coordinator.finishTurn(replacement!);
+    await replacementWait;
+    expect(bIdle).toBe(true);
+  });
+
+  test("preemption abort callbacks cannot finish or overwrite the replacement", () => {
+    const { coordinator } = setup();
+    const controller = new AbortController();
+    const a = coordinator.prepare(controller);
+    const operation = coordinator.registerOperation(a);
+    const thinkingB = {};
+    controller.signal.addEventListener("abort", () => {
+      const b = coordinator.prepare();
+      coordinator.acceptThinkingOverride(thinkingB, b);
+    });
+    expect(coordinator.preemptPreparation()).toBe(true);
+    coordinator.finishPreparation(a);
+    coordinator.acceptThinkingOverride({}, a);
+    expect(coordinator.isCurrentOperation(operation)).toBe(false);
+    expect(coordinator.isBusy()).toBe(true);
+    expect(coordinator.thinkingOverride).toBe(thinkingB);
+    // Controllerless B does not inherit A's preparation cancellation resource.
+    expect(coordinator.preemptPreparation()).toBe(false);
+  });
+
+  test("disposal from lifecycle publication releases captured waiters and preparation exactly once", async () => {
+    let disposeOnIdle = false;
+    const { coordinator, callbacks } = setup({
+      phaseChanged: (phase) => {
+        if (phase === "idle" && disposeOnIdle) coordinator.dispose();
+      },
+    });
+    const controller = new AbortController();
+    const aborted = mock(() => undefined);
+    controller.signal.addEventListener("abort", aborted);
+    coordinator.prepare(controller);
+    const idle = coordinator.waitForIdle();
+    disposeOnIdle = true;
+    coordinator.dispose();
+    await idle;
+    coordinator.dispose();
+    expect(aborted).toHaveBeenCalledTimes(1);
+    expect(coordinator.disposed).toBe(true);
+    expect(coordinator.isCurrentTurn(coordinator.prepare())).toBe(false);
+    expect(callbacks.drainQueue).not.toHaveBeenCalled();
+  });
+
+  test("admission, edit busy reservations, and manual work remain independent of phase idle", async () => {
+    const { coordinator, callbacks } = setup();
+    const admission = coordinator.reserve("admission");
+    const edit = coordinator.reserve("edit");
+    const manual = coordinator.registerManualFollowUp();
+    await coordinator.waitForIdle();
+    expect(coordinator.isBusy()).toBe(true);
+    const rejected = coordinator.prepare();
+    expect(coordinator.isCurrentTurn(rejected)).toBe(false);
+    admission[Symbol.dispose]();
+    admission[Symbol.dispose]();
+    expect(callbacks.drainQueue).not.toHaveBeenCalled();
+    edit[Symbol.dispose]();
+    expect(callbacks.drainQueue).toHaveBeenCalledTimes(1);
+    edit[Symbol.dispose]();
+    expect(callbacks.drainQueue).toHaveBeenCalledTimes(1);
+    expect(coordinator.manualFollowUpPending).toBe(true);
+    expect(coordinator.isBusy()).toBe(false);
+    manual();
+    manual();
+    expect(coordinator.manualFollowUpPending).toBe(false);
+    const shutdownHold = coordinator.reserve("admission");
+    coordinator.beginShutdown();
+    shutdownHold[Symbol.dispose]();
+    expect(callbacks.drainQueue).toHaveBeenCalledTimes(1);
+  });
+
+  test("raw success publishes its pending decision before reentrant completing observers", async () => {
+    let observed: Promise<boolean> | undefined;
+    const { coordinator } = setup({
+      phaseChanged: (phase) => {
+        if (phase === "completing") observed = coordinator.waitForCompactionDecision("A", false);
+      },
+    });
+    const a = coordinator.prepare();
+    const operation = coordinator.registerOperation(a);
+    coordinator.configureOperation(operation, true);
+    coordinator.streamStarted(startEvent("A"));
+    coordinator.rawTerminal("completed", "A");
+    coordinator.resolveCompactionDecision("A", true);
+    coordinator.resolveCompactionDecision("A", false);
+    expect(await observed).toBe(true);
+    coordinator.resolveCompactionDecision("A", false);
+    expect(await coordinator.waitForCompactionDecision("A", false)).toBe(false);
+  });
+
+  test.each(["error", "compaction"] as const)(
+    "stale delivered completion settles A's %s decision without touching B",
+    async (kind) => {
+      const { coordinator, callbacks } = setup();
+      const a = coordinator.prepare();
+      const operation = coordinator.registerOperation(a);
+      coordinator.configureOperation(operation, true);
+      coordinator.streamStarted(startEvent("A"));
+      let oldDecision: Promise<unknown>;
+      if (kind === "error") {
+        coordinator.beginErrorDecision("A");
+        oldDecision = coordinator.waitForErrorDecision("A");
+      } else {
+        coordinator.rawTerminal("completed", "A");
+        oldDecision = coordinator.waitForCompactionDecision("A", false);
+      }
+      const b = coordinator.prepare();
+      await coordinator.consumeCompletion(operation, {
+        messageId: "A",
+        completion: Promise.resolve(completed),
+      });
+      expect(await oldDecision).toBe(kind === "error" ? "terminal" : false);
+      expect(coordinator.isCurrentTurn(b)).toBe(true);
+      expect(coordinator.phase).toBe("preparing");
+      expect(callbacks.policy).not.toHaveBeenCalled();
+    }
+  );
+
+  test("A policy may hand off B; A finally settles A without publishing or draining B", async () => {
+    const continueA = Promise.withResolvers<void>();
+    let b: TurnId | undefined;
+    const { coordinator, callbacks } = setup({
+      policy: async () => {
+        b = coordinator.prepare();
+        await continueA.promise;
+      },
+    });
+    const a = coordinator.prepare();
+    const operation = coordinator.registerOperation(a);
+    coordinator.streamStarted(startEvent("A"));
+    const hardStop = coordinator.captureInterruptSettlement();
+    const policy = coordinator.consumeCompletion(operation, {
+      messageId: "A",
+      completion: Promise.resolve(completed),
+    });
+    await hardStop;
+    expect(coordinator.isCurrentTurn(b!)).toBe(true);
+    continueA.resolve();
+    await policy;
+    expect(coordinator.isCurrentTurn(b!)).toBe(true);
+    expect(coordinator.phase).toBe("preparing");
+    expect(callbacks.drainQueue).not.toHaveBeenCalled();
+  });
+
+  test("hard stop joins started policy, but soft and registered startup stop do not", async () => {
+    const done = Promise.withResolvers<void>();
+    const { coordinator } = setup({ policy: () => done.promise });
+    const a = coordinator.prepare();
+    const operation = coordinator.registerOperation(a);
+    expect(coordinator.captureInterruptSettlement()).toBeUndefined();
+    coordinator.streamStarted(startEvent("A"));
+    expect(coordinator.captureInterruptSettlement(true)).toBeUndefined();
+    let settled = false;
+    const interrupted = coordinator.captureInterruptSettlement()!.then(() => {
+      settled = true;
+    });
+    const consumed = coordinator.consumeCompletion(operation, {
+      messageId: "A",
+      completion: Promise.resolve(completed),
+    });
+    await Promise.resolve();
+    coordinator.finishTurn(a);
+    await coordinator.waitForIdle();
+    expect(settled).toBe(false);
+    done.resolve();
+    await consumed;
+    await interrupted;
+    expect(settled).toBe(true);
+  });
+  test.each([true, false])(
+    "delivered startup abort with payload=%s claims only its matching notification",
+    async (withPayload) => {
+      const { coordinator, callbacks } = setup();
+      const a = coordinator.prepare();
+      const operation = coordinator.registerOperation(a);
+      coordinator.streamStarting(operation, "synthetic-A");
+      await coordinator.consumeCompletion(operation, {
+        messageId: "registered-A",
+        completion: Promise.resolve({
+          status: "aborted",
+          abortReason: "user",
+          ...(withPayload
+            ? { streamAbort: { type: "stream-abort" as const, workspaceId: "test" } }
+            : {}),
+        }),
+      });
+      const notified = coordinator.observeStartupAbort({
+        type: "stream-abort",
+        workspaceId: "test",
+        messageId: "synthetic-A",
+        abortReason: "user",
+      });
+      expect(notified).toBe(!withPayload);
+      expect(callbacks.policy).toHaveBeenCalledTimes(1);
+    }
+  );
+  test("throwing idle publication still releases its detached waiter and disposal resources", async () => {
+    const { coordinator } = setup({
+      phaseChanged: (phase) => {
+        if (phase === "idle") throw new Error("observer failed");
+      },
+    });
+    const controller = new AbortController();
+    coordinator.prepare(controller);
+    const idle = coordinator.waitForIdle();
+    expect(() => coordinator.dispose()).toThrow("observer failed");
+    await idle;
+    expect(controller.signal.aborted).toBe(true);
+    coordinator.dispose();
+    await coordinator.waitForIdle();
+  });
+
+  test("start bookkeeping observes ownership before callbacks; reentrant replacement rejects stale publication", () => {
+    let reentered = false;
+    const { coordinator, callbacks } = setup({
+      streamStarted: () => {
+        expect(coordinator.captureInterruptSettlement()).toBeDefined();
+        reentered = true;
+        coordinator.prepare();
+      },
+    });
+    const a = coordinator.prepare();
+    coordinator.registerOperation(a);
+    expect(coordinator.streamStarted(startEvent("A"))).toBe(false);
+    expect(reentered).toBe(true);
+    expect(coordinator.phase).toBe("preparing");
+    expect(callbacks.phaseChanged).not.toHaveBeenCalledWith("streaming", expect.any(Function));
+  });
+  test("duplicate stream start cannot reopen a raw-terminal completing turn", () => {
+    const streamStarted = mock(() => undefined);
+    const { coordinator } = setup({ streamStarted });
+    const a = coordinator.prepare();
+    coordinator.registerOperation(a);
+    expect(coordinator.streamStarted(startEvent("A"))).toBe(true);
+    expect(coordinator.streamStarted(startEvent("A"))).toBe(false);
+    coordinator.rawTerminal("completed", "A");
+    expect(coordinator.streamStarted(startEvent("A"))).toBe(false);
+    expect(coordinator.phase).toBe("completing");
+    expect(streamStarted).toHaveBeenCalledTimes(1);
+  });
+  test("throwing preemption publication still aborts retired preparation", async () => {
+    const { coordinator } = setup({
+      phaseChanged: (phase) => {
+        if (phase === "idle") throw new Error("observer failed");
+      },
+    });
+    const controller = new AbortController();
+    const a = coordinator.prepare(controller);
+    const idle = coordinator.waitForIdle();
+    expect(() => coordinator.preemptPreparation()).toThrow("observer failed");
+    await idle;
+    expect(controller.signal.aborted).toBe(true);
+    // The old reservation cannot restart an idle owner after preemption.
+    expect(coordinator.isCurrentTurn(coordinator.prepare(undefined, a))).toBe(false);
+  });
+});

--- a/src/node/services/turnCoordinator.ts
+++ b/src/node/services/turnCoordinator.ts
@@ -1,0 +1,661 @@
+import assert from "@/common/utils/assert";
+import type { StreamAbortEvent, StreamStartEvent } from "@/common/types/stream";
+import type { TurnCompletion, TurnStreamHandle } from "./streamManager";
+import type { ActiveTurnThinkingOverride } from "./thinkingOverride";
+
+export type TurnId = symbol;
+export type OperationId = symbol;
+export type TurnPhase = "idle" | "preparing" | "streaming" | "completing";
+export type StreamErrorRecoveryOutcome = "retry-started" | "terminal";
+type ReservationKind = "admission" | "edit" | "manual";
+type DecisionKind = "error" | "compaction";
+type DecisionOutcome = StreamErrorRecoveryOutcome | boolean;
+
+type Operation = {
+  readonly id: OperationId;
+  readonly startupMessageId?: string;
+  readonly startupAbortNotified: boolean;
+  readonly compaction: boolean;
+  readonly delivery: "waiting" | "policy";
+} & (
+  | { readonly stage: "registered"; readonly messageId?: string }
+  | { readonly stage: "started"; readonly messageId: string }
+);
+
+type Turn =
+  | { readonly phase: "idle"; readonly id: TurnId; readonly operation?: Operation }
+  | {
+      readonly phase: Exclude<TurnPhase, "idle">;
+      readonly id: TurnId;
+      readonly operation?: Operation;
+    };
+interface Decision {
+  readonly kind: DecisionKind;
+  readonly messageId: string;
+  readonly outcome?: DecisionOutcome;
+}
+
+/** Lifecycle ownership only. Timers, persistence, queue and recovery policy stay in collaborators. */
+export interface CoordinatorState {
+  readonly lifetime: "open" | "shutting-down" | "disposed";
+  readonly turn: Turn;
+  readonly reservations: ReadonlyArray<{ id: symbol; kind: ReservationKind }>;
+  readonly retry?: symbol;
+  readonly decisions: readonly Decision[];
+}
+
+export type CoordinatorEvent =
+  | { type: "prepare"; id: TurnId }
+  | { type: "finish"; id: TurnId; preparingOnly: boolean }
+  | { type: "preempt"; id: TurnId }
+  | { type: "forget-compaction"; messageId: string }
+  | { type: "register"; id: OperationId; turnId: TurnId }
+  | { type: "configure-operation"; id: OperationId; compaction: boolean }
+  | { type: "starting"; id: OperationId; messageId: string }
+  | { type: "started"; payload: StreamStartEvent }
+  | { type: "raw-terminal"; kind: "completed" | "aborted"; messageId: string }
+  | { type: "startup-abort"; messageId: string }
+  | { type: "completion"; id: OperationId; messageId: string; outcome: TurnCompletion }
+  | { type: "complete-policy"; id: TurnId }
+  | { type: "reserve" | "release"; id: symbol; kind: ReservationKind }
+  | { type: "retry-start" | "retry-finish"; id: symbol }
+  | { type: "decision"; kind: DecisionKind; messageId: string; outcome?: DecisionOutcome }
+  | { type: "shutdown" | "dispose" };
+
+type CoordinatorCommand =
+  | { type: "phase"; previous: Turn; next: Turn }
+  | { type: "retire"; id: OperationId }
+  | { type: "record-start"; turnId: TurnId; payload: StreamStartEvent }
+  | {
+      type: "policy";
+      id: OperationId;
+      messageId: string;
+      outcome: TurnCompletion;
+      started: boolean;
+      notifyStartup: boolean;
+    }
+  | { type: "decision"; decision: Decision }
+  | { type: "drain"; turnId: TurnId }
+  | { type: "dispose" };
+
+export function initialCoordinatorState(id: TurnId): CoordinatorState {
+  return { lifetime: "open", turn: { phase: "idle", id }, reservations: [], decisions: [] };
+}
+
+/** Pure transition seam: stale events cannot publish, launch policy, or release another owner. */
+export function transition(
+  state: CoordinatorState,
+  event: CoordinatorEvent
+): { state: CoordinatorState; commands: readonly CoordinatorCommand[] } {
+  const commands: CoordinatorCommand[] = [];
+  let next = state;
+  const phase = (turn: Turn) => {
+    const previous = next.turn;
+    next = { ...next, turn };
+    commands.push({ type: "phase", previous, next: turn });
+  };
+  const operation = (value: Operation) => {
+    next = { ...next, turn: { ...next.turn, operation: value } };
+  };
+  const decision = (kind: DecisionKind, messageId: string, outcome?: DecisionOutcome) => {
+    const previous = next.decisions.find(
+      (entry) => entry.kind === kind && entry.messageId === messageId
+    );
+    if (previous?.outcome != null || (previous != null && outcome == null)) return;
+    // Resolution never creates a missing decision: a late fallback cannot resurrect a consumed one.
+    if (previous == null && outcome != null) return;
+    const value = { kind, messageId, outcome };
+    let retained = [...next.decisions];
+    if (previous != null) retained = retained.map((entry) => (entry === previous ? value : entry));
+    else {
+      // Error outcomes retain insertion order for late observers; never evict a pending waiter.
+      const maxRetainedDecisions = 8;
+      if (kind === "error") {
+        for (const entry of retained) {
+          if (
+            retained.filter((candidate) => candidate.kind === "error").length < maxRetainedDecisions
+          )
+            break;
+          if (entry.kind === "error" && entry.outcome != null)
+            retained = retained.filter((candidate) => candidate !== entry);
+        }
+      }
+      retained.push(value);
+    }
+    next = { ...next, decisions: retained };
+    commands.push({ type: "decision", decision: value });
+  };
+  const current = state.turn.operation;
+  if (state.lifetime === "disposed") return { state, commands };
+  switch (event.type) {
+    case "prepare":
+      if (
+        state.lifetime !== "open" ||
+        state.reservations.some((entry) => entry.kind === "admission")
+      )
+        break;
+      if (current) commands.push({ type: "retire", id: current.id });
+      phase({ phase: "preparing", id: event.id });
+      break;
+    case "preempt":
+      if (state.turn.id !== event.id || state.turn.phase !== "preparing") break;
+      if (current) commands.push({ type: "retire", id: current.id });
+      phase({ phase: "idle", id: event.id });
+      break;
+    case "forget-compaction":
+      next = {
+        ...state,
+        decisions: state.decisions.filter(
+          (entry) => entry.kind !== "compaction" || entry.messageId !== event.messageId
+        ),
+      };
+      break;
+    case "finish":
+      if (state.turn.phase === "idle") break;
+      if (state.turn.id !== event.id || (event.preparingOnly && state.turn.phase !== "preparing"))
+        break;
+      phase({ ...state.turn, phase: "idle" });
+      break;
+    case "register":
+      if (state.lifetime !== "open" || state.turn.id !== event.turnId) break;
+      if (current) commands.push({ type: "retire", id: current.id });
+      operation({
+        id: event.id,
+        stage: "registered",
+        startupAbortNotified: false,
+        compaction: false,
+        delivery: "waiting",
+      });
+      break;
+    case "configure-operation":
+      if (current?.id === event.id) operation({ ...current, compaction: event.compaction });
+      break;
+    case "starting":
+      if (current?.id === event.id) operation({ ...current, startupMessageId: event.messageId });
+      break;
+    case "started":
+      if (current && (current.delivery !== "waiting" || current.stage === "started")) break;
+      if (current?.delivery === "waiting") {
+        operation({ ...current, stage: "started", messageId: event.payload.messageId });
+      }
+      commands.push({ type: "record-start", turnId: state.turn.id, payload: event.payload });
+      // Existing raw streams also restore sessions constructed around an already-running engine.
+      phase({ ...next.turn, phase: "streaming" });
+      break;
+    case "raw-terminal":
+      if (current?.messageId !== event.messageId || current.delivery !== "waiting") break;
+      if (event.kind === "completed" && current.compaction) decision("compaction", event.messageId);
+      if (current.stage === "started" && state.turn.phase === "streaming")
+        phase({ ...next.turn, phase: "completing" });
+      break;
+    case "startup-abort":
+      if (
+        current &&
+        (!event.messageId ||
+          (current.startupMessageId === event.messageId && !current.startupAbortNotified))
+      ) {
+        operation({ ...current, startupAbortNotified: true });
+      }
+      break;
+    case "completion":
+      if (current?.id !== event.id || current.delivery !== "waiting") break;
+      operation({
+        ...current,
+        messageId: event.messageId,
+        delivery: "policy",
+        startupAbortNotified:
+          current.startupAbortNotified ||
+          (current.stage === "registered" &&
+            event.outcome.status === "aborted" &&
+            event.outcome.streamAbort != null),
+      });
+      commands.push({
+        type: "policy",
+        id: event.id,
+        messageId: event.messageId,
+        outcome: event.outcome,
+        started: current.stage === "started",
+        notifyStartup: !current.startupAbortNotified,
+      });
+      break;
+    case "complete-policy":
+      if (state.turn.id === event.id) phase({ ...state.turn, phase: "completing" });
+      break;
+    case "reserve":
+      if (state.reservations.some((entry) => entry.id === event.id)) break;
+      next = {
+        ...state,
+        reservations: [...state.reservations, { id: event.id, kind: event.kind }],
+      };
+      break;
+    case "release":
+      if (!state.reservations.some((entry) => entry.id === event.id && entry.kind === event.kind))
+        break;
+      next = {
+        ...state,
+        reservations: state.reservations.filter((entry) => entry.id !== event.id),
+      };
+      if (
+        event.kind !== "manual" &&
+        state.turn.phase === "idle" &&
+        !next.reservations.some((entry) => entry.kind === event.kind)
+      ) {
+        commands.push({ type: "drain", turnId: state.turn.id });
+      }
+      break;
+    case "retry-start":
+      next = { ...state, retry: event.id };
+      break;
+    case "retry-finish":
+      if (state.retry === event.id) next = { ...state, retry: undefined };
+      break;
+    case "decision":
+      decision(event.kind, event.messageId, event.outcome);
+      break;
+    case "shutdown":
+      next = { ...state, lifetime: "shutting-down" };
+      break;
+    case "dispose":
+      next = { ...state, lifetime: "disposed", retry: undefined, reservations: [] };
+      for (const entry of state.decisions)
+        decision(entry.kind, entry.messageId, entry.kind === "error" ? "terminal" : false);
+      if (current) commands.push({ type: "retire", id: current.id });
+      phase({ phase: "idle", id: state.turn.id });
+      commands.push({ type: "dispose" });
+      break;
+  }
+  return { state: next, commands };
+}
+
+interface CoordinatorCallbacks {
+  streamStarted?: (payload: StreamStartEvent) => void;
+  phaseChanged: (phase: TurnPhase, isCurrent: () => boolean) => void;
+  drainQueue: () => void;
+  policy: (
+    id: OperationId,
+    messageId: string,
+    outcome: TurnCompletion,
+    started: boolean,
+    notifyStartup: boolean
+  ) => Promise<void>;
+  policyError: (error: unknown) => void;
+}
+
+/**
+ * The sole owner of lifecycle state and runtime registries. Dispatch publishes state before any
+ * callback; cleanup captures retired resources before publication so observer reentrancy is safe.
+ * Promise policy is deliberately outside the engine sink: a follow-up can await engine cleanup.
+ */
+export class TurnCoordinator {
+  private state = initialCoordinatorState(Symbol("idle"));
+  private readonly settlements = new Map<
+    OperationId,
+    ReturnType<typeof Promise.withResolvers<void>>
+  >();
+  private readonly decisions = new Map<
+    string,
+    ReturnType<typeof Promise.withResolvers<DecisionOutcome>>
+  >();
+  private idleWaiters = new Set<() => void>();
+  private prepared?: { id: TurnId; controller: AbortController };
+  private thinking: ActiveTurnThinkingOverride | null = null;
+
+  constructor(private readonly callbacks: CoordinatorCallbacks) {}
+
+  get phase(): TurnPhase {
+    return this.state.turn.phase;
+  }
+  get turnId(): TurnId {
+    return this.state.turn.id;
+  }
+  get operationId(): OperationId | undefined {
+    return this.state.turn.operation?.id;
+  }
+  get disposed(): boolean {
+    return this.state.lifetime === "disposed";
+  }
+  get closing(): boolean {
+    return this.state.lifetime !== "open";
+  }
+  get admissionBlocked(): boolean {
+    return this.hasReservation("admission");
+  }
+  get editReserved(): boolean {
+    return this.hasReservation("edit");
+  }
+  get manualFollowUpPending(): boolean {
+    return this.hasReservation("manual");
+  }
+  get retryStarting(): boolean {
+    return this.state.retry != null;
+  }
+  get thinkingOverride(): ActiveTurnThinkingOverride | null {
+    return this.thinking;
+  }
+  isBusy(): boolean {
+    return this.phase !== "idle" || this.editReserved;
+  }
+  isCurrentTurn(id: TurnId): boolean {
+    return !this.disposed && this.turnId === id;
+  }
+  isCurrentOperation(id: OperationId | undefined): boolean {
+    return !this.disposed && this.operationId === id;
+  }
+
+  private hasReservation(kind: ReservationKind): boolean {
+    return this.state.reservations.some((entry) => entry.kind === kind);
+  }
+
+  private dispatch(
+    event: Extract<CoordinatorEvent, { type: "completion" }>
+  ): Promise<void> | undefined;
+  private dispatch(event: Exclude<CoordinatorEvent, { type: "completion" }>): void;
+  private dispatch(event: CoordinatorEvent): Promise<void> | undefined {
+    let launchedPolicy: Promise<void> | undefined;
+    let publicationError: { error: unknown } | undefined;
+    const result = transition(this.state, event);
+    this.state = result.state;
+    // Detach before *any* callback. An idle observer may synchronously admit a new turn and waiter.
+    const idle = result.commands.some(
+      (command) => command.type === "phase" && command.next.phase === "idle"
+    );
+    const waiters = idle ? this.idleWaiters : undefined;
+    const retiredPrepared =
+      idle && this.prepared?.id === result.state.turn.id ? this.prepared : undefined;
+    if (idle) {
+      this.idleWaiters = new Set();
+      this.thinking = null;
+      if (this.prepared?.id === result.state.turn.id) this.prepared = undefined;
+    }
+    for (const command of result.commands) {
+      switch (command.type) {
+        case "phase": {
+          const isCurrent = () =>
+            this.state.turn.id === command.next.id &&
+            this.phase === command.next.phase &&
+            !this.disposed;
+          if (isCurrent() || (event.type === "dispose" && this.disposed)) {
+            try {
+              this.callbacks.phaseChanged(command.next.phase, isCurrent);
+            } catch (error) {
+              publicationError ??= { error };
+            }
+          }
+          break;
+        }
+        case "record-start":
+          if (this.isCurrentTurn(command.turnId)) this.callbacks.streamStarted?.(command.payload);
+          break;
+        case "retire":
+          this.settleOperation(command.id);
+          break;
+        case "decision": {
+          const key = this.decisionKey(command.decision.kind, command.decision.messageId);
+          if (command.decision.outcome == null)
+            this.decisions.set(key, Promise.withResolvers<DecisionOutcome>());
+          else this.decisions.get(key)?.resolve(command.decision.outcome);
+          break;
+        }
+        case "policy":
+          if (this.isCurrentOperation(command.id)) {
+            // Invoke synchronously up to the policy's first await; never insert an admission gap.
+            let policy: Promise<void>;
+            try {
+              policy = this.callbacks.policy(
+                command.id,
+                command.messageId,
+                command.outcome,
+                command.started,
+                command.notifyStartup
+              );
+            } catch (error) {
+              policy = Promise.reject(error instanceof Error ? error : new Error(String(error)));
+            }
+            launchedPolicy = policy
+              .catch(this.callbacks.policyError)
+              .finally(() => {
+                this.resolveErrorDecision(command.messageId, "terminal");
+                this.resolveCompactionDecision(command.messageId, false);
+                this.settleOperation(command.id);
+              })
+              .catch(this.callbacks.policyError);
+          }
+          break;
+        case "drain":
+          if (
+            this.state.lifetime === "open" &&
+            this.isCurrentTurn(command.turnId) &&
+            !this.isBusy() &&
+            !this.admissionBlocked
+          )
+            this.callbacks.drainQueue();
+          break;
+        case "dispose": {
+          const prepared = retiredPrepared ?? this.prepared;
+          this.prepared = undefined;
+          prepared?.controller.abort();
+          for (const id of this.settlements.keys()) this.settleOperation(id);
+          break;
+        }
+      }
+    }
+    for (const resolve of waiters ?? []) resolve();
+    // Outcomes live in pure state; the registry holds resources only, including pending waiters.
+    const keys = new Set(
+      this.state.decisions.map((entry) => this.decisionKey(entry.kind, entry.messageId))
+    );
+    for (const key of this.decisions.keys()) if (!keys.has(key)) this.decisions.delete(key);
+    // Publication failures retain their original propagation, but cannot orphan the detached
+    // batch or skip disposal's retired resources. A later dispose no longer owns that batch.
+    if (publicationError) throw publicationError.error;
+    return launchedPolicy;
+  }
+
+  prepare(controller?: AbortController, reservation?: TurnId): TurnId {
+    const id = reservation ?? Symbol("turn");
+    if (reservation && (!this.isCurrentTurn(reservation) || this.phase !== "preparing"))
+      return Symbol("rejected admission");
+    // Resource publication precedes lifecycle callbacks, just like ownership publication.
+    if (this.state.lifetime !== "open" || this.admissionBlocked)
+      return Symbol("rejected admission");
+    this.prepared = controller ? { id, controller } : undefined;
+    this.dispatch({ type: "prepare", id });
+    return id;
+  }
+
+  finishPreparation(id: TurnId): void {
+    if (this.prepared?.id === id) this.prepared = undefined;
+    this.dispatch({ type: "finish", id, preparingOnly: true });
+  }
+
+  preemptPreparation(): boolean {
+    if (this.phase !== "preparing" || this.prepared?.id !== this.turnId) return false;
+    const prepared = this.prepared;
+    this.prepared = undefined;
+    // Invalidate before abort callbacks or lifecycle observers can admit the replacement.
+    try {
+      this.dispatch({ type: "preempt", id: prepared.id });
+    } finally {
+      prepared.controller.abort();
+    }
+    return true;
+  }
+
+  finishTurn(id: TurnId): void {
+    this.dispatch({ type: "finish", id, preparingOnly: false });
+  }
+  beginPolicy(id: TurnId): void {
+    this.dispatch({ type: "complete-policy", id });
+  }
+  acceptThinkingOverride(holder: ActiveTurnThinkingOverride, turnId: TurnId): void {
+    if (this.isCurrentTurn(turnId)) this.thinking = holder;
+  }
+  releaseThinkingOverride(holder: ActiveTurnThinkingOverride): void {
+    if (this.thinking === holder) this.thinking = null;
+  }
+  beginShutdown(): void {
+    this.dispatch({ type: "shutdown" });
+  }
+  dispose(): void {
+    this.dispatch({ type: "dispose" });
+  }
+
+  reserve(kind: ReservationKind): Disposable {
+    const id = Symbol(kind);
+    this.dispatch({ type: "reserve", id, kind });
+    return { [Symbol.dispose]: () => this.dispatch({ type: "release", id, kind }) };
+  }
+
+  registerManualFollowUp(signal?: AbortSignal): () => void {
+    assert(
+      signal == null || typeof signal.aborted === "boolean",
+      "registerExternalManualFollowUp signal must be an AbortSignal"
+    );
+    if (signal?.aborted) throw new Error("External manual follow-up canceled.");
+    const reservation = this.reserve("manual");
+    const release = () => {
+      signal?.removeEventListener("abort", release);
+      reservation[Symbol.dispose]();
+    };
+    signal?.addEventListener("abort", release, { once: true });
+    return release;
+  }
+
+  waitForIdle(signal?: AbortSignal): Promise<void> {
+    assert(
+      signal == null || typeof signal.aborted === "boolean",
+      "waitForIdle signal must be an AbortSignal"
+    );
+    if (signal?.aborted) return Promise.reject(new Error("Waiting for session idle canceled."));
+    if (this.phase === "idle") return Promise.resolve();
+    return new Promise<void>((resolve, reject) => {
+      const batch = this.idleWaiters;
+      const finish = () => {
+        signal?.removeEventListener("abort", abort);
+        batch.delete(finish);
+        resolve();
+      };
+      const abort = () => {
+        signal?.removeEventListener("abort", abort);
+        batch.delete(finish);
+        reject(new Error("Waiting for session idle canceled."));
+      };
+      batch.add(finish);
+      signal?.addEventListener("abort", abort, { once: true });
+    });
+  }
+
+  beginRetry(): symbol {
+    const id = Symbol("retry");
+    this.dispatch({ type: "retry-start", id });
+    return id;
+  }
+  finishRetry(id: symbol): void {
+    this.dispatch({ type: "retry-finish", id });
+  }
+  clearRetryStarting(): void {
+    if (this.state.retry) this.finishRetry(this.state.retry);
+  }
+
+  registerOperation(turnId: TurnId): OperationId {
+    const id = Symbol("operation");
+    this.settlements.set(id, Promise.withResolvers<void>());
+    this.dispatch({ type: "register", id, turnId });
+    if (!this.isCurrentOperation(id)) this.settleOperation(id);
+    return id;
+  }
+  configureOperation(id: OperationId, compaction: boolean): void {
+    this.dispatch({ type: "configure-operation", id, compaction });
+  }
+  streamStarting(id: OperationId, messageId: string): void {
+    this.dispatch({ type: "starting", id, messageId });
+  }
+  streamStarted(payload: StreamStartEvent): boolean {
+    const previous = this.state;
+    const turn = this.turnId;
+    this.dispatch({ type: "started", payload });
+    return (
+      this.state !== previous &&
+      this.isCurrentTurn(turn) &&
+      this.phase === "streaming" &&
+      (this.state.turn.operation == null ||
+        this.state.turn.operation.messageId === payload.messageId)
+    );
+  }
+  rawTerminal(kind: "completed" | "aborted", messageId: string): void {
+    this.dispatch({ type: "raw-terminal", kind, messageId });
+  }
+  observeStartupAbort(payload: StreamAbortEvent): boolean {
+    const operation = this.state.turn.operation;
+    const notify =
+      !payload.messageId ||
+      (operation?.startupMessageId === payload.messageId && !operation.startupAbortNotified);
+    if (notify && !this.disposed)
+      this.dispatch({ type: "startup-abort", messageId: payload.messageId });
+    return notify && !this.disposed;
+  }
+
+  captureInterruptSettlement(soft?: boolean): Promise<void> | undefined {
+    const operation = this.state.turn.operation;
+    return !soft && operation?.stage === "started"
+      ? this.settlements.get(operation.id)?.promise
+      : undefined;
+  }
+  finishStartup(id: OperationId): void {
+    this.settleOperation(id);
+  }
+  private settleOperation(id: OperationId): void {
+    this.settlements.get(id)?.resolve();
+    this.settlements.delete(id);
+  }
+  consumeCompletion(id: OperationId, handle: TurnStreamHandle): Promise<void> {
+    return handle.completion
+      .then((outcome) => {
+        if (!this.isCurrentOperation(id)) {
+          this.resolveErrorDecision(handle.messageId, "terminal");
+          this.resolveCompactionDecision(handle.messageId, false);
+          this.settleOperation(id);
+          return;
+        }
+        return this.dispatch({ type: "completion", id, messageId: handle.messageId, outcome });
+      })
+      .catch((error: unknown) => {
+        this.settleOperation(id);
+        this.callbacks.policyError(error);
+      });
+  }
+
+  private decisionKey(kind: DecisionKind, messageId: string): string {
+    return `${kind}:${messageId}`;
+  }
+  beginErrorDecision(messageId: string): void {
+    this.dispatch({ type: "decision", kind: "error", messageId });
+  }
+  resolveErrorDecision(messageId: string, outcome: StreamErrorRecoveryOutcome): void {
+    this.dispatch({ type: "decision", kind: "error", messageId, outcome });
+  }
+  resolveCompactionDecision(messageId: string, outcome: boolean): void {
+    this.dispatch({ type: "decision", kind: "compaction", messageId, outcome });
+  }
+  async waitForErrorDecision(messageId: string): Promise<StreamErrorRecoveryOutcome | undefined> {
+    const decision = this.state.decisions.find(
+      (entry) => entry.kind === "error" && entry.messageId === messageId
+    );
+    const outcome =
+      decision?.outcome ??
+      (await this.decisions.get(this.decisionKey("error", messageId))?.promise);
+    return typeof outcome === "string" ? outcome : undefined;
+  }
+  async waitForCompactionDecision(messageId: string, allowPending: boolean): Promise<boolean> {
+    if (allowPending && !this.disposed)
+      this.dispatch({ type: "decision", kind: "compaction", messageId });
+    const decision = this.state.decisions.find(
+      (entry) => entry.kind === "compaction" && entry.messageId === messageId
+    );
+    const outcome =
+      decision?.outcome ??
+      (await this.decisions.get(this.decisionKey("compaction", messageId))?.promise);
+    this.dispatch({ type: "forget-compaction", messageId });
+    return outcome === true;
+  }
+}


### PR DESCRIPTION
AgentSession's lifecycle fields, operation identity, reservations, and completion waiters currently share ownership across asynchronous handlers. This extracts a TurnCoordinator with a pure transition core and private runtime registries, so stale work cannot change a replacement turn's lifecycle or resources.

AgentSession delegates admission, phase queries, attempt completion, and decision waits through semantic coordinator methods. Synchronous state publication still precedes callbacks and awaits. Provider completion remains separate from session policy settlement; startup aborts, edit reservations, phase-only idle waits, manual priority, and existing retry/compaction policy retain their distinct behavior.

Owner-scoped cleanup preserves replacement thinking settings and idle waiters during reentrant callbacks. Retired attempts still settle their decisions, publication failures cannot orphan detached waiters, queued sends retain one admission identity through startup failure, and duplicate start events cannot reopen a completing attempt.

Validation: 360 coordinator and AgentSession tests pass, as does make static-check. Tests cover reentrant admission/disposal, late preparation errors, duplicate startup notifications, queue startup failure, and captured interruption settlement. On the final rebuilt code, the send-mode UI suite passed 4/5; its pointer/menu case passed an unchanged isolated rerun. An earlier complete run passed 5/5. Complete frozen-revision validation remains a CI gate. The long local source-suite run overlapped edits and is diagnostic only; separately reproduced base failures include macOS filesystem assumptions, Git fixture configuration, hook timing, and existing Storybook snapshot budgets. No related tests or thresholds were relaxed.

Regression risk centers on admission, cancellation, retry, and compaction ordering: a mistake could stall a turn or let stale work affect a successor. This phase changes lifecycle ownership while retaining existing policy implementations and engine event timing; the Effect interpreter follows in the next phase.

---

_Generated with `xum` • Model: `unavailable` • Thinking: `unavailable` • Cost: `$unavailable`_

<!-- mux-attribution: model=unavailable thinking=unavailable costs=unavailable -->
