### PR TITLE
🤖 refactor: supervise agent turn work with scoped Effect lifetimes

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -8,6 +8,7 @@
  *   xum run --runtime "ssh user@host" "Deploy changes"
  */
 
+import { EffectRunnerTag } from "@/node/services/di/effectRunner";
 import { Command } from "commander";
 import { resolveXumEnvironmentValue } from "@/common/compat/legacyMux";
 import { tool } from "ai";
@@ -735,6 +736,8 @@ async function main(): Promise<number> {
   turnRequestBuilderBindings.extraTools = { set_exit_code: setExitCodeTool };
 
   const session = new AgentSession({
+    effectRunner: coreRuntime.get(EffectRunnerTag),
+    appFiberScope,
     workspaceId,
     config,
     historyService,

--- a/src/cli/workflow.ts
+++ b/src/cli/workflow.ts
@@ -3,6 +3,7 @@
  * `xum workflow` - Headless CLI runner for durable workflow scripts.
  */
 
+import { EffectRunnerTag } from "@/node/services/di/effectRunner";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
@@ -397,6 +398,8 @@ async function createWorkflowContext(options: {
     // below would lose TypeScript's definite-assignment narrowing.
     const workspaceServiceForSanitize = services.workspaceService;
     session = new AgentSession({
+      effectRunner: services.runtime.get(EffectRunnerTag),
+      appFiberScope: services.appFiberScope,
       workspaceId,
       config,
       historyService: services.historyService,

--- a/src/node/services/agentSession.scopedLifetimes.test.ts
+++ b/src/node/services/agentSession.scopedLifetimes.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, mock, spyOn, test } from "bun:test";
+import { Effect, Exit, Scope } from "effect";
+import { Err } from "@/common/types/result";
+import { defaultEffectRunner as runner } from "./di/effectRunner";
+import { createAgentSessionHarness } from "./agentSession.testHarness";
+
+const workspaceId = "scoped-turn";
+const options = { model: "openai:gpt-4o", agentId: "exec" };
+
+describe("AgentSession scoped turn lifetimes", () => {
+  test("queue clear publication cannot outrun its cancellation refund", async () => {
+    const appFiberScope = Scope.makeUnsafe("parallel");
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const h = await createAgentSessionHarness({ workspaceId, appFiberScope });
+    h.session.queueMessage("clear me", options, {
+      onCanceled: () => {
+        entered.resolve();
+        return release.promise;
+      },
+    });
+    let closing: Promise<void> | undefined;
+    let closed = false;
+    h.session.onChatEvent(({ message }) => {
+      if (message.type === "queued-message-changed") {
+        closing = runner.runPromise(Scope.close(appFiberScope, Exit.void)).then(() => {
+          closed = true;
+        });
+      }
+    });
+    try {
+      h.session.clearQueue();
+      await entered.promise;
+      await runner.runPromise(Effect.yieldNow);
+      expect(closing).toBeDefined();
+      expect(closed).toBe(false);
+      release.resolve();
+      await closing;
+    } finally {
+      release.resolve();
+      h.session.dispose();
+      await h.cleanup();
+    }
+  });
+
+  test("actual startup recovery remains supervised before any send", async () => {
+    const appFiberScope = Scope.makeUnsafe("parallel");
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const h = await createAgentSessionHarness({ workspaceId, appFiberScope });
+    const recovery = h.session as unknown as {
+      requireGoalAcknowledgmentForCrashRecoveredPartial(): Promise<void>;
+    };
+    const original = recovery.requireGoalAcknowledgmentForCrashRecoveredPartial.bind(h.session);
+    spyOn(recovery, "requireGoalAcknowledgmentForCrashRecoveredPartial").mockImplementation(
+      async () => {
+        await original();
+        entered.resolve();
+        await release.promise;
+      }
+    );
+    const recovering = h.session.runStartupRecovery();
+    try {
+      await entered.promise;
+      let closed = false;
+      const closing = runner.runPromise(Scope.close(appFiberScope, Exit.void)).then(() => {
+        closed = true;
+      });
+      await runner.runPromise(Effect.yieldNow);
+      expect(closed).toBe(false);
+      release.resolve();
+      await Promise.all([recovering, closing]);
+      expect(spyOn(h.aiService, "streamMessage")).not.toHaveBeenCalled();
+    } finally {
+      release.resolve();
+      await recovering;
+      h.session.dispose();
+      await h.cleanup();
+    }
+  });
+
+  test.each([false, true])(
+    "queued failure cleanup stays supervised (reentrant close=%s)",
+    async (reentrant) => {
+      const appFiberScope = Scope.makeUnsafe("parallel");
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const h = await createAgentSessionHarness({ workspaceId, appFiberScope });
+      spyOn(h.historyService, "appendToHistory").mockResolvedValueOnce(Err("disk unavailable"));
+      let closing: Promise<void> | undefined;
+      let closed = false;
+      const close = (): void => {
+        closing ??= runner.runPromise(Scope.close(appFiberScope, Exit.void)).then(() => {
+          closed = true;
+        });
+      };
+      h.session.queueMessage("queued", options, {
+        synthetic: true,
+        onAcceptedPreStreamFailure: () => {
+          entered.resolve();
+          return release.promise;
+        },
+      });
+      if (reentrant) {
+        // Dequeue publication precedes sendMessage. A missing outer lease would let the guardian
+        // finish here before the queued producer's own call has even been registered.
+        h.session.onChatEvent(({ message }) => {
+          if (message.type === "queued-message-changed") {
+            close();
+          }
+        });
+      }
+      try {
+        h.session.sendQueuedMessages();
+        if (!reentrant) await entered.promise;
+        close();
+        if (!reentrant) {
+          await runner.runPromise(Effect.yieldNow);
+          expect(closed).toBe(false);
+        }
+        release.resolve();
+        await closing;
+        expect(spyOn(h.aiService, "streamMessage")).not.toHaveBeenCalled();
+      } finally {
+        release.resolve();
+        h.session.dispose();
+        await h.cleanup();
+      }
+    }
+  );
+
+  test("shutdown joins a durable user append admitted before preparation", async () => {
+    const appFiberScope = Scope.makeUnsafe("parallel");
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const h = await createAgentSessionHarness({ workspaceId, appFiberScope });
+    const append = h.historyService.appendToHistory.bind(h.historyService);
+    spyOn(h.historyService, "appendToHistory").mockImplementation(async (id, message) => {
+      const result = await append(id, message);
+      if (message.role === "user") {
+        entered.resolve();
+        await release.promise;
+      }
+      return result;
+    });
+    const send = h.session.sendMessage("persist before preparing", options);
+    let closed = false;
+    try {
+      await entered.promise;
+      expect(h.session.isBusy()).toBe(false);
+      const closing = runner.runPromise(Scope.close(appFiberScope, Exit.void)).then(() => {
+        closed = true;
+      });
+      await runner.runPromise(Effect.yieldNow);
+      expect(closed).toBe(false);
+      expect(spyOn(h.aiService, "streamMessage")).not.toHaveBeenCalled();
+      release.resolve();
+      await Promise.all([send, closing]);
+      expect(spyOn(h.aiService, "streamMessage")).not.toHaveBeenCalled();
+      const history = await h.historyService.getHistoryFromLatestBoundary(workspaceId);
+      expect(history.success && history.data.some((message) => message.role === "user")).toBe(true);
+    } finally {
+      release.resolve();
+      await send;
+      h.session.dispose();
+      await h.cleanup();
+    }
+  });
+
+  test("background startup and its failure callback outlive the foreground lease", async () => {
+    const appFiberScope = Scope.makeUnsafe("parallel");
+    const started = Promise.withResolvers<void>();
+    const releaseStartup = Promise.withResolvers<void>();
+    const failed = Promise.withResolvers<void>();
+    const releaseFailure = Promise.withResolvers<void>();
+    const h = await createAgentSessionHarness({
+      workspaceId,
+      appFiberScope,
+      aiServiceOverrides: {
+        streamMessage: mock(async () => {
+          started.resolve();
+          await releaseStartup.promise;
+          return Err({ type: "unknown" as const, raw: "held startup failure" });
+        }),
+      },
+    });
+    const onAcceptedPreStreamFailure = mock(() => {
+      failed.resolve();
+      return releaseFailure.promise;
+    });
+    try {
+      await h.session.sendMessage("background", options, {
+        startStreamInBackground: true,
+        onAcceptedPreStreamFailure,
+      });
+      await started.promise;
+      let closed = false;
+      const closing = runner.runPromise(Scope.close(appFiberScope, Exit.void)).then(() => {
+        closed = true;
+      });
+      expect(closed).toBe(false);
+      releaseStartup.resolve();
+      await failed.promise;
+      expect(closed).toBe(false);
+      releaseFailure.resolve();
+      await closing;
+      expect(onAcceptedPreStreamFailure).toHaveBeenCalledTimes(1);
+    } finally {
+      releaseStartup.resolve();
+      releaseFailure.resolve();
+      h.session.dispose();
+      await h.cleanup();
+    }
+  });
+
+  test.each(["throw", "reject", "empty-history"])(
+    "registered preparation %s does not orphan shutdown",
+    async (failure) => {
+      const appFiberScope = Scope.makeUnsafe("parallel");
+      const h = await createAgentSessionHarness({ workspaceId, appFiberScope });
+      if (failure !== "empty-history") {
+        spyOn(h.historyService, "commitPartial").mockImplementationOnce(() => {
+          if (failure === "throw") throw new Error("preparation failed");
+          return Promise.reject(new Error("preparation failed"));
+        });
+      }
+      try {
+        const resumed = h.session.resumeStream(options);
+        if (failure === "empty-history") expect((await resumed).success).toBe(false);
+        else expect(await resumed.catch((error: unknown) => error)).toBeInstanceOf(Error);
+        await runner.runPromise(Scope.close(appFiberScope, Exit.void));
+        expect(spyOn(h.aiService, "streamMessage")).not.toHaveBeenCalled();
+      } finally {
+        h.session.dispose();
+        await h.cleanup();
+      }
+    }
+  );
+
+  test("a session constructed after app close refuses admission with initialized collaborators", async () => {
+    const appFiberScope = Scope.makeUnsafe("parallel");
+    await runner.runPromise(Scope.close(appFiberScope, Exit.void));
+    const h = await createAgentSessionHarness({ workspaceId, appFiberScope });
+    const append = spyOn(h.historyService, "appendToHistory");
+    try {
+      expect((await h.session.sendMessage("too late", options)).success).toBe(false);
+      expect(await h.session.resumeStream(options)).toEqual({
+        success: true,
+        data: { started: false },
+      });
+      expect(append).not.toHaveBeenCalled();
+      expect(spyOn(h.aiService, "streamMessage")).not.toHaveBeenCalled();
+    } finally {
+      h.session.dispose();
+      await h.cleanup();
+    }
+  });
+
+  test("a disposed session remains supervised while its accepted write settles", async () => {
+    const appFiberScope = Scope.makeUnsafe("parallel");
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const h = await createAgentSessionHarness({ workspaceId, appFiberScope });
+    const send = h.session.sendMessage("accepted", options, {
+      onAccepted: () => {
+        entered.resolve();
+        return release.promise;
+      },
+    });
+    try {
+      await entered.promise;
+      h.session.dispose();
+      let closed = false;
+      const closing = runner.runPromise(Scope.close(appFiberScope, Exit.void)).then(() => {
+        closed = true;
+      });
+      await runner.runPromise(Effect.yieldNow);
+      expect(closed).toBe(false);
+      release.resolve();
+      await Promise.all([send, closing]);
+      expect(spyOn(h.aiService, "streamMessage")).not.toHaveBeenCalled();
+    } finally {
+      release.resolve();
+      await send;
+      h.session.dispose();
+      await h.cleanup();
+    }
+  });
+});

--- a/src/node/services/agentSession.testHarness.ts
+++ b/src/node/services/agentSession.testHarness.ts
@@ -127,7 +127,10 @@ function createMockAiService(args?: {
   return { aiEmitter, aiService };
 }
 
-export interface AgentSessionHarnessOptions {
+export interface AgentSessionHarnessOptions extends Pick<
+  ConstructorParameters<typeof AgentSession>[0],
+  "effectRunner" | "appFiberScope"
+> {
   workspaceId: string;
   config?: Config;
   historyService?: HistoryService;
@@ -177,6 +180,8 @@ export async function createAgentSessionHarness(
     createMockBackgroundProcessManager(options.backgroundProcessManagerOverrides);
 
   const session = new AgentSession({
+    effectRunner: options.effectRunner,
+    appFiberScope: options.appFiberScope,
     workspaceId: options.workspaceId,
     config,
     historyService,

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -140,7 +140,8 @@ import { getTotalCost } from "@/common/utils/tokens/usageAggregator";
 import type { CompactionCompletionMetadata } from "@/common/types/compaction";
 import { CompactionHandler } from "./compactionHandler";
 import { RetryManager, type RetryFailureError, type RetryStatusEvent } from "./retryManager";
-import type { EffectRunner } from "./di/effectRunner";
+import { defaultEffectRunner, type EffectRunner } from "./di/effectRunner";
+import type { Scope } from "effect";
 import type { TelemetryService } from "./telemetryService";
 import type { BackgroundProcessManager } from "./backgroundProcessManager";
 
@@ -613,6 +614,8 @@ export interface AgentSessionAIService extends BranchSummaryAiService {
 }
 
 interface AgentSessionOptions {
+  effectRunner?: EffectRunner;
+  appFiberScope?: Scope.Scope;
   workspaceId: string;
   config: Config;
   historyService: HistoryService;
@@ -1047,6 +1050,14 @@ export class AgentSession {
       this.streamManager.effectRunner
     );
 
+    // App close can interrupt the guardian synchronously. Attach only after retry/compaction
+    // collaborators exist, so a session created during shutdown can safely latch admission.
+    this.coordinator.supervise(
+      options.effectRunner ?? this.streamManager.effectRunner ?? defaultEffectRunner,
+      options.appFiberScope,
+      () => this.beginShutdown()
+    );
+
     this.attachAiListeners();
     this.attachInitListeners();
     eventSpine.emit("session.start", { workspaceId: this.workspaceId });
@@ -1343,6 +1354,8 @@ export class AgentSession {
   }
 
   private async retryActiveStream(): Promise<void> {
+    if (this.coordinator.closing) return;
+    using _execution = this.coordinator.enterExecution();
     const retry = this.coordinator.beginRetry();
     try {
       const request = this.lastAutoRetryResumeRequest;
@@ -2259,6 +2272,8 @@ export class AgentSession {
   }
 
   private async scheduleStartupAutoRetryIfNeeded(): Promise<StartupAutoRetryCheckOutcome> {
+    if (this.coordinator.closing) return "completed";
+    using _execution = this.coordinator.enterExecution();
     if (this.coordinator.disposed || this.isBusy() || this.isAiStreaming()) {
       // Busy/streaming deferrals are state-driven; do not carry history-error backoff.
       this.startupAutoRetryDeferredRetryDelayMs = 0;
@@ -2473,6 +2488,8 @@ export class AgentSession {
       // a pending follow-up that was never dispatched. If so, dispatch it now.
       // This handles the case where the app crashed after compaction completed
       // but before the follow-up was sent.
+      // Track actual recovery I/O through its final callback, not the later idle/timer gate.
+      const recoveryExecution = this.coordinator.enterExecution();
       this.startupRecoveryPromise = this.requireGoalAcknowledgmentForCrashRecoveredPartial()
         .then(() => this.continuousCompactor.recover())
         .then(() => this.dispatchPendingFollowUp())
@@ -2496,6 +2513,7 @@ export class AgentSession {
         })
         .finally(() => {
           this.startupRecoveryPromise = null;
+          recoveryExecution[Symbol.dispose]();
         });
     }
 
@@ -3142,6 +3160,11 @@ export class AgentSession {
     }
   ): Promise<AgentSessionResult<void>> {
     this.assertNotDisposed("sendMessage");
+    if (this.coordinator.closing)
+      return Err(createUnknownSendMessageError(SESSION_SHUTDOWN_SEND_BLOCKED_MESSAGE));
+    // Durable acceptance precedes PREPARING. This physical lease changes no busy/queue policy,
+    // but shutdown must join its writes and acceptance callbacks before dependencies disappear.
+    using _execution = this.coordinator.enterExecution();
 
     assert(typeof message === "string", "sendMessage requires a string message");
 
@@ -4228,6 +4251,8 @@ export class AgentSession {
           this.sendQueuedMessages();
         }
       };
+      // Transfer supervision before the foreground lease releases; include failure callbacks.
+      const backgroundExecution = this.coordinator.enterExecution();
       startPreparedStream()
         .then(async (result) => {
           if (!result.success) {
@@ -4253,7 +4278,8 @@ export class AgentSession {
             });
           }
           drainQueuedMessagesAfterFailedStartup();
-        });
+        })
+        .finally(() => backgroundExecution[Symbol.dispose]());
       return Ok(undefined);
     }
 
@@ -4267,6 +4293,8 @@ export class AgentSession {
     internal?: { agentInitiated?: boolean; goalKind?: GoalSyntheticMessageKind; goalId?: string }
   ): Promise<AgentSessionResult<{ started: boolean }>> {
     this.assertNotDisposed("resumeStream");
+    if (this.coordinator.closing) return Ok({ started: false });
+    using _execution = this.coordinator.enterExecution();
 
     assert(options, "resumeStream requires options");
     const { model } = options;
@@ -4965,6 +4993,10 @@ export class AgentSession {
   private async runContinuousCompactionObservation<T>(
     observe: () => Promise<T>
   ): Promise<T | undefined> {
+    if (this.coordinator.closing) return undefined;
+    // Own the actual apply and its continuation; the compactor's detached eager summary job
+    // retains its existing cancellation contract until the later compaction migration.
+    using _execution = this.coordinator.enterExecution();
     if (this.continuousCompactionObservation) {
       await this.continuousCompactionObservation;
       return undefined;
@@ -5123,9 +5155,10 @@ export class AgentSession {
   }
 
   private async interruptForCompaction(): Promise<void> {
-    if (this.midStreamCompactionPending || this.coordinator.disposed) {
+    if (this.midStreamCompactionPending || this.coordinator.closing) {
       return;
     }
+    using _execution = this.coordinator.enterExecution();
 
     const streamContext = this.activeStreamContext;
     if (!streamContext?.modelString || !streamContext.options) {
@@ -5369,255 +5402,266 @@ export class AgentSession {
     }
 
     const operation = this.coordinator.registerOperation(turn);
+    let completionTransferred = false;
+    try {
+      // Reset per-stream flags (used for retries / crash-safe bookkeeping).
+      this.compactionMonitor.resetForNewStream();
+      this.clearLiveUsageState();
+      this.ackPendingPostCompactionStateOnStreamEnd = false;
+      this.activeStreamHadAnyDelta = false;
+      this.activeStreamHadPostCompactionInjection = false;
+      const providersConfig = this.getProvidersConfigSafe();
+      this.activeStreamContext = {
+        modelString,
+        options,
+        agentInitiated,
+        openaiTruncationModeOverride,
+        ...(goalKind != null ? { goalKind } : {}),
+        ...(goalId != null ? { goalId } : {}),
+        providersConfig,
+      };
+      this.activeStreamUserMessageId = undefined;
 
-    // Reset per-stream flags (used for retries / crash-safe bookkeeping).
-    this.compactionMonitor.resetForNewStream();
-    this.clearLiveUsageState();
-    this.ackPendingPostCompactionStateOnStreamEnd = false;
-    this.activeStreamHadAnyDelta = false;
-    this.activeStreamHadPostCompactionInjection = false;
-    const providersConfig = this.getProvidersConfigSafe();
-    this.activeStreamContext = {
-      modelString,
-      options,
-      agentInitiated,
-      openaiTruncationModeOverride,
-      ...(goalKind != null ? { goalKind } : {}),
-      ...(goalId != null ? { goalId } : {}),
-      providersConfig,
-    };
-    this.activeStreamUserMessageId = undefined;
-
-    const commitResult = await this.historyService.commitPartial(this.workspaceId);
-    if (!commitResult.success) {
-      return await this.handleStreamWithHistoryFailure(
-        turn,
-        operation,
-        createUnknownSendMessageError(commitResult.error)
-      );
-    }
-
-    if (isStreamStartAborted()) {
-      return Ok(undefined);
-    }
-
-    // Detect external file edits (timestamp-based polling) BEFORE reading history
-    // and append the <system-file-update> notification as a durable row. The
-    // provider request is built purely from chat.jsonl, so anything the model
-    // sees must be logged first — there is no request-time injection path.
-    // Detection is side-effect-free; tracker state advances via commit() only
-    // AFTER the notification row is durably appended. A retry after a startup
-    // abort or append failure therefore re-detects the same change (nothing is
-    // dropped), while a successful append cannot produce a duplicate row.
-    const fileChangeDetection = await this.fileChangeTracker.getChangedAttachments();
-    if (isStreamStartAborted()) {
-      return Ok(undefined);
-    }
-    if (fileChangeDetection.attachments.length > 0) {
-      const notificationAppendResult = await this.historyService.appendToHistory(
-        this.workspaceId,
-        createFileChangeNotificationMessage(fileChangeDetection.attachments)
-      );
-      if (!notificationAppendResult.success) {
+      const commitResult = await this.historyService.commitPartial(this.workspaceId);
+      if (!commitResult.success) {
         return await this.handleStreamWithHistoryFailure(
           turn,
           operation,
-          createUnknownSendMessageError(notificationAppendResult.error)
+          createUnknownSendMessageError(commitResult.error)
         );
       }
-      fileChangeDetection.commit();
-    }
 
-    const historyResult = await this.historyService.getHistoryFromLatestBoundary(this.workspaceId);
-    if (isStreamStartAborted()) {
-      return Ok(undefined);
-    }
-
-    if (!historyResult.success) {
-      return await this.handleStreamWithHistoryFailure(
-        turn,
-        operation,
-        createUnknownSendMessageError(historyResult.error)
-      );
-    }
-
-    // A crash between snapshot and user-row appends can leave orphaned prompt
-    // expansions on disk; exclude them from every provider request.
-    let requestMessages = filterOrphanedMcpPromptSnapshots(historyResult.data);
-
-    if (requestMessages.length === 0) {
-      return await this.handleStreamWithHistoryFailure(
-        turn,
-        operation,
-        createUnknownSendMessageError(
-          "Cannot resume stream: workspace history is empty. Send a new message instead."
-        )
-      );
-    }
-
-    // Structural invariant: API requests must not end with a non-partial assistant message.
-    // Partial assistants are handled by addInterruptedSentinel at transform time.
-    // Non-partial trailing assistants indicate a missing user message upstream — inject a
-    // [CONTINUE] sentinel so the model has a valid conversation to respond to. This is
-    // defense-in-depth; callers should prefer sendMessage() which persists a real user message.
-    const lastMsg = requestMessages[requestMessages.length - 1];
-    if (lastMsg?.role === "assistant" && !lastMsg.metadata?.partial) {
-      log.warn("streamWithHistory: trailing non-partial assistant detected, injecting [CONTINUE]", {
-        workspaceId: this.workspaceId,
-        messageId: lastMsg.id,
-      });
-      const sentinelMessage = createMuxMessage(createUserMessageId(), "user", "[CONTINUE]", {
-        timestamp: Date.now(),
-        synthetic: true,
-      });
-      await this.historyService.appendToHistory(this.workspaceId, sentinelMessage);
-      const refreshed = await this.historyService.getHistoryFromLatestBoundary(this.workspaceId);
-      if (refreshed.success) {
-        requestMessages = filterOrphanedMcpPromptSnapshots(refreshed.data);
+      if (isStreamStartAborted()) {
+        return Ok(undefined);
       }
-    }
 
-    // Capture the current user message id so retries are stable across assistant message ids.
-    // Retry-eligible rows only: startup recovery matches this persisted ID
-    // against shouldUseUserMessageForRetry candidates, so selecting an
-    // invisible synthetic row (file-update notification, [CONTINUE] sentinel,
-    // snapshot) would persist non-retryable failures against a row recovery
-    // never selects and break the tail match after restart.
-    const lastUserMessage = [...requestMessages]
-      .reverse()
-      .find((m) => this.shouldUseUserMessageForRetry(m));
-    this.activeStreamUserMessageId = lastUserMessage?.id;
+      // Detect external file edits (timestamp-based polling) BEFORE reading history
+      // and append the <system-file-update> notification as a durable row. The
+      // provider request is built purely from chat.jsonl, so anything the model
+      // sees must be logged first — there is no request-time injection path.
+      // Detection is side-effect-free; tracker state advances via commit() only
+      // AFTER the notification row is durably appended. A retry after a startup
+      // abort or append failure therefore re-detects the same change (nothing is
+      // dropped), while a successful append cannot produce a duplicate row.
+      const fileChangeDetection = await this.fileChangeTracker.getChangedAttachments();
+      if (isStreamStartAborted()) {
+        return Ok(undefined);
+      }
+      if (fileChangeDetection.attachments.length > 0) {
+        const notificationAppendResult = await this.historyService.appendToHistory(
+          this.workspaceId,
+          createFileChangeNotificationMessage(fileChangeDetection.attachments)
+        );
+        if (!notificationAppendResult.success) {
+          return await this.handleStreamWithHistoryFailure(
+            turn,
+            operation,
+            createUnknownSendMessageError(notificationAppendResult.error)
+          );
+        }
+        fileChangeDetection.commit();
+      }
 
-    this.activeCompactionRequest = this.resolveCompactionRequest(
-      requestMessages,
-      modelString,
-      options
-    );
+      const historyResult = await this.historyService.getHistoryFromLatestBoundary(
+        this.workspaceId
+      );
+      if (isStreamStartAborted()) {
+        return Ok(undefined);
+      }
 
-    if (isStreamStartAborted()) {
-      return Ok(undefined);
-    }
+      if (!historyResult.success) {
+        return await this.handleStreamWithHistoryFailure(
+          turn,
+          operation,
+          createUnknownSendMessageError(historyResult.error)
+        );
+      }
 
-    // Check if post-compaction attachments should be injected.
-    const postCompactionAttachments =
-      disablePostCompactionAttachments === true
-        ? null
-        : await this.getPostCompactionAttachmentsIfNeeded(this.isRlmCompactionEnabled(options));
-    if (isStreamStartAborted()) {
-      return Ok(undefined);
-    }
+      // A crash between snapshot and user-row appends can leave orphaned prompt
+      // expansions on disk; exclude them from every provider request.
+      let requestMessages = filterOrphanedMcpPromptSnapshots(historyResult.data);
 
-    this.activeStreamHadPostCompactionInjection =
-      postCompactionAttachments !== null && postCompactionAttachments.length > 0;
+      if (requestMessages.length === 0) {
+        return await this.handleStreamWithHistoryFailure(
+          turn,
+          operation,
+          createUnknownSendMessageError(
+            "Cannot resume stream: workspace history is empty. Send a new message instead."
+          )
+        );
+      }
 
-    // Apply per-model thinking floors once so desktop, mobile, and ACP requests match.
-    // Tests may provide partial config mocks, so read overrides only when available.
-    const maybeConfig = this.config as Config & {
-      loadConfigOrDefault?: () => {
-        minThinkingLevelByModel?: Record<string, ThinkingLevel>;
-      } | null;
-    };
-    // Gateway-preserving key first (an explicit coder:<instance>/<model>
-    // floor stays distinct from a direct model with the same ID), with a
-    // legacy name-canonical fallback for floors persisted by older versions.
-    const minThinkingOverride =
-      typeof maybeConfig.loadConfigOrDefault === "function"
-        ? lookupMinThinkingLevelOverride(
-            maybeConfig.loadConfigOrDefault()?.minThinkingLevelByModel,
-            modelString
+      // Structural invariant: API requests must not end with a non-partial assistant message.
+      // Partial assistants are handled by addInterruptedSentinel at transform time.
+      // Non-partial trailing assistants indicate a missing user message upstream — inject a
+      // [CONTINUE] sentinel so the model has a valid conversation to respond to. This is
+      // defense-in-depth; callers should prefer sendMessage() which persists a real user message.
+      const lastMsg = requestMessages[requestMessages.length - 1];
+      if (lastMsg?.role === "assistant" && !lastMsg.metadata?.partial) {
+        log.warn(
+          "streamWithHistory: trailing non-partial assistant detected, injecting [CONTINUE]",
+          {
+            workspaceId: this.workspaceId,
+            messageId: lastMsg.id,
+          }
+        );
+        const sentinelMessage = createMuxMessage(createUserMessageId(), "user", "[CONTINUE]", {
+          timestamp: Date.now(),
+          synthetic: true,
+        });
+        await this.historyService.appendToHistory(this.workspaceId, sentinelMessage);
+        const refreshed = await this.historyService.getHistoryFromLatestBoundary(this.workspaceId);
+        if (refreshed.success) {
+          requestMessages = filterOrphanedMcpPromptSnapshots(refreshed.data);
+        }
+      }
+
+      // Capture the current user message id so retries are stable across assistant message ids.
+      // Retry-eligible rows only: startup recovery matches this persisted ID
+      // against shouldUseUserMessageForRetry candidates, so selecting an
+      // invisible synthetic row (file-update notification, [CONTINUE] sentinel,
+      // snapshot) would persist non-retryable failures against a row recovery
+      // never selects and break the tail match after restart.
+      const lastUserMessage = [...requestMessages]
+        .reverse()
+        .find((m) => this.shouldUseUserMessageForRetry(m));
+      this.activeStreamUserMessageId = lastUserMessage?.id;
+
+      this.activeCompactionRequest = this.resolveCompactionRequest(
+        requestMessages,
+        modelString,
+        options
+      );
+
+      if (isStreamStartAborted()) {
+        return Ok(undefined);
+      }
+
+      // Check if post-compaction attachments should be injected.
+      const postCompactionAttachments =
+        disablePostCompactionAttachments === true
+          ? null
+          : await this.getPostCompactionAttachmentsIfNeeded(this.isRlmCompactionEnabled(options));
+      if (isStreamStartAborted()) {
+        return Ok(undefined);
+      }
+
+      this.activeStreamHadPostCompactionInjection =
+        postCompactionAttachments !== null && postCompactionAttachments.length > 0;
+
+      // Apply per-model thinking floors once so desktop, mobile, and ACP requests match.
+      // Tests may provide partial config mocks, so read overrides only when available.
+      const maybeConfig = this.config as Config & {
+        loadConfigOrDefault?: () => {
+          minThinkingLevelByModel?: Record<string, ThinkingLevel>;
+        } | null;
+      };
+      // Gateway-preserving key first (an explicit coder:<instance>/<model>
+      // floor stays distinct from a direct model with the same ID), with a
+      // legacy name-canonical fallback for floors persisted by older versions.
+      const minThinkingOverride =
+        typeof maybeConfig.loadConfigOrDefault === "function"
+          ? lookupMinThinkingLevelOverride(
+              maybeConfig.loadConfigOrDefault()?.minThinkingLevelByModel,
+              modelString
+            )
+          : undefined;
+      // Pass providersConfig so mapped aliases (mappedToModel -> e.g. GPT-5.6)
+      // clamp against the target model's policy — otherwise a capability level
+      // like native max would be stripped here before buildProviderOptions can
+      // resolve the alias.
+      const minThinkingLevel = resolveMinimumThinkingLevel(
+        modelString,
+        minThinkingOverride,
+        providersConfig
+      );
+      const effectiveThinkingLevel = options?.thinkingLevel
+        ? enforceThinkingPolicy(
+            modelString,
+            options.thinkingLevel,
+            minThinkingLevel,
+            providersConfig
           )
         : undefined;
-    // Pass providersConfig so mapped aliases (mappedToModel -> e.g. GPT-5.6)
-    // clamp against the target model's policy — otherwise a capability level
-    // like native max would be stripped here before buildProviderOptions can
-    // resolve the alias.
-    const minThinkingLevel = resolveMinimumThinkingLevel(
-      modelString,
-      minThinkingOverride,
-      providersConfig
-    );
-    const effectiveThinkingLevel = options?.thinkingLevel
-      ? enforceThinkingPolicy(modelString, options.thinkingLevel, minThinkingLevel, providersConfig)
-      : undefined;
 
-    // Bind recordFileState to this session for the propose_plan tool
-    const recordFileState = this.fileChangeTracker.record.bind(this.fileChangeTracker);
+      // Bind recordFileState to this session for the propose_plan tool
+      const recordFileState = this.fileChangeTracker.record.bind(this.fileChangeTracker);
 
-    const optionsMuxMetadata = options?.muxMetadata as MuxMessageMetadata | undefined;
-    const retryMuxMetadata = lastUserMessage?.metadata?.muxMetadata;
-    // Bash-monitor-wake continuations inherit the correlation of a delegated
-    // workspace turn that was cut mid-work by the wake's queued dispatch, so
-    // the turn's eventual terminal stream-end can settle the parent's handle.
-    const streamMuxMetadata =
-      optionsMuxMetadata?.type === "workspace-turn-task"
-        ? optionsMuxMetadata
-        : retryMuxMetadata?.type === "workspace-turn-task"
-          ? retryMuxMetadata
-          : retryMuxMetadata?.type === "bash-monitor-wake"
-            ? inheritOpenWorkspaceTurnMetadata(requestMessages)
-            : undefined;
-    // Mid-stream compaction runs after the original send options have already been resolved against
-    // history (notably bash-monitor wakes). Persist the actual correlation used by this stream so the
-    // post-compaction continuation remains the same delegated workspace turn.
-    if (this.activeStreamContext != null) {
-      this.activeStreamContext.workspaceTurnMetadata = streamMuxMetadata;
-    }
-    const acpPromptId =
-      normalizeAcpPromptId(options?.acpPromptId) ?? extractAcpPromptId(optionsMuxMetadata);
-    const delegatedToolNames =
-      normalizeDelegatedToolNames(options?.delegatedToolNames) ??
-      extractAcpDelegatedTools(optionsMuxMetadata);
+      const optionsMuxMetadata = options?.muxMetadata as MuxMessageMetadata | undefined;
+      const retryMuxMetadata = lastUserMessage?.metadata?.muxMetadata;
+      // Bash-monitor-wake continuations inherit the correlation of a delegated
+      // workspace turn that was cut mid-work by the wake's queued dispatch, so
+      // the turn's eventual terminal stream-end can settle the parent's handle.
+      const streamMuxMetadata =
+        optionsMuxMetadata?.type === "workspace-turn-task"
+          ? optionsMuxMetadata
+          : retryMuxMetadata?.type === "workspace-turn-task"
+            ? retryMuxMetadata
+            : retryMuxMetadata?.type === "bash-monitor-wake"
+              ? inheritOpenWorkspaceTurnMetadata(requestMessages)
+              : undefined;
+      // Mid-stream compaction runs after the original send options have already been resolved against
+      // history (notably bash-monitor wakes). Persist the actual correlation used by this stream so the
+      // post-compaction continuation remains the same delegated workspace turn.
+      if (this.activeStreamContext != null) {
+        this.activeStreamContext.workspaceTurnMetadata = streamMuxMetadata;
+      }
+      const acpPromptId =
+        normalizeAcpPromptId(options?.acpPromptId) ?? extractAcpPromptId(optionsMuxMetadata);
+      const delegatedToolNames =
+        normalizeDelegatedToolNames(options?.delegatedToolNames) ??
+        extractAcpDelegatedTools(optionsMuxMetadata);
 
-    // Fatal pre-start failures (runtime readiness, strict agent resolution)
-    // emit an error event for fire-and-forget senders and then return Err;
-    // collect them so the Err path resolves each exactly once.
-    const preStartErrors: StreamErrorPayload[] = [];
-    this.coordinator.configureOperation(operation, this.activeCompactionRequest != null);
-    const streamResult = await this.aiService.streamMessage({
-      messages: requestMessages,
-      workspaceId: this.workspaceId,
-      modelString,
-      abortSignal,
-      thinkingLevel: effectiveThinkingLevel,
-      // Orthogonal to thinking level; buildRequestHeaders gates it per model.
-      reasoningMode: options?.reasoningMode,
-      toolPolicy: options?.toolPolicy,
-      additionalSystemContext: options?.additionalSystemContext,
-      additionalSystemInstructions: options?.additionalSystemInstructions,
-      maxOutputTokens: options?.maxOutputTokens,
-      muxProviderOptions: options?.providerOptions,
-      agentInitiated,
-      agentId: options?.agentId,
-      acpPromptId,
-      delegatedToolNames,
-      muxMetadata: streamMuxMetadata,
-      recordFileState,
-      postCompactionAttachments,
-      // Invoked by AIService after runtime.ensureReady() (project-scope
-      // listing needs a running runtime). Still ordered after the
-      // post-compaction check above: a just-consumed compaction boundary has
-      // already reset the segment cache, so this stream recomputes the context.
-      resolveMemoryContext: (forModelString, memoryOptions) =>
-        this.resolveMemoryContext(forModelString, memoryOptions),
-      allowAgentSetGoal: options?.allowAgentSetGoal === true,
-      workspaceGoalService: this.workspaceGoalService,
-      experiments: options?.experiments,
-      disableWorkspaceAgents: options?.disableWorkspaceAgents,
-      strictAgentResolution: options?.strictAgentResolution,
-      hasQueuedMessages: this.hasQueuedMessages.bind(this),
-      openaiTruncationModeOverride,
-      // Mid-turn thinking overrides clamp against the same floor as the
-      // send-time level above (single source of truth for the floor).
-      minThinkingLevel,
-      activeTurnThinkingOverride,
-      onPreStartError: ({ workspaceId: _workspaceId, ...payload }) => preStartErrors.push(payload),
-      onStreamStarting: (messageId) => {
-        this.coordinator.streamStarting(operation, messageId);
-      },
-    });
+      // Fatal pre-start failures (runtime readiness, strict agent resolution)
+      // emit an error event for fire-and-forget senders and then return Err;
+      // collect them so the Err path resolves each exactly once.
+      const preStartErrors: StreamErrorPayload[] = [];
+      this.coordinator.configureOperation(operation, this.activeCompactionRequest != null);
+      const streamResult = await this.aiService.streamMessage({
+        messages: requestMessages,
+        workspaceId: this.workspaceId,
+        modelString,
+        abortSignal,
+        thinkingLevel: effectiveThinkingLevel,
+        // Orthogonal to thinking level; buildRequestHeaders gates it per model.
+        reasoningMode: options?.reasoningMode,
+        toolPolicy: options?.toolPolicy,
+        additionalSystemContext: options?.additionalSystemContext,
+        additionalSystemInstructions: options?.additionalSystemInstructions,
+        maxOutputTokens: options?.maxOutputTokens,
+        muxProviderOptions: options?.providerOptions,
+        agentInitiated,
+        agentId: options?.agentId,
+        acpPromptId,
+        delegatedToolNames,
+        muxMetadata: streamMuxMetadata,
+        recordFileState,
+        postCompactionAttachments,
+        // Invoked by AIService after runtime.ensureReady() (project-scope
+        // listing needs a running runtime). Still ordered after the
+        // post-compaction check above: a just-consumed compaction boundary has
+        // already reset the segment cache, so this stream recomputes the context.
+        resolveMemoryContext: (forModelString, memoryOptions) =>
+          this.resolveMemoryContext(forModelString, memoryOptions),
+        allowAgentSetGoal: options?.allowAgentSetGoal === true,
+        workspaceGoalService: this.workspaceGoalService,
+        experiments: options?.experiments,
+        disableWorkspaceAgents: options?.disableWorkspaceAgents,
+        strictAgentResolution: options?.strictAgentResolution,
+        hasQueuedMessages: this.hasQueuedMessages.bind(this),
+        openaiTruncationModeOverride,
+        // Mid-turn thinking overrides clamp against the same floor as the
+        // send-time level above (single source of truth for the floor).
+        minThinkingLevel,
+        activeTurnThinkingOverride,
+        onPreStartError: ({ workspaceId: _workspaceId, ...payload }) =>
+          preStartErrors.push(payload),
+        onStreamStarting: (messageId) => {
+          this.coordinator.streamStarting(operation, messageId);
+        },
+      });
 
-    if (!streamResult.success) {
-      try {
+      if (!streamResult.success) {
         if (!this.coordinator.isCurrentOperation(operation)) {
           for (const payload of preStartErrors) {
             this.coordinator.resolveErrorDecision(payload.messageId, "terminal");
@@ -5631,15 +5675,18 @@ export class AgentSession {
           acpPromptId,
           preStartErrors
         );
-      } finally {
-        this.coordinator.finishStartup(operation);
       }
-    }
 
-    this.coordinator.consumeCompletion(operation, streamResult.data).catch((error: unknown) => {
-      log.error("Failed to consume turn completion", { error: getErrorMessage(error) });
-    });
-    return Ok(undefined);
+      this.coordinator.consumeCompletion(operation, streamResult.data).catch((error: unknown) => {
+        log.error("Failed to consume turn completion", { error: getErrorMessage(error) });
+      });
+      completionTransferred = true;
+      return Ok(undefined);
+    } finally {
+      // Every pre-handle return/throw retires physical startup, including history and attachment
+      // failures. A delivered handle keeps ownership through independent engine + policy completion.
+      if (!completionTransferred) this.coordinator.finishStartup(operation);
+    }
   }
 
   private resolveCompactionRequest(
@@ -6236,82 +6283,126 @@ export class AgentSession {
     this.coordinator.beginPolicy(turn);
     if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
       return;
-    const activeModelForAbort = this.activeStreamContext?.modelString;
-    const activeOptionsForAbort = this.activeStreamContext?.options;
-    this.lastSystemMessageTokens = systemMessageTokens ?? this.lastSystemMessageTokens;
-    if (activeModelForAbort) {
-      this.updateUsageStateFromModelUsage({
-        model: activeModelForAbort,
-        usage: payload.metadata?.contextUsage,
-        providerMetadata:
-          payload.metadata?.contextProviderMetadata ?? payload.metadata?.providerMetadata,
-        live: false,
-      });
-    }
-    this.clearLiveUsageState();
+    const hadAnyOutput = this.activeStreamHadAnyDelta;
+    let emittedAbort = false;
+    try {
+      const activeModelForAbort = this.activeStreamContext?.modelString;
+      const activeOptionsForAbort = this.activeStreamContext?.options;
+      this.lastSystemMessageTokens = systemMessageTokens ?? this.lastSystemMessageTokens;
+      if (activeModelForAbort) {
+        this.updateUsageStateFromModelUsage({
+          model: activeModelForAbort,
+          usage: payload.metadata?.contextUsage,
+          providerMetadata:
+            payload.metadata?.contextProviderMetadata ?? payload.metadata?.providerMetadata,
+          live: false,
+        });
+      }
+      this.clearLiveUsageState();
 
-    const failedUserMessageId = this.activeStreamUserMessageId;
-    const hadCompactionRequest = this.activeCompactionRequest !== undefined;
-    const abortReason = "abortReason" in payload ? payload.abortReason : undefined;
-    const isQueuedProviderToolEndAbort =
-      this.queuedProviderToolEndAbortInFlight && abortReason !== "user";
-    if (abortReason === "user") {
-      await this.workspaceGoalService?.recordUserStoppedStream(this.workspaceId);
+      const failedUserMessageId = this.activeStreamUserMessageId;
+      const hadCompactionRequest = this.activeCompactionRequest !== undefined;
+      const abortReason = "abortReason" in payload ? payload.abortReason : undefined;
+      const isQueuedProviderToolEndAbort =
+        this.queuedProviderToolEndAbortInFlight && abortReason !== "user";
+      if (abortReason === "user") {
+        await this.workspaceGoalService?.recordUserStoppedStream(this.workspaceId);
+        if (
+          !this.coordinator.isCurrentTurn(turn) ||
+          !this.coordinator.isCurrentOperation(operation)
+        )
+          return;
+      }
+      if (activeModelForAbort) {
+        // Forward goalKind / agentInitiated from the active stream context so
+        // an interrupted continuation/wrap stream is correctly classified
+        // as `goal_continuation` / `goal_budget_limit` and counts toward
+        // the turn cap. Without this, getGoalStreamOriginKind falls back to
+        // `"user"` and the interrupted synthetic turn would not consume a
+        // turn, under-enforcing limits (Codex P2 PRRT_kwDOPxxmWM5_t9Bu).
+        await this.recordGoalAccountingFromUsage({
+          model: activeModelForAbort,
+          usage: payload.metadata?.usage,
+          providerMetadata: payload.metadata?.providerMetadata,
+          goalKind: this.activeStreamContext?.goalKind,
+          agentInitiated: this.activeStreamContext?.agentInitiated,
+          isCompaction: hadCompactionRequest,
+        });
+        if (
+          !this.coordinator.isCurrentTurn(turn) ||
+          !this.coordinator.isCurrentOperation(operation)
+        )
+          return;
+      }
+      if (abortReason !== "user") {
+        await this.workspaceGoalService?.applyPendingAfterStreamEnd(this.workspaceId);
+        if (
+          !this.coordinator.isCurrentTurn(turn) ||
+          !this.coordinator.isCurrentOperation(operation)
+        )
+          return;
+      }
+      this.setTerminalStreamLifecycle("interrupted", { abortReason });
+      this.activeCompactionRequest = undefined;
+      this.resetActiveStreamState();
+      if (!hadCompactionRequest && activeModelForAbort && !this.continuousCompactionAbandoned) {
+        await this.observeContinuousCompactionAtStreamEnd(
+          activeModelForAbort,
+          activeOptionsForAbort
+        );
+        if (
+          !this.coordinator.isCurrentTurn(turn) ||
+          !this.coordinator.isCurrentOperation(operation)
+        )
+          return;
+      }
+      if (hadCompactionRequest && !this.coordinator.disposed) {
+        this.clearQueue();
+      }
+      if (!isQueuedProviderToolEndAbort) {
+        await this.handleStreamFailureForAutoRetry({
+          type: "aborted",
+          message: abortReason,
+        });
+        if (
+          !this.coordinator.isCurrentTurn(turn) ||
+          !this.coordinator.isCurrentOperation(operation)
+        )
+          return;
+      }
+      await this.updateStartupAutoRetryAbandonFromAbort(abortReason, failedUserMessageId);
       if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
         return;
-    }
-    if (activeModelForAbort) {
-      // Forward goalKind / agentInitiated from the active stream context so
-      // an interrupted continuation/wrap stream is correctly classified
-      // as `goal_continuation` / `goal_budget_limit` and counts toward
-      // the turn cap. Without this, getGoalStreamOriginKind falls back to
-      // `"user"` and the interrupted synthetic turn would not consume a
-      // turn, under-enforcing limits (Codex P2 PRRT_kwDOPxxmWM5_t9Bu).
-      await this.recordGoalAccountingFromUsage({
-        model: activeModelForAbort,
-        usage: payload.metadata?.usage,
-        providerMetadata: payload.metadata?.providerMetadata,
-        goalKind: this.activeStreamContext?.goalKind,
-        agentInitiated: this.activeStreamContext?.agentInitiated,
-        isCompaction: hadCompactionRequest,
-      });
-      if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
-        return;
-    }
-    if (abortReason !== "user") {
-      await this.workspaceGoalService?.applyPendingAfterStreamEnd(this.workspaceId);
-      if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
-        return;
-    }
-    this.setTerminalStreamLifecycle("interrupted", { abortReason });
-    this.activeCompactionRequest = undefined;
-    this.resetActiveStreamState();
-    if (!hadCompactionRequest && activeModelForAbort && !this.continuousCompactionAbandoned) {
-      await this.observeContinuousCompactionAtStreamEnd(activeModelForAbort, activeOptionsForAbort);
-      if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
-        return;
-    }
-    if (hadCompactionRequest && !this.coordinator.disposed) {
-      this.clearQueue();
-    }
-    if (!isQueuedProviderToolEndAbort) {
-      await this.handleStreamFailureForAutoRetry({
-        type: "aborted",
-        message: abortReason,
-      });
-      if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
-        return;
-    }
-    await this.updateStartupAutoRetryAbandonFromAbort(abortReason, failedUserMessageId);
-    if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
-      return;
-    this.emitChatEvent(payload);
-    const dispatchedQueuedMessage =
-      !this.midStreamCompactionPending &&
-      !this.continuousCompactor.isApplying() &&
-      this.dispatchQueuedProviderToolEndMessageAfterAbort(abortReason);
-    if (!dispatchedQueuedMessage) {
-      this.coordinator.finishTurn(turn);
+      emittedAbort = true;
+      this.emitChatEvent(payload);
+      const dispatchedQueuedMessage =
+        !this.midStreamCompactionPending &&
+        !this.continuousCompactor.isApplying() &&
+        this.dispatchQueuedProviderToolEndMessageAfterAbort(abortReason);
+      if (!dispatchedQueuedMessage) {
+        this.coordinator.finishTurn(turn);
+      }
+    } finally {
+      // Accounting failure must not strand COMPLETING: an edit may be waiting for idle while
+      // app shutdown joins its physical lease. Keep the failure visible to the policy reporter,
+      // deliver the terminal once, and never finalize a replacement admitted by a callback.
+      if (
+        this.coordinator.isCurrentOperation(operation) &&
+        this.coordinator.isCurrentTurn(turn) &&
+        this.coordinator.phase === "completing"
+      ) {
+        this.setTerminalStreamLifecycle("interrupted", {
+          abortReason: payload.abortReason,
+          hadAnyOutput,
+        });
+        this.activeCompactionRequest = undefined;
+        this.resetActiveStreamState();
+        try {
+          if (!emittedAbort) this.emitChatEvent(payload);
+        } finally {
+          if (this.coordinator.isCurrentOperation(operation)) this.coordinator.finishTurn(turn);
+        }
+      }
     }
   }
 
@@ -7018,6 +7109,7 @@ export class AgentSession {
 
   clearQueue(cancelReason = "Queued message cleared before dispatch."): void {
     this.assertNotDisposed("clearQueue");
+    using _execution = this.coordinator.enterExecution();
     const callbackSets = this.messageQueue.getClearCallbacks();
     this.messageQueue.clear();
     this.emitQueuedMessageChanged();
@@ -7052,6 +7144,7 @@ export class AgentSession {
     cancelReason: string
   ): void {
     const notify = async () => {
+      using _execution = this.coordinator.enterExecution();
       if (callbacks.onCanceled != null) {
         await callbacks.onCanceled(cancelReason);
         return;
@@ -7072,6 +7165,7 @@ export class AgentSession {
     options?: { skipCancelCallbacks?: boolean }
   ): number {
     this.assertNotDisposed("removeQueuedMessagesByDedupeKeyPrefix");
+    using _execution = this.coordinator.enterExecution();
     assert(prefix.length > 0, "removeQueuedMessagesByDedupeKeyPrefix requires prefix");
     const removal = this.messageQueue.removeByDedupeKeyPrefix(prefix);
     if (removal.removedCount === 0) {
@@ -7107,6 +7201,7 @@ export class AgentSession {
    */
   removeQueuedWorkspaceTurn(handleId: string, cancelReason: string): boolean {
     this.assertNotDisposed("removeQueuedWorkspaceTurn");
+    using _execution = this.coordinator.enterExecution();
     assert(handleId.length > 0, "removeQueuedWorkspaceTurn requires handleId");
     const callbacks = this.messageQueue.removeWorkspaceTurn(handleId);
     if (callbacks == null) {
@@ -7431,9 +7526,12 @@ export class AgentSession {
     // sendQueuedMessages can race with teardown (e.g. workspace.remove) because we
     // trigger it off stream/tool events and disposal does not await stopStream().
     // If the session is already disposed, do nothing.
-    if (this.coordinator.disposed) {
+    if (this.coordinator.closing) {
       return;
     }
+    // Queue publication can reenter shutdown. Register physical ownership before callbacks;
+    // the child below retains it through asynchronous correlated failure/refund settlement.
+    using _dispatch = this.coordinator.enterExecution();
 
     // r40: leave entries queued while a context-discarding mutation blocks
     // turn admission — dispatching would set PREPARING and stream across the
@@ -7467,7 +7565,8 @@ export class AgentSession {
       this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(options?.muxMetadata);
       const preparedTurn = this.coordinator.prepare();
 
-      void this.sendMessage(message, options, {
+      const queuedExecution = this.coordinator.enterExecution();
+      this.sendMessage(message, options, {
         ...internal,
         enqueuedAtMs,
         turnReservation: preparedTurn,
@@ -7521,7 +7620,8 @@ export class AgentSession {
             this.coordinator.finishPreparation(preparedTurn);
           }
           this.drainQueuedMessagesIfIdle();
-        });
+        })
+        .finally(() => queuedExecution[Symbol.dispose]());
     }
   }
 
@@ -7603,6 +7703,7 @@ export class AgentSession {
     if (this.coordinator.disposed || this.coordinator.closing) {
       return false;
     }
+    using _execution = this.coordinator.enterExecution();
 
     let summaryMessage: MuxMessage | undefined;
     if (summaryMessageId) {

--- a/src/node/services/agentSession.turnCompletion.test.ts
+++ b/src/node/services/agentSession.turnCompletion.test.ts
@@ -1,6 +1,9 @@
 import type { TurnCoordinator } from "./turnCoordinator";
 import { createMuxMessage } from "@/common/types/message";
 import { describe, expect, mock, spyOn, test } from "bun:test";
+import { Exit, Scope } from "effect";
+import { defaultEffectRunner as runner } from "./di/effectRunner";
+import { log } from "./log";
 import { EventEmitter } from "events";
 import type { StreamAbortEvent, StreamEndEvent } from "@/common/types/stream";
 import { Err, Ok } from "@/common/types/result";
@@ -19,6 +22,7 @@ interface InternalSession {
   activeCompactionRequest?: { id: string; modelString: string };
   clearStartupAutoRetryAbandon(): Promise<void>;
   recordGoalAccountingFromUsage(input: unknown): Promise<void>;
+  updateStartupAutoRetryAbandonFromAbort(...args: unknown[]): Promise<void>;
   observeContinuousCompactionAtStreamEnd(...args: unknown[]): Promise<void>;
   coordinator: TurnCoordinator;
   getEditTruncateTargetId(messageId: string): Promise<string>;
@@ -58,6 +62,165 @@ function observePolicy(session: AgentSession) {
 }
 
 describe("AgentSession turn completion", () => {
+  test("late abort bookkeeping failure preserves output in the renderer lifecycle", async () => {
+    const completion = Promise.withResolvers<TurnCompletion>();
+    const emitter = new EventEmitter();
+    const h = await createAgentSessionHarness({
+      workspaceId,
+      aiEmitter: emitter,
+      captureEvents: true,
+      aiServiceOverrides: {
+        streamMessage: mock(() => {
+          start(emitter);
+          return Promise.resolve(Ok({ messageId: "assistant-1", completion: completion.promise }));
+        }),
+      },
+    });
+    const consumer = observePolicy(h.session);
+    const bookkeeping = spyOn(
+      internal(h.session),
+      "updateStartupAutoRetryAbandonFromAbort"
+    ).mockRejectedValueOnce(new Error("late bookkeeping failure"));
+    try {
+      await h.session.sendMessage("original", sendOptions);
+      emitter.emit("stream-delta", {
+        type: "stream-delta",
+        workspaceId,
+        messageId: "assistant-1",
+        delta: "Visible partial output",
+        tokens: 3,
+        timestamp: Date.now(),
+      });
+      completion.resolve({ status: "aborted", abortReason: "user", streamAbort: abort() });
+      await policyPromise(consumer);
+      expect(bookkeeping).toHaveBeenCalledTimes(1);
+      expect(h.events.filter((event) => event.type === "stream-abort")).toHaveLength(1);
+      expect(h.events.filter((event) => event.type === "stream-lifecycle").at(-1)).toMatchObject({
+        phase: "interrupted",
+        hadAnyOutput: true,
+        abortReason: "user",
+      });
+    } finally {
+      h.session.dispose();
+      await h.cleanup();
+    }
+  });
+
+  test("abort failure finalization cannot finish a replacement admitted by its renderer event", async () => {
+    const completion = Promise.withResolvers<TurnCompletion>();
+    const emitter = new EventEmitter();
+    const h = await createAgentSessionHarness({
+      workspaceId,
+      aiEmitter: emitter,
+      aiServiceOverrides: {
+        streamMessage: mock(() => {
+          start(emitter);
+          return Promise.resolve(Ok({ messageId: "assistant-1", completion: completion.promise }));
+        }),
+      },
+    });
+    const consumer = observePolicy(h.session);
+    const coordinator = internal(h.session).coordinator;
+    const replacementThinking = {};
+    let replacement: symbol | undefined;
+    let aborted = 0;
+    h.session.onChatEvent(({ message }) => {
+      if (message.type !== "stream-abort") return;
+      aborted++;
+      replacement = coordinator.prepare();
+      coordinator.acceptThinkingOverride(replacementThinking, replacement);
+    });
+    try {
+      await h.session.sendMessage("original", sendOptions);
+      Reflect.set(h.session, "workspaceGoalService", {
+        recordUserStoppedStream: mock(() => Promise.reject(new Error("accounting failed"))),
+      } satisfies Partial<WorkspaceGoalService>);
+      completion.resolve({ status: "aborted", abortReason: "user", streamAbort: abort() });
+      await policyPromise(consumer);
+      expect(aborted).toBe(1);
+      if (replacement == null) throw new Error("Renderer did not admit the replacement");
+      expect(coordinator.turnId).toBe(replacement);
+      expect(coordinator.phase).toBe("preparing");
+      expect(coordinator.thinkingOverride).toBe(replacementThinking);
+    } finally {
+      h.session.dispose();
+      await h.cleanup();
+    }
+  });
+
+  test("failed abort accounting releases a waiting edit before app shutdown drains", async () => {
+    const appFiberScope = Scope.makeUnsafe("parallel");
+    const completion = Promise.withResolvers<TurnCompletion>();
+    const accountingEntered = Promise.withResolvers<void>();
+    const releaseAccounting = Promise.withResolvers<void>();
+    const editWaiting = Promise.withResolvers<void>();
+    const emitter = new EventEmitter();
+    const h = await createAgentSessionHarness({
+      workspaceId,
+      appFiberScope,
+      aiEmitter: emitter,
+      captureEvents: true,
+      aiServiceOverrides: {
+        streamMessage: mock(() => {
+          start(emitter);
+          return Promise.resolve(Ok({ messageId: "assistant-1", completion: completion.promise }));
+        }),
+      },
+    });
+    const consumer = observePolicy(h.session);
+    const accountingError = new Error("abort accounting failed");
+    const recordUserStoppedStream = mock(async () => {
+      accountingEntered.resolve();
+      await releaseAccounting.promise;
+      throw accountingError;
+    });
+    const errorLog = spyOn(log, "error");
+    const coordinator = internal(h.session).coordinator;
+    const waitForIdle = coordinator.waitForIdle.bind(coordinator);
+    spyOn(coordinator, "waitForIdle").mockImplementation((signal) => {
+      editWaiting.resolve();
+      return waitForIdle(signal);
+    });
+    let edit: ReturnType<AgentSession["sendMessage"]> | undefined;
+    let closing: Promise<void> | undefined;
+    try {
+      await h.session.sendMessage("original", sendOptions);
+      const history = await h.historyService.getHistoryFromLatestBoundary(workspaceId);
+      if (!history.success) throw new Error(history.error);
+      const user = history.data.find((message) => message.role === "user")!;
+      Reflect.set(h.session, "workspaceGoalService", {
+        recordUserStoppedStream,
+        assertPricedModelForBudgetedGoal: () => Promise.resolve(Ok(undefined)),
+      } satisfies Partial<WorkspaceGoalService>);
+      emitter.emit("stream-abort", abort());
+      completion.resolve({ status: "aborted", abortReason: "user", streamAbort: abort() });
+      await accountingEntered.promise;
+      edit = h.session.sendMessage("edited", { ...sendOptions, editMessageId: user.id });
+      await editWaiting.promise;
+      closing = runner.runPromise(Scope.close(appFiberScope, Exit.void));
+      releaseAccounting.resolve();
+      await policyPromise(consumer);
+      // This used to remain COMPLETING forever: the edit lease waited for idle while the
+      // guardian waited for that lease before closing the idle-waiter resource scope.
+      expect(coordinator.phase).toBe("idle");
+      expect((await edit).success).toBe(false);
+      await closing;
+      expect(h.events.filter((event) => event.type === "stream-abort")).toHaveLength(1);
+      expect(spyOn(h.aiService, "streamMessage")).toHaveBeenCalledTimes(1);
+      expect(errorLog).toHaveBeenCalledWith("Failed to consume turn completion", {
+        workspaceId,
+        error: accountingError.message,
+      });
+    } finally {
+      releaseAccounting.resolve();
+      h.session.dispose();
+      await edit;
+      await closing;
+      errorLog.mockRestore();
+      await h.cleanup();
+    }
+  });
+
   test("raw success defers policy; completion uses handle identity and runs policy once", async () => {
     const completion = Promise.withResolvers<TurnCompletion>();
     const emitter = new EventEmitter();

--- a/src/node/services/di/appFiberScope.ts
+++ b/src/node/services/di/appFiberScope.ts
@@ -11,10 +11,16 @@
  * later re-closes it idempotently as a backstop.
  *
  * This is the seam for I/O-suspended, long-lived work that shutdown must wait
- * for. Its occupant is the stream engine: `StreamManager.superviseEngine`
+ * for. Its occupants include the stream engine: `StreamManager.superviseEngine`
  * forks one supervisor fiber per stream into it, whose interruption cancels the
  * stream (`"system"` abort) and awaits the turn's settlement, so dispose()
- * commits the partial into chat.jsonl before the bridges stop. It is the
+ * commits the partial into chat.jsonl before the bridges stop. Each AgentSession also
+ * registers a guardian after initialization. The guardian closes admission, joins registered
+ * preparation and physical policy work, then closes its detached resource scope. Engine
+ * completion stays independent of policy: parallel scope close must let engines deliver late
+ * terminal results while the session is still draining. A directly attached child policy scope
+ * could close too early and drop those results. The app's bounded close remains a timeout,
+ * not cancellation of non-cooperative Promise I/O. This scope is the
  * counterpart of `EffectRunner` (`./effectRunner.ts`), which is unsupervised: a
  * fiber forked through the runner is interrupted by neither close. Anything
  * forked here must tolerate interruption at any suspension point and must not

--- a/src/node/services/di/layers/core.ts
+++ b/src/node/services/di/layers/core.ts
@@ -399,7 +399,9 @@ export const WorkspaceLive = Layer.effect(
       yield* StreamManagerTag,
       yield* SecretsStoreTag,
       yield* ProvidersConfigStoreTag,
-      yield* DesktopInputCoordinatorTag
+      yield* DesktopInputCoordinatorTag,
+      yield* EffectRunnerTag,
+      yield* AppFiberScopeTag
     );
   })
 );

--- a/src/node/services/serviceContainer.test.ts
+++ b/src/node/services/serviceContainer.test.ts
@@ -1,4 +1,7 @@
 import * as path from "path";
+import { EventEmitter } from "events";
+import { createAgentSessionHarness } from "./agentSession.testHarness";
+import type { AgentSession } from "./agentSession";
 import * as fs from "fs";
 import * as os from "os";
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
@@ -716,110 +719,185 @@ describe("ServiceContainer", () => {
     expect(services.appFiberScope.state._tag).toBe("Closed");
   });
 
-  it("dispose() aborts and awaits an in-flight stream before desktopBridgeServer.stop()", async () => {
-    // The AppFiberScope occupant end to end: a real stream on the container's
-    // StreamManager (wired with the runtime's scope), its provider stubbed to
-    // flow one delta and then block until the stream's AbortSignal fires.
-    // dispose() must abort it as "system", let AIService commit the partial
-    // into chat.jsonl and delete partial.json, and only then stop the bridge.
-    services = new ServiceContainer(stores);
-    const workspaceId = "dispose-in-flight-stream-workspace";
-    const messageId = "dispose-in-flight-stream-message";
-    const steps: string[] = [];
-    Reflect.set(services.streamManager, "tokenTracker", {
-      setModel: () => Promise.resolve(undefined),
-      countTokens: () => Promise.resolve(0),
-    });
-    Reflect.set(
-      services.streamManager,
-      "createStreamResult",
-      (_request: unknown, abortController: AbortController) => ({
-        fullStream: (async function* () {
-          yield { type: "text-delta", text: "hello from a stream shutdown must not lose" };
-          await new Promise<void>((resolve) => {
-            if (abortController.signal.aborted) return resolve();
-            abortController.signal.addEventListener("abort", () => resolve(), { once: true });
+  it.each([false, true])(
+    "dispose() joins engine and session policy before bridge teardown (session=%s)",
+    async (throughSession) => {
+      // The AppFiberScope occupant end to end: a real stream on the container's
+      // StreamManager (wired with the runtime's scope), its provider stubbed to
+      // flow one delta and then block until the stream's AbortSignal fires.
+      // dispose() must abort it as "system", let AIService commit the partial
+      // into chat.jsonl and delete partial.json, and only then stop the bridge.
+      services = new ServiceContainer(stores);
+      const workspaceId = "dispose-in-flight-stream-workspace";
+      const messageId = "dispose-in-flight-stream-message";
+      const steps: string[] = [];
+      Reflect.set(services.streamManager, "tokenTracker", {
+        setModel: () => Promise.resolve(undefined),
+        countTokens: () => Promise.resolve(0),
+      });
+      Reflect.set(
+        services.streamManager,
+        "createStreamResult",
+        (_request: unknown, abortController: AbortController) => ({
+          fullStream: (async function* () {
+            yield { type: "text-delta", text: "hello from a stream shutdown must not lose" };
+            await new Promise<void>((resolve) => {
+              if (abortController.signal.aborted) return resolve();
+              abortController.signal.addEventListener("abort", () => resolve(), { once: true });
+            });
+          })(),
+          totalUsage: Promise.resolve(undefined),
+          usage: Promise.resolve(undefined),
+          providerMetadata: Promise.resolve(undefined),
+          steps: Promise.resolve([]),
+        })
+      );
+      Reflect.set(services.streamManager, "createTempDirForStream", () =>
+        Promise.resolve(path.join(tempDir, "stream-tempdir"))
+      );
+      Reflect.set(services.streamManager, "cleanupStreamTempDir", () => undefined);
+      services.aiService.on("stream-abort", (event: { abortReason?: string }) => {
+        steps.push(`stream-abort:${event.abortReason ?? "none"}`);
+      });
+      const bridgeStopSpy = spyOn(services.desktopBridgeServer, "stop").mockImplementation(() => {
+        steps.push("bridge-stop");
+        return Promise.resolve(undefined);
+      });
+
+      const historyService = services.runtime.get(History);
+      const partialWritten = Promise.withResolvers<void>();
+      const writePartial = historyService.writePartial.bind(historyService);
+      spyOn(historyService, "writePartial").mockImplementation(async (...args) => {
+        const result = await writePartial(...args);
+        partialWritten.resolve();
+        return result;
+      });
+      const startEngine = async () => {
+        const appendResult = await historyService.appendToHistory(workspaceId, {
+          id: messageId,
+          role: "assistant",
+          metadata: { historySequence: 1, partial: true },
+          parts: [],
+        });
+        expect(appendResult.success).toBe(true);
+        return services!.streamManager.startStream({
+          workspaceId,
+          messageId,
+          model: {
+            specificationVersion: "v3",
+            provider: "test",
+            modelId: "dispose-model",
+            supportedUrls: {},
+            doGenerate: () => Promise.reject(new Error("unused")),
+            doStream: () => Promise.reject(new Error("unused")),
+          },
+          messages: [{ role: "user", content: "hello" }],
+          modelString: "openai:gpt-4.1-mini",
+          historySequence: 1,
+          system: "system",
+          runtime: createRuntime({ type: "local", srcBaseDir: tempDir }),
+          providedRuntimeTempDir: "",
+        });
+      };
+      const policyEntered = Promise.withResolvers<void>();
+      const releasePolicy = Promise.withResolvers<void>();
+      const handleDelivered = Promise.withResolvers<Awaited<ReturnType<typeof startEngine>>>();
+      let session: AgentSession | undefined;
+      if (throughSession) {
+        const emitter = new EventEmitter();
+        for (const event of ["stream-start", "stream-abort", "stream-end", "stream-error"]) {
+          services.aiService.on(event, (payload: unknown) => emitter.emit(event, payload));
+        }
+        const h = await createAgentSessionHarness({
+          workspaceId,
+          historyService,
+          aiEmitter: emitter,
+          streamManager: services.streamManager,
+          effectRunner: services.runtime.get(EffectRunnerTag),
+          appFiberScope: services.appFiberScope,
+          aiServiceOverrides: {
+            streamMessage: async () => {
+              const result = await startEngine();
+              handleDelivered.resolve(result);
+              return result;
+            },
+          },
+        });
+        session = h.session;
+        services.workspaceService.registerSession(workspaceId, session);
+        // Hold only session policy. The actual engine still aborts, retires partial.json,
+        // and delivers its independent completion while the app guardian is closing.
+        const policy = session as unknown as {
+          recordGoalAccountingFromUsage(input: unknown): Promise<void>;
+        };
+        const record = policy.recordGoalAccountingFromUsage.bind(session);
+        spyOn(policy, "recordGoalAccountingFromUsage").mockImplementation(async (input) => {
+          policyEntered.resolve();
+          await releasePolicy.promise;
+          await record(input);
+        });
+        session.onChatEvent(({ message }) => {
+          if (message.type === "stream-abort") steps.push("renderer-abort");
+        });
+        expect(
+          (await session.sendMessage("hello", { model: "openai:gpt-4.1-mini", agentId: "exec" }))
+            .success
+        ).toBe(true);
+      } else {
+        handleDelivered.resolve(await startEngine());
+      }
+      const started = await handleDelivered.promise;
+      expect(started.success).toBe(true);
+      if (!started.success) throw new Error("expected the stream to start");
+      // Signal after real disk persistence, so shutdown starts with a partial worth committing.
+      await partialWritten.promise;
+      expect(services.streamManager.isStreaming(workspaceId)).toBe(true);
+
+      const disposing = services.dispose();
+      try {
+        if (throughSession) {
+          await policyEntered.promise;
+          expect(await started.data.completion).toMatchObject({
+            status: "aborted",
+            abortReason: "system",
           });
-        })(),
-        totalUsage: Promise.resolve(undefined),
-        usage: Promise.resolve(undefined),
-        providerMetadata: Promise.resolve(undefined),
-        steps: Promise.resolve([]),
-      })
-    );
-    Reflect.set(services.streamManager, "createTempDirForStream", () =>
-      Promise.resolve(path.join(tempDir, "stream-tempdir"))
-    );
-    Reflect.set(services.streamManager, "cleanupStreamTempDir", () => undefined);
-    services.aiService.on("stream-abort", (event: { abortReason?: string }) => {
-      steps.push(`stream-abort:${event.abortReason ?? "none"}`);
-    });
-    const bridgeStopSpy = spyOn(services.desktopBridgeServer, "stop").mockImplementation(() => {
-      steps.push("bridge-stop");
-      return Promise.resolve(undefined);
-    });
+          expect(bridgeStopSpy).not.toHaveBeenCalled();
+          expect(await historyService.readPartial(workspaceId)).toBeNull();
+        }
+      } finally {
+        releasePolicy.resolve();
+        await disposing;
+      }
 
-    const historyService = services.runtime.get(History);
-    const appendResult = await historyService.appendToHistory(workspaceId, {
-      id: messageId,
-      role: "assistant",
-      metadata: { historySequence: 1, partial: true },
-      parts: [],
-    });
-    expect(appendResult.success).toBe(true);
-    const started = await services.streamManager.startStream({
-      workspaceId,
-      messageId,
-      model: {
-        specificationVersion: "v3",
-        provider: "test",
-        modelId: "dispose-model",
-        supportedUrls: {},
-        doGenerate: () => Promise.reject(new Error("unused")),
-        doStream: () => Promise.reject(new Error("unused")),
-      },
-      messages: [{ role: "user", content: "hello" }],
-      modelString: "openai:gpt-4.1-mini",
-      historySequence: 1,
-      system: "system",
-      runtime: createRuntime({ type: "local", srcBaseDir: tempDir }),
-      providedRuntimeTempDir: "",
-    });
-    expect(started.success).toBe(true);
-    if (!started.success) throw new Error("expected the stream to start");
-    // Wait for the delta to reach partial.json so there is something to commit.
-    const deadline = Date.now() + 5_000;
-    while ((await historyService.readPartial(workspaceId)) === null) {
-      if (Date.now() > deadline) throw new Error("partial never written");
-      await new Promise((resolve) => setTimeout(resolve, 5));
+      expect(bridgeStopSpy).toHaveBeenCalledTimes(1);
+      expect(steps).toEqual(
+        throughSession
+          ? ["stream-abort:system", "renderer-abort", "bridge-stop"]
+          : ["stream-abort:system", "bridge-stop"]
+      );
+      expect(await started.data.completion).toMatchObject({
+        status: "aborted",
+        abortReason: "system",
+      });
+      expect(services.streamManager.isStreaming(workspaceId)).toBe(false);
+      // Durable outcome at the moment the bridge stopped: partial.json gone, the
+      // interrupted assistant message (still flagged partial, as every
+      // interrupted turn is) committed to chat.jsonl with its streamed text —
+      // instead of an empty placeholder row plus an orphan partial.json that only
+      // the next load would reconcile.
+      expect(await historyService.readPartial(workspaceId)).toBeNull();
+      const history = await historyService.getHistoryFromLatestBoundary(workspaceId);
+      expect(history.success).toBe(true);
+      if (!history.success) throw new Error(history.error);
+      const committed = history.data.find((message) => message.id === messageId);
+      expect(
+        committed?.parts.some(
+          (part) =>
+            part.type === "text" && part.text === "hello from a stream shutdown must not lose"
+        )
+      ).toBe(true);
     }
-    expect(services.streamManager.isStreaming(workspaceId)).toBe(true);
-
-    await services.dispose();
-
-    expect(bridgeStopSpy).toHaveBeenCalledTimes(1);
-    expect(steps).toEqual(["stream-abort:system", "bridge-stop"]);
-    expect(await started.data.completion).toMatchObject({
-      status: "aborted",
-      abortReason: "system",
-    });
-    expect(services.streamManager.isStreaming(workspaceId)).toBe(false);
-    // Durable outcome at the moment the bridge stopped: partial.json gone, the
-    // interrupted assistant message (still flagged partial, as every
-    // interrupted turn is) committed to chat.jsonl with its streamed text —
-    // instead of an empty placeholder row plus an orphan partial.json that only
-    // the next load would reconcile.
-    expect(await historyService.readPartial(workspaceId)).toBeNull();
-    const history = await historyService.getHistoryFromLatestBoundary(workspaceId);
-    expect(history.success).toBe(true);
-    if (!history.success) throw new Error(history.error);
-    const committed = history.data.find((message) => message.id === messageId);
-    expect(
-      committed?.parts.some(
-        (part) => part.type === "text" && part.text === "hello from a stream shutdown must not lose"
-      )
-    ).toBe(true);
-  });
+  );
 
   it("shares one teardown across concurrent dispose() calls", async () => {
     services = new ServiceContainer(stores);

--- a/src/node/services/turnCoordinator.test.ts
+++ b/src/node/services/turnCoordinator.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
+import { Effect, Exit, Scope } from "effect";
+import { defaultEffectRunner as runner } from "./di/effectRunner";
 import {
   TurnCoordinator,
   initialCoordinatorState,
@@ -50,6 +52,148 @@ function reduce(events: CoordinatorEvent[]) {
 }
 
 describe("TurnCoordinator", () => {
+  test("session scope releases thinking and idle listeners even without another idle event", async () => {
+    const scope = Scope.makeUnsafe("parallel");
+    const { coordinator } = setup();
+    coordinator.supervise(runner, scope, () => coordinator.beginShutdown());
+    const turn = coordinator.prepare();
+    coordinator.acceptThinkingOverride({}, turn);
+    const signal = new AbortController();
+    const canceled = coordinator.waitForIdle(signal.signal);
+    signal.abort();
+    expect(await canceled.catch((error: unknown) => error)).toBeInstanceOf(Error);
+    const idle = coordinator.waitForIdle();
+    await runner.runPromise(Scope.close(scope, Exit.void));
+    await idle;
+    expect(coordinator.thinkingOverride).toBeNull();
+    expect(coordinator.phase).toBe("preparing");
+  });
+
+  test("completion callback reserves synchronously before the next Promise observer", async () => {
+    const order: string[] = [];
+    const { coordinator } = setup({
+      policy: async () => {
+        order.push("policy");
+        await Promise.resolve();
+        order.push("settled");
+      },
+    });
+    const op = coordinator.registerOperation(coordinator.prepare());
+    const engine = Promise.resolve(completed);
+    const consumed = coordinator.consumeCompletion(op, { messageId: "sync", completion: engine });
+    await engine.then(() => order.push("observer"));
+    await consumed;
+    expect(order).toEqual(["policy", "observer", "settled"]);
+    coordinator.dispose();
+  });
+
+  test("app shutdown accepts a registered engine's late terminal and joins its policy", async () => {
+    const scope = Scope.makeUnsafe("parallel");
+    const engine = Promise.withResolvers<TurnCompletion>();
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const { coordinator, callbacks } = setup({
+      policy: () => {
+        entered.resolve();
+        return release.promise;
+      },
+    });
+    coordinator.supervise(runner, scope, () => coordinator.beginShutdown());
+    const turn = coordinator.prepare();
+    const op = coordinator.registerOperation(turn);
+    coordinator.streamStarted(startEvent("late"));
+    const consumed = coordinator.consumeCompletion(op, {
+      messageId: "late",
+      completion: engine.promise,
+    });
+    let closed = false;
+    const closing = runner.runPromise(Scope.close(scope, Exit.void)).then(() => {
+      closed = true;
+    });
+    expect(coordinator.closing).toBe(true);
+    expect(coordinator.prepare()).not.toBe(coordinator.turnId);
+    engine.resolve(completed);
+    await entered.promise;
+    // Engine completion never joins the policy that may itself need engine cleanup.
+    expect(await engine.promise).toBe(completed);
+    expect(closed).toBe(false);
+    release.resolve();
+    await Promise.all([consumed, closing]);
+    expect(callbacks.policyError).not.toHaveBeenCalled();
+  });
+
+  test("interruption joins the original policy once and retains retired physical work", async () => {
+    const scope = Scope.makeUnsafe("parallel");
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    let calls = 0;
+    const { coordinator } = setup({
+      policy: () => {
+        calls++;
+        entered.resolve();
+        return release.promise;
+      },
+    });
+    coordinator.supervise(runner, scope, () => coordinator.beginShutdown());
+    const turn = coordinator.prepare();
+    const op = coordinator.registerOperation(turn);
+    coordinator.streamStarted(startEvent("retired"));
+    coordinator.beginErrorDecision("retired");
+    const logical = coordinator.captureInterruptSettlement();
+    const consumed = coordinator.consumeCompletion(op, {
+      messageId: "retired",
+      completion: Promise.resolve(completed),
+    });
+    await entered.promise;
+    const replacement = coordinator.prepare();
+    await logical;
+    let settled = false;
+    const decision = coordinator.waitForErrorDecision("retired").then((outcome) => {
+      settled = true;
+      return outcome;
+    });
+    let closed = false;
+    const closing = runner.runPromise(Scope.close(scope, Exit.void)).then(() => {
+      closed = true;
+    });
+    // A turn may retire logically while its Promise is still writing. Interruption cannot
+    // finalize its decisions or let app teardown pass that write.
+    await runner.runPromise(Effect.yieldNow);
+    expect(closed).toBe(false);
+    expect(settled).toBe(false);
+    expect(calls).toBe(1);
+    expect(coordinator.turnId).toBe(replacement);
+    release.resolve();
+    await Promise.all([consumed, closing]);
+    expect(await decision).toBe("terminal");
+    expect(calls).toBe(1);
+    expect(coordinator.turnId).toBe(replacement);
+  });
+
+  test.each(["throw", "reject"])(
+    "policy %s finalizes decisions and physical shutdown",
+    async (failure) => {
+      const scope = Scope.makeUnsafe("parallel");
+      const error = new Error("policy failed");
+      const { coordinator, callbacks } = setup({
+        policy: () => {
+          if (failure === "throw") throw error;
+          return Promise.reject(error);
+        },
+      });
+      coordinator.supervise(runner, scope, () => coordinator.beginShutdown());
+      const op = coordinator.registerOperation(coordinator.prepare());
+      coordinator.beginErrorDecision("failed");
+      await coordinator.consumeCompletion(op, {
+        messageId: "failed",
+        completion: Promise.resolve(completed),
+      });
+      await runner.runPromise(Scope.close(scope, Exit.void));
+      expect(await coordinator.waitForErrorDecision("failed")).toBe("terminal");
+      expect(callbacks.policyError).toHaveBeenCalledWith(error);
+    }
+  );
+
   test("retired preparation, operation, reservation and retry events cannot affect their replacements", () => {
     const a = Symbol("A"),
       b = Symbol("B"),

--- a/src/node/services/turnCoordinator.ts
+++ b/src/node/services/turnCoordinator.ts
@@ -1,4 +1,6 @@
 import assert from "@/common/utils/assert";
+import { Cause, Effect, Exit, Fiber, Scope } from "effect";
+import { defaultEffectRunner, type EffectRunner } from "./di/effectRunner";
 import type { StreamAbortEvent, StreamStartEvent } from "@/common/types/stream";
 import type { TurnCompletion, TurnStreamHandle } from "./streamManager";
 import type { ActiveTurnThinkingOverride } from "./thinkingOverride";
@@ -281,6 +283,120 @@ interface CoordinatorCallbacks {
   policyError: (error: unknown) => void;
 }
 
+/** Physical resources only: the reducer remains the authority for admission and turn ownership. */
+class TurnExecution {
+  private readonly scope = Scope.makeUnsafe("parallel");
+  // Registered producers may add correlated terminal work while closing. The app retains its
+  // bounded shutdown: timing out this drain does not cancel non-cooperative Promise I/O.
+  private readonly pending = new Set<Promise<void>>();
+  private readonly policies = new Set<Fiber.Fiber<void>>();
+  private guardian?: Fiber.Fiber<void>;
+  private closePromise?: Promise<void>;
+
+  constructor(private runner: EffectRunner) {}
+
+  lease(): Disposable {
+    const settled = Promise.withResolvers<void>();
+    this.pending.add(settled.promise);
+    return {
+      [Symbol.dispose]: () => {
+        this.pending.delete(settled.promise);
+        settled.resolve();
+      },
+    };
+  }
+
+  resource(release: () => void): Disposable {
+    const scope = this.runner.runSync(Scope.fork(this.scope, "sequential"));
+    this.runner.runSync(Scope.addFinalizer(scope, Effect.sync(release)));
+    return { [Symbol.dispose]: () => this.runner.runSync(Scope.close(scope, Exit.void)) };
+  }
+
+  supervise(runner: EffectRunner, appScope: Scope.Scope | undefined, shutdown: () => void): void {
+    assert(this.guardian == null, "Turn execution supervision already attached");
+    this.runner = runner;
+    // The session calls this only after its collaborators exist. A closed parent interrupts
+    // synchronously, latching shutdown before a newly constructed session can accept a send.
+    const guardian = Effect.never.pipe(
+      Effect.onInterrupt(() =>
+        Effect.sync(shutdown).pipe(Effect.ensuring(Effect.promise(() => this.close())))
+      )
+    );
+    this.guardian = appScope
+      ? this.runner.runSync(Effect.forkIn(guardian, appScope, { startImmediately: true }))
+      : this.runner.runFork(guardian);
+  }
+
+  requestClose(): void {
+    if (this.guardian) this.guardian.interruptUnsafe();
+    else this.runner.runFork(Effect.promise(() => this.close()));
+  }
+
+  private close(): Promise<void> {
+    if (this.closePromise) return this.closePromise;
+    const closed = Promise.withResolvers<void>();
+    // Publish the close latch before interrupting fibers: their finalizers can reenter disposal.
+    this.closePromise = closed.promise;
+    this.runner
+      .runPromise(
+        Effect.gen({ self: this }, function* () {
+          // Interruption cannot cancel existing Promise I/O. Policy finalizers join the exact
+          // original Promise before releasing resources. Late terminals still have an open scope.
+          for (const fiber of this.policies) fiber.interruptUnsafe();
+          while (this.pending.size > 0) {
+            yield* Effect.promise(() => Promise.all([...this.pending]));
+          }
+          // Engine supervisors close in parallel with the guardian. A direct child policy scope
+          // would close before those engines deliver their final abort, silently losing policy.
+          yield* Scope.close(this.scope, Exit.void);
+        })
+      )
+      .then(closed.resolve, closed.reject);
+    return closed.promise;
+  }
+
+  policy(
+    start: () => Promise<void>,
+    finalize: () => void,
+    report: (error: unknown) => void
+  ): Promise<void> {
+    const lease = this.lease();
+    let original: Promise<void> | undefined;
+    const program = Effect.tryPromise({
+      try: () => (original = start()),
+      catch: (error) => error,
+    }).pipe(
+      Effect.onInterrupt(() => {
+        const started = original;
+        return started
+          ? Effect.tryPromise({ try: () => started, catch: (error) => error }).pipe(
+              Effect.catch((error) => Effect.sync(() => report(error)))
+            )
+          : Effect.void;
+      }),
+      Effect.catch((error) => Effect.sync(() => report(error))),
+      Effect.ensuring(
+        Effect.sync(() => {
+          try {
+            finalize();
+          } finally {
+            lease[Symbol.dispose]();
+          }
+        })
+      )
+    );
+    // rc112 requires startImmediately to preserve callback execution through its first await.
+    const fiber = this.runner.runSync(
+      Effect.forkIn(program, this.scope, { startImmediately: true })
+    );
+    this.policies.add(fiber);
+    fiber.addObserver(() => this.policies.delete(fiber));
+    return this.runner.runPromise(Fiber.await(fiber)).then((exit) => {
+      if (Exit.isFailure(exit) && !Cause.hasInterruptsOnly(exit.cause)) report(exit.cause);
+    });
+  }
+}
+
 /**
  * The sole owner of lifecycle state and runtime registries. Dispatch publishes state before any
  * callback; cleanup captures retired resources before publication so observer reentrancy is safe.
@@ -298,9 +414,21 @@ export class TurnCoordinator {
   >();
   private idleWaiters = new Set<() => void>();
   private prepared?: { id: TurnId; controller: AbortController };
-  private thinking: ActiveTurnThinkingOverride | null = null;
+  private thinking: { holder: ActiveTurnThinkingOverride; resource?: Disposable } | null = null;
+  private readonly execution = new TurnExecution(defaultEffectRunner);
+  private readonly operations = new Map<OperationId, Disposable>();
 
   constructor(private readonly callbacks: CoordinatorCallbacks) {}
+
+  /** Attach after AgentSession initialization, including when the app scope is already closed. */
+  supervise(runner: EffectRunner, scope: Scope.Scope | undefined, shutdown: () => void): void {
+    this.execution.supervise(runner, scope, shutdown);
+  }
+
+  /** An opaque physical lease must never reserve semantic admission or change queue priority. */
+  enterExecution(): Disposable {
+    return this.execution.lease();
+  }
 
   get phase(): TurnPhase {
     return this.state.turn.phase;
@@ -330,7 +458,7 @@ export class TurnCoordinator {
     return this.state.retry != null;
   }
   get thinkingOverride(): ActiveTurnThinkingOverride | null {
-    return this.thinking;
+    return this.thinking?.holder ?? null;
   }
   isBusy(): boolean {
     return this.phase !== "idle" || this.editReserved;
@@ -360,6 +488,7 @@ export class TurnCoordinator {
       (command) => command.type === "phase" && command.next.phase === "idle"
     );
     const waiters = idle ? this.idleWaiters : undefined;
+    const retiredThinking = idle ? this.thinking : undefined;
     const retiredPrepared =
       idle && this.prepared?.id === result.state.turn.id ? this.prepared : undefined;
     if (idle) {
@@ -398,27 +527,22 @@ export class TurnCoordinator {
         }
         case "policy":
           if (this.isCurrentOperation(command.id)) {
-            // Invoke synchronously up to the policy's first await; never insert an admission gap.
-            let policy: Promise<void>;
-            try {
-              policy = this.callbacks.policy(
-                command.id,
-                command.messageId,
-                command.outcome,
-                command.started,
-                command.notifyStartup
-              );
-            } catch (error) {
-              policy = Promise.reject(error instanceof Error ? error : new Error(String(error)));
-            }
-            launchedPolicy = policy
-              .catch(this.callbacks.policyError)
-              .finally(() => {
+            launchedPolicy = this.execution.policy(
+              () =>
+                this.callbacks.policy(
+                  command.id,
+                  command.messageId,
+                  command.outcome,
+                  command.started,
+                  command.notifyStartup
+                ),
+              () => {
                 this.resolveErrorDecision(command.messageId, "terminal");
                 this.resolveCompactionDecision(command.messageId, false);
                 this.settleOperation(command.id);
-              })
-              .catch(this.callbacks.policyError);
+              },
+              this.callbacks.policyError
+            );
           }
           break;
         case "drain":
@@ -440,6 +564,7 @@ export class TurnCoordinator {
       }
     }
     for (const resolve of waiters ?? []) resolve();
+    retiredThinking?.resource?.[Symbol.dispose]();
     // Outcomes live in pure state; the registry holds resources only, including pending waiters.
     const keys = new Set(
       this.state.decisions.map((entry) => this.decisionKey(entry.kind, entry.messageId))
@@ -488,16 +613,26 @@ export class TurnCoordinator {
     this.dispatch({ type: "complete-policy", id });
   }
   acceptThinkingOverride(holder: ActiveTurnThinkingOverride, turnId: TurnId): void {
-    if (this.isCurrentTurn(turnId)) this.thinking = holder;
+    if (!this.isCurrentTurn(turnId)) return;
+    this.thinking?.resource?.[Symbol.dispose]();
+    const thinking: NonNullable<typeof this.thinking> = { holder };
+    this.thinking = thinking;
+    thinking.resource = this.execution.resource(() => {
+      if (this.thinking === thinking) this.thinking = null;
+    });
   }
   releaseThinkingOverride(holder: ActiveTurnThinkingOverride): void {
-    if (this.thinking === holder) this.thinking = null;
+    if (this.thinking?.holder === holder) this.thinking.resource?.[Symbol.dispose]();
   }
   beginShutdown(): void {
     this.dispatch({ type: "shutdown" });
   }
   dispose(): void {
-    this.dispatch({ type: "dispose" });
+    try {
+      this.dispatch({ type: "dispose" });
+    } finally {
+      this.execution.requestClose();
+    }
   }
 
   reserve(kind: ReservationKind): Disposable {
@@ -530,18 +665,22 @@ export class TurnCoordinator {
     if (this.phase === "idle") return Promise.resolve();
     return new Promise<void>((resolve, reject) => {
       const batch = this.idleWaiters;
-      const finish = () => {
-        signal?.removeEventListener("abort", abort);
-        batch.delete(finish);
-        resolve();
-      };
+      let canceled = false;
+      const finish = () => resource[Symbol.dispose]();
       const abort = () => {
-        signal?.removeEventListener("abort", abort);
-        batch.delete(finish);
-        reject(new Error("Waiting for session idle canceled."));
+        canceled = true;
+        finish();
       };
       batch.add(finish);
       signal?.addEventListener("abort", abort, { once: true });
+      // Session scope finalization also releases waiters without a future idle publication.
+      // Capture this batch: closing a retired waiter must never delete a replacement's waiter.
+      const resource = this.execution.resource(() => {
+        signal?.removeEventListener("abort", abort);
+        batch.delete(finish);
+        if (canceled) reject(new Error("Waiting for session idle canceled."));
+        else resolve();
+      });
     });
   }
 
@@ -560,8 +699,9 @@ export class TurnCoordinator {
   registerOperation(turnId: TurnId): OperationId {
     const id = Symbol("operation");
     this.settlements.set(id, Promise.withResolvers<void>());
+    this.operations.set(id, this.enterExecution());
     this.dispatch({ type: "register", id, turnId });
-    if (!this.isCurrentOperation(id)) this.settleOperation(id);
+    if (!this.isCurrentOperation(id)) this.finishStartup(id);
     return id;
   }
   configureOperation(id: OperationId, compaction: boolean): void {
@@ -603,6 +743,8 @@ export class TurnCoordinator {
   }
   finishStartup(id: OperationId): void {
     this.settleOperation(id);
+    this.operations.get(id)?.[Symbol.dispose]();
+    this.operations.delete(id);
   }
   private settleOperation(id: OperationId): void {
     this.settlements.get(id)?.resolve();
@@ -622,7 +764,8 @@ export class TurnCoordinator {
       .catch((error: unknown) => {
         this.settleOperation(id);
         this.callbacks.policyError(error);
-      });
+      })
+      .finally(() => this.finishStartup(id));
   }
 
   private decisionKey(kind: DecisionKind, messageId: string): string {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -1,4 +1,6 @@
 import type { RestartBlocker } from "@/common/orpc/types";
+import type { Scope } from "effect";
+import { defaultEffectRunner, type EffectRunner } from "./di/effectRunner";
 import {
   DesktopInputCoordinator,
   settleArchivedSharedDesktopTask,
@@ -2357,7 +2359,9 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       config.rootDir
     ),
     private readonly providersConfigStore = new ProvidersConfigStore(config.rootDir),
-    private readonly desktopInputCoordinator = new DesktopInputCoordinator(config)
+    private readonly desktopInputCoordinator = new DesktopInputCoordinator(config),
+    private readonly effectRunner: EffectRunner = defaultEffectRunner,
+    private readonly appFiberScope?: Scope.Scope
   ) {
     super();
     this.bashMonitorRegistryStore = new BashMonitorRegistryStore(config);
@@ -4069,6 +4073,8 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
   private createSession(workspaceId: string): AgentSession {
     if (this.shuttingDown) throw new Error("Server is shutting down");
     return new AgentSession({
+      effectRunner: this.effectRunner,
+      appFiberScope: this.appFiberScope,
       workspaceId,
       config: this.config,
       historyService: this.historyService,


### PR DESCRIPTION
Turn admission can write history before a stream exists, and terminal accounting can continue after the engine finishes. The session now supervises these lifetimes so app shutdown waits for already admitted work before tearing down its dependencies.

The synchronous TurnCoordinator remains the source of admission and ownership decisions. A private Effect interpreter owns terminal-policy fibers and scoped resources, while physical execution leases cover preparation, queue callbacks, and turn-owned recovery/continuation work. A guardian registered in the app scope accepts late engine completions during shutdown, joins the original Promise-backed work, then closes the session scope. Engine completion remains independent of session policy settlement.

This also fixes an adjacent failure path: rejected abort bookkeeping still reports its error, delivers the abort once, and finalizes only the original turn, preventing an edit waiting for idle from blocking shutdown. Reentrant replacement turns retain their ownership and thinking state.

Validation includes held pre-preparation history writes, background startup and queue cancellation callbacks, late engine completion with blocked accounting, construction after app scope closure, retired physical work, abort-bookkeeping failures, and real engine partial persistence before bridge teardown. Final local checks: exact static-check passed; 591 affected backend tests and 2 AI completion tests passed; the rebuilt send-mode UI suite passed all 5 scenarios with unchanged timeouts.

Regression risk is concentrated in interruption, edits, and shutdown ordering. Existing Promise I/O is joined rather than treated as canceled. The app's bounded shutdown remains unchanged; speculative continuous-compaction jobs and service work before session entry retain their existing separate ownership for later migration phases.

---
_Generated with `xum` • Model: `unavailable` • Thinking: `unavailable` • Cost: `$unavailable`_
<!-- mux-attribution: model=unavailable thinking=unavailable costs=unavailable -->