### PR TITLE
🤖 feat: add default-hidden Daybreak models

### DIFF
--- a/docs/config/models.mdx
+++ b/docs/config/models.mdx
@@ -29,6 +29,8 @@ Xum ships with curated models kept up to date with the frontier. Use any custom 
 | Spark 5.3              | openai:gpt-5.3-codex-spark    | `spark`                                                      |         |
 | Codex Mini 5.1         | openai:gpt-5.1-codex-mini     | `codex-mini`                                                 |         |
 | Codex Max 5.1          | openai:gpt-5.1-codex-max      | `codex-max`                                                  |         |
+| Daybreak Blue Latest   | openai:daybreak-blue-latest   | —                                                            |         |
+| Daybreak Red Latest    | openai:daybreak-red-latest    | —                                                            |         |
 | Gemini 3.1 Pro Preview | google:gemini-3.1-pro-preview | `gemini`, `gemini-pro`                                       |         |
 | Gemini 3.8 Flash       | google:gemini-3.8-flash       | `gemini-flash`                                               |         |
 | Grok 4.6               | xai:grok-4.6                  | `grok`, `grok-4.6`                                           |         |

--- a/src/browser/contexts/WorkspaceContext.modelMigration.test.ts
+++ b/src/browser/contexts/WorkspaceContext.modelMigration.test.ts
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { GlobalWindow } from "happy-dom";
 import type { APIClient } from "@/browser/contexts/API";
 import { KNOWN_MODELS } from "@/common/constants/knownModels";
-import { DEFAULT_MODEL_KEY } from "@/common/constants/storage";
+import { DEFAULT_MODEL_KEY, HIDDEN_MODELS_KEY } from "@/common/constants/storage";
+import { updatePersistedState } from "@/browser/hooks/usePersistedState";
 import { WORKSPACE_DEFAULTS } from "@/constants/workspaceDefaults";
 import { migrateLocalModelPrefsToBackend } from "./WorkspaceContext";
 
@@ -50,11 +51,11 @@ describe("migrateLocalModelPrefsToBackend", () => {
     globalThis.localStorage = undefined as unknown as Storage;
   });
 
-  test("migrates an explicit local default when it matches the built-in default", () => {
+  test("migrates an explicit local default when it matches the built-in default", async () => {
     setLocalDefaultModel(WORKSPACE_DEFAULTS.model);
     const { api, updateModelPreferences } = createApiMock();
 
-    migrateLocalModelPrefsToBackend(api, {});
+    await migrateLocalModelPrefsToBackend(api, {});
 
     expect(updateModelPreferences).toHaveBeenCalledTimes(1);
     expect(updateModelPreferences).toHaveBeenCalledWith({
@@ -62,52 +63,80 @@ describe("migrateLocalModelPrefsToBackend", () => {
     });
   });
 
-  test("migrates an explicit local default when it differs from the built-in default", () => {
+  test("migrates an explicit local default when it differs from the built-in default", async () => {
     const nonDefaultModel = getNonDefaultModel();
     setLocalDefaultModel(nonDefaultModel);
     const { api, updateModelPreferences } = createApiMock();
 
-    migrateLocalModelPrefsToBackend(api, {});
+    await migrateLocalModelPrefsToBackend(api, {});
 
     expect(updateModelPreferences).toHaveBeenCalledTimes(1);
     expect(updateModelPreferences).toHaveBeenCalledWith({ defaultModel: nonDefaultModel });
   });
 
-  test("does not overwrite a backend default model", () => {
+  test("does not overwrite a backend default model", async () => {
     setLocalDefaultModel(getNonDefaultModel());
     const { api, updateModelPreferences } = createApiMock();
 
-    migrateLocalModelPrefsToBackend(api, { defaultModel: WORKSPACE_DEFAULTS.model });
+    await migrateLocalModelPrefsToBackend(api, { defaultModel: WORKSPACE_DEFAULTS.model });
 
     expect(updateModelPreferences).not.toHaveBeenCalled();
   });
 
-  test("does not migrate when no local default model is stored", () => {
+  test("does not migrate when no local default model is stored", async () => {
     const { api, updateModelPreferences } = createApiMock();
 
-    migrateLocalModelPrefsToBackend(api, {});
+    await migrateLocalModelPrefsToBackend(api, {});
 
     expect(updateModelPreferences).not.toHaveBeenCalled();
   });
 
-  test("does not migrate when the local default model is empty after trimming", () => {
+  test("does not migrate when the local default model is empty after trimming", async () => {
     setLocalDefaultModel("   ");
     const { api, updateModelPreferences } = createApiMock();
 
-    migrateLocalModelPrefsToBackend(api, {});
+    await migrateLocalModelPrefsToBackend(api, {});
 
     expect(updateModelPreferences).not.toHaveBeenCalled();
   });
 
-  test("preserves explicit gateway-scoped local default during migration", () => {
+  test("preserves explicit gateway-scoped local default during migration", async () => {
     setLocalDefaultModel("openrouter:openai/gpt-5");
     const { api, updateModelPreferences } = createApiMock();
 
-    migrateLocalModelPrefsToBackend(api, {});
+    await migrateLocalModelPrefsToBackend(api, {});
 
     expect(updateModelPreferences).toHaveBeenCalledTimes(1);
     expect(updateModelPreferences).toHaveBeenCalledWith({
       defaultModel: "openrouter:openai/gpt-5",
     });
   });
+
+  test("merges legacy hides with seeded defaults before hydration", async () => {
+    const legacyHidden = "openrouter:openai/gpt-5";
+    const seeded = ["openai:daybreak-blue-latest", "openai:daybreak-red-latest"];
+    updatePersistedState(HIDDEN_MODELS_KEY, [legacyHidden]);
+    const { api, updateModelPreferences } = createApiMock();
+
+    const prefs = await migrateLocalModelPrefsToBackend(api, {
+      hiddenModels: seeded,
+      hiddenModelsInitialized: false,
+    });
+    expect(prefs.hiddenModels).toEqual([...seeded, legacyHidden]);
+    expect(updateModelPreferences).toHaveBeenCalledWith({ hiddenModels: prefs.hiddenModels });
+  });
+
+  test.each([{ hiddenModels: [] }, { hiddenModels: ["openai:daybreak-red-latest"] }])(
+    "keeps initialized backend choices authoritative over stale local hides: %j",
+    async ({ hiddenModels }) => {
+      updatePersistedState(HIDDEN_MODELS_KEY, ["openai:daybreak-blue-latest"]);
+      const { api, updateModelPreferences } = createApiMock();
+      const prefs = await migrateLocalModelPrefsToBackend(api, {
+        hiddenModels: [...hiddenModels],
+        hiddenModelsInitialized: true,
+      });
+      expect(prefs.hiddenModels).toEqual([...hiddenModels]);
+      expect(updateModelPreferences).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/src/browser/contexts/WorkspaceContext.modelMigration.test.ts
+++ b/src/browser/contexts/WorkspaceContext.modelMigration.test.ts
@@ -51,11 +51,11 @@ describe("migrateLocalModelPrefsToBackend", () => {
     globalThis.localStorage = undefined as unknown as Storage;
   });
 
-  test("migrates an explicit local default when it matches the built-in default", async () => {
+  test("migrates an explicit local default when it matches the built-in default", () => {
     setLocalDefaultModel(WORKSPACE_DEFAULTS.model);
     const { api, updateModelPreferences } = createApiMock();
 
-    await migrateLocalModelPrefsToBackend(api, {});
+    migrateLocalModelPrefsToBackend(api, {});
 
     expect(updateModelPreferences).toHaveBeenCalledTimes(1);
     expect(updateModelPreferences).toHaveBeenCalledWith({
@@ -63,48 +63,48 @@ describe("migrateLocalModelPrefsToBackend", () => {
     });
   });
 
-  test("migrates an explicit local default when it differs from the built-in default", async () => {
+  test("migrates an explicit local default when it differs from the built-in default", () => {
     const nonDefaultModel = getNonDefaultModel();
     setLocalDefaultModel(nonDefaultModel);
     const { api, updateModelPreferences } = createApiMock();
 
-    await migrateLocalModelPrefsToBackend(api, {});
+    migrateLocalModelPrefsToBackend(api, {});
 
     expect(updateModelPreferences).toHaveBeenCalledTimes(1);
     expect(updateModelPreferences).toHaveBeenCalledWith({ defaultModel: nonDefaultModel });
   });
 
-  test("does not overwrite a backend default model", async () => {
+  test("does not overwrite a backend default model", () => {
     setLocalDefaultModel(getNonDefaultModel());
     const { api, updateModelPreferences } = createApiMock();
 
-    await migrateLocalModelPrefsToBackend(api, { defaultModel: WORKSPACE_DEFAULTS.model });
+    migrateLocalModelPrefsToBackend(api, { defaultModel: WORKSPACE_DEFAULTS.model });
 
     expect(updateModelPreferences).not.toHaveBeenCalled();
   });
 
-  test("does not migrate when no local default model is stored", async () => {
+  test("does not migrate when no local default model is stored", () => {
     const { api, updateModelPreferences } = createApiMock();
 
-    await migrateLocalModelPrefsToBackend(api, {});
+    migrateLocalModelPrefsToBackend(api, {});
 
     expect(updateModelPreferences).not.toHaveBeenCalled();
   });
 
-  test("does not migrate when the local default model is empty after trimming", async () => {
+  test("does not migrate when the local default model is empty after trimming", () => {
     setLocalDefaultModel("   ");
     const { api, updateModelPreferences } = createApiMock();
 
-    await migrateLocalModelPrefsToBackend(api, {});
+    migrateLocalModelPrefsToBackend(api, {});
 
     expect(updateModelPreferences).not.toHaveBeenCalled();
   });
 
-  test("preserves explicit gateway-scoped local default during migration", async () => {
+  test("preserves explicit gateway-scoped local default during migration", () => {
     setLocalDefaultModel("openrouter:openai/gpt-5");
     const { api, updateModelPreferences } = createApiMock();
 
-    await migrateLocalModelPrefsToBackend(api, {});
+    migrateLocalModelPrefsToBackend(api, {});
 
     expect(updateModelPreferences).toHaveBeenCalledTimes(1);
     expect(updateModelPreferences).toHaveBeenCalledWith({
@@ -112,13 +112,13 @@ describe("migrateLocalModelPrefsToBackend", () => {
     });
   });
 
-  test("merges legacy hides with seeded defaults before hydration", async () => {
+  test("merges legacy hides with seeded defaults before hydration", () => {
     const legacyHidden = "openrouter:openai/gpt-5";
     const seeded = ["openai:daybreak-blue-latest", "openai:daybreak-red-latest"];
     updatePersistedState(HIDDEN_MODELS_KEY, [legacyHidden]);
     const { api, updateModelPreferences } = createApiMock();
 
-    const prefs = await migrateLocalModelPrefsToBackend(api, {
+    const prefs = migrateLocalModelPrefsToBackend(api, {
       hiddenModels: seeded,
       hiddenModelsInitialized: false,
     });
@@ -128,10 +128,10 @@ describe("migrateLocalModelPrefsToBackend", () => {
 
   test.each([{ hiddenModels: [] }, { hiddenModels: ["openai:daybreak-red-latest"] }])(
     "keeps initialized backend choices authoritative over stale local hides: %j",
-    async ({ hiddenModels }) => {
+    ({ hiddenModels }) => {
       updatePersistedState(HIDDEN_MODELS_KEY, ["openai:daybreak-blue-latest"]);
       const { api, updateModelPreferences } = createApiMock();
-      const prefs = await migrateLocalModelPrefsToBackend(api, {
+      const prefs = migrateLocalModelPrefsToBackend(api, {
         hiddenModels: [...hiddenModels],
         hiddenModelsInitialized: true,
       });

--- a/src/browser/contexts/WorkspaceContext.modelMigration.test.ts
+++ b/src/browser/contexts/WorkspaceContext.modelMigration.test.ts
@@ -126,6 +126,17 @@ describe("migrateLocalModelPrefsToBackend", () => {
     expect(updateModelPreferences).toHaveBeenCalledWith({ hiddenModels: prefs.hiddenModels });
   });
 
+  test.each([{ hiddenModels: [] }, { hiddenModels: ["openai:gpt-5"] }])(
+    "restores local hides when migrated backend data is lost: %j",
+    ({ hiddenModels }) => {
+      updatePersistedState(HIDDEN_MODELS_KEY, hiddenModels);
+      const { api, updateModelPreferences } = createApiMock();
+      const prefs = migrateLocalModelPrefsToBackend(api, { hiddenModelsInitialized: false });
+      expect(prefs.hiddenModels).toEqual([...hiddenModels]);
+      expect(updateModelPreferences).toHaveBeenCalledWith({ hiddenModels });
+    }
+  );
+
   test.each([{ hiddenModels: [] }, { hiddenModels: ["openai:daybreak-red-latest"] }])(
     "keeps initialized backend choices authoritative over stale local hides: %j",
     ({ hiddenModels }) => {

--- a/src/browser/contexts/WorkspaceContext.test.tsx
+++ b/src/browser/contexts/WorkspaceContext.test.tsx
@@ -8,6 +8,8 @@ import { ProjectProvider, useProjectContext } from "@/browser/contexts/ProjectCo
 import { RouterProvider } from "@/browser/contexts/RouterContext";
 import { useWorkspaceStoreRaw as getWorkspaceStoreRaw } from "@/browser/stores/WorkspaceStore";
 import {
+  DEFAULT_MODEL_KEY,
+  HIDDEN_MODELS_KEY,
   LAST_VISITED_ROUTE_KEY,
   LAUNCH_BEHAVIOR_KEY,
   SELECTED_WORKSPACE_KEY,
@@ -19,6 +21,7 @@ import {
 } from "@/common/constants/storage";
 import { SCRATCH_PROJECT_CONFIG_KEY } from "@/common/constants/scratch";
 import { MULTI_PROJECT_CONFIG_KEY } from "@/common/constants/multiProject";
+import { createMockORPCClient } from "@/browser/stories/mocks/orpc";
 import type { RecursivePartial } from "@/browser/testUtils";
 import { readPersistedState } from "@/browser/hooks/usePersistedState";
 import { getProjectRouteId } from "@/common/utils/projectRouteId";
@@ -70,6 +73,37 @@ describe("WorkspaceContext", () => {
     globalThis.localStorage = undefined as unknown as Storage;
 
     currentClientMock = {};
+  });
+
+  test("imports legacy hidden preferences before backend hydration", async () => {
+    const seeded = ["openai:daybreak-blue-latest", "openai:daybreak-red-latest"];
+    const legacyHidden = "openrouter:openai/gpt-5";
+    const defaultModel = "openai:gpt-5.6-terra";
+    createMockAPI({
+      localStorage: {
+        [HIDDEN_MODELS_KEY]: JSON.stringify([legacyHidden]),
+        [DEFAULT_MODEL_KEY]: JSON.stringify(defaultModel),
+      },
+    });
+    const updateModelPreferences = mock(() => Promise.resolve());
+    const cfg = await createMockORPCClient().config.getConfig();
+    currentClientMock.config = {
+      getConfig: () =>
+        Promise.resolve({ ...cfg, hiddenModels: seeded, hiddenModelsInitialized: false }),
+      updateModelPreferences,
+    };
+    await setup();
+    await waitFor(() => {
+      expect(readPersistedState<string[]>(HIDDEN_MODELS_KEY, [])).toEqual([
+        ...seeded,
+        legacyHidden,
+      ]);
+    });
+    expect(updateModelPreferences).toHaveBeenCalledWith({
+      defaultModel,
+      hiddenModels: [...seeded, legacyHidden],
+    });
+    expect(readPersistedState(DEFAULT_MODEL_KEY, "")).toBe(defaultModel);
   });
 
   test("syncs workspace store subscriptions when metadata loads", async () => {

--- a/src/browser/contexts/WorkspaceContext.test.tsx
+++ b/src/browser/contexts/WorkspaceContext.test.tsx
@@ -10,6 +10,7 @@ import { useWorkspaceStoreRaw as getWorkspaceStoreRaw } from "@/browser/stores/W
 import {
   DEFAULT_MODEL_KEY,
   HIDDEN_MODELS_KEY,
+  RUNTIME_ENABLEMENT_KEY,
   LAST_VISITED_ROUTE_KEY,
   LAUNCH_BEHAVIOR_KEY,
   SELECTED_WORKSPACE_KEY,
@@ -75,36 +76,48 @@ describe("WorkspaceContext", () => {
     currentClientMock = {};
   });
 
-  test("imports legacy hidden preferences before backend hydration", async () => {
-    const seeded = ["openai:daybreak-blue-latest", "openai:daybreak-red-latest"];
-    const legacyHidden = "openrouter:openai/gpt-5";
-    const defaultModel = "openai:gpt-5.6-terra";
-    createMockAPI({
-      localStorage: {
-        [HIDDEN_MODELS_KEY]: JSON.stringify([legacyHidden]),
-        [DEFAULT_MODEL_KEY]: JSON.stringify(defaultModel),
-      },
-    });
-    const updateModelPreferences = mock(() => Promise.resolve());
-    const cfg = await createMockORPCClient().config.getConfig();
-    currentClientMock.config = {
-      getConfig: () =>
-        Promise.resolve({ ...cfg, hiddenModels: seeded, hiddenModelsInitialized: false }),
-      updateModelPreferences,
-    };
-    await setup();
-    await waitFor(() => {
-      expect(readPersistedState<string[]>(HIDDEN_MODELS_KEY, [])).toEqual([
-        ...seeded,
-        legacyHidden,
-      ]);
-    });
-    expect(updateModelPreferences).toHaveBeenCalledWith({
-      defaultModel,
-      hiddenModels: [...seeded, legacyHidden],
-    });
-    expect(readPersistedState(DEFAULT_MODEL_KEY, "")).toBe(defaultModel);
-  });
+  test.each([false, true])(
+    "hydrates preferences when migration write fails: %s",
+    async (writeFails) => {
+      const seeded = ["openai:daybreak-blue-latest", "openai:daybreak-red-latest"];
+      const legacyHidden = "openrouter:openai/gpt-5";
+      const defaultModel = "openai:gpt-5.6-terra";
+      createMockAPI({
+        localStorage: {
+          [HIDDEN_MODELS_KEY]: JSON.stringify([legacyHidden]),
+          [DEFAULT_MODEL_KEY]: JSON.stringify(defaultModel),
+          [RUNTIME_ENABLEMENT_KEY]: JSON.stringify({ ssh: true }),
+        },
+      });
+      const updateModelPreferences = mock(() =>
+        writeFails ? Promise.reject(new Error("config write failed")) : Promise.resolve()
+      );
+      const cfg = await createMockORPCClient().config.getConfig();
+      currentClientMock.config = {
+        getConfig: () =>
+          Promise.resolve({
+            ...cfg,
+            hiddenModels: seeded,
+            hiddenModelsInitialized: false,
+            runtimeEnablement: { ssh: false },
+          }),
+        updateModelPreferences,
+      };
+      await setup();
+      await waitFor(() => {
+        expect(readPersistedState<string[]>(HIDDEN_MODELS_KEY, [])).toEqual([
+          ...seeded,
+          legacyHidden,
+        ]);
+      });
+      expect(updateModelPreferences).toHaveBeenCalledWith({
+        defaultModel,
+        hiddenModels: [...seeded, legacyHidden],
+      });
+      expect(readPersistedState(DEFAULT_MODEL_KEY, "")).toBe(defaultModel);
+      expect(readPersistedState(RUNTIME_ENABLEMENT_KEY, {})).toEqual({ ssh: false });
+    }
+  );
 
   test("syncs workspace store subscriptions when metadata loads", async () => {
     const initialWorkspaces: FrontendWorkspaceMetadata[] = [

--- a/src/browser/contexts/WorkspaceContext.test.tsx
+++ b/src/browser/contexts/WorkspaceContext.test.tsx
@@ -24,7 +24,11 @@ import { SCRATCH_PROJECT_CONFIG_KEY } from "@/common/constants/scratch";
 import { MULTI_PROJECT_CONFIG_KEY } from "@/common/constants/multiProject";
 import { createMockORPCClient } from "@/browser/stories/mocks/orpc";
 import type { RecursivePartial } from "@/browser/testUtils";
-import { readPersistedState, updatePersistedState } from "@/browser/hooks/usePersistedState";
+import {
+  readPersistedState,
+  syncPersistedStateFromBackend,
+  updatePersistedState,
+} from "@/browser/hooks/usePersistedState";
 import { getProjectRouteId } from "@/common/utils/projectRouteId";
 import type { RightSidebarLayoutState } from "@/browser/utils/rightSidebarLayout";
 
@@ -121,9 +125,16 @@ describe("WorkspaceContext", () => {
     }
   );
 
-  test.each(["hidden", "default", "hidden-aba"])(
-    "keeps %s edits ahead of stale startup config",
-    async (changed) => {
+  test.each(
+    ["local", "cross-tab", "cross-tab-delayed"].flatMap((source) =>
+      (source === "cross-tab-delayed"
+        ? ["hidden", "default"]
+        : ["hidden", "default", "hidden-aba", "default-aba"]
+      ).map((changed) => [source, changed])
+    )
+  )(
+    "keeps %s %s preference edits ahead of stale startup config until reconnect",
+    async (source, changed) => {
       const blue = "openai:daybreak-blue-latest";
       const red = "openai:daybreak-red-latest";
       const legacyHidden = "openrouter:openai/gpt-5";
@@ -143,12 +154,25 @@ describe("WorkspaceContext", () => {
       const updateModelPreferences = mock(() => Promise.resolve());
       currentClientMock.config = { getConfig: () => pendingConfig, updateModelPreferences };
       await setup();
+      const writePreference = (key: string, value: unknown) => {
+        if (source === "local") {
+          updatePersistedState(key, value);
+          return;
+        }
+        // Seed the shared value without emitting a local write in this tab.
+        syncPersistedStateFromBackend(key, value);
+        if (source === "cross-tab-delayed") return;
+        window.dispatchEvent(
+          new window.StorageEvent("storage", { key, storageArea: window.localStorage })
+        );
+      };
       act(() => {
-        if (changed === "default") {
-          updatePersistedState(DEFAULT_MODEL_KEY, chosenDefault);
+        if (changed.startsWith("default")) {
+          writePreference(DEFAULT_MODEL_KEY, chosenDefault);
+          if (changed === "default-aba") writePreference(DEFAULT_MODEL_KEY, legacyDefault);
         } else {
-          updatePersistedState(HIDDEN_MODELS_KEY, [red, legacyHidden]);
-          if (changed === "hidden-aba") updatePersistedState(HIDDEN_MODELS_KEY, [legacyHidden]);
+          writePreference(HIDDEN_MODELS_KEY, [red, legacyHidden]);
+          if (changed === "hidden-aba") writePreference(HIDDEN_MODELS_KEY, [legacyHidden]);
         }
       });
       resolveConfig({
@@ -164,14 +188,14 @@ describe("WorkspaceContext", () => {
         changed === "default" ? chosenDefault : legacyDefault
       );
       expect(readPersistedState<string[]>(HIDDEN_MODELS_KEY, [])).toEqual(
-        changed === "default"
+        changed.startsWith("default")
           ? [blue, red, legacyHidden]
           : changed === "hidden"
             ? [red, legacyHidden]
             : [legacyHidden]
       );
       expect(updateModelPreferences).toHaveBeenCalledWith(
-        changed === "default"
+        changed.startsWith("default")
           ? { hiddenModels: [blue, red, legacyHidden] }
           : { defaultModel: legacyDefault }
       );

--- a/src/browser/contexts/WorkspaceContext.test.tsx
+++ b/src/browser/contexts/WorkspaceContext.test.tsx
@@ -24,7 +24,7 @@ import { SCRATCH_PROJECT_CONFIG_KEY } from "@/common/constants/scratch";
 import { MULTI_PROJECT_CONFIG_KEY } from "@/common/constants/multiProject";
 import { createMockORPCClient } from "@/browser/stories/mocks/orpc";
 import type { RecursivePartial } from "@/browser/testUtils";
-import { readPersistedState } from "@/browser/hooks/usePersistedState";
+import { readPersistedState, updatePersistedState } from "@/browser/hooks/usePersistedState";
 import { getProjectRouteId } from "@/common/utils/projectRouteId";
 import type { RightSidebarLayoutState } from "@/browser/utils/rightSidebarLayout";
 
@@ -76,9 +76,9 @@ describe("WorkspaceContext", () => {
     currentClientMock = {};
   });
 
-  test.each([false, true])(
-    "hydrates preferences when migration write fails: %s",
-    async (writeFails) => {
+  test.each(["resolves", "rejects", "stalls"])(
+    "hydrates preferences when migration persistence %s",
+    async (writeState) => {
       const seeded = ["openai:daybreak-blue-latest", "openai:daybreak-red-latest"];
       const legacyHidden = "openrouter:openai/gpt-5";
       const defaultModel = "openai:gpt-5.6-terra";
@@ -89,9 +89,11 @@ describe("WorkspaceContext", () => {
           [RUNTIME_ENABLEMENT_KEY]: JSON.stringify({ ssh: true }),
         },
       });
-      const updateModelPreferences = mock(() =>
-        writeFails ? Promise.reject(new Error("config write failed")) : Promise.resolve()
-      );
+      const updateModelPreferences = mock(() => {
+        if (writeState === "stalls") return new Promise<void>(() => undefined);
+        if (writeState === "rejects") return Promise.reject(new Error("config write failed"));
+        return Promise.resolve();
+      });
       const cfg = await createMockORPCClient().config.getConfig();
       currentClientMock.config = {
         getConfig: () =>
@@ -116,6 +118,81 @@ describe("WorkspaceContext", () => {
       });
       expect(readPersistedState(DEFAULT_MODEL_KEY, "")).toBe(defaultModel);
       expect(readPersistedState(RUNTIME_ENABLEMENT_KEY, {})).toEqual({ ssh: false });
+    }
+  );
+
+  test.each(["hidden", "default", "hidden-aba"])(
+    "keeps %s edits ahead of stale startup config",
+    async (changed) => {
+      const blue = "openai:daybreak-blue-latest";
+      const red = "openai:daybreak-red-latest";
+      const legacyHidden = "openrouter:openai/gpt-5";
+      const legacyDefault = "openai:gpt-5.6-terra";
+      const chosenDefault = "anthropic:claude-opus-4-6";
+      createMockAPI({
+        localStorage: {
+          [HIDDEN_MODELS_KEY]: JSON.stringify([legacyHidden]),
+          [DEFAULT_MODEL_KEY]: JSON.stringify(legacyDefault),
+        },
+      });
+      const cfg = await createMockORPCClient().config.getConfig();
+      let resolveConfig!: (value: typeof cfg) => void;
+      const pendingConfig = new Promise<typeof cfg>((resolve) => {
+        resolveConfig = resolve;
+      });
+      const updateModelPreferences = mock(() => Promise.resolve());
+      currentClientMock.config = { getConfig: () => pendingConfig, updateModelPreferences };
+      await setup();
+      act(() => {
+        if (changed === "default") {
+          updatePersistedState(DEFAULT_MODEL_KEY, chosenDefault);
+        } else {
+          updatePersistedState(HIDDEN_MODELS_KEY, [red, legacyHidden]);
+          if (changed === "hidden-aba") updatePersistedState(HIDDEN_MODELS_KEY, [legacyHidden]);
+        }
+      });
+      resolveConfig({
+        ...cfg,
+        hiddenModels: [blue, red],
+        hiddenModelsInitialized: false,
+        runtimeEnablement: { ssh: false },
+      });
+      await waitFor(() =>
+        expect(readPersistedState(RUNTIME_ENABLEMENT_KEY, {})).toEqual({ ssh: false })
+      );
+      expect(readPersistedState(DEFAULT_MODEL_KEY, "")).toBe(
+        changed === "default" ? chosenDefault : legacyDefault
+      );
+      expect(readPersistedState<string[]>(HIDDEN_MODELS_KEY, [])).toEqual(
+        changed === "default"
+          ? [blue, red, legacyHidden]
+          : changed === "hidden"
+            ? [red, legacyHidden]
+            : [legacyHidden]
+      );
+      expect(updateModelPreferences).toHaveBeenCalledWith(
+        changed === "default"
+          ? { hiddenModels: [blue, red, legacyHidden] }
+          : { defaultModel: legacyDefault }
+      );
+
+      cleanup();
+      getWorkspaceStoreRaw().dispose();
+      currentClientMock.config = {
+        getConfig: () =>
+          Promise.resolve({
+            ...cfg,
+            defaultModel: legacyDefault,
+            hiddenModels: [],
+            hiddenModelsInitialized: true,
+          }),
+        updateModelPreferences,
+      };
+      await setup();
+      await waitFor(() =>
+        expect(readPersistedState<string[] | null>(HIDDEN_MODELS_KEY, null)).toEqual([])
+      );
+      expect(readPersistedState(DEFAULT_MODEL_KEY, "")).toBe(legacyDefault);
     }
   );
 

--- a/src/browser/contexts/WorkspaceContext.tsx
+++ b/src/browser/contexts/WorkspaceContext.tsx
@@ -77,17 +77,20 @@ import { getErrorMessage } from "@/common/utils/errors";
 import type { WorkspaceCreationScope } from "@/common/utils/subProjects";
 
 /**
- * One-time best-effort migration: if the backend doesn't have model preferences yet,
- * persist explicit localStorage values so future port/origin changes keep them.
+ * One-time best-effort migration: when backend preferences are missing or hidden-model
+ * preferences remain uninitialized, persist explicit localStorage values.
  * Called once on startup after backend config is fetched.
  *
  * Exported for focused migration tests.
  */
-export function migrateLocalModelPrefsToBackend(
+export async function migrateLocalModelPrefsToBackend(
   api: APIClient,
-  cfg: { defaultModel?: string; hiddenModels?: string[] }
-): void {
-  if (!api.config.updateModelPreferences) return;
+  cfg: Pick<
+    Awaited<ReturnType<APIClient["config"]["getConfig"]>>,
+    "defaultModel" | "hiddenModels" | "hiddenModelsInitialized"
+  >
+) {
+  if (!api.config.updateModelPreferences) return cfg;
 
   const localDefaultModelRaw = readPersistedString(DEFAULT_MODEL_KEY);
   const localDefaultModel =
@@ -109,18 +112,24 @@ export function migrateLocalModelPrefsToBackend(
   }
 
   if (
-    cfg.hiddenModels === undefined &&
-    Array.isArray(localHiddenModels) &&
-    localHiddenModels.length > 0
+    cfg.hiddenModelsInitialized === false ||
+    (cfg.hiddenModels === undefined &&
+      Array.isArray(localHiddenModels) &&
+      localHiddenModels.length > 0)
   ) {
-    patch.hiddenModels = localHiddenModels;
+    // Backend defaults are not evidence that legacy local preferences were imported.
+    patch.hiddenModels = [
+      ...new Set([
+        ...(cfg.hiddenModels ?? []),
+        ...(Array.isArray(localHiddenModels) ? localHiddenModels : []),
+      ]),
+    ];
   }
 
   if (Object.keys(patch).length > 0) {
-    api.config.updateModelPreferences(patch).catch(() => {
-      // Best-effort only.
-    });
+    await api.config.updateModelPreferences(patch);
   }
+  return { ...cfg, ...patch };
 }
 
 /**
@@ -659,18 +668,20 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
 
     void api.config
       .getConfig()
-      .then((cfg) => {
+      .then(async (cfg) => {
+        // Read legacy local preferences before backend hydration can overwrite them.
+        const modelPrefs = await migrateLocalModelPrefsToBackend(api, cfg);
         updatePersistedState(
           AGENT_AI_DEFAULTS_KEY,
           normalizeAgentAiDefaults(cfg.agentAiDefaults ?? {})
         );
 
         // Seed global model preferences from backend so switching ports doesn't reset the UI.
-        if (cfg.defaultModel !== undefined) {
-          updatePersistedState(DEFAULT_MODEL_KEY, cfg.defaultModel);
+        if (modelPrefs.defaultModel !== undefined) {
+          updatePersistedState(DEFAULT_MODEL_KEY, modelPrefs.defaultModel);
         }
-        if (cfg.hiddenModels !== undefined) {
-          updatePersistedState(HIDDEN_MODELS_KEY, cfg.hiddenModels);
+        if (modelPrefs.hiddenModels !== undefined) {
+          updatePersistedState(HIDDEN_MODELS_KEY, modelPrefs.hiddenModels);
         }
 
         // Seed runtime enablement from backend so switching ports doesn't reset the UI.
@@ -682,10 +693,6 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
         if (cfg.defaultRuntime !== undefined) {
           updatePersistedState(DEFAULT_RUNTIME_KEY, cfg.defaultRuntime);
         }
-
-        // One-time best-effort migration: if the backend doesn't have model prefs yet,
-        // persist explicit localStorage values so future port changes keep them.
-        migrateLocalModelPrefsToBackend(api, cfg);
 
         // One-time gateway pref migration: if the backend doesn't have gateway prefs yet,
         // check if the user had non-default values in the old localStorage keys.

--- a/src/browser/contexts/WorkspaceContext.tsx
+++ b/src/browser/contexts/WorkspaceContext.tsx
@@ -669,18 +669,39 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
     if (!api?.config?.getConfig) return;
 
     let active = true;
-    // Track writes, not equality: toggling twice is still local intent.
+    // Track writes, not just equality: toggling twice is still local intent.
     const dirtyKeys = new Set<string>();
-    const unsubscribeWrites = subscribePersistedStateWrites(({ key, source }) => {
-      if (source === "local" && (key === DEFAULT_MODEL_KEY || key === HIDDEN_MODELS_KEY)) {
-        dirtyKeys.add(key);
+    const initialPreferences = [DEFAULT_MODEL_KEY, HIDDEN_MODELS_KEY].map((key) => ({
+      key,
+      value: JSON.stringify(readPersistedState<unknown>(key, undefined)),
+    }));
+    const markDirty = (key: string | null) => {
+      for (const preference of initialPreferences) {
+        if (key === null || key === preference.key) dirtyKeys.add(preference.key);
       }
+    };
+    const unsubscribeWrites = subscribePersistedStateWrites(({ key, source }) => {
+      if (source === "local") markDirty(key);
     });
+    const storageWindow = window;
+    const onStorage = (event: StorageEvent) => {
+      if (event.storageArea === storageWindow.localStorage) markDirty(event.key);
+    };
+    storageWindow.addEventListener("storage", onStorage);
+    const stopTrackingWrites = () => {
+      unsubscribeWrites();
+      storageWindow.removeEventListener("storage", onStorage);
+    };
 
     api.config
       .getConfig()
       .then((cfg) => {
         if (!active) return;
+        // Cross-tab writes can land before their queued storage events arrive.
+        for (const { key, value } of initialPreferences) {
+          if (JSON.stringify(readPersistedState<unknown>(key, undefined)) !== value)
+            dirtyKeys.add(key);
+        }
         // Read legacy local preferences before backend hydration can overwrite them.
         const modelPrefs = migrateLocalModelPrefsToBackend(api, cfg, dirtyKeys);
         updatePersistedState(
@@ -714,11 +735,11 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
       .catch(() => {
         // Best-effort only.
       })
-      .finally(unsubscribeWrites);
+      .finally(stopTrackingWrites);
 
     return () => {
       active = false;
-      unsubscribeWrites();
+      stopTrackingWrites();
     };
   }, [api]);
   // Get project refresh function from ProjectContext

--- a/src/browser/contexts/WorkspaceContext.tsx
+++ b/src/browser/contexts/WorkspaceContext.tsx
@@ -51,6 +51,8 @@ import { setWorkspaceModelWithOrigin } from "@/browser/utils/modelChange";
 import {
   readPersistedState,
   readPersistedString,
+  subscribePersistedStateWrites,
+  syncPersistedStateFromBackend,
   updatePersistedState,
   usePersistedState,
 } from "@/browser/hooks/usePersistedState";
@@ -80,12 +82,13 @@ import type { WorkspaceCreationScope } from "@/common/utils/subProjects";
  * Preserve legacy local model choices across port/origin changes.
  * Exported for focused migration tests.
  */
-export async function migrateLocalModelPrefsToBackend(
+export function migrateLocalModelPrefsToBackend(
   api: APIClient,
   cfg: Pick<
     Awaited<ReturnType<APIClient["config"]["getConfig"]>>,
     "defaultModel" | "hiddenModels" | "hiddenModelsInitialized"
-  >
+  >,
+  dirtyKeys: ReadonlySet<string> = new Set()
 ) {
   if (!api.config.updateModelPreferences) return cfg;
 
@@ -104,15 +107,16 @@ export async function migrateLocalModelPrefsToBackend(
   // localStorage presence implies explicit user choice (usePersistedState never
   // writes fallback defaults). Always migrate to backend so the preference
   // survives future changes to the built-in default constant.
-  if (cfg.defaultModel === undefined && localDefaultModel) {
+  if (!dirtyKeys.has(DEFAULT_MODEL_KEY) && cfg.defaultModel === undefined && localDefaultModel) {
     patch.defaultModel = localDefaultModel;
   }
 
   if (
-    cfg.hiddenModelsInitialized === false ||
-    (cfg.hiddenModels === undefined &&
-      Array.isArray(localHiddenModels) &&
-      localHiddenModels.length > 0)
+    !dirtyKeys.has(HIDDEN_MODELS_KEY) &&
+    (cfg.hiddenModelsInitialized === false ||
+      (cfg.hiddenModels === undefined &&
+        Array.isArray(localHiddenModels) &&
+        localHiddenModels.length > 0))
   ) {
     // Backend defaults are not evidence that legacy local preferences were imported.
     patch.hiddenModels = [
@@ -124,9 +128,8 @@ export async function migrateLocalModelPrefsToBackend(
   }
 
   if (Object.keys(patch).length > 0) {
-    await api.config.updateModelPreferences(patch).catch(() => {
-      // A failed migration write must not block unrelated startup hydration.
-    });
+    // Migration persistence must not delay hydration of unrelated settings.
+    api.config.updateModelPreferences(patch).catch(() => undefined);
   }
   return { ...cfg, ...patch };
 }
@@ -665,22 +668,32 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
   useEffect(() => {
     if (!api?.config?.getConfig) return;
 
-    void api.config
+    let active = true;
+    // Track writes, not equality: toggling twice is still local intent.
+    const dirtyKeys = new Set<string>();
+    const unsubscribeWrites = subscribePersistedStateWrites(({ key, source }) => {
+      if (source === "local" && (key === DEFAULT_MODEL_KEY || key === HIDDEN_MODELS_KEY)) {
+        dirtyKeys.add(key);
+      }
+    });
+
+    api.config
       .getConfig()
-      .then(async (cfg) => {
+      .then((cfg) => {
+        if (!active) return;
         // Read legacy local preferences before backend hydration can overwrite them.
-        const modelPrefs = await migrateLocalModelPrefsToBackend(api, cfg);
+        const modelPrefs = migrateLocalModelPrefsToBackend(api, cfg, dirtyKeys);
         updatePersistedState(
           AGENT_AI_DEFAULTS_KEY,
           normalizeAgentAiDefaults(cfg.agentAiDefaults ?? {})
         );
 
         // Seed global model preferences from backend so switching ports doesn't reset the UI.
-        if (modelPrefs.defaultModel !== undefined) {
-          updatePersistedState(DEFAULT_MODEL_KEY, modelPrefs.defaultModel);
+        if (!dirtyKeys.has(DEFAULT_MODEL_KEY) && modelPrefs.defaultModel !== undefined) {
+          syncPersistedStateFromBackend(DEFAULT_MODEL_KEY, modelPrefs.defaultModel);
         }
-        if (modelPrefs.hiddenModels !== undefined) {
-          updatePersistedState(HIDDEN_MODELS_KEY, modelPrefs.hiddenModels);
+        if (!dirtyKeys.has(HIDDEN_MODELS_KEY) && modelPrefs.hiddenModels !== undefined) {
+          syncPersistedStateFromBackend(HIDDEN_MODELS_KEY, modelPrefs.hiddenModels);
         }
 
         // Seed runtime enablement from backend so switching ports doesn't reset the UI.
@@ -700,7 +713,13 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
       })
       .catch(() => {
         // Best-effort only.
-      });
+      })
+      .finally(unsubscribeWrites);
+
+    return () => {
+      active = false;
+      unsubscribeWrites();
+    };
   }, [api]);
   // Get project refresh function from ProjectContext
   const {

--- a/src/browser/contexts/WorkspaceContext.tsx
+++ b/src/browser/contexts/WorkspaceContext.tsx
@@ -77,10 +77,7 @@ import { getErrorMessage } from "@/common/utils/errors";
 import type { WorkspaceCreationScope } from "@/common/utils/subProjects";
 
 /**
- * One-time best-effort migration: when backend preferences are missing or hidden-model
- * preferences remain uninitialized, persist explicit localStorage values.
- * Called once on startup after backend config is fetched.
- *
+ * Preserve legacy local model choices across port/origin changes.
  * Exported for focused migration tests.
  */
 export async function migrateLocalModelPrefsToBackend(
@@ -127,7 +124,9 @@ export async function migrateLocalModelPrefsToBackend(
   }
 
   if (Object.keys(patch).length > 0) {
-    await api.config.updateModelPreferences(patch);
+    await api.config.updateModelPreferences(patch).catch(() => {
+      // A failed migration write must not block unrelated startup hydration.
+    });
   }
   return { ...cfg, ...patch };
 }

--- a/src/browser/hooks/useModelsFromSettings.test.ts
+++ b/src/browser/hooks/useModelsFromSettings.test.ts
@@ -11,12 +11,14 @@ import {
   getSuggestedModels,
   useModelsFromSettings,
 } from "./useModelsFromSettings";
-import { KNOWN_MODELS } from "@/common/constants/knownModels";
+import { DEFAULT_HIDDEN_MODELS, KNOWN_MODELS } from "@/common/constants/knownModels";
 import type {
   ProviderConfigInfo,
   ProviderModelEntry,
   ProvidersConfigMap,
 } from "@/common/orpc/types";
+import { updatePersistedState } from "./usePersistedState";
+import { shouldShowModelInSettings } from "@/browser/features/Settings/Sections/ModelsSection";
 import { DEFAULT_MODEL_KEY, HIDDEN_MODELS_KEY } from "@/common/constants/storage";
 
 function countOccurrences(haystack: string[], needle: string): number {
@@ -749,7 +751,7 @@ describe("useModelsFromSettings provider availability gating", () => {
 
     expect(result.current.models).toContain(KNOWN_MODELS.OPUS.id);
     expect(result.current.models).toContain(KNOWN_MODELS.GPT.id);
-    expect(result.current.hiddenModelsForSelector.length).toBe(0);
+    expect(result.current.hiddenModelsForSelector).toEqual(DEFAULT_HIDDEN_MODELS);
   });
 
   test("gateway-prefixed custom model stays available via canonical route override when gateway is unavailable", () => {
@@ -837,5 +839,46 @@ describe("useModelsFromSettings hidden-model gateway identity", () => {
     await waitFor(() => {
       expect(result.current.models).toContain("coder:openai/claude-opus-4-1");
     });
+  });
+});
+
+describe("Daybreak settings and selector visibility", () => {
+  beforeEach(setupUseModelsHookTest);
+  afterEach(cleanupUseModelsHookTest);
+
+  test.each([
+    ["openai:daybreak-blue-latest", "openai:daybreak-red-latest"],
+    ["openai:daybreak-red-latest", "openai:daybreak-blue-latest"],
+  ])("enables %s independently and preserves visibility across reload", async (first, second) => {
+    providersConfig = { openai: { apiKeySet: true, isEnabled: true, isConfigured: true } };
+    const persist = mock(() => Promise.resolve());
+    apiMock = { config: { updateModelPreferences: persist } };
+    updatePersistedState(DEFAULT_MODEL_KEY, KNOWN_MODELS.GPT.id);
+    let hook = renderHook(() => useModelsFromSettings());
+    for (const id of [first, second]) {
+      expect(
+        getSuggestedModels(providersConfig).filter((m) => shouldShowModelInSettings(m, false))
+      ).toContain(id);
+      expect(hook.result.current.models).not.toContain(id);
+      expect(hook.result.current.hiddenModels).toContain(id);
+    }
+    act(() => hook.result.current.hideModel(KNOWN_MODELS.GPT_PRO.id));
+    act(() => hook.result.current.unhideModel(first));
+    await waitFor(() => expect(hook.result.current.models).toContain(first));
+    expect(hook.result.current.models).not.toContain(second);
+    expect(persist).toHaveBeenLastCalledWith({ hiddenModels: [second, KNOWN_MODELS.GPT_PRO.id] });
+
+    hook.unmount();
+    hook = renderHook(() => useModelsFromSettings());
+    expect(hook.result.current.models).toContain(first);
+    expect(hook.result.current.models).not.toContain(second);
+    expect(hook.result.current.defaultModel).toBe(KNOWN_MODELS.GPT.id);
+    expect(hook.result.current.hiddenModels).toContain(KNOWN_MODELS.GPT_PRO.id);
+
+    act(() => hook.result.current.unhideModel(second));
+    await waitFor(() => expect(hook.result.current.models).toContain(second));
+    act(() => hook.result.current.hideModel(first));
+    await waitFor(() => expect(hook.result.current.models).not.toContain(first));
+    expect(hook.result.current.models).toContain(second);
   });
 });

--- a/src/browser/hooks/useModelsFromSettings.ts
+++ b/src/browser/hooks/useModelsFromSettings.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { readPersistedString, usePersistedState } from "./usePersistedState";
-import { KNOWN_MODELS } from "@/common/constants/knownModels";
+import { DEFAULT_HIDDEN_MODELS, KNOWN_MODELS } from "@/common/constants/knownModels";
 import { isCodexOauthAllowedModel, isCodexOauthRequiredModel } from "@/common/constants/codexOAuth";
 import { WORKSPACE_DEFAULTS } from "@/constants/workspaceDefaults";
 import { useProvidersConfig } from "./useProvidersConfig";
@@ -165,9 +165,13 @@ export function useModelsFromSettings() {
     [persistModelPrefs, setDefaultModel]
   );
 
-  const [hiddenModels, setHiddenModels] = usePersistedState<string[]>(HIDDEN_MODELS_KEY, [], {
-    listener: true,
-  });
+  const [hiddenModels, setHiddenModels] = usePersistedState<string[]>(
+    HIDDEN_MODELS_KEY,
+    DEFAULT_HIDDEN_MODELS,
+    {
+      listener: true,
+    }
+  );
 
   const isConfigured = useCallback(
     (provider: string) =>

--- a/src/common/config/schemas/appConfigOnDisk.ts
+++ b/src/common/config/schemas/appConfigOnDisk.ts
@@ -115,6 +115,9 @@ export const AppConfigMigrationsSchema = z
      */
     execSubagentDefaultsSplit: z.boolean().optional(),
     userPreferencesInitialized: z.boolean().optional(),
+    daybreakModelsHidden: z.boolean().optional(),
+    // Default seeding must not claim legacy local-only hidden preferences.
+    hiddenModelsInitialized: z.boolean().optional(),
     /** One-time seed of DEFAULT_MODEL_FALLBACKS; not re-applied while true. */
     defaultModelFallbacksSeeded: z.boolean().optional(),
     /**

--- a/src/common/constants/knownModels.ts
+++ b/src/common/constants/knownModels.ts
@@ -186,6 +186,16 @@ const MODEL_DEFINITIONS = {
     warm: true,
     tokenizerOverride: "openai/gpt-5",
   },
+  DAYBREAK_BLUE: {
+    provider: "openai",
+    providerModelId: "daybreak-blue-latest",
+    tokenizerOverride: "openai/gpt-5",
+  },
+  DAYBREAK_RED: {
+    provider: "openai",
+    providerModelId: "daybreak-red-latest",
+    tokenizerOverride: "openai/gpt-5",
+  },
   // Gemini 3.1 Pro supersedes Gemini 3 Pro; keep bare aliases pointed at the latest Pro tier.
   GEMINI_31_PRO: {
     provider: "google",
@@ -287,6 +297,8 @@ export function getKnownModel(key: KnownModelKey): KnownModel {
 const DEFAULT_KNOWN_MODEL_KEY: KnownModelKey = "OPUS";
 
 export const DEFAULT_MODEL = KNOWN_MODELS[DEFAULT_KNOWN_MODEL_KEY].id;
+
+export const DEFAULT_HIDDEN_MODELS = [KNOWN_MODELS.DAYBREAK_BLUE.id, KNOWN_MODELS.DAYBREAK_RED.id];
 
 export const DEFAULT_WARM_MODELS = Object.values(KNOWN_MODELS)
   .filter((model) => model.warm)

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -2539,6 +2539,7 @@ export const config = {
       advisorMaxUsesPerTurn: AdvisorMaxUsesPerTurnSchema.optional(),
       advisorMaxOutputTokens: AdvisorMaxOutputTokensSchema.optional(),
       hiddenModels: z.array(z.string()).optional(),
+      hiddenModelsInitialized: z.boolean().optional(),
       coderWorkspaceArchiveBehavior: z.enum(CODER_ARCHIVE_BEHAVIORS),
       worktreeArchiveBehavior: z.enum(WORKTREE_ARCHIVE_BEHAVIORS),
       runtimeEnablement: z.record(z.string(), z.boolean()),

--- a/src/node/acp/configOptions.ts
+++ b/src/node/acp/configOptions.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import type { SessionConfigOption, SessionConfigSelectOption } from "@agentclientprotocol/sdk";
-import { KNOWN_MODELS } from "@/common/constants/knownModels";
+import { DEFAULT_HIDDEN_MODELS, KNOWN_MODELS } from "@/common/constants/knownModels";
 import type { AgentDefinitionFrontmatter } from "@/common/types/agentDefinition";
 import { getThinkingOptionLabel, isThinkingLevel } from "@/common/types/thinking";
 import { enforceThinkingPolicy, getThinkingPolicyForModel } from "@/common/utils/thinking/policy";
@@ -217,11 +217,14 @@ function buildAgentModeSelectOptions(
   return options;
 }
 
-function buildModelSelectOptions(currentModel: string): SessionConfigSelectOption[] {
-  const options: SessionConfigSelectOption[] = Object.values(KNOWN_MODELS).map((model) => ({
-    value: model.id,
-    name: model.id,
-  }));
+function buildModelSelectOptions(
+  currentModel: string,
+  hiddenModels: readonly string[]
+): SessionConfigSelectOption[] {
+  const hidden = new Set(hiddenModels);
+  const options: SessionConfigSelectOption[] = Object.values(KNOWN_MODELS)
+    .filter((model) => !hidden.has(model.id))
+    .map((model) => ({ value: model.id, name: model.id }));
 
   if (!options.some((option) => option.value === currentModel)) {
     options.unshift({ value: currentModel, name: currentModel });
@@ -272,9 +275,10 @@ export async function buildConfigOptions(
 
   const workspace = await getWorkspaceInfoOrThrow(client, workspaceId);
   const overrideAgentId = args?.activeAgentId?.trim();
-  const [exposedAgentModes, availableAgentIds] = await Promise.all([
+  const [exposedAgentModes, availableAgentIds, config] = await Promise.all([
     resolveExposedAgentModes(client, workspaceId),
     resolveAvailableAgentIds(client, workspaceId),
+    client.config.getConfig(),
   ]);
   const currentAgentId = resolveCurrentAgentId(
     typeof overrideAgentId === "string" && overrideAgentId.length > 0
@@ -310,7 +314,10 @@ export async function buildConfigOptions(
       type: "select",
       category: "model",
       currentValue: currentAiSettings.model,
-      options: buildModelSelectOptions(currentAiSettings.model),
+      options: buildModelSelectOptions(
+        currentAiSettings.model,
+        config.hiddenModels ?? DEFAULT_HIDDEN_MODELS
+      ),
     },
     {
       id: THINKING_LEVEL_CONFIG_ID,

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -32,6 +32,46 @@ describe("Config", () => {
     await config.editConfig((cfg) => cfg);
   }
 
+  describe("Daybreak visibility migration", () => {
+    const blue = "openai:daybreak-blue-latest";
+    const red = "openai:daybreak-red-latest";
+    const unrelated = "openrouter:openai/gpt-5";
+
+    it.each([
+      { name: "fresh install", persisted: false, hiddenModels: undefined },
+      { name: "legacy local-only preferences", persisted: true, hiddenModels: undefined },
+      { name: "explicit empty backend preferences", persisted: true, hiddenModels: [] },
+      { name: "existing backend preferences", persisted: true, hiddenModels: [unrelated, blue] },
+    ])("seeds once for $name and preserves later choices", async ({ persisted, hiddenModels }) => {
+      if (persisted) {
+        fs.writeFileSync(
+          path.join(tempDir, "config.json"),
+          JSON.stringify({
+            projects: [],
+            defaultModel: KNOWN_MODELS.GPT.id,
+            hiddenModels,
+          })
+        );
+      }
+      const seeded = config.getClientConfig();
+      expect(seeded.hiddenModels).toEqual([...new Set([...(hiddenModels ?? []), blue, red])]);
+      expect(seeded.hiddenModelsInitialized).toBe(hiddenModels !== undefined);
+      expect(seeded.defaultModel).toBe(persisted ? KNOWN_MODELS.GPT.id : undefined);
+      await flushConfigEdits();
+
+      for (const visible of [[blue], [red], [blue, red], []]) {
+        const hidden = [unrelated, ...[blue, red].filter((id) => !visible.includes(id))];
+        await config.updateModelPreferences({ hiddenModels: hidden });
+        const reloaded = new Config(tempDir).getClientConfig();
+        expect(reloaded.hiddenModels).toEqual(hidden);
+        expect(reloaded.hiddenModelsInitialized).toBe(true);
+        expect(reloaded.defaultModel).toBe(seeded.defaultModel);
+      }
+      await config.updateModelPreferences({ hiddenModels: [] });
+      expect(new Config(tempDir).getClientConfig().hiddenModels).toEqual([]);
+    });
+  });
+
   describe("loadConfigOrDefault corrupt config recovery", () => {
     function configFilePath(): string {
       return path.join(tempDir, "config.json");

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -37,9 +37,22 @@ describe("Config", () => {
     const red = "openai:daybreak-red-latest";
     const unrelated = "openrouter:openai/gpt-5";
 
-    it.each([null, "invalid", {}])(
+    const malformedHiddenModels = [
+      undefined,
+      null,
+      "invalid",
+      {},
+      [null],
+      [""],
+      ["  "],
+      ["invalid"],
+      ["mux-gateway:openai"],
+      [42, false, {}],
+    ].map((hiddenModels) => ({ hiddenModels }));
+
+    it.each(malformedHiddenModels)(
       "keeps legacy fallback for malformed hides: %j",
-      async (hiddenModels) => {
+      async ({ hiddenModels }) => {
         fs.writeFileSync(
           path.join(tempDir, "config.json"),
           JSON.stringify({ projects: [], hiddenModels })
@@ -51,9 +64,9 @@ describe("Config", () => {
       }
     );
 
-    it.each([undefined, null, "invalid", {}])(
+    it.each(malformedHiddenModels)(
       "reopens preference recovery for malformed hides after migration: %j",
-      async (hiddenModels) => {
+      async ({ hiddenModels }) => {
         fs.writeFileSync(
           path.join(tempDir, "config.json"),
           JSON.stringify({
@@ -73,6 +86,21 @@ describe("Config", () => {
         expect(recovered.hiddenModelsInitialized).toBe(true);
       }
     );
+
+    it("preserves valid hides when discarding malformed entries", async () => {
+      fs.writeFileSync(
+        path.join(tempDir, "config.json"),
+        JSON.stringify({
+          projects: [],
+          hiddenModels: [null, unrelated, ""],
+          migrations: { daybreakModelsHidden: true, hiddenModelsInitialized: true },
+        })
+      );
+      await flushConfigEdits();
+      const reloaded = new Config(tempDir).getClientConfig();
+      expect(reloaded.hiddenModels).toEqual([unrelated]);
+      expect(reloaded.hiddenModelsInitialized).toBe(true);
+    });
 
     it.each([
       { name: "fresh install", persisted: false, hiddenModels: undefined },

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -51,6 +51,29 @@ describe("Config", () => {
       }
     );
 
+    it.each([undefined, null, "invalid", {}])(
+      "reopens preference recovery for malformed hides after migration: %j",
+      async (hiddenModels) => {
+        fs.writeFileSync(
+          path.join(tempDir, "config.json"),
+          JSON.stringify({
+            projects: [],
+            hiddenModels,
+            migrations: { daybreakModelsHidden: true, hiddenModelsInitialized: true },
+          })
+        );
+        await flushConfigEdits();
+        const reloaded = new Config(tempDir).getClientConfig();
+        expect(reloaded.hiddenModels).toBeUndefined();
+        expect(reloaded.hiddenModelsInitialized).toBe(false);
+
+        await config.updateModelPreferences({ hiddenModels: [] });
+        const recovered = new Config(tempDir).getClientConfig();
+        expect(recovered.hiddenModels).toEqual([]);
+        expect(recovered.hiddenModelsInitialized).toBe(true);
+      }
+    );
+
     it.each([
       { name: "fresh install", persisted: false, hiddenModels: undefined },
       { name: "legacy local-only preferences", persisted: true, hiddenModels: undefined },

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -37,6 +37,20 @@ describe("Config", () => {
     const red = "openai:daybreak-red-latest";
     const unrelated = "openrouter:openai/gpt-5";
 
+    it.each([null, "invalid", {}])(
+      "keeps legacy fallback for malformed hides: %j",
+      async (hiddenModels) => {
+        fs.writeFileSync(
+          path.join(tempDir, "config.json"),
+          JSON.stringify({ projects: [], hiddenModels })
+        );
+        await flushConfigEdits();
+        const reloaded = new Config(tempDir).getClientConfig();
+        expect(reloaded.hiddenModels).toEqual([blue, red]);
+        expect(reloaded.hiddenModelsInitialized).toBe(false);
+      }
+    );
+
     it.each([
       { name: "fresh install", persisted: false, hiddenModels: undefined },
       { name: "legacy local-only preferences", persisted: true, hiddenModels: undefined },

--- a/src/node/config/index.ts
+++ b/src/node/config/index.ts
@@ -54,6 +54,7 @@ import { DEFAULT_RUNTIME_CONFIG } from "@/common/constants/workspace";
 import { isIncompatibleRuntimeConfig } from "@/common/utils/runtimeCompatibility";
 import { LEGACY_MUX_PRODUCT_NAME, LEGACY_MUX_PRODUCT_SLUG } from "@/common/compat/legacyMux";
 import { XUM_PRODUCT_NAME, XUM_PRODUCT_SLUG } from "@/common/constants/product";
+import { DEFAULT_HIDDEN_MODELS } from "@/common/constants/knownModels";
 import { GATEWAY_PROVIDERS } from "@/common/constants/providers";
 import {
   DEFAULT_CODER_ARCHIVE_BEHAVIOR,
@@ -1689,6 +1690,24 @@ export class Config {
           parsed.advisorMaxOutputTokens === null
             ? null
             : parseOptionalPositiveInteger(parsed.advisorMaxOutputTokens);
+        const hiddenMigrations = normalizeConfigMigrations(parsed.migrations);
+        if (hiddenMigrations.daybreakModelsHidden !== true) {
+          // Seed once, without losing unrelated hides or re-hiding models users later enable.
+          parsed.migrations = {
+            ...hiddenMigrations,
+            daybreakModelsHidden: true,
+            hiddenModelsInitialized:
+              hiddenMigrations.hiddenModelsInitialized === true ||
+              parsed.hiddenModels !== undefined,
+          };
+          parsed.hiddenModels = [
+            ...new Set([
+              ...(normalizeOptionalModelStringArray(parsed.hiddenModels) ?? []),
+              ...DEFAULT_HIDDEN_MODELS,
+            ]),
+          ];
+          configModified = true;
+        }
         const hiddenModels = normalizeOptionalModelStringArray(parsed.hiddenModels);
         // Legacy root subagentAiDefaults (written by older builds and by the
         // save-time downgrade projection) folds into the canonical nested
@@ -1853,7 +1872,9 @@ export class Config {
       // migration flag rides along so the first save locks in seed-once
       // semantics (later loads never re-apply the defaults).
       modelFallbacks: { ...LEGACY_DEFAULT_MODEL_FALLBACKS, ...DEFAULT_MODEL_FALLBACKS },
+      hiddenModels: [...DEFAULT_HIDDEN_MODELS],
       migrations: {
+        daybreakModelsHidden: true,
         defaultModelFallbacksSeeded: true,
         defaultModelFallbacksSeededFable51: true,
         persistentSubagentsDefaulted: true,
@@ -2317,6 +2338,7 @@ export class Config {
       advisorMaxUsesPerTurn: config.advisorMaxUsesPerTurn,
       advisorMaxOutputTokens: config.advisorMaxOutputTokens,
       hiddenModels: config.hiddenModels,
+      hiddenModelsInitialized: config.migrations?.hiddenModelsInitialized === true,
       coderWorkspaceArchiveBehavior:
         config.coderWorkspaceArchiveBehavior ?? DEFAULT_CODER_ARCHIVE_BEHAVIOR,
       worktreeArchiveBehavior: config.worktreeArchiveBehavior ?? DEFAULT_WORKTREE_ARCHIVE_BEHAVIOR,
@@ -2464,6 +2486,7 @@ export class Config {
       }
       if (input.hiddenModels !== undefined) {
         next.hiddenModels = normalizeOptionalModelStringArray(input.hiddenModels) ?? [];
+        next.migrations = { ...next.migrations, hiddenModelsInitialized: true };
       }
       return next;
     });

--- a/src/node/config/index.ts
+++ b/src/node/config/index.ts
@@ -517,7 +517,7 @@ function normalizeOptionalModelStringArray(value: unknown): string[] | undefined
     out.push(normalized);
   }
 
-  return out;
+  return value.length > 0 && out.length === 0 ? undefined : out;
 }
 
 function normalizeAiDefaultsModelStrings<
@@ -1425,16 +1425,10 @@ export class Config {
         }
 
         if (Array.isArray(parsed.hiddenModels)) {
-          const sourceHiddenModels = parsed.hiddenModels.filter(
-            (model): model is string => typeof model === "string"
-          );
-          const normalizedHiddenModels = sourceHiddenModels.map((model) =>
-            normalizeSelectedModel(model.trim())
-          );
-
+          const normalizedHiddenModels = normalizeOptionalModelStringArray(parsed.hiddenModels);
           if (
-            sourceHiddenModels.length !== parsed.hiddenModels.length ||
-            !areStringArraysEqual(sourceHiddenModels, normalizedHiddenModels)
+            normalizedHiddenModels === undefined ||
+            !areStringArraysEqual(parsed.hiddenModels, normalizedHiddenModels)
           ) {
             parsed.hiddenModels = normalizedHiddenModels;
             configModified = true;

--- a/src/node/config/index.ts
+++ b/src/node/config/index.ts
@@ -1691,6 +1691,7 @@ export class Config {
             ? null
             : parseOptionalPositiveInteger(parsed.advisorMaxOutputTokens);
         const hiddenMigrations = normalizeConfigMigrations(parsed.migrations);
+        const existingHiddenModels = normalizeOptionalModelStringArray(parsed.hiddenModels);
         if (hiddenMigrations.daybreakModelsHidden !== true) {
           // Seed once, without losing unrelated hides or re-hiding models users later enable.
           parsed.migrations = {
@@ -1698,13 +1699,10 @@ export class Config {
             daybreakModelsHidden: true,
             hiddenModelsInitialized:
               hiddenMigrations.hiddenModelsInitialized === true ||
-              parsed.hiddenModels !== undefined,
+              existingHiddenModels !== undefined,
           };
           parsed.hiddenModels = [
-            ...new Set([
-              ...(normalizeOptionalModelStringArray(parsed.hiddenModels) ?? []),
-              ...DEFAULT_HIDDEN_MODELS,
-            ]),
+            ...new Set([...(existingHiddenModels ?? []), ...DEFAULT_HIDDEN_MODELS]),
           ];
           configModified = true;
         }

--- a/src/node/config/index.ts
+++ b/src/node/config/index.ts
@@ -1692,6 +1692,14 @@ export class Config {
             : parseOptionalPositiveInteger(parsed.advisorMaxOutputTokens);
         const hiddenMigrations = normalizeConfigMigrations(parsed.migrations);
         const existingHiddenModels = normalizeOptionalModelStringArray(parsed.hiddenModels);
+        if (
+          existingHiddenModels === undefined &&
+          hiddenMigrations.hiddenModelsInitialized === true
+        ) {
+          hiddenMigrations.hiddenModelsInitialized = false;
+          parsed.migrations = hiddenMigrations;
+          configModified = true;
+        }
         if (hiddenMigrations.daybreakModelsHidden !== true) {
           // Seed once, without losing unrelated hides or re-hiding models users later enable.
           parsed.migrations = {

--- a/src/node/services/agentSkills/builtInSkillContent.generated.ts
+++ b/src/node/services/agentSkills/builtInSkillContent.generated.ts
@@ -3902,6 +3902,8 @@ export const BUILTIN_SKILL_FILES: Record<string, Record<string, string>> = {
       "| Spark 5.3              | openai:gpt-5.3-codex-spark    | `spark`                                                      |         |",
       "| Codex Mini 5.1         | openai:gpt-5.1-codex-mini     | `codex-mini`                                                 |         |",
       "| Codex Max 5.1          | openai:gpt-5.1-codex-max      | `codex-max`                                                  |         |",
+      "| Daybreak Blue Latest   | openai:daybreak-blue-latest   | —                                                            |         |",
+      "| Daybreak Red Latest    | openai:daybreak-red-latest    | —                                                            |         |",
       "| Gemini 3.1 Pro Preview | google:gemini-3.1-pro-preview | `gemini`, `gemini-pro`                                       |         |",
       "| Gemini 3.8 Flash       | google:gemini-3.8-flash       | `gemini-flash`                                               |         |",
       "| Grok 4.6               | xai:grok-4.6                  | `grok`, `grok-4.6`                                           |         |",

--- a/src/node/services/providerService.test.ts
+++ b/src/node/services/providerService.test.ts
@@ -7,6 +7,7 @@ import { writeFile } from "node:fs/promises";
 import * as os from "os";
 import * as path from "path";
 import { CUSTOM_PROVIDER_TYPES } from "@/common/utils/providers/customProviders";
+import { DEFAULT_HIDDEN_MODELS } from "@/common/constants/knownModels";
 import type { ProviderModelEntry } from "@/common/orpc/types";
 import { WORKSPACE_DEFAULTS } from "@/constants/workspaceDefaults";
 import { Config } from "@/node/config";
@@ -1581,7 +1582,11 @@ describe("ProviderService custom provider mutations", () => {
 
       const appConfig = freshConfig.loadConfigOrDefault();
       expect(appConfig.defaultModel).toBeUndefined();
-      expect(appConfig.hiddenModels).toEqual(["openai:gpt-5", "other-custom:model"]);
+      expect(appConfig.hiddenModels).toEqual([
+        "openai:gpt-5",
+        "other-custom:model",
+        ...DEFAULT_HIDDEN_MODELS,
+      ]);
       expect(appConfig.routeOverrides).toEqual({
         "openai:gpt-4": "openai",
         "other-custom:model": "other-custom",

--- a/tests/ipc/acp.configOptions.test.ts
+++ b/tests/ipc/acp.configOptions.test.ts
@@ -1,4 +1,5 @@
 import type { SessionConfigOption, SessionConfigSelectOption } from "@agentclientprotocol/sdk";
+import { DEFAULT_HIDDEN_MODELS, KNOWN_MODELS } from "../../src/common/constants/knownModels";
 import {
   AGENT_MODE_CONFIG_ID,
   buildConfigOptions,
@@ -53,6 +54,7 @@ function createHarness(
   initial: WorkspaceState,
   options?: {
     agents?: AgentDescriptor[];
+    hiddenModels?: string[];
   }
 ): {
   client: ORPCClient;
@@ -88,6 +90,7 @@ function createHarness(
   const availableAgents = options?.agents ?? DEFAULT_AGENT_DESCRIPTORS;
 
   const client = {
+    config: { getConfig: async () => ({ hiddenModels: options?.hiddenModels }) },
     workspace: {
       getInfo: async (): Promise<WorkspaceInfo> => ({
         id: "ws-1",
@@ -171,6 +174,51 @@ function flattenSelectOptions(
 }
 
 describe("ACP config options", () => {
+  it.each([
+    { hiddenModels: undefined, current: KNOWN_MODELS.GPT.id, blue: false, red: false },
+    {
+      hiddenModels: [...DEFAULT_HIDDEN_MODELS],
+      current: KNOWN_MODELS.GPT.id,
+      blue: false,
+      red: false,
+    },
+    { hiddenModels: [], current: KNOWN_MODELS.GPT.id, blue: true, red: true },
+    {
+      hiddenModels: [KNOWN_MODELS.DAYBREAK_BLUE.id],
+      current: KNOWN_MODELS.GPT.id,
+      blue: false,
+      red: true,
+    },
+    {
+      hiddenModels: [KNOWN_MODELS.DAYBREAK_RED.id],
+      current: KNOWN_MODELS.GPT.id,
+      blue: true,
+      red: false,
+    },
+    {
+      hiddenModels: [...DEFAULT_HIDDEN_MODELS],
+      current: KNOWN_MODELS.DAYBREAK_BLUE.id,
+      blue: true,
+      red: false,
+    },
+  ])("respects model visibility while retaining the current selection: %j", async (scenario) => {
+    const harness = createHarness(
+      {
+        agentId: "exec",
+        aiSettings: { model: scenario.current, thinkingLevel: "high" },
+        aiSettingsByAgent: {},
+      },
+      { hiddenModels: scenario.hiddenModels }
+    );
+    const option = getSelectConfigOption(await buildConfigOptions(harness.client, "ws-1"), "model");
+    const values = flattenSelectOptions(option).map((entry) => entry.value);
+    expect(values.includes(KNOWN_MODELS.DAYBREAK_BLUE.id)).toBe(scenario.blue);
+    expect(values.includes(KNOWN_MODELS.DAYBREAK_RED.id)).toBe(scenario.red);
+    expect(values).toContain(scenario.current);
+    expect(new Set(values).size).toBe(values.length);
+    expect(option.currentValue).toBe(scenario.current);
+  });
+
   it("includes agent mode descriptions and model-aware thinking labels for Opus 4.6", async () => {
     const harness = createHarness({
       agentId: "exec",

--- a/tests/ipc/config/modelPreferences.test.ts
+++ b/tests/ipc/config/modelPreferences.test.ts
@@ -14,6 +14,20 @@ describe("config.updateModelPreferences", () => {
     }
   });
 
+  it("defaults Daybreak models to hidden and keeps independent choices across config reads", async () => {
+    const blue = "openai:daybreak-blue-latest";
+    const red = "openai:daybreak-red-latest";
+    expect((await env.orpc.config.getConfig()).hiddenModels).toEqual([blue, red]);
+
+    for (const hiddenModels of [[red], [blue], [], [blue, red]]) {
+      await env.orpc.config.updateModelPreferences({ hiddenModels });
+      const cfg = await env.orpc.config.getConfig();
+      expect(cfg.hiddenModels).toEqual(hiddenModels);
+      expect(cfg.hiddenModelsInitialized).toBe(true);
+      expect(env.config.loadConfigOrDefault().hiddenModels).toEqual(hiddenModels);
+    }
+  });
+
   it("persists model preferences", async () => {
     await env.orpc.config.updateModelPreferences({
       defaultModel: "openai:gpt-4o",


### PR DESCRIPTION
## Summary

Add `openai:daybreak-blue-latest` and `openai:daybreak-red-latest` to the known models, hidden by default and available to enable independently in Settings.

Seed visibility once so later enable/disable choices survive reloads. Preserve existing defaults, legacy local-only preferences, and same-tab or cross-tab changes made while startup config is loading. Persist migrations without delaying settings hydration. ACP model options honor the same visibility preferences while retaining the current selection. Update the model reference and generated built-in docs.

## Validation

- `make static-check` passed.
- Focused suites passed: known models, backend config, model settings hook, local preference migration, and WorkspaceContext.
- 114 non-live ACP and model-preference IPC tests passed, covering visibility choices, current-selection retention, and persistence.
- Red-green regression coverage covers failed or stalled migration writes, malformed persisted visibility, and edits made before startup config resolves. Tests also verify cross-tab writes before their storage events arrive, toggling back to the original value, per-field migration, and backend authority after reconnect.
- Live ACP API tests were blocked by the missing `ANTHROPIC_API_KEY`. Remote UAT was not run: no agent-enabled Coder template for `coder/xum` was available.

## Risk

The startup migration changes preference synchronization. It preserves edits made during the current client's startup and keeps unrelated settings hydration independent of persistence. Separate clients still use the existing last-write-wins preference API.

