### PR TITLE
🤖 refactor: centralize turn preparation and queue admission

### DIFF
--- a/src/node/services/agentSession.preStreamError.test.ts
+++ b/src/node/services/agentSession.preStreamError.test.ts
@@ -296,7 +296,11 @@ describe("AgentSession pre-stream errors", () => {
       coordinator: TurnCoordinator;
     };
 
-    privateSession.coordinator.prepare();
+    privateSession.coordinator.prepare({
+      kind: "fresh",
+      intent: "handoff",
+      expectedTurnId: privateSession.coordinator.turnId,
+    });
     aiEmitter.emit("runtime-status", {
       type: "runtime-status",
       workspaceId,

--- a/src/node/services/agentSession.preparationAdmission.test.ts
+++ b/src/node/services/agentSession.preparationAdmission.test.ts
@@ -1,0 +1,531 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { createMuxMessage } from "@/common/types/message";
+import { Err, Ok } from "@/common/types/result";
+import type { WorkspaceGoalService } from "./workspaceGoalService";
+import type { CompactionMonitor } from "./compactionMonitor";
+import type { PreparationAdmission, TurnCoordinator } from "./turnCoordinator";
+import {
+  createAgentSessionHarness,
+  createStartedTurnHandle,
+  createFailedTurnHandle,
+  type AgentSessionHarness,
+} from "./agentSession.testHarness";
+
+const options = { model: "anthropic:claude-sonnet-4-5", agentId: "exec" };
+const harnesses: AgentSessionHarness[] = [];
+async function harness(workspaceId: string) {
+  const h = await createAgentSessionHarness({ workspaceId });
+  harnesses.push(h);
+  return h;
+}
+afterEach(async () => {
+  for (const h of harnesses.splice(0)) {
+    h.session.dispose();
+    await h.cleanup();
+  }
+});
+
+// Only lifecycle reservations are inspected directly; persistence and provider starts cross
+// the same interfaces as production, with deterministic gates instead of timing windows.
+function coordinator(h: AgentSessionHarness): TurnCoordinator {
+  return (h.session as unknown as { coordinator: TurnCoordinator }).coordinator;
+}
+
+describe("preparation admission", () => {
+  test("PREPARING publishes the captured queue correlation and nested drains cannot pop its successor", async () => {
+    const h = await harness("queue-publication-owner");
+    const started = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const metadata = {
+      type: "workspace-turn-task" as const,
+      taskHandleId: "task",
+      ownerWorkspaceId: "parent",
+      turnId: "turn",
+    };
+    const stream = spyOn(h.aiService, "streamMessage").mockImplementation(async () => {
+      started.resolve();
+      await release.promise;
+      return Ok(createStartedTurnHandle());
+    });
+    h.session.queueMessage("head", { ...options, muxMetadata: metadata }, { synthetic: true });
+    h.session.queueMessage("tail", options);
+    let observed = false;
+    h.session.onChatEvent(({ message }) => {
+      if (message.type !== "stream-lifecycle" || message.phase !== "preparing" || observed) return;
+      observed = true;
+      expect(h.session.getQueueCutCutter()).toMatchObject({
+        stage: "preparing",
+        muxMetadata: metadata,
+      });
+      expect(h.session.queuedMessageEntryCount()).toBe(2);
+      h.session.sendQueuedMessages();
+      expect(h.session.queuedMessageEntryCount()).toBe(2);
+    });
+    try {
+      h.session.sendQueuedMessages();
+      await started.promise;
+      expect(observed).toBe(true);
+      expect(stream).toHaveBeenCalledTimes(1);
+      expect(h.session.queuedMessageEntryCount()).toBe(1);
+    } finally {
+      release.resolve();
+      await h.session.waitForIdle();
+    }
+  });
+
+  test("removing the head during PREPARING neither dispatches it nor double-cancels it", async () => {
+    const h = await harness("queue-publication-head-removed");
+    const canceled = mock(() => undefined);
+    const started = Promise.withResolvers<void>();
+    const stream = spyOn(h.aiService, "streamMessage").mockImplementation(() => {
+      started.resolve();
+      return Promise.resolve(Ok(createStartedTurnHandle()));
+    });
+    h.session.queueMessage("removed", options, { synthetic: true, onCanceled: canceled });
+    let removed = false;
+    h.session.onChatEvent(({ message }) => {
+      if (message.type !== "stream-lifecycle" || message.phase !== "preparing" || removed) return;
+      removed = true;
+      h.session.clearQueue();
+      h.session.queueMessage("replacement", options);
+    });
+    h.session.sendQueuedMessages();
+    await started.promise;
+    await h.session.waitForIdle();
+    expect(canceled).toHaveBeenCalledTimes(1);
+    expect(stream).toHaveBeenCalledTimes(1);
+    const history = await h.historyService.getHistoryFromLatestBoundary(
+      "queue-publication-head-removed"
+    );
+    expect(history).toMatchObject(
+      Ok([{ role: "user", parts: [{ type: "text", text: "replacement" }] }])
+    );
+  });
+
+  test.each(["direct", "queued"] as const)(
+    "%s claim retired during publication never releases service preflight or starts a provider",
+    async (source) => {
+      const h = await harness(`publication-shutdown-${source}`);
+      const handedOff = mock(() => undefined);
+      const failed = Promise.withResolvers<void>();
+      const onFailure = mock(() => failed.resolve());
+      const stream = spyOn(h.aiService, "streamMessage");
+      h.session.onChatEvent(({ message }) => {
+        if (message.type === "stream-lifecycle" && message.phase === "preparing")
+          coordinator(h).beginShutdown();
+      });
+      if (source === "direct") {
+        const result = await h.session.sendMessage("accepted", options, {
+          onTurnAdmissionCommitted: handedOff,
+          onAcceptedPreStreamFailure: onFailure,
+        });
+        expect(result.success).toBe(false);
+        await failed.promise;
+        expect(onFailure).toHaveBeenCalledTimes(1);
+      } else {
+        h.session.queueMessage("still queued", options, { onAcceptedPreStreamFailure: onFailure });
+        h.session.sendQueuedMessages();
+        await h.session.waitForIdle();
+        expect(h.session.queuedMessageEntryCount()).toBe(1);
+        expect(onFailure).not.toHaveBeenCalled();
+      }
+      expect(handedOff).not.toHaveBeenCalled();
+      expect(stream).not.toHaveBeenCalled();
+    }
+  );
+
+  test.each(["busy", "admission", "shutdown"] as const)(
+    "resume rechecks %s after pricing without overwriting the latest retry request",
+    async (blocker) => {
+      const h = await harness(`resume-recheck-${blocker}`);
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      Reflect.set(h.session, "workspaceGoalService", {
+        assertPricedModelForBudgetedGoal: async () => {
+          entered.resolve();
+          await release.promise;
+          return Ok(undefined);
+        },
+      } satisfies Partial<WorkspaceGoalService>);
+      const sentinel = { options: { ...options, model: "openai:gpt-4o" } };
+      Reflect.set(h.session, "lastAutoRetryResumeRequest", sentinel);
+      const stream = spyOn(h.aiService, "streamMessage");
+      const resume = h.session.resumeStream(options);
+      await entered.promise;
+      let reservation: Disposable | undefined;
+      if (blocker === "busy") {
+        expect(
+          coordinator(h).prepare({
+            kind: "fresh",
+            intent: "direct",
+            expectedTurnId: coordinator(h).turnId,
+          }).status
+        ).toBe("admitted");
+      } else if (blocker === "admission") reservation = coordinator(h).reserve("admission");
+      else coordinator(h).beginShutdown();
+      release.resolve();
+      expect(await resume).toEqual(Ok({ started: false }));
+      expect(Reflect.get(h.session, "lastAutoRetryResumeRequest")).toBe(sentinel);
+      expect(stream).not.toHaveBeenCalled();
+      reservation?.[Symbol.dispose]();
+    }
+  );
+
+  test.each(["return", "throw"] as const)(
+    "queued %s failure retries a throwing cleanup before idle and drains the successor",
+    async (failure) => {
+      const h = await harness(`cleanup-retry-${failure}`);
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const started = Promise.withResolvers<void>();
+      const append = spyOn(h.historyService, "appendToHistory");
+      if (failure === "return") append.mockResolvedValueOnce(Err("disk failure"));
+      else append.mockRejectedValueOnce(new Error("disk failure"));
+      let cleanups = 0;
+      const stream = spyOn(h.aiService, "streamMessage").mockImplementation(() => {
+        expect(cleanups).toBe(2);
+        started.resolve();
+        return Promise.resolve(Ok(createStartedTurnHandle()));
+      });
+      h.session.queueMessage("failed", options, {
+        synthetic: true,
+        onAcceptedPreStreamFailure: async () => {
+          if (++cleanups === 1) throw new Error("cleanup transient");
+          entered.resolve();
+          await release.promise;
+        },
+      });
+      h.session.queueMessage("survivor", options);
+      h.session.sendQueuedMessages();
+      await entered.promise;
+      expect(h.session.isBusy()).toBe(true);
+      expect(stream).not.toHaveBeenCalled();
+      release.resolve();
+      await started.promise;
+      await h.session.waitForIdle();
+      expect(stream).toHaveBeenCalledTimes(1);
+      expect(
+        await h.historyService.getHistoryFromLatestBoundary(`cleanup-retry-${failure}`)
+      ).toMatchObject(Ok([{ parts: [{ type: "text", text: "survivor" }] }]));
+    }
+  );
+
+  test("an invalid non-PDF attachment cannot truncate an edit's existing history", async () => {
+    const h = await harness("invalid-edit-attachment");
+    const original = createMuxMessage("original", "user", "keep me");
+    const reply = createMuxMessage("reply", "assistant", "keep this too");
+    await h.historyService.appendToHistory("invalid-edit-attachment", original);
+    await h.historyService.appendToHistory("invalid-edit-attachment", reply);
+    const before = await h.historyService.getHistoryFromLatestBoundary("invalid-edit-attachment");
+    const truncate = spyOn(h.historyService, "truncateAfterMessage");
+    const rejected = await h.session
+      .sendMessage("edit", {
+        ...options,
+        editMessageId: "original",
+        fileParts: [{ url: "https://invalid.example/file", mediaType: "image/png" }],
+      })
+      .catch((error: unknown) => error);
+    expect(rejected).toBeInstanceOf(Error);
+    if (!(rejected instanceof Error)) throw new Error("Expected invalid attachment rejection");
+    expect(rejected.message).toContain("data URL");
+    expect(truncate).not.toHaveBeenCalled();
+    expect(await h.historyService.getHistoryFromLatestBoundary("invalid-edit-attachment")).toEqual(
+      before
+    );
+  });
+  test.each(["transient", "persistent"] as const)(
+    "%s failure cleanup cannot suppress original provider failure policy",
+    async (failure) => {
+      const h = await harness(`provider-cleanup-${failure}`);
+      const providerError = { type: "api_key_not_found" as const, provider: "anthropic" as const };
+      const stream = spyOn(h.aiService, "streamMessage").mockResolvedValue(Err(providerError));
+      const terminalErrors: unknown[] = [];
+      h.session.onChatEvent(({ message }) => {
+        if (message.type === "stream-error") terminalErrors.push(message);
+      });
+      let callbacks = 0;
+      const result = await h.session.sendMessage("durable input", options, {
+        onAcceptedPreStreamFailure: (error) => {
+          expect(error).toEqual(providerError);
+          expect(h.session.isBusy()).toBe(true);
+          if (++callbacks === 1 || failure === "persistent") throw new Error("cleanup unavailable");
+        },
+      });
+      expect(result).toMatchObject(Err(providerError));
+      expect(callbacks).toBe(2);
+      expect(terminalErrors).toHaveLength(1);
+      expect(terminalErrors[0]).toMatchObject({ errorType: "authentication" });
+      expect(stream).toHaveBeenCalledTimes(1);
+      expect(h.session.isBusy()).toBe(false);
+      expect(
+        await h.historyService.getHistoryFromLatestBoundary(`provider-cleanup-${failure}`)
+      ).toMatchObject(Ok([{ parts: [{ type: "text", text: "durable input" }] }]));
+    }
+  );
+
+  test("a superseded direct append rolls back only its own row and preserves replacement thinking and retry state", async () => {
+    const h = await harness("superseded-direct-state");
+    const appended = Promise.withResolvers<void>();
+    const releaseAppend = Promise.withResolvers<void>();
+    const provider = Promise.withResolvers<void>();
+    const releaseProvider = Promise.withResolvers<void>();
+    const append = h.historyService.appendToHistory.bind(h.historyService);
+    spyOn(h.historyService, "appendToHistory").mockImplementationOnce(async (...args) => {
+      const result = await append(...args);
+      appended.resolve();
+      await releaseAppend.promise;
+      return result;
+    });
+    const stream = spyOn(h.aiService, "streamMessage").mockImplementation(async () => {
+      provider.resolve();
+      await releaseProvider.promise;
+      return Ok(createStartedTurnHandle());
+    });
+    const oldSend = h.session.sendMessage("old", options);
+    await appended.promise;
+    const replacement = h.session.sendMessage("replacement", {
+      ...options,
+      model: "openai:gpt-4o",
+    });
+    await provider.promise;
+    const owner = coordinator(h).turnId;
+    const holder = coordinator(h).thinkingOverride;
+    const retry: unknown = Reflect.get(h.session, "lastAutoRetryResumeRequest");
+    try {
+      releaseAppend.resolve();
+      expect((await oldSend).success).toBe(false);
+      expect(coordinator(h).turnId).toBe(owner);
+      expect(coordinator(h).thinkingOverride).toBe(holder);
+      expect(Reflect.get(h.session, "lastAutoRetryResumeRequest")).toBe(retry);
+      expect(h.session.setActiveTurnThinkingLevel("high")).toEqual({ accepted: true });
+      expect(holder?.pending).toBe("high");
+      expect(stream).toHaveBeenCalledTimes(1);
+      expect(
+        await h.historyService.getHistoryFromLatestBoundary("superseded-direct-state")
+      ).toMatchObject(Ok([{ parts: [{ type: "text", text: "replacement" }] }]));
+    } finally {
+      releaseAppend.resolve();
+      releaseProvider.resolve();
+      await replacement;
+    }
+  });
+
+  test("a stale on-send compaction append is rolled back before its request can be replayed", async () => {
+    const h = await harness("stale-compaction-append");
+    const monitor = (h.session as unknown as { compactionMonitor: CompactionMonitor })
+      .compactionMonitor;
+    spyOn(monitor, "getThreshold").mockReturnValue(0.85);
+    spyOn(monitor, "checkBeforeSend").mockReturnValue({
+      shouldShowWarning: true,
+      shouldForceCompact: true,
+      usagePercentage: 99,
+      thresholdPercentage: 85,
+    });
+    let stale = false;
+    const append = h.historyService.appendToHistory.bind(h.historyService);
+    spyOn(h.historyService, "appendToHistory").mockImplementationOnce(async (...args) => {
+      const result = await append(...args);
+      stale = true;
+      return result;
+    });
+    const stream = spyOn(h.aiService, "streamMessage");
+    const result = await h.session.sendMessage("deferred question", options, {
+      admissionStale: () => stale,
+    });
+    expect(result.success).toBe(false);
+    expect(await h.historyService.getHistoryFromLatestBoundary("stale-compaction-append")).toEqual(
+      Ok([])
+    );
+    expect(stream).not.toHaveBeenCalled();
+  });
+  test("a superseded marker cleanup cannot cancel or enable the replacement's retry", async () => {
+    const h = await harness("superseded-marker-clear");
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const provider = Promise.withResolvers<void>();
+    const releaseProvider = Promise.withResolvers<void>();
+    const session = h.session as unknown as {
+      clearStartupAutoRetryAbandon(): Promise<void>;
+      retryManager: { cancel(): void; setEnabled(enabled: boolean): void };
+    };
+    spyOn(session, "clearStartupAutoRetryAbandon").mockImplementationOnce(async () => {
+      entered.resolve();
+      await release.promise;
+    });
+    spyOn(h.aiService, "streamMessage").mockImplementation(async () => {
+      provider.resolve();
+      await releaseProvider.promise;
+      return Ok(createStartedTurnHandle());
+    });
+    const cancel = spyOn(session.retryManager, "cancel");
+    const enable = spyOn(session.retryManager, "setEnabled");
+    const oldSend = h.session.sendMessage("old durable row", options);
+    await entered.promise;
+    const replacement = h.session.sendMessage("replacement", options);
+    await provider.promise;
+    await h.session.setAutoRetryEnabled(false);
+    const canceled = cancel.mock.calls.length;
+    const enabled = enable.mock.calls.length;
+    const retry: unknown = Reflect.get(h.session, "lastAutoRetryResumeRequest");
+    try {
+      release.resolve();
+      expect((await oldSend).success).toBe(false);
+      expect(cancel.mock.calls).toHaveLength(canceled);
+      expect(enable.mock.calls).toHaveLength(enabled);
+      expect(Reflect.get(h.session, "lastAutoRetryResumeRequest")).toBe(retry);
+      expect(Reflect.get(h.session, "autoRetryEnabledPreference")).toBe(false);
+      const history =
+        await h.historyService.getHistoryFromLatestBoundary("superseded-marker-clear");
+      expect(history).toMatchObject(
+        Ok([
+          { parts: [{ type: "text", text: "old durable row" }] },
+          { parts: [{ type: "text", text: "replacement" }] },
+        ])
+      );
+    } finally {
+      release.resolve();
+      releaseProvider.resolve();
+      await replacement;
+    }
+  });
+  test("a held edit owns history before PREPARING and competing direct sends cannot write or start", async () => {
+    const h = await harness("held-edit-admission");
+    await h.historyService.appendToHistory(
+      "held-edit-admission",
+      createMuxMessage("original", "user", "before")
+    );
+    await h.historyService.appendToHistory(
+      "held-edit-admission",
+      createMuxMessage("reply", "assistant", "old reply")
+    );
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const started = Promise.withResolvers<void>();
+    const truncate = h.historyService.truncateAfterMessage.bind(h.historyService);
+    spyOn(h.historyService, "truncateAfterMessage").mockImplementationOnce(async (...args) => {
+      entered.resolve();
+      await release.promise;
+      return truncate(...args);
+    });
+    const stream = spyOn(h.aiService, "streamMessage").mockImplementation(() => {
+      started.resolve();
+      return Promise.resolve(Ok(createStartedTurnHandle()));
+    });
+    const edit = h.session.sendMessage("edited", { ...options, editMessageId: "original" });
+    await entered.promise;
+    try {
+      expect(h.session.isPreparingTurn()).toBe(false);
+      expect(h.session.isBusy()).toBe(true);
+      const before = await h.historyService.getHistoryFromLatestBoundary("held-edit-admission");
+      expect((await h.session.sendMessage("competing direct", options)).success).toBe(false);
+      expect(await h.historyService.getHistoryFromLatestBoundary("held-edit-admission")).toEqual(
+        before
+      );
+      expect(stream).not.toHaveBeenCalled();
+    } finally {
+      release.resolve();
+    }
+    expect((await edit).success).toBe(true);
+    await started.promise;
+    await h.session.waitForIdle();
+    expect(stream).toHaveBeenCalledTimes(1);
+    expect(
+      await h.historyService.getHistoryFromLatestBoundary("held-edit-admission")
+    ).toMatchObject(Ok([{ parts: [{ type: "text", text: "edited" }] }]));
+  });
+  test.each(["publication", "handoff"] as const)(
+    "retired edit %s settles its failure callback before releasing the queue",
+    async (seam) => {
+      const h = await harness("edit-failure-callback-order");
+      await h.historyService.appendToHistory(
+        "edit-failure-callback-order",
+        createMuxMessage("original", "user", "before")
+      );
+      const failure = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const started = Promise.withResolvers<void>();
+      const stream = spyOn(h.aiService, "streamMessage").mockImplementation(() => {
+        started.resolve();
+        return Promise.resolve(Ok(createStartedTurnHandle()));
+      });
+      let retire = true;
+      const retireEdit = () => {
+        if (!retire) return;
+        retire = false;
+        expect(coordinator(h).preemptPreparation()).toBe(true);
+        h.session.queueMessage("successor", options);
+      };
+      h.session.onChatEvent(({ message }) => {
+        if (
+          seam === "publication" &&
+          message.type === "stream-lifecycle" &&
+          message.phase === "preparing"
+        )
+          retireEdit();
+      });
+      const edit = h.session.sendMessage(
+        "edited",
+        { ...options, editMessageId: "original" },
+        {
+          onTurnAdmissionCommitted: seam === "handoff" ? retireEdit : undefined,
+          onAcceptedPreStreamFailure: async () => {
+            failure.resolve();
+            await release.promise;
+          },
+        }
+      );
+      await failure.promise;
+      try {
+        expect(h.session.queuedMessageEntryCount()).toBe(1);
+        expect(stream).not.toHaveBeenCalled();
+        expect(h.session.isBusy()).toBe(true);
+      } finally {
+        release.resolve();
+        expect((await edit).success).toBe(seam === "handoff");
+      }
+      await started.promise;
+      await h.session.waitForIdle();
+      expect(stream).toHaveBeenCalledTimes(1);
+    }
+  );
+  test.each(["before-handle", "delivered-handle"] as const)(
+    "edit %s failure releases its exclusion before recovery can claim a turn",
+    async (stage) => {
+      const h = await harness(`edit-policy-handoff-${stage}`);
+      await h.historyService.appendToHistory(
+        `edit-policy-handoff-${stage}`,
+        createMuxMessage("original", "user", "before")
+      );
+      const handoff = Promise.withResolvers<PreparationAdmission>();
+      spyOn(h.aiService, "streamMessage").mockImplementation(() =>
+        Promise.resolve(
+          stage === "before-handle"
+            ? Err({ type: "api_key_not_found" as const, provider: "anthropic" as const })
+            : Ok(
+                createFailedTurnHandle("edit-failed", {
+                  error: "missing credentials",
+                  errorType: "authentication",
+                })
+              )
+        )
+      );
+      h.session.onChatEvent(({ message }) => {
+        if (message.type !== "stream-error") return;
+        handoff.resolve(
+          coordinator(h).prepare({
+            kind: "fresh",
+            intent: "handoff",
+            expectedTurnId: coordinator(h).turnId,
+          })
+        );
+      });
+      expect(
+        (await h.session.sendMessage("edited", { ...options, editMessageId: "original" })).success
+      ).toBe(true);
+      const admission = await handoff.promise;
+      expect(admission.status).toBe("admitted");
+      if (admission.status === "admitted") coordinator(h).finishPreparation(admission.turnId);
+      await h.session.waitForIdle();
+    }
+  );
+});

--- a/src/node/services/agentSession.startupAutoRetry.test.ts
+++ b/src/node/services/agentSession.startupAutoRetry.test.ts
@@ -520,7 +520,11 @@ describe("AgentSession startup auto-retry recovery", () => {
       startupAutoRetryCheckScheduled: boolean;
     };
 
-    privateSession.coordinator.prepare();
+    privateSession.coordinator.prepare({
+      kind: "fresh",
+      intent: "handoff",
+      expectedTurnId: privateSession.coordinator.turnId,
+    });
     session.ensureStartupAutoRetryCheck();
 
     const firstCheckPromise = privateSession.startupAutoRetryCheckPromise;
@@ -1757,7 +1761,11 @@ describe("AgentSession startup auto-retry recovery", () => {
     };
 
     privateSession.activeStreamUserMessageId = "user-1";
-    privateSession.coordinator.prepare();
+    privateSession.coordinator.prepare({
+      kind: "fresh",
+      intent: "handoff",
+      expectedTurnId: privateSession.coordinator.turnId,
+    });
 
     void runSessionTerminalPolicy(session, aiEmitter, {
       type: "stream-abort",

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -14,6 +14,7 @@ import {
   TurnCoordinator,
   type TurnPhase,
   type TurnId,
+  type QueueDrainTrigger,
   type OperationId,
   type StreamErrorRecoveryOutcome,
 } from "./turnCoordinator";
@@ -666,6 +667,96 @@ interface CachedMemoryContext {
   includesHotMemories: boolean;
 }
 
+interface SendMessageInternalOptions {
+  preparation?: PreparationAttempt;
+  /** A dequeued send keeps its admission owner through acceptance and startup failure. */
+  turnReservation?: TurnId;
+  synthetic?: boolean;
+  agentInitiated?: boolean;
+  goalContinuation?: boolean;
+  goalKind?: GoalSyntheticMessageKind;
+  /** Goal identity persisted alongside goalKind so chat-tail reconciliation can scope the row. */
+  goalId?: string;
+  startStreamInBackground?: boolean;
+  onAccepted?: () => Promise<void> | void;
+  onAcceptedPreStreamFailure?: (error: SendMessageError) => Promise<void> | void;
+  onCanceled?: (reason: string) => Promise<void> | void;
+  cancelState?: { canceledBeforeAcceptance: boolean };
+  cancelSignal?: AbortSignal;
+  /**
+   * For queue-dispatched sends: when the user last added to the queued
+   * entry. Goal safety compares it against the goal's explicit
+   * user-activation consent stamp — a message the user visibly left
+   * pending while activating the goal must not auto-pause it (Codex
+   * security P2 PRRT_kwDOPxxmWM6cSGrq: creation time alone is not
+   * consent).
+   */
+  enqueuedAtMs?: number;
+  /**
+   * Codex P2 (PRRT_kwDOPxxmWM6cSRkH): fired synchronously the moment this
+   * turn claims PREPARING (isBusy() becomes true). WorkspaceService keeps
+   * its session-invisible preflight reservation armed until this fires so
+   * follow-up recovery cannot observe the idle gap between the service
+   * handoff and the busy claim (cancelBeforeAcceptance and the other
+   * admission awaits yield) and admit a synthetic turn ahead of the
+   * accepted manual send. Refusal paths never fire it — the service's
+   * scoped disposal releases the reservation when the call returns.
+   */
+  onTurnAdmissionCommitted?: () => void;
+  /**
+   * Synthetic assistant rows persisted immediately before this turn's user
+   * row (family-message payloads). Persisting them inside turn admission —
+   * instead of a direct history append from the sender — keeps them out of
+   * another turn's PREPARING window, where they could land between that
+   * turn's user row and its assistant response (consecutive assistant
+   * messages a tool-using response makes unmergeable) or silently enter an
+   * in-flight request without their trigger (r30).
+   */
+  preTurnMessages?: MuxMessage[];
+  /**
+   * r54: fired once the pre-turn batch has crossed the rollback horizon —
+   * durably committed AND past the last cancellation/rollback gate. From
+   * that point every failure (goal sync, acceptance, stream start) keeps
+   * the rows in the transcript, so budget-style accounting must treat the
+   * delivery as persisted. Turn ACCEPTANCE is the wrong signal: it can
+   * fail after the rows are already irrevocable.
+   */
+  onPreTurnRowsPersisted?: () => void;
+  /**
+   * r41: staleness probe for this send's admission epoch, captured
+   * synchronously with WorkspaceService's entry checks. Returns true when
+   * a context-discarding mutation COMPLETED after the send entered — the
+   * level-triggered admission block check cannot catch a mutation
+   * that started and finished while the send sat in pre-admission
+   * awaits. Not threaded through queued entries: those dispatch into the
+   * post-mutation context by design.
+   */
+  admissionEpochStale?: () => boolean;
+  /**
+   * Caller-supplied staleness probe that, unlike the epoch probe above, IS threaded
+   * through queued entries (MessageQueue stores it per entry and re-emits it at
+   * dispatch). Peer agent sends use it so a Stop/task_stop landing after dequeue —
+   * where queue clearing can no longer see the entry — still refuses the turn at
+   * these admission gates instead of starting a privileged turn on a stopped target.
+   */
+  admissionStale?: () => boolean;
+}
+
+// Enqueueing creates no preparation attempt. Once dispatched, Promise success alone cannot
+// distinguish cancellation, a background transfer, and delivery to terminal policy.
+interface PreparationAttempt {
+  owner?: TurnId;
+  expectedTurn: TurnId;
+  editReservation?: ReturnType<TurnCoordinator["reserve"]>;
+  outcome: "preparing" | "background" | "delivered" | "canceled";
+  durability: "rollback-eligible" | "durable" | "accepted";
+  queued: boolean;
+  failureNotified: boolean;
+  failureAttempts?: number;
+  failure?: SendMessageError;
+  onFailure?: (error: SendMessageError) => Promise<void> | void;
+}
+
 export class AgentSession {
   private readonly workspaceId: string;
   private readonly config: Config;
@@ -703,7 +794,7 @@ export class AgentSession {
     },
     phaseChanged: (phase, isCurrent) => this.publishTurnPhase(phase, isCurrent),
     drainQueue: () => {
-      if (!this.messageQueue.isEmpty()) this.sendQueuedMessages();
+      if (!this.messageQueue.isEmpty()) this.sendQueuedMessages("idle");
     },
     policy: async (operation, messageId, outcome, started, notifyStartup) => {
       if (!this.coordinator.isCurrentOperation(operation)) return;
@@ -3085,94 +3176,114 @@ export class AgentSession {
   async sendMessage(
     message: string,
     options?: SendMessageOptions & { fileParts?: FilePart[] },
-    internal?: {
-      /** A dequeued send keeps its admission owner through acceptance and startup failure. */
-      turnReservation?: TurnId;
-      synthetic?: boolean;
-      agentInitiated?: boolean;
-      goalContinuation?: boolean;
-      goalKind?: GoalSyntheticMessageKind;
-      /** Goal identity persisted alongside goalKind so chat-tail reconciliation can scope the row. */
-      goalId?: string;
-      startStreamInBackground?: boolean;
-      onAccepted?: () => Promise<void> | void;
-      onAcceptedPreStreamFailure?: (error: SendMessageError) => Promise<void> | void;
-      onCanceled?: (reason: string) => Promise<void> | void;
-      cancelState?: { canceledBeforeAcceptance: boolean };
-      cancelSignal?: AbortSignal;
-      /**
-       * For queue-dispatched sends: when the user last added to the queued
-       * entry. Goal safety compares it against the goal's explicit
-       * user-activation consent stamp — a message the user visibly left
-       * pending while activating the goal must not auto-pause it (Codex
-       * security P2 PRRT_kwDOPxxmWM6cSGrq: creation time alone is not
-       * consent).
-       */
-      enqueuedAtMs?: number;
-      /**
-       * Codex P2 (PRRT_kwDOPxxmWM6cSRkH): fired synchronously the moment this
-       * turn claims PREPARING (isBusy() becomes true). WorkspaceService keeps
-       * its session-invisible preflight reservation armed until this fires so
-       * follow-up recovery cannot observe the idle gap between the service
-       * handoff and the busy claim (cancelBeforeAcceptance and the other
-       * admission awaits yield) and admit a synthetic turn ahead of the
-       * accepted manual send. Refusal paths never fire it — the service's
-       * scoped disposal releases the reservation when the call returns.
-       */
-      onTurnAdmissionCommitted?: () => void;
-      /**
-       * Synthetic assistant rows persisted immediately before this turn's user
-       * row (family-message payloads). Persisting them inside turn admission —
-       * instead of a direct history append from the sender — keeps them out of
-       * another turn's PREPARING window, where they could land between that
-       * turn's user row and its assistant response (consecutive assistant
-       * messages a tool-using response makes unmergeable) or silently enter an
-       * in-flight request without their trigger (r30).
-       */
-      preTurnMessages?: MuxMessage[];
-      /**
-       * r54: fired once the pre-turn batch has crossed the rollback horizon —
-       * durably committed AND past the last cancellation/rollback gate. From
-       * that point every failure (goal sync, acceptance, stream start) keeps
-       * the rows in the transcript, so budget-style accounting must treat the
-       * delivery as persisted. Turn ACCEPTANCE is the wrong signal: it can
-       * fail after the rows are already irrevocable.
-       */
-      onPreTurnRowsPersisted?: () => void;
-      /**
-       * r41: staleness probe for this send's admission epoch, captured
-       * synchronously with WorkspaceService's entry checks. Returns true when
-       * a context-discarding mutation COMPLETED after the send entered — the
-       * level-triggered admission block check cannot catch a mutation
-       * that started and finished while the send sat in pre-admission
-       * awaits. Not threaded through queued entries: those dispatch into the
-       * post-mutation context by design.
-       */
-      admissionEpochStale?: () => boolean;
-      /**
-       * Caller-supplied staleness probe that, unlike the epoch probe above, IS threaded
-       * through queued entries (MessageQueue stores it per entry and re-emits it at
-       * dispatch). Peer agent sends use it so a Stop/task_stop landing after dequeue —
-       * where queue clearing can no longer see the entry — still refuses the turn at
-       * these admission gates instead of starting a privileged turn on a stopped target.
-       */
-      admissionStale?: () => boolean;
-    }
+    internal?: SendMessageInternalOptions
   ): Promise<AgentSessionResult<void>> {
     this.assertNotDisposed("sendMessage");
     if (this.coordinator.closing)
       return Err(createUnknownSendMessageError(SESSION_SHUTDOWN_SEND_BLOCKED_MESSAGE));
-    // Durable acceptance precedes PREPARING. This physical lease changes no busy/queue policy,
-    // but shutdown must join its writes and acceptance callbacks before dependencies disappear.
-    using _execution = this.coordinator.enterExecution();
+    if (internal?.preparation)
+      return this.prepareMessage(message, options, internal, internal.preparation);
+    const attempt: PreparationAttempt = {
+      owner: internal?.turnReservation,
+      expectedTurn: this.coordinator.turnId,
+      outcome: "preparing",
+      durability: "rollback-eligible",
+      queued: internal?.turnReservation != null,
+      failureNotified: false,
+      onFailure: internal?.onAcceptedPreStreamFailure,
+    };
+    return this.completePreparation(attempt, () =>
+      this.prepareMessage(message, options, internal, attempt)
+    );
+  }
 
+  /** Correlated callbacks settle before publishing idle; teardown joins this whole physical lease. */
+  private async completePreparation<T>(
+    attempt: PreparationAttempt,
+    run: () => Promise<AgentSessionResult<T>>
+  ): Promise<AgentSessionResult<T>> {
+    using _execution = this.coordinator.enterExecution();
+    try {
+      const result = await run();
+      if (!result.success) await this.settlePreparationFailure(attempt, result.error);
+      else if (attempt.outcome === "preparing" && attempt.durability === "accepted") {
+        await this.settlePreparationFailure(
+          attempt,
+          createUnknownSendMessageError("Accepted stream startup was canceled before streaming.")
+        );
+      }
+      return result;
+    } catch (error) {
+      await this.settlePreparationFailure(
+        attempt,
+        createUnknownSendMessageError(getErrorMessage(error))
+      );
+      throw error;
+    } finally {
+      try {
+        if (attempt.outcome !== "background" && attempt.owner != null)
+          this.coordinator.finishPreparation(attempt.owner);
+      } finally {
+        // Failed admission may be idle. The resource follows a background transfer and
+        // releases only after correlated cleanup or a valid handoff to terminal policy.
+        this.releasePreparationEdit(attempt);
+        if (
+          attempt.outcome !== "background" &&
+          attempt.outcome !== "delivered" &&
+          attempt.owner != null &&
+          this.coordinator.isCurrentTurn(attempt.owner)
+        )
+          this.drainQueuedMessagesIfIdle();
+      }
+    }
+  }
+
+  private releasePreparationEdit(attempt: PreparationAttempt): void {
+    const reservation = attempt.editReservation;
+    attempt.editReservation = undefined;
+    reservation?.[Symbol.dispose]();
+  }
+
+  private async settlePreparationFailure(
+    attempt: PreparationAttempt,
+    error: SendMessageError
+  ): Promise<void> {
+    if (attempt.failureNotified || (!attempt.queued && attempt.durability !== "accepted")) return;
+    attempt.failure ??= error;
+    while ((attempt.failureAttempts ?? 0) < 2) {
+      attempt.failureAttempts = (attempt.failureAttempts ?? 0) + 1;
+      try {
+        await attempt.onFailure?.(attempt.failure);
+        attempt.failureNotified = true;
+        return;
+      } catch (callbackError) {
+        // Retry cleanup without rerunning persistence or terminal policy. Even persistent
+        // callback failure must not replace the original error or suppress its retry decision.
+        if (attempt.failureAttempts === 2)
+          log.error("Preparation failure callback failed", {
+            workspaceId: this.workspaceId,
+            error: getErrorMessage(callbackError),
+          });
+      }
+    }
+  }
+
+  private async prepareMessage(
+    message: string,
+    options: (SendMessageOptions & { fileParts?: FilePart[] }) | undefined,
+    internal: SendMessageInternalOptions | undefined,
+    attempt: PreparationAttempt
+  ): Promise<AgentSessionResult<void>> {
     assert(typeof message === "string", "sendMessage requires a string message");
 
     const isManualUserMessage = internal?.synthetic !== true;
 
     // Single admission-staleness predicate for all three turn-admission gates below.
     const isAdmissionStale = () =>
-      internal?.admissionEpochStale?.() === true || internal?.admissionStale?.() === true;
+      internal?.admissionEpochStale?.() === true ||
+      internal?.admissionStale?.() === true ||
+      !this.coordinator.isCurrentTurn(attempt.owner ?? attempt.expectedTurn) ||
+      this.coordinator.editBlocked(attempt.editReservation?.id);
 
     const cancelSignal = internal?.cancelSignal;
     const persistedCancelableMessageIds: string[] = [];
@@ -3207,51 +3318,37 @@ export class AgentSession {
         )
       );
     };
+    const markRowsDurable = (): void => {
+      if (attempt.durability !== "rollback-eligible") return;
+      attempt.durability = "durable";
+      if ((internal?.preTurnMessages?.length ?? 0) > 0) internal?.onPreTurnRowsPersisted?.();
+    };
+    const accept = async (): Promise<void> => {
+      await internal?.onAccepted?.();
+      attempt.durability = "accepted";
+    };
+    const refuseBeforeAcceptance = async (
+      error: SendMessageError
+    ): Promise<AgentSessionResult<void>> => {
+      if (attempt.durability === "rollback-eligible" && !(await rollbackPersistedTurnRows()))
+        markRowsDurable();
+      return Err(error);
+    };
     let cancellationHandled = false;
     let cancellationDisabled = false;
     const cancelBeforeAcceptance = async (): Promise<boolean> => {
       if (cancelSignal?.aborted !== true || cancellationDisabled) return false;
       if (cancellationHandled) return true;
 
-      if (persistedCancelableMessageIds.length > 0) {
-        // History also has non-session writers (for example goal pause boundaries). Delete exactly
-        // this preparing turn's rows in one atomic rewrite so later concurrent rows are preserved.
-        this.continuousCompactor.reset("delete-messages");
-        const rollbackResult = await this.historyService.deleteMessages(
-          this.workspaceId,
-          persistedCancelableMessageIds
-        );
-        if (!rollbackResult.success) {
-          // deleteMessages can fail after its atomic rewrite (for example while refreshing
-          // sequence metadata). Verify the durable result before deciding whether cancellation won.
-          const historyResult = await this.historyService.getHistoryFromLatestBoundary(
-            this.workspaceId
-          );
-          const rollbackCommitted =
-            historyResult.success &&
-            persistedCancelableMessageIds.every(
-              (messageId) => !historyResult.data.some((message) => message.id === messageId)
-            );
-          if (!rollbackCommitted) {
-            // Do not report cancellation (which would supersede the durable monitor wake) unless the
-            // not-yet-accepted row is actually gone. Continue accepting this wake instead of leaving
-            // a hidden synthetic row that can leak into a later provider request.
-            cancellationDisabled = true;
-            log.error("Failed to roll back canceled preparing turn; continuing acceptance", {
-              workspaceId: this.workspaceId,
-              error: rollbackResult.error,
-              verificationError: historyResult.success ? undefined : historyResult.error,
-            });
-            return false;
-          }
-          log.warn("Preparing-turn rollback reported failure after its rewrite committed", {
-            workspaceId: this.workspaceId,
-            error: rollbackResult.error,
-          });
-        }
+      // Delete only this attempt's rows; concurrent non-session history writers survive.
+      if (!(await rollbackPersistedTurnRows())) {
+        // The wake remains provider-visible, so cancellation must not refund or supersede it.
+        cancellationDisabled = true;
+        return false;
       }
 
       cancellationHandled = true;
+      attempt.outcome = "canceled";
       await internal?.onCanceled?.(cancelReasonBeforeAcceptance(cancelSignal));
       if (internal?.cancelState != null) {
         internal.cancelState.canceledBeforeAcceptance = true;
@@ -3287,6 +3384,10 @@ export class AgentSession {
       if (await cancelBeforeAcceptance()) {
         return Ok(undefined);
       }
+      if (isAdmissionStale())
+        return refuseBeforeAcceptance(
+          createUnknownSendMessageError(CONTEXT_MUTATION_SEND_BLOCKED_MESSAGE)
+        );
       if (!pricingGate.success) {
         if (isManualUserMessage) {
           const persisted = await this.preserveRejectedManualSend(
@@ -3423,6 +3524,39 @@ export class AgentSession {
       }
     }
 
+    // Validate the actual payload before truncate+replace, including non-PDF attachment shape.
+    const additionalParts =
+      preservedEditFileParts && preservedEditFileParts.length > 0
+        ? preservedEditFileParts
+        : fileParts && fileParts.length > 0
+          ? fileParts.map((part, index) => {
+              assert(
+                typeof part.url === "string",
+                `file part [${index}] must include url string content (got ${typeof part.url}): ${JSON.stringify(part).slice(0, 200)}`
+              );
+              assert(
+                part.url.startsWith("data:"),
+                `file part [${index}] url must be a data URL (got: ${part.url.slice(0, 50)}...)`
+              );
+              assert(
+                typeof part.mediaType === "string" && part.mediaType.trim().length > 0,
+                `file part [${index}] must include a mediaType (got ${typeof part.mediaType}): ${JSON.stringify(part).slice(0, 200)}`
+              );
+              if (part.filename !== undefined) {
+                assert(
+                  typeof part.filename === "string",
+                  `file part [${index}] filename must be a string if present (got ${typeof part.filename}): ${JSON.stringify(part).slice(0, 200)}`
+                );
+              }
+              return {
+                type: "file" as const,
+                url: part.url,
+                mediaType: part.mediaType,
+                filename: part.filename,
+              };
+            })
+          : undefined;
+
     // A fork starts its abandoned-branch summary in the background so the fork
     // itself returns fast; the first send must then await that pending row so
     // it keeps its position BEFORE this turn's user message and request build
@@ -3449,23 +3583,13 @@ export class AgentSession {
       this.emitChatEvent({ ...pendingBranchSummary, type: "message" });
     }
 
-    // r32: reserve turn admission for the whole edit flow. Armed AFTER the
-    // preempt/wait section below (arming earlier would make the edit's own
-    // busy-preemption logic see the reservation as an active turn) and
-    // released automatically on every sendMessage exit: on success the turn
-    // phase has taken over busy-ness by then; on a pre-PREPARING failure the
-    // session returns to idle, so drain anything queued behind the
-    // reservation (mirrors the queued-dispatch failure contract).
-    let editReservation: Disposable | undefined;
-    const editAdmission = {
-      arm: () => {
-        editReservation ??= this.coordinator.reserve("edit");
-      },
-      [Symbol.dispose]: () => editReservation?.[Symbol.dispose](),
-    };
-    using _editAdmission = editAdmission;
-
+    // The shared completion owns the edit reservation: a reentrant PREPARING observer
+    // may retire admission back to idle, but queued work must still wait for failure cleanup.
     if (editMessageId) {
+      if (this.coordinator.editBlocked())
+        return refuseBeforeAcceptance(
+          createUnknownSendMessageError(CONTEXT_MUTATION_SEND_BLOCKED_MESSAGE)
+        );
       this.continuousCompactor.reset("edit");
       // Ensure no in-flight completion code can append after we truncate.
       if (this.isBusy()) {
@@ -3520,16 +3644,21 @@ export class AgentSession {
       // other. The epoch probe (r41) also refuses edits whose target rows a
       // completed mutation already discarded.
       if (this.coordinator.admissionBlocked || isAdmissionStale()) {
-        return Err(createUnknownSendMessageError(CONTEXT_MUTATION_SEND_BLOCKED_MESSAGE));
+        return refuseBeforeAcceptance(
+          createUnknownSendMessageError(CONTEXT_MUTATION_SEND_BLOCKED_MESSAGE)
+        );
       }
       if (this.coordinator.closing) {
-        return Err(createUnknownSendMessageError(SESSION_SHUTDOWN_SEND_BLOCKED_MESSAGE));
+        return refuseBeforeAcceptance(
+          createUnknownSendMessageError(SESSION_SHUTDOWN_SEND_BLOCKED_MESSAGE)
+        );
       }
 
       // Idle (or preempted to idle) now: hold busy-ness from here until the
       // turn phase takes over, so concurrent sends queue instead of racing the
       // truncate + summary + append sequence below.
-      editAdmission.arm();
+      attempt.expectedTurn = this.coordinator.turnId;
+      attempt.editReservation ??= this.coordinator.reserve("edit");
 
       // The edit is about to truncate and rewrite history. Any queued content from
       // the previous turn was written in the old context — return it to the input
@@ -3593,37 +3722,6 @@ export class AgentSession {
     }
 
     const messageId = createUserMessageId();
-    const additionalParts =
-      preservedEditFileParts && preservedEditFileParts.length > 0
-        ? preservedEditFileParts
-        : fileParts && fileParts.length > 0
-          ? fileParts.map((part, index) => {
-              assert(
-                typeof part.url === "string",
-                `file part [${index}] must include url string content (got ${typeof part.url}): ${JSON.stringify(part).slice(0, 200)}`
-              );
-              assert(
-                part.url.startsWith("data:"),
-                `file part [${index}] url must be a data URL (got: ${part.url.slice(0, 50)}...)`
-              );
-              assert(
-                typeof part.mediaType === "string" && part.mediaType.trim().length > 0,
-                `file part [${index}] must include a mediaType (got ${typeof part.mediaType}): ${JSON.stringify(part).slice(0, 200)}`
-              );
-              if (part.filename !== undefined) {
-                assert(
-                  typeof part.filename === "string",
-                  `file part [${index}] filename must be a string if present (got ${typeof part.filename}): ${JSON.stringify(part).slice(0, 200)}`
-                );
-              }
-              return {
-                type: "file" as const,
-                url: part.url,
-                mediaType: part.mediaType,
-                filename: part.filename,
-              };
-            })
-          : undefined;
 
     // toolPolicy is properly typed via Zod schema inference
     const typedToolPolicy = options?.toolPolicy;
@@ -3834,6 +3932,15 @@ export class AgentSession {
           }
         );
 
+        if (this.coordinator.admissionBlocked || isAdmissionStale())
+          return refuseBeforeAcceptance(
+            createUnknownSendMessageError(CONTEXT_MUTATION_SEND_BLOCKED_MESSAGE)
+          );
+        if (this.coordinator.closing)
+          return refuseBeforeAcceptance(
+            createUnknownSendMessageError(SESSION_SHUTDOWN_SEND_BLOCKED_MESSAGE)
+          );
+
         // Persist compaction request (NOT the user message — it's the follow-up)
         const appendCompactionResult = await this.historyService.appendToHistory(
           this.workspaceId,
@@ -3872,12 +3979,16 @@ export class AgentSession {
     // after a mutation commits; this check and the PREPARING gate remain
     // backstops for entry-accounting bypasses.
     if (this.coordinator.admissionBlocked || isAdmissionStale()) {
-      return Err(createUnknownSendMessageError(CONTEXT_MUTATION_SEND_BLOCKED_MESSAGE));
+      return refuseBeforeAcceptance(
+        createUnknownSendMessageError(CONTEXT_MUTATION_SEND_BLOCKED_MESSAGE)
+      );
     }
     // Still pre-persist: a row appended now would read as a dispatched turn on the next startup
     // while streamWithHistory's own latch check keeps its stream from ever running.
     if (this.coordinator.closing) {
-      return Err(createUnknownSendMessageError(SESSION_SHUTDOWN_SEND_BLOCKED_MESSAGE));
+      return refuseBeforeAcceptance(
+        createUnknownSendMessageError(SESSION_SHUTDOWN_SEND_BLOCKED_MESSAGE)
+      );
     }
 
     // Persist snapshots only when this turn will be sent immediately.
@@ -4006,7 +4117,10 @@ export class AgentSession {
     // leaves no trace for a later human resume to replay into provider context. Past this point
     // rollback is forbidden by design (goal sync observes the durable row), so a Stop landing in
     // the remaining pre-stream awaits refuses the turn at the PREPARING gate with rows retained.
-    if (internal?.admissionStale?.() === true) {
+    if (
+      internal?.admissionStale?.() === true ||
+      !this.coordinator.isCurrentTurn(attempt.owner ?? attempt.expectedTurn)
+    ) {
       const rolledBack = await rollbackPersistedTurnRows();
       // Probe-carrying sends are peer messages whose caller already returned success when the
       // entry was queued — the cancellation hook is their only way to observe this refusal and
@@ -4022,7 +4136,7 @@ export class AgentSession {
         // OUTER refund paths (the direct-call failure branch and sendQueuedMessages'
         // onAcceptedPreStreamFailure). Mark the rows persisted first so those payload-guarded
         // refunds keep the charge — refunding here would leave provider-visible rows uncharged.
-        internal?.onPreTurnRowsPersisted?.();
+        markRowsDurable();
       }
       return Err(
         createUnknownSendMessageError(
@@ -4040,16 +4154,14 @@ export class AgentSession {
     // r54: the pre-turn batch is now irrevocable — rollbackPersistedTurnRows
     // is never invoked past this point, so even a failure in goal sync or
     // acceptance leaves the payload + trigger rows durable in the transcript.
-    if (internal?.preTurnMessages != null && internal.preTurnMessages.length > 0) {
-      internal.onPreTurnRowsPersisted?.();
-    }
+    markRowsDurable();
     try {
       await this.workspaceGoalService?.syncGoalModeWithChatTail(this.workspaceId);
     } catch (error) {
       if (cancelSignal != null) {
         // The durable row crossed the point of no return, so every later goal-sync failure must still
         // finalize this monitor wake. Startup recovery can resume the row without redelivering it.
-        await internal?.onAccepted?.();
+        await accept();
       }
       throw error;
     }
@@ -4066,7 +4178,7 @@ export class AgentSession {
     // wake past the point of no return is already durable, so finalize it before leaving.
     if (this.coordinator.disposed) {
       if (cancelSignal != null && cancellationDisabled) {
-        await internal?.onAccepted?.();
+        await accept();
       }
       return Ok(undefined);
     }
@@ -4076,7 +4188,12 @@ export class AgentSession {
     // await, so a slider change during PREPARING (runtime warmup, model
     // creation) lands in the holder the stream's prepareStep will read.
     const turnThinkingOverride: ActiveTurnThinkingOverride = {};
-    this.coordinator.acceptThinkingOverride(turnThinkingOverride, this.coordinator.turnId);
+    if (isAdmissionStale())
+      return Err(createUnknownSendMessageError(CONTEXT_MUTATION_SEND_BLOCKED_MESSAGE));
+    this.coordinator.acceptThinkingOverride(
+      turnThinkingOverride,
+      attempt.owner ?? attempt.expectedTurn
+    );
 
     // Emit snapshots only for immediately-sent turns. On on-send compaction paths,
     // snapshots are deferred with the follow-up message to avoid duplicate ephemeral
@@ -4121,7 +4238,11 @@ export class AgentSession {
     if (isManualUserMessage) {
       // A fresh accepted user send supersedes any persisted startup-abandon
       // classification from previous turns.
+      if (isAdmissionStale())
+        return Err(createUnknownSendMessageError(CONTEXT_MUTATION_SEND_BLOCKED_MESSAGE));
       await this.clearStartupAutoRetryAbandon();
+      if (isAdmissionStale())
+        return Err(createUnknownSendMessageError(CONTEXT_MUTATION_SEND_BLOCKED_MESSAGE));
       this.retryManager.cancel();
       this.retryManager.setEnabled(true);
       await this.persistAutoRetryEnabledPreference(true);
@@ -4129,9 +4250,11 @@ export class AgentSession {
 
     // Same-session retry should resume the exact accepted request we just finalized
     // in history, even if runtime warmup fails before streamWithHistory() starts.
+    if (isAdmissionStale())
+      return Err(createUnknownSendMessageError(CONTEXT_MUTATION_SEND_BLOCKED_MESSAGE));
     this.setAutoRetryResumeState(optionsForStream, agentInitiated, goalKind, internal?.goalId);
     try {
-      await internal?.onAccepted?.();
+      await accept();
     } catch (error) {
       // Pre-stream failure: identity-guarded so a replacement turn's holder
       // (created while this one unwound) is never cleared by mistake.
@@ -4140,17 +4263,6 @@ export class AgentSession {
       }
       return Err(createUnknownSendMessageError(getErrorMessage(error)));
     }
-
-    let acceptedPreStreamFailureNotified = false;
-    const notifyAcceptedPreStreamFailure = async (error: SendMessageError): Promise<void> => {
-      if (acceptedPreStreamFailureNotified) {
-        return;
-      }
-      await internal?.onAcceptedPreStreamFailure?.(error);
-      // Only suppress duplicate notifications after cleanup succeeds. A transient callback failure
-      // must remain retryable from the surrounding catch path so durable reservations do not stick.
-      acceptedPreStreamFailureNotified = true;
-    };
 
     // r40: a context-discarding mutation (reset, full clear, destructive
     // replace) may have started while this send was validating and persisting
@@ -4170,122 +4282,111 @@ export class AgentSession {
       // delivered in onAccepted and rely on the accepted pre-stream failure
       // callback to revert it — returning without notifying would strand
       // that bookkeeping (r41).
-      await notifyAcceptedPreStreamFailure(error);
+      await this.settlePreparationFailure(attempt, error);
       return Err(error);
     }
 
     const preparedTurnAbortController = new AbortController();
-    this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(optionsForStream.muxMetadata);
-    const preparedTurn = this.coordinator.prepare(
+    const admission = this.coordinator.prepare(
+      attempt.owner != null
+        ? { kind: "adopt", turnId: attempt.owner }
+        : {
+            kind: "fresh",
+            intent: "direct",
+            expectedTurnId: attempt.expectedTurn,
+            editReservation: attempt.editReservation?.id,
+          },
       preparedTurnAbortController,
-      internal?.turnReservation
+      (turnId) => {
+        attempt.owner = turnId;
+        this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(
+          optionsForStream.muxMetadata
+        );
+      }
     );
-    // From this synchronous point isBusy() reports the turn — release the
-    // service-side preflight reservation (see onTurnAdmissionCommitted doc).
+    if (admission.status !== "admitted") {
+      return Err(
+        createUnknownSendMessageError(
+          admission.status === "rejected" && admission.reason === "closing"
+            ? SESSION_SHUTDOWN_SEND_BLOCKED_MESSAGE
+            : CONTEXT_MUTATION_SEND_BLOCKED_MESSAGE
+        )
+      );
+    }
+    const preparedTurn = admission.turnId;
+
     internal?.onTurnAdmissionCommitted?.();
 
-    const startPreparedStream = async (): Promise<AgentSessionResult<void>> => {
-      try {
-        if (
-          !this.coordinator.isCurrentTurn(preparedTurn) ||
-          preparedTurnAbortController.signal.aborted
-        ) {
-          await notifyAcceptedPreStreamFailure(
-            createUnknownSendMessageError("Accepted stream startup was canceled before it began.")
-          );
-          return Ok(undefined);
-        }
-        // Background processes are workspace-scoped, not context-scoped. Compaction must preserve
-        // processes, monitors, and queued wakes so a waiting agent is not stranded.
-        // Note: Follow-up content for compaction is now stored on the summary message
-        // and dispatched via dispatchPendingFollowUp() after compaction completes.
-        // This provides crash safety - the follow-up survives app restarts.
-
-        if (this.coordinator.disposed || preparedTurnAbortController.signal.aborted) {
-          await notifyAcceptedPreStreamFailure(
-            createUnknownSendMessageError("Accepted stream startup was canceled before streaming.")
-          );
-          return Ok(undefined);
-        }
-
-        // Raw terminals reserve COMPLETING; delivered completion runs terminal policy.
-        const streamResult = await this.streamWithHistory(
-          preparedTurn,
-          modelForStream,
-          optionsForStream,
-          undefined,
-          undefined,
-          agentInitiated,
-          preparedTurnAbortController.signal,
-          goalKind,
-          internal?.goalId,
-          turnThinkingOverride
+    const startPreparedStream = async (
+      startup: PreparationAttempt
+    ): Promise<AgentSessionResult<void>> => {
+      if (
+        !this.coordinator.isCurrentTurn(preparedTurn) ||
+        preparedTurnAbortController.signal.aborted
+      ) {
+        await this.settlePreparationFailure(
+          startup,
+          createUnknownSendMessageError("Accepted stream startup was canceled before it began.")
         );
-        if (streamResult.success && preparedTurnAbortController.signal.aborted) {
-          await notifyAcceptedPreStreamFailure(
-            createUnknownSendMessageError(
-              "Accepted stream startup was canceled during preparation."
-            )
-          );
-        }
-        return streamResult;
-      } finally {
-        // Success should advance via stream events; if startup never emitted any, don't leave the
-        // session stuck in PREPARING. Guard by controller identity so an aborted startup cannot
-        // mark the replacement edit's new PREPARING turn idle when it unwinds later.
-        this.coordinator.finishPreparation(preparedTurn);
+        return Ok(undefined);
       }
+      // Background processes are workspace-scoped, not context-scoped. Compaction must preserve
+      // processes, monitors, and queued wakes so a waiting agent is not stranded.
+      // Note: Follow-up content for compaction is now stored on the summary message
+      // and dispatched via dispatchPendingFollowUp() after compaction completes.
+      // This provides crash safety - the follow-up survives app restarts.
+
+      if (this.coordinator.disposed || preparedTurnAbortController.signal.aborted) {
+        await this.settlePreparationFailure(
+          startup,
+          createUnknownSendMessageError("Accepted stream startup was canceled before streaming.")
+        );
+        return Ok(undefined);
+      }
+
+      // Raw terminals reserve COMPLETING; delivered completion runs terminal policy.
+      const streamResult = await this.streamWithHistory(
+        preparedTurn,
+        modelForStream,
+        optionsForStream,
+        undefined,
+        undefined,
+        agentInitiated,
+        preparedTurnAbortController.signal,
+        goalKind,
+        internal?.goalId,
+        turnThinkingOverride,
+        startup
+      );
+      if (streamResult.success && preparedTurnAbortController.signal.aborted) {
+        await this.settlePreparationFailure(
+          startup,
+          createUnknownSendMessageError("Accepted stream startup was canceled during preparation.")
+        );
+      }
+      return streamResult;
     };
 
     if (editMessageId || internal?.startStreamInBackground === true) {
-      // The user turn is already persisted + emitted above. Edits and backend
-      // goal continuations should unblock once the user message exists: for
-      // Resume, that makes chat history the durable source of truth for the
-      // running goal before runtime warmup or streaming can race/fail.
-      const drainQueuedMessagesAfterFailedStartup = (): void => {
-        if (
-          this.coordinator.isCurrentTurn(preparedTurn) &&
-          this.coordinator.phase === "idle" &&
-          !this.messageQueue.isEmpty()
-        ) {
-          this.sendQueuedMessages();
-        }
-      };
-      // Transfer supervision before the foreground lease releases; include failure callbacks.
-      const backgroundExecution = this.coordinator.enterExecution();
-      startPreparedStream()
-        .then(async (result) => {
-          if (!result.success) {
-            await notifyAcceptedPreStreamFailure(result.error);
-          }
-          drainQueuedMessagesAfterFailedStartup();
-        })
-        .catch(async (error: unknown) => {
-          log.error("Accepted background stream failed before startup completed", {
-            workspaceId: this.workspaceId,
-            editMessageId,
-            goalKind,
-            error: getErrorMessage(error),
-          });
-          try {
-            await notifyAcceptedPreStreamFailure(
-              createUnknownSendMessageError(getErrorMessage(error))
-            );
-          } catch (callbackError: unknown) {
-            log.error("Accepted background stream failure callback failed", {
-              workspaceId: this.workspaceId,
-              error: getErrorMessage(callbackError),
-            });
-          }
-          drainQueuedMessagesAfterFailedStartup();
-        })
-        .finally(() => backgroundExecution[Symbol.dispose]());
+      // Transfer physical work before the foreground lease releases. The child has its own
+      // completion outcome so a resolved foreground Ok cannot finish a still-starting turn.
+      attempt.outcome = "background";
+      const backgroundAttempt: PreparationAttempt = { ...attempt, outcome: "preparing" };
+      // Handoff callbacks may already have preempted back to idle. Transfer the edit
+      // exclusion too, so only the child's settled startup can release queued work.
+      attempt.editReservation = undefined;
+      this.completePreparation(backgroundAttempt, () =>
+        startPreparedStream(backgroundAttempt)
+      ).catch((error: unknown) => {
+        log.error("Accepted background stream failed before startup completed", {
+          workspaceId: this.workspaceId,
+          error: getErrorMessage(error),
+        });
+      });
       return Ok(undefined);
     }
 
-    // Non-edit sends preserve the old behavior so pre-stream startup failures still propagate to
-    // synchronous callers (draft restore, interrupted-task rollback, etc.).
-    return await startPreparedStream();
+    return await startPreparedStream(attempt);
   }
 
   async resumeStream(
@@ -4295,6 +4396,7 @@ export class AgentSession {
     this.assertNotDisposed("resumeStream");
     if (this.coordinator.closing) return Ok({ started: false });
     using _execution = this.coordinator.enterExecution();
+    const expectedTurnId = this.coordinator.turnId;
 
     assert(options, "resumeStream requires options");
     const { model } = options;
@@ -4331,21 +4433,36 @@ export class AgentSession {
       return Ok({ started: false });
     }
 
-    // A resumed attempt becomes the latest live resume request as soon as we
-    // accept its options, even if startup fails before the stream fully begins.
-    this.setAutoRetryResumeState(
-      optionsForStream,
-      internal?.agentInitiated,
-      internal?.goalKind,
-      internal?.goalId
-    );
-    this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(optionsForStream.muxMetadata);
-    const preparedTurn = this.coordinator.prepare();
-    // Open the mid-turn thinking override window for the resumed turn (after
-    // preparation publication; the coordinator expires the holder when the turn becomes idle).
-    const turnThinkingOverride: ActiveTurnThinkingOverride = {};
-    this.coordinator.acceptThinkingOverride(turnThinkingOverride, preparedTurn);
-    try {
+    const attempt: PreparationAttempt = {
+      expectedTurn: expectedTurnId,
+      outcome: "preparing",
+      durability: "accepted",
+      queued: false,
+      failureNotified: false,
+    };
+    return this.completePreparation(attempt, async () => {
+      const admission = this.coordinator.prepare(
+        { kind: "fresh", intent: "resume", expectedTurnId },
+        undefined,
+        (turnId) => {
+          attempt.owner = turnId;
+          this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(
+            optionsForStream.muxMetadata
+          );
+        }
+      );
+      if (admission.status !== "admitted") return Ok({ started: false });
+      const preparedTurn = admission.turnId;
+      this.setAutoRetryResumeState(
+        optionsForStream,
+        internal?.agentInitiated,
+        internal?.goalKind,
+        internal?.goalId
+      );
+      // Open the mid-turn thinking override window for the resumed turn (after
+      // preparation publication; the coordinator expires the holder when the turn becomes idle).
+      const turnThinkingOverride: ActiveTurnThinkingOverride = {};
+      this.coordinator.acceptThinkingOverride(turnThinkingOverride, preparedTurn);
       // Must await here so the finally block runs after streaming completes,
       // not immediately when the Promise is returned.
       const result = await this.streamWithHistory(
@@ -4358,18 +4475,15 @@ export class AgentSession {
         undefined,
         internal?.goalKind,
         internal?.goalId,
-        turnThinkingOverride
+        turnThinkingOverride,
+        attempt
       );
       if (!result.success) {
         return result;
       }
 
-      return Ok({ started: true });
-    } finally {
-      if (this.coordinator.isCurrentTurn(preparedTurn)) {
-        this.coordinator.finishPreparation(preparedTurn);
-      }
-    }
+      return Ok({ started: attempt.outcome === "delivered" });
+    });
   }
 
   async setAutoRetryEnabled(
@@ -5322,8 +5436,15 @@ export class AgentSession {
     operation: OperationId,
     error: SendMessageError,
     acpPromptId?: string,
-    preStartErrors?: StreamErrorPayload[] | null
+    preStartErrors?: StreamErrorPayload[] | null,
+    preparation?: PreparationAttempt
   ): Promise<AgentSessionResult<void>> {
+    if (preparation) {
+      await this.settlePreparationFailure(preparation, error);
+      // Recovery may synchronously claim a follow-up. Its predecessor's callback has
+      // settled, and PREPARING still owns the queue until policy decides the outcome.
+      this.releasePreparationEdit(preparation);
+    }
     // A disposed session must not persist retry/goal state or error rows
     // post-teardown (mirrors delivered completion). Settle collected recovery
     // decisions in memory so waiters cannot hang, then skip all recovery
@@ -5387,8 +5508,22 @@ export class AgentSession {
     // Session-owned per-turn holder for mid-turn thinking changes. Passed
     // explicitly (not read from the field) so a preempted turn can never pick
     // up its replacement's holder. Absent for internal retry paths.
-    activeTurnThinkingOverride?: ActiveTurnThinkingOverride
+    activeTurnThinkingOverride?: ActiveTurnThinkingOverride,
+    preparation?: PreparationAttempt
   ): Promise<AgentSessionResult<void>> {
+    const fail = (
+      error: SendMessageError,
+      acpPromptId?: string,
+      preStartErrors?: StreamErrorPayload[]
+    ) =>
+      this.handleStreamWithHistoryFailure(
+        turn,
+        operation,
+        error,
+        acpPromptId,
+        preStartErrors,
+        preparation
+      );
     // Re-read at every pre-stream checkpoint below: dispose or shutdown can land while a
     // recovery-initiated stream (which carries no abortSignal) awaits commitPartial, file-change
     // detection, or history reads, and must not reach the provider afterwards.
@@ -5424,11 +5559,7 @@ export class AgentSession {
 
       const commitResult = await this.historyService.commitPartial(this.workspaceId);
       if (!commitResult.success) {
-        return await this.handleStreamWithHistoryFailure(
-          turn,
-          operation,
-          createUnknownSendMessageError(commitResult.error)
-        );
+        return await fail(createUnknownSendMessageError(commitResult.error));
       }
 
       if (isStreamStartAborted()) {
@@ -5453,11 +5584,7 @@ export class AgentSession {
           createFileChangeNotificationMessage(fileChangeDetection.attachments)
         );
         if (!notificationAppendResult.success) {
-          return await this.handleStreamWithHistoryFailure(
-            turn,
-            operation,
-            createUnknownSendMessageError(notificationAppendResult.error)
-          );
+          return await fail(createUnknownSendMessageError(notificationAppendResult.error));
         }
         fileChangeDetection.commit();
       }
@@ -5470,11 +5597,7 @@ export class AgentSession {
       }
 
       if (!historyResult.success) {
-        return await this.handleStreamWithHistoryFailure(
-          turn,
-          operation,
-          createUnknownSendMessageError(historyResult.error)
-        );
+        return await fail(createUnknownSendMessageError(historyResult.error));
       }
 
       // A crash between snapshot and user-row appends can leave orphaned prompt
@@ -5482,9 +5605,7 @@ export class AgentSession {
       let requestMessages = filterOrphanedMcpPromptSnapshots(historyResult.data);
 
       if (requestMessages.length === 0) {
-        return await this.handleStreamWithHistoryFailure(
-          turn,
-          operation,
+        return await fail(
           createUnknownSendMessageError(
             "Cannot resume stream: workspace history is empty. Send a new message instead."
           )
@@ -5668,15 +5789,20 @@ export class AgentSession {
           }
           return { success: false, error: streamResult.error, failureHandled: true };
         }
-        return await this.handleStreamWithHistoryFailure(
-          turn,
-          operation,
-          streamResult.error,
-          acpPromptId,
-          preStartErrors
-        );
+        return await fail(streamResult.error, acpPromptId, preStartErrors);
       }
 
+      if (preparation) {
+        preparation.outcome = "delivered";
+        // An already-resolved handle can launch recovery synchronously. Release the
+        // valid edit's history exclusion first; canceled startup keeps it through its callback.
+        if (
+          this.coordinator.isCurrentTurn(turn) &&
+          !this.coordinator.closing &&
+          !abortSignal?.aborted
+        )
+          this.releasePreparationEdit(preparation);
+      }
       this.coordinator.consumeCompletion(operation, streamResult.data).catch((error: unknown) => {
         log.error("Failed to consume turn completion", { error: getErrorMessage(error) });
       });
@@ -5841,6 +5967,8 @@ export class AgentSession {
     messageId: string;
     errorType?: string;
   }): Promise<boolean> {
+    const expectedTurnId = this.coordinator.turnId;
+    const expectedOperationId = this.coordinator.operationId;
     if (data.errorType !== "context_exceeded") {
       return false;
     }
@@ -5912,16 +6040,36 @@ export class AgentSession {
       return false;
     }
 
+    if (!this.coordinator.isCurrentOperation(expectedOperationId)) return false;
+    let claimedTurn: TurnId | undefined;
+    using _preparation = {
+      [Symbol.dispose]: () => {
+        if (claimedTurn != null) this.coordinator.finishPreparation(claimedTurn);
+      },
+    };
+    const admission = this.coordinator.prepare(
+      {
+        kind: "fresh",
+        intent: "handoff",
+        expectedTurnId,
+      },
+      undefined,
+      (turnId) => {
+        claimedTurn = turnId;
+        this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(
+          retryOptionsForResume.muxMetadata
+        );
+      }
+    );
+    if (admission.status !== "admitted") return false;
+    const preparedTurn = admission.turnId;
     this.setAutoRetryResumeState(
       retryOptionsForResume,
       retryAgentInitiated,
       retryGoalKind,
       retryGoalId
     );
-    this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(
-      retryOptionsForResume.muxMetadata
-    );
-    const preparedTurn = this.coordinator.prepare();
+
     let retryResult: Result<void, SendMessageError>;
     try {
       retryResult = await this.streamWithHistory(
@@ -5963,6 +6111,8 @@ export class AgentSession {
     messageId: string;
     errorType?: string;
   }): Promise<boolean> {
+    const expectedTurnId = this.coordinator.turnId;
+    const expectedOperationId = this.coordinator.operationId;
     if (data.errorType !== "context_exceeded") {
       return false;
     }
@@ -6028,8 +6178,30 @@ export class AgentSession {
     }
 
     // Retry the same request, but without post-compaction injection.
-    this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(context.options?.muxMetadata);
-    const preparedTurn = this.coordinator.prepare();
+    if (!this.coordinator.isCurrentOperation(expectedOperationId)) return false;
+    let claimedTurn: TurnId | undefined;
+    using _preparation = {
+      [Symbol.dispose]: () => {
+        if (claimedTurn != null) this.coordinator.finishPreparation(claimedTurn);
+      },
+    };
+    const admission = this.coordinator.prepare(
+      {
+        kind: "fresh",
+        intent: "handoff",
+        expectedTurnId,
+      },
+      undefined,
+      (turnId) => {
+        claimedTurn = turnId;
+        this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(
+          context.options?.muxMetadata
+        );
+      }
+    );
+    if (admission.status !== "admitted") return false;
+    const preparedTurn = admission.turnId;
+
     let retryResult: Result<void, SendMessageError>;
     try {
       retryResult = await this.streamWithHistory(
@@ -6548,7 +6720,7 @@ export class AgentSession {
         // Do not dispatch stream-end follow-ups while the edit flow is waiting
         // for IDLE; truncation must run before any synthetic turn resumes.
       } else {
-        this.sendQueuedMessages();
+        this.sendQueuedMessages("terminal");
       }
 
       if (
@@ -7410,7 +7582,7 @@ export class AgentSession {
       return false;
     }
 
-    this.sendQueuedMessages();
+    this.sendQueuedMessages("provider-tool");
     return true;
   }
 
@@ -7492,7 +7664,7 @@ export class AgentSession {
     if (!this.messageQueue.prioritizeNextUserEntry()) {
       return false;
     }
-    this.sendQueuedMessages();
+    this.sendQueuedMessages("send-immediately");
     return true;
   }
 
@@ -7515,114 +7687,79 @@ export class AgentSession {
     ) {
       return;
     }
-    this.sendQueuedMessages();
+    this.sendQueuedMessages("idle");
   }
 
   /**
    * Send queued messages if any exist.
    * Called when the current turn ends or the user chooses to send immediately.
    */
-  sendQueuedMessages(): void {
-    // sendQueuedMessages can race with teardown (e.g. workspace.remove) because we
-    // trigger it off stream/tool events and disposal does not await stopStream().
-    // If the session is already disposed, do nothing.
-    if (this.coordinator.closing) {
+  sendQueuedMessages(trigger: QueueDrainTrigger = "terminal"): void {
+    if (
+      this.coordinator.closing ||
+      this.deferQueuedFlushUntilAfterEdit ||
+      this.midStreamCompactionPending
+    )
       return;
-    }
-    // Queue publication can reenter shutdown. Register physical ownership before callbacks;
-    // the child below retains it through asynchronous correlated failure/refund settlement.
     using _dispatch = this.coordinator.enterExecution();
-
-    // r40: leave entries queued while a context-discarding mutation blocks
-    // turn admission — dispatching would set PREPARING and stream across the
-    // mutation. The block's release drains the queue (holdTurnAdmission).
-    if (this.coordinator.admissionBlocked) {
+    const candidate = this.messageQueue.peekNext();
+    if (candidate == null) {
+      this.backgroundProcessManager.setMessageQueued(this.workspaceId, false);
       return;
     }
-
-    this.queuedProviderToolEndAbortInFlight = false;
-    // Clear the queued message flag (even if queue is empty, to handle race conditions)
-    this.backgroundProcessManager.setMessageQueued(this.workspaceId, false);
-
-    if (!this.messageQueue.isEmpty()) {
-      // Entries dispatch one at a time (FIFO): special sends (compaction, agent
-      // skills, workspace-turn follow-ups) own their turn, and anything queued
-      // behind them dispatches on a later drain instead of batching into them.
+    const expectedTurnId = this.coordinator.turnId;
+    const attempt: PreparationAttempt = {
+      expectedTurn: expectedTurnId,
+      outcome: "preparing",
+      durability: "rollback-eligible",
+      queued: false,
+      failureNotified: false,
+    };
+    this.completePreparation(attempt, async () => {
+      const admission = this.coordinator.prepare(
+        { kind: "fresh", intent: trigger, expectedTurnId },
+        undefined,
+        (turnId) => {
+          attempt.owner = turnId;
+          this.dispatchingQueuedEntry = true;
+          this.dispatchingQueuedEntryMuxMetadata = candidate.muxMetadata;
+          this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(candidate.muxMetadata);
+        }
+      );
+      if (admission.status !== "admitted") return Ok(undefined);
+      const preparedTurn = admission.turnId;
+      // PREPARING observers can clear/reorder the head without retiring its owner. Never
+      // consume a replacement entry or notify callbacks already handled by queue removal.
+      if (this.messageQueue.peekNext()?.identity !== candidate.identity) return Ok(undefined);
+      attempt.queued = true;
       const { message, options, internal, enqueuedAtMs } = this.messageQueue.dequeueNext();
+      attempt.onFailure = internal?.onAcceptedPreStreamFailure;
       this.dispatchingQueuedEntry = true;
       this.dispatchingQueuedEntryMuxMetadata = options?.muxMetadata;
+      this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(options?.muxMetadata);
+      this.queuedProviderToolEndAbortInFlight = false;
       this.emitQueuedMessageChanged();
-
-      // Re-arm dispatch signals for the remaining entries so the stream we are
-      // about to start drains them at its next tool end (or stream end).
+      if (!this.coordinator.isCurrentTurn(preparedTurn) || this.coordinator.closing) {
+        return Err(
+          createUnknownSendMessageError("Queued preparation was retired before dispatch.")
+        );
+      }
       this.backgroundProcessManager.setMessageQueued(
         this.workspaceId,
         this.messageQueue.getNextDispatchableMode() === "tool-end"
       );
-
-      // Set PREPARING synchronously before the async sendMessage to prevent
-      // incoming messages from bypassing the queue during the await gap.
-      this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(options?.muxMetadata);
-      const preparedTurn = this.coordinator.prepare();
-
-      const queuedExecution = this.coordinator.enterExecution();
-      this.sendMessage(message, options, {
+      return this.sendMessage(message, options, {
         ...internal,
         enqueuedAtMs,
         turnReservation: preparedTurn,
-      })
-        .then(async (result) => {
-          // Keep the dispatch marker through the dequeue-to-stream-start window. A background
-          // send can resolve before startup emits stream-start, and later reports must not claim
-          // that window as the next continuation.
-          // If sendMessage fails before it can start streaming, ensure we don't
-          // leave the session stuck in PREPARING and notify correlated internal callers.
-          if (!result.success) {
-            await internal?.onAcceptedPreStreamFailure?.(result.error);
-            if (this.coordinator.isCurrentTurn(preparedTurn)) {
-              this.coordinator.finishPreparation(preparedTurn);
-            }
-            // No stream started, so no stream-end drain will fire for the
-            // remaining entries — try the next one now (each attempt pops an
-            // entry, so this terminates).
-            if (this.coordinator.isCurrentTurn(preparedTurn)) this.drainQueuedMessagesIfIdle();
-            return;
-          }
-          if (internal?.cancelState?.canceledBeforeAcceptance === true) {
-            // Cancellation can arrive after dequeue while sendMessage is validating or writing
-            // history. No stream will start, so release PREPARING and continue with later entries.
-            if (this.coordinator.isCurrentTurn(preparedTurn)) {
-              this.coordinator.finishPreparation(preparedTurn);
-            }
-            if (this.coordinator.isCurrentTurn(preparedTurn)) this.drainQueuedMessagesIfIdle();
-          }
-        })
-        .catch(async (error: unknown) => {
-          // A REJECTED sendMessage (thrown, not returned Err — e.g. an awaited history or goal
-          // service throwing pre-persistence) must reach the same failure hook as the
-          // returned-error branch above: peer sends refund their family-message reservation
-          // through it (payload-persistence-guarded, so post-persistence throws keep the
-          // charge). Swallowing the rejection here would strand the reservation until restart.
-          try {
-            await internal?.onAcceptedPreStreamFailure?.(
-              createUnknownSendMessageError(error instanceof Error ? error.message : String(error))
-            );
-          } catch (hookError: unknown) {
-            log.error("sendQueuedMessages: onAcceptedPreStreamFailure hook threw", {
-              workspaceId: this.workspaceId,
-              hookError,
-            });
-          }
-          if (!this.coordinator.isCurrentTurn(preparedTurn)) return;
-          this.dispatchingQueuedEntry = false;
-          this.dispatchingQueuedEntryMuxMetadata = undefined;
-          if (this.coordinator.isCurrentTurn(preparedTurn)) {
-            this.coordinator.finishPreparation(preparedTurn);
-          }
-          this.drainQueuedMessagesIfIdle();
-        })
-        .finally(() => queuedExecution[Symbol.dispose]());
-    }
+        preparation: attempt,
+      });
+    }).catch((error: unknown) => {
+      log.error("Queued preparation failed", {
+        workspaceId: this.workspaceId,
+        error: getErrorMessage(error),
+      });
+    });
   }
 
   /**

--- a/src/node/services/agentSession.turnCompletion.test.ts
+++ b/src/node/services/agentSession.turnCompletion.test.ts
@@ -127,7 +127,13 @@ describe("AgentSession turn completion", () => {
     h.session.onChatEvent(({ message }) => {
       if (message.type !== "stream-abort") return;
       aborted++;
-      replacement = coordinator.prepare();
+      const admission = coordinator.prepare({
+        kind: "fresh",
+        intent: "handoff",
+        expectedTurnId: coordinator.turnId,
+      });
+      if (admission.status !== "admitted") throw new Error("Expected replacement admission");
+      replacement = admission.turnId;
       coordinator.acceptThinkingOverride(replacementThinking, replacement);
     });
     try {

--- a/src/node/services/agentSession.waitForIdle.test.ts
+++ b/src/node/services/agentSession.waitForIdle.test.ts
@@ -24,7 +24,11 @@ describe("AgentSession.waitForIdle", () => {
     const internalSession = session as unknown as IdleWaiterTestSession;
 
     try {
-      internalSession.coordinator.prepare();
+      internalSession.coordinator.prepare({
+        kind: "fresh",
+        intent: "handoff",
+        expectedTurnId: internalSession.coordinator.turnId,
+      });
       const controller = new AbortController();
       const waitResult = captureWaitForIdleResult(session.waitForIdle(controller.signal));
 
@@ -104,7 +108,11 @@ describe("AgentSession.waitForIdle", () => {
     const internalSession = session as unknown as IdleWaiterTestSession;
 
     try {
-      internalSession.coordinator.prepare();
+      internalSession.coordinator.prepare({
+        kind: "fresh",
+        intent: "handoff",
+        expectedTurnId: internalSession.coordinator.turnId,
+      });
       const waits = Array.from({ length: 3 }, () => {
         const controller = new AbortController();
         return {

--- a/src/node/services/messageQueue.ts
+++ b/src/node/services/messageQueue.ts
@@ -937,6 +937,12 @@ export class MessageQueue {
     return true;
   }
 
+  /** Capture before admission publication; observers may remove or reorder the head. */
+  peekNext(): { identity: object; muxMetadata: unknown } | undefined {
+    const entry = this.entries[0];
+    return entry ? { identity: entry, muxMetadata: entry.muxMetadata } : undefined;
+  }
+
   /**
    * Remove the first entry and return its combined message and options for sending.
    * Later entries stay queued and dispatch on subsequent drains (FIFO).

--- a/src/node/services/serviceContainer.test.ts
+++ b/src/node/services/serviceContainer.test.ts
@@ -181,7 +181,13 @@ describe("ServiceContainer", () => {
     expect(services.collectRestartBlockers()).toEqual([]);
     const session = services.workspaceService.getOrCreateSession("restart-test");
     const { coordinator } = session as unknown as { coordinator: TurnCoordinator };
-    const turn = coordinator.prepare();
+    const admission = coordinator.prepare({
+      kind: "fresh",
+      intent: "handoff",
+      expectedTurnId: coordinator.turnId,
+    });
+    if (admission.status !== "admitted") throw new Error("Expected turn admission");
+    const turn = admission.turnId;
     expect(services.collectRestartBlockers()).toContainEqual({ kind: "pending-turns", count: 1 });
     coordinator.finishPreparation(turn);
     session.queueMessage("queued for later");

--- a/src/node/services/turnCoordinator.test.ts
+++ b/src/node/services/turnCoordinator.test.ts
@@ -33,6 +33,15 @@ function startEvent(messageId: string): StreamStartEvent {
   };
 }
 
+function prepare(coordinator: TurnCoordinator, controller?: AbortController): TurnId {
+  const result = coordinator.prepare(
+    { kind: "fresh", intent: "handoff", expectedTurnId: coordinator.turnId },
+    controller
+  );
+  if (result.status !== "admitted") throw new Error(`Preparation ${result.status}`);
+  return result.turnId;
+}
+
 function setup(overrides: Partial<ConstructorParameters<typeof TurnCoordinator>[0]> = {}) {
   const callbacks = {
     phaseChanged: mock(() => undefined),
@@ -44,9 +53,11 @@ function setup(overrides: Partial<ConstructorParameters<typeof TurnCoordinator>[
   return { coordinator: new TurnCoordinator(callbacks), callbacks };
 }
 
+const initialTurn = Symbol("idle");
+
 // Commands are observable work, so a stale event must not merely leave the phase looking right.
 function reduce(events: CoordinatorEvent[]) {
-  let state = initialCoordinatorState(Symbol("idle"));
+  let state = initialCoordinatorState(initialTurn);
   for (const event of events) state = transition(state, event).state;
   return state;
 }
@@ -56,7 +67,7 @@ describe("TurnCoordinator", () => {
     const scope = Scope.makeUnsafe("parallel");
     const { coordinator } = setup();
     coordinator.supervise(runner, scope, () => coordinator.beginShutdown());
-    const turn = coordinator.prepare();
+    const turn = prepare(coordinator);
     coordinator.acceptThinkingOverride({}, turn);
     const signal = new AbortController();
     const canceled = coordinator.waitForIdle(signal.signal);
@@ -78,7 +89,7 @@ describe("TurnCoordinator", () => {
         order.push("settled");
       },
     });
-    const op = coordinator.registerOperation(coordinator.prepare());
+    const op = coordinator.registerOperation(prepare(coordinator));
     const engine = Promise.resolve(completed);
     const consumed = coordinator.consumeCompletion(op, { messageId: "sync", completion: engine });
     await engine.then(() => order.push("observer"));
@@ -99,7 +110,7 @@ describe("TurnCoordinator", () => {
       },
     });
     coordinator.supervise(runner, scope, () => coordinator.beginShutdown());
-    const turn = coordinator.prepare();
+    const turn = prepare(coordinator);
     const op = coordinator.registerOperation(turn);
     coordinator.streamStarted(startEvent("late"));
     const consumed = coordinator.consumeCompletion(op, {
@@ -111,7 +122,10 @@ describe("TurnCoordinator", () => {
       closed = true;
     });
     expect(coordinator.closing).toBe(true);
-    expect(coordinator.prepare()).not.toBe(coordinator.turnId);
+    expect(
+      coordinator.prepare({ kind: "fresh", intent: "resume", expectedTurnId: coordinator.turnId })
+        .status
+    ).toBe("rejected");
     engine.resolve(completed);
     await entered.promise;
     // Engine completion never joins the policy that may itself need engine cleanup.
@@ -135,7 +149,7 @@ describe("TurnCoordinator", () => {
       },
     });
     coordinator.supervise(runner, scope, () => coordinator.beginShutdown());
-    const turn = coordinator.prepare();
+    const turn = prepare(coordinator);
     const op = coordinator.registerOperation(turn);
     coordinator.streamStarted(startEvent("retired"));
     coordinator.beginErrorDecision("retired");
@@ -145,7 +159,7 @@ describe("TurnCoordinator", () => {
       completion: Promise.resolve(completed),
     });
     await entered.promise;
-    const replacement = coordinator.prepare();
+    const replacement = prepare(coordinator);
     await logical;
     let settled = false;
     const decision = coordinator.waitForErrorDecision("retired").then((outcome) => {
@@ -182,7 +196,7 @@ describe("TurnCoordinator", () => {
         },
       });
       coordinator.supervise(runner, scope, () => coordinator.beginShutdown());
-      const op = coordinator.registerOperation(coordinator.prepare());
+      const op = coordinator.registerOperation(prepare(coordinator));
       coordinator.beginErrorDecision("failed");
       await coordinator.consumeCompletion(op, {
         messageId: "failed",
@@ -201,9 +215,13 @@ describe("TurnCoordinator", () => {
       retryA = Symbol("retry A"),
       retryB = Symbol("retry B");
     const state = reduce([
-      { type: "prepare", id: a },
+      {
+        type: "prepare",
+        id: a,
+        request: { kind: "fresh", intent: "handoff", expectedTurnId: initialTurn },
+      },
       { type: "register", id: op, turnId: a },
-      { type: "prepare", id: b },
+      { type: "prepare", id: b, request: { kind: "fresh", intent: "handoff", expectedTurnId: a } },
       { type: "retry-start", id: retryA },
       { type: "retry-start", id: retryB },
     ]);
@@ -227,14 +245,14 @@ describe("TurnCoordinator", () => {
     const { coordinator } = setup({
       phaseChanged: (phase) => {
         if (phase !== "idle" || replacement) return;
-        replacement = coordinator.prepare();
+        replacement = prepare(coordinator);
         coordinator.acceptThinkingOverride(thinkingB, replacement);
         replacementWait = coordinator.waitForIdle().then(() => {
           bIdle = true;
         });
       },
     });
-    const a = coordinator.prepare();
+    const a = prepare(coordinator);
     coordinator.acceptThinkingOverride(thinkingA, a);
     const aWait = coordinator.waitForIdle();
     coordinator.finishTurn(a);
@@ -253,11 +271,11 @@ describe("TurnCoordinator", () => {
   test("preemption abort callbacks cannot finish or overwrite the replacement", () => {
     const { coordinator } = setup();
     const controller = new AbortController();
-    const a = coordinator.prepare(controller);
+    const a = prepare(coordinator, controller);
     const operation = coordinator.registerOperation(a);
     const thinkingB = {};
     controller.signal.addEventListener("abort", () => {
-      const b = coordinator.prepare();
+      const b = prepare(coordinator);
       coordinator.acceptThinkingOverride(thinkingB, b);
     });
     expect(coordinator.preemptPreparation()).toBe(true);
@@ -280,7 +298,7 @@ describe("TurnCoordinator", () => {
     const controller = new AbortController();
     const aborted = mock(() => undefined);
     controller.signal.addEventListener("abort", aborted);
-    coordinator.prepare(controller);
+    prepare(coordinator, controller);
     const idle = coordinator.waitForIdle();
     disposeOnIdle = true;
     coordinator.dispose();
@@ -288,7 +306,10 @@ describe("TurnCoordinator", () => {
     coordinator.dispose();
     expect(aborted).toHaveBeenCalledTimes(1);
     expect(coordinator.disposed).toBe(true);
-    expect(coordinator.isCurrentTurn(coordinator.prepare())).toBe(false);
+    expect(
+      coordinator.prepare({ kind: "fresh", intent: "resume", expectedTurnId: coordinator.turnId })
+        .status
+    ).toBe("rejected");
     expect(callbacks.drainQueue).not.toHaveBeenCalled();
   });
 
@@ -299,8 +320,12 @@ describe("TurnCoordinator", () => {
     const manual = coordinator.registerManualFollowUp();
     await coordinator.waitForIdle();
     expect(coordinator.isBusy()).toBe(true);
-    const rejected = coordinator.prepare();
-    expect(coordinator.isCurrentTurn(rejected)).toBe(false);
+    const rejected = coordinator.prepare({
+      kind: "fresh",
+      intent: "resume",
+      expectedTurnId: coordinator.turnId,
+    });
+    expect(rejected.status).toBe("rejected");
     admission[Symbol.dispose]();
     admission[Symbol.dispose]();
     expect(callbacks.drainQueue).not.toHaveBeenCalled();
@@ -326,7 +351,7 @@ describe("TurnCoordinator", () => {
         if (phase === "completing") observed = coordinator.waitForCompactionDecision("A", false);
       },
     });
-    const a = coordinator.prepare();
+    const a = prepare(coordinator);
     const operation = coordinator.registerOperation(a);
     coordinator.configureOperation(operation, true);
     coordinator.streamStarted(startEvent("A"));
@@ -342,7 +367,7 @@ describe("TurnCoordinator", () => {
     "stale delivered completion settles A's %s decision without touching B",
     async (kind) => {
       const { coordinator, callbacks } = setup();
-      const a = coordinator.prepare();
+      const a = prepare(coordinator);
       const operation = coordinator.registerOperation(a);
       coordinator.configureOperation(operation, true);
       coordinator.streamStarted(startEvent("A"));
@@ -354,7 +379,7 @@ describe("TurnCoordinator", () => {
         coordinator.rawTerminal("completed", "A");
         oldDecision = coordinator.waitForCompactionDecision("A", false);
       }
-      const b = coordinator.prepare();
+      const b = prepare(coordinator);
       await coordinator.consumeCompletion(operation, {
         messageId: "A",
         completion: Promise.resolve(completed),
@@ -371,11 +396,11 @@ describe("TurnCoordinator", () => {
     let b: TurnId | undefined;
     const { coordinator, callbacks } = setup({
       policy: async () => {
-        b = coordinator.prepare();
+        b = prepare(coordinator);
         await continueA.promise;
       },
     });
-    const a = coordinator.prepare();
+    const a = prepare(coordinator);
     const operation = coordinator.registerOperation(a);
     coordinator.streamStarted(startEvent("A"));
     const hardStop = coordinator.captureInterruptSettlement();
@@ -395,7 +420,7 @@ describe("TurnCoordinator", () => {
   test("hard stop joins started policy, but soft and registered startup stop do not", async () => {
     const done = Promise.withResolvers<void>();
     const { coordinator } = setup({ policy: () => done.promise });
-    const a = coordinator.prepare();
+    const a = prepare(coordinator);
     const operation = coordinator.registerOperation(a);
     expect(coordinator.captureInterruptSettlement()).toBeUndefined();
     coordinator.streamStarted(startEvent("A"));
@@ -421,7 +446,7 @@ describe("TurnCoordinator", () => {
     "delivered startup abort with payload=%s claims only its matching notification",
     async (withPayload) => {
       const { coordinator, callbacks } = setup();
-      const a = coordinator.prepare();
+      const a = prepare(coordinator);
       const operation = coordinator.registerOperation(a);
       coordinator.streamStarting(operation, "synthetic-A");
       await coordinator.consumeCompletion(operation, {
@@ -451,7 +476,7 @@ describe("TurnCoordinator", () => {
       },
     });
     const controller = new AbortController();
-    coordinator.prepare(controller);
+    prepare(coordinator, controller);
     const idle = coordinator.waitForIdle();
     expect(() => coordinator.dispose()).toThrow("observer failed");
     await idle;
@@ -466,10 +491,10 @@ describe("TurnCoordinator", () => {
       streamStarted: () => {
         expect(coordinator.captureInterruptSettlement()).toBeDefined();
         reentered = true;
-        coordinator.prepare();
+        prepare(coordinator);
       },
     });
-    const a = coordinator.prepare();
+    const a = prepare(coordinator);
     coordinator.registerOperation(a);
     expect(coordinator.streamStarted(startEvent("A"))).toBe(false);
     expect(reentered).toBe(true);
@@ -479,7 +504,7 @@ describe("TurnCoordinator", () => {
   test("duplicate stream start cannot reopen a raw-terminal completing turn", () => {
     const streamStarted = mock(() => undefined);
     const { coordinator } = setup({ streamStarted });
-    const a = coordinator.prepare();
+    const a = prepare(coordinator);
     coordinator.registerOperation(a);
     expect(coordinator.streamStarted(startEvent("A"))).toBe(true);
     expect(coordinator.streamStarted(startEvent("A"))).toBe(false);
@@ -495,12 +520,99 @@ describe("TurnCoordinator", () => {
       },
     });
     const controller = new AbortController();
-    const a = coordinator.prepare(controller);
+    const a = prepare(coordinator, controller);
     const idle = coordinator.waitForIdle();
     expect(() => coordinator.preemptPreparation()).toThrow("observer failed");
     await idle;
     expect(controller.signal.aborted).toBe(true);
     // The old reservation cannot restart an idle owner after preemption.
-    expect(coordinator.isCurrentTurn(coordinator.prepare(undefined, a))).toBe(false);
+    expect(coordinator.prepare({ kind: "adopt", turnId: a }).status).toBe("rejected");
+  });
+  test("fresh admission cannot replace a busy direct owner, but exact queue adoption does not republish", () => {
+    const published = mock(() => undefined);
+    const { coordinator } = setup({ phaseChanged: published });
+    const first = coordinator.prepare({
+      kind: "fresh",
+      intent: "direct",
+      expectedTurnId: coordinator.turnId,
+    });
+    if (first.status !== "admitted") throw new Error("Expected admission");
+    const events = published.mock.calls.length;
+    for (const intent of [
+      "direct",
+      "resume",
+      "idle",
+      "terminal",
+      "provider-tool",
+      "send-immediately",
+    ] as const) {
+      expect(
+        coordinator.prepare({ kind: "fresh", intent, expectedTurnId: first.turnId }).status
+      ).toBe("deferred");
+    }
+    expect(coordinator.prepare({ kind: "adopt", turnId: first.turnId })).toEqual(first);
+    expect(published.mock.calls).toHaveLength(events);
+    coordinator.finishPreparation(first.turnId);
+    expect(coordinator.prepare({ kind: "adopt", turnId: first.turnId }).status).toBe("rejected");
+  });
+
+  test("a stale handoff cannot install resources or retire its replacement", () => {
+    const { coordinator } = setup();
+    const first = prepare(coordinator);
+    const replacement = prepare(coordinator);
+    const installed = mock(() => undefined);
+    expect(
+      coordinator.prepare(
+        { kind: "fresh", intent: "handoff", expectedTurnId: first },
+        undefined,
+        installed
+      )
+    ).toEqual({ status: "rejected", reason: "retired" });
+    expect(installed).not.toHaveBeenCalled();
+    expect(coordinator.turnId).toBe(replacement);
+    expect(coordinator.phase).toBe("preparing");
+  });
+
+  test("publication retirement returns rejection even when a replacement also publishes PREPARING", () => {
+    let replace = true;
+    let replacement: TurnId | undefined;
+    const { coordinator } = setup({
+      phaseChanged: (phase) => {
+        if (phase !== "preparing" || !replace) return;
+        replace = false;
+        replacement = prepare(coordinator);
+      },
+    });
+    const result = coordinator.prepare({
+      kind: "fresh",
+      intent: "direct",
+      expectedTurnId: coordinator.turnId,
+    });
+    expect(result).toEqual({ status: "rejected", reason: "retired" });
+    if (replacement == null) throw new Error("Expected replacement admission");
+    expect(coordinator.turnId).toBe(replacement);
+    expect(coordinator.phase).toBe("preparing");
+  });
+  test("only the exact edit reservation can claim its idle replacement", () => {
+    const { coordinator } = setup();
+    using edit = coordinator.reserve("edit");
+    const expectedTurnId = coordinator.turnId;
+    for (const editReservation of [undefined, Symbol("unrelated")]) {
+      expect(
+        coordinator.prepare({ kind: "fresh", intent: "direct", expectedTurnId, editReservation })
+      ).toEqual({ status: "deferred", reason: "busy" });
+    }
+    expect(coordinator.turnId).toBe(expectedTurnId);
+    expect(coordinator.prepare({ kind: "fresh", intent: "handoff", expectedTurnId }).status).toBe(
+      "deferred"
+    );
+    expect(
+      coordinator.prepare({
+        kind: "fresh",
+        intent: "direct",
+        expectedTurnId,
+        editReservation: edit.id,
+      }).status
+    ).toBe("admitted");
   });
 });

--- a/src/node/services/turnCoordinator.ts
+++ b/src/node/services/turnCoordinator.ts
@@ -9,6 +9,20 @@ export type TurnId = symbol;
 export type OperationId = symbol;
 export type TurnPhase = "idle" | "preparing" | "streaming" | "completing";
 export type StreamErrorRecoveryOutcome = "retry-started" | "terminal";
+export type QueueDrainTrigger = "idle" | "terminal" | "provider-tool" | "send-immediately";
+export type PreparationRequest =
+  | {
+      kind: "fresh";
+      intent: "direct" | "resume" | "handoff" | QueueDrainTrigger;
+      expectedTurnId: TurnId;
+      editReservation?: symbol;
+    }
+  | { kind: "adopt"; turnId: TurnId };
+export type PreparationAdmission =
+  | { status: "admitted"; turnId: TurnId }
+  | { status: "rejected"; reason: "closing" | "blocked" | "retired" }
+  | { status: "deferred"; reason: "busy" };
+
 type ReservationKind = "admission" | "edit" | "manual";
 type DecisionKind = "error" | "compaction";
 type DecisionOutcome = StreamErrorRecoveryOutcome | boolean;
@@ -47,7 +61,7 @@ export interface CoordinatorState {
 }
 
 export type CoordinatorEvent =
-  | { type: "prepare"; id: TurnId }
+  | { type: "prepare"; id: TurnId; request: PreparationRequest }
   | { type: "finish"; id: TurnId; preparingOnly: boolean }
   | { type: "preempt"; id: TurnId }
   | { type: "forget-compaction"; messageId: string }
@@ -84,13 +98,22 @@ export function initialCoordinatorState(id: TurnId): CoordinatorState {
   return { lifetime: "open", turn: { phase: "idle", id }, reservations: [], decisions: [] };
 }
 
+function hasConflictingEdit(state: CoordinatorState, owner?: symbol): boolean {
+  return state.reservations.some((entry) => entry.kind === "edit" && entry.id !== owner);
+}
+
 /** Pure transition seam: stale events cannot publish, launch policy, or release another owner. */
 export function transition(
   state: CoordinatorState,
   event: CoordinatorEvent
-): { state: CoordinatorState; commands: readonly CoordinatorCommand[] } {
+): {
+  state: CoordinatorState;
+  commands: readonly CoordinatorCommand[];
+  admission?: PreparationAdmission;
+} {
   const commands: CoordinatorCommand[] = [];
   let next = state;
+  let admission: PreparationAdmission | undefined;
   const phase = (turn: Turn) => {
     const previous = next.turn;
     next = { ...next, turn };
@@ -128,17 +151,66 @@ export function transition(
     commands.push({ type: "decision", decision: value });
   };
   const current = state.turn.operation;
-  if (state.lifetime === "disposed") return { state, commands };
+  if (state.lifetime === "disposed")
+    return {
+      state,
+      commands,
+      ...(event.type === "prepare"
+        ? { admission: { status: "rejected", reason: "closing" } as const }
+        : {}),
+    };
   switch (event.type) {
-    case "prepare":
-      if (
-        state.lifetime !== "open" ||
-        state.reservations.some((entry) => entry.kind === "admission")
-      )
+    case "prepare": {
+      if (state.lifetime !== "open") {
+        admission = { status: "rejected", reason: "closing" };
         break;
-      if (current) commands.push({ type: "retire", id: current.id });
-      phase({ phase: "preparing", id: event.id });
+      }
+      if (state.reservations.some((entry) => entry.kind === "admission")) {
+        admission = { status: "rejected", reason: "blocked" };
+        break;
+      }
+      const request = event.request;
+      // An edit owns history before PREPARING. Only its exact reservation can claim the
+      // replacement; sharing the idle turn epoch never authorizes a competing send.
+      const editOwner =
+        request.kind === "fresh" && request.intent === "direct"
+          ? request.editReservation
+          : undefined;
+      if (hasConflictingEdit(state, editOwner)) {
+        admission = { status: "deferred", reason: "busy" };
+        break;
+      }
+      if (request.kind === "adopt") {
+        if (state.turn.id !== request.turnId || state.turn.phase !== "preparing") {
+          admission = { status: "rejected", reason: "retired" };
+          break;
+        }
+        // Adoption attaches startup to the exact queued owner, without retiring or republishing it.
+      } else {
+        if (state.turn.id !== request.expectedTurnId) {
+          admission = { status: "rejected", reason: "retired" };
+          break;
+        }
+        const idleOnly = request.intent === "resume" || request.intent === "idle";
+        const queue =
+          request.intent === "terminal" ||
+          request.intent === "provider-tool" ||
+          request.intent === "send-immediately" ||
+          request.intent === "idle";
+        if (
+          (idleOnly && state.turn.phase !== "idle") ||
+          ((queue || request.intent === "direct") && state.turn.phase === "preparing") ||
+          (request.intent === "direct" && state.turn.phase === "streaming")
+        ) {
+          admission = { status: "deferred", reason: "busy" };
+          break;
+        }
+        if (current) commands.push({ type: "retire", id: current.id });
+        phase({ phase: "preparing", id: event.id });
+      }
+      admission = { status: "admitted", turnId: event.id };
       break;
+    }
     case "preempt":
       if (state.turn.id !== event.id || state.turn.phase !== "preparing") break;
       if (current) commands.push({ type: "retire", id: current.id });
@@ -266,7 +338,7 @@ export function transition(
       commands.push({ type: "dispose" });
       break;
   }
-  return { state: next, commands };
+  return { state: next, commands, admission };
 }
 
 interface CoordinatorCallbacks {
@@ -451,6 +523,9 @@ export class TurnCoordinator {
   get editReserved(): boolean {
     return this.hasReservation("edit");
   }
+  editBlocked(owner?: symbol): boolean {
+    return hasConflictingEdit(this.state, owner);
+  }
   get manualFollowUpPending(): boolean {
     return this.hasReservation("manual");
   }
@@ -475,14 +550,22 @@ export class TurnCoordinator {
   }
 
   private dispatch(
+    event: Extract<CoordinatorEvent, { type: "prepare" }>,
+    install: () => void
+  ): PreparationAdmission;
+  private dispatch(
     event: Extract<CoordinatorEvent, { type: "completion" }>
   ): Promise<void> | undefined;
   private dispatch(event: Exclude<CoordinatorEvent, { type: "completion" }>): void;
-  private dispatch(event: CoordinatorEvent): Promise<void> | undefined {
+  private dispatch(
+    event: CoordinatorEvent,
+    install?: () => void
+  ): Promise<void> | PreparationAdmission | undefined {
     let launchedPolicy: Promise<void> | undefined;
     let publicationError: { error: unknown } | undefined;
     const result = transition(this.state, event);
     this.state = result.state;
+    if (result.admission?.status === "admitted") install?.();
     // Detach before *any* callback. An idle observer may synchronously admit a new turn and waiter.
     const idle = result.commands.some(
       (command) => command.type === "phase" && command.next.phase === "idle"
@@ -573,19 +656,34 @@ export class TurnCoordinator {
     // Publication failures retain their original propagation, but cannot orphan the detached
     // batch or skip disposal's retired resources. A later dispose no longer owns that batch.
     if (publicationError) throw publicationError.error;
-    return launchedPolicy;
+    return result.admission ?? launchedPolicy;
   }
 
-  prepare(controller?: AbortController, reservation?: TurnId): TurnId {
-    const id = reservation ?? Symbol("turn");
-    if (reservation && (!this.isCurrentTurn(reservation) || this.phase !== "preparing"))
-      return Symbol("rejected admission");
-    // Resource publication precedes lifecycle callbacks, just like ownership publication.
-    if (this.state.lifetime !== "open" || this.admissionBlocked)
-      return Symbol("rejected admission");
-    this.prepared = controller ? { id, controller } : undefined;
-    this.dispatch({ type: "prepare", id });
-    return id;
+  prepare(
+    request: PreparationRequest,
+    controller?: AbortController,
+    install?: (turnId: TurnId) => void
+  ): PreparationAdmission {
+    const id = request.kind === "adopt" ? request.turnId : Symbol("turn");
+    let admission: PreparationAdmission;
+    try {
+      admission = this.dispatch({ type: "prepare", id, request }, () => {
+        // Ownership and abort resources precede callbacks, including synchronous shutdown.
+        this.prepared = controller ? { id, controller } : undefined;
+        install?.(id);
+      });
+    } catch (error) {
+      if (!install) this.finishPreparation(id);
+      throw error;
+    }
+    // A PREPARING observer can retire this claim before dispatch returns. Never signal a
+    // service preflight handoff or dequeue on the strength of that obsolete publication.
+    if (
+      admission.status === "admitted" &&
+      (!this.isCurrentTurn(id) || this.closing || this.phase !== "preparing")
+    )
+      return { status: "rejected", reason: "retired" };
+    return admission;
   }
 
   finishPreparation(id: TurnId): void {
@@ -635,10 +733,10 @@ export class TurnCoordinator {
     }
   }
 
-  reserve(kind: ReservationKind): Disposable {
+  reserve(kind: ReservationKind): Disposable & { readonly id: symbol } {
     const id = Symbol(kind);
     this.dispatch({ type: "reserve", id, kind });
-    return { [Symbol.dispose]: () => this.dispatch({ type: "release", id, kind }) };
+    return { id, [Symbol.dispose]: () => this.dispatch({ type: "release", id, kind }) };
   }
 
   registerManualFollowUp(signal?: AbortSignal): () => void {


### PR DESCRIPTION
Turn preparation now uses explicit coordinator admission results and one preparation lifecycle for direct sends, queued sends, background startup, and resume. This closes races where a stale send could change its replacement's retry state, a queue observer could replace the entry being dispatched, or a direct send could write history while an edit owned it.

The coordinator claims ownership and installs correlation before publishing PREPARING. Queued work adopts that exact owner, revalidates the queue head before dequeue, and settles failure callbacks before releasing preparation. Preparation tracks rollback eligibility, durable rows, acceptance, and background/provider handoff separately. Edit replacement requires its exact reservation token and retains that reservation through correlated failure settlement, including background startup; payload validation runs before truncation. These changes preserve the Promise facade and the existing scoped Effect execution introduced in #4111.

Validation covers real-history rollback and held edit writes, reentrant queue mutation/shutdown, stale thinking and retry updates, and transient or persistent failure-callback rejection. All AgentSession/coordinator/MessageQueue/service-container suites pass (514 tests), along with the WorkspaceService admission/queue/resume/shutdown subset (104 tests). The full static checks, Electron main build, and real Electron send-mode workflow all pass (5 integration tests).

Risk is concentrated in admission ordering, cancellation, and accepted pre-stream failures: a regression could strand queued work or associate history with the wrong turn. Deterministic barriers exercise these boundaries, while full CI and the real Electron send-mode workflow cover integration.

---

_Generated with `xum` • Model: `unavailable` • Thinking: `unavailable` • Cost: `$unavailable`_

<!-- mux-attribution: model=unavailable thinking=unavailable costs=unavailable -->