### PR TITLE
🤖 refactor: make turn cancellation and session disposal awaitable

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -1580,7 +1580,9 @@ async function main(): Promise<number> {
         // Interrupt + await the runtime's supervised fibers while their
         // dependencies are still alive (same slot as ServiceContainer.dispose).
         { name: "appFiberScope.close", run: () => closeScopeBounded(appFiberScope) },
-        { name: "session.dispose", run: () => session.dispose() },
+        // The service guardian joins disposal inside closeScopeBounded. After a timeout,
+        // only initiate cleanup here: a second unbounded join would prevent CLI exit.
+        { name: "session.dispose", run: () => session.beginDispose() },
         { name: "mcpServerManager.dispose", run: () => mcpServerManager.dispose() },
         { name: "codexOauthService.dispose", run: () => codexOauthService.dispose() },
         { name: "coderOauthService.dispose", run: () => coderOauthService.dispose() },

--- a/src/cli/runCleanup.test.ts
+++ b/src/cli/runCleanup.test.ts
@@ -1,4 +1,10 @@
-import { describe, test, expect } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { createConfigStores } from "@/node/config";
+import { ServiceContainer } from "@/node/services/serviceContainer";
+import { closeScopeBounded } from "@/node/services/di/appRuntime";
+import { describe, test, expect, spyOn } from "bun:test";
 import { runBestEffortCleanup, type RunCleanupStep } from "./runCleanup";
 
 describe("runBestEffortCleanup", () => {
@@ -60,5 +66,41 @@ describe("runBestEffortCleanup", () => {
       }
     );
     expect(ran).toEqual(["after"]);
+  });
+  test("CLI cleanup proceeds after the shared scope budget expires without a second disposal join", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "mux-cli-disposal-test-"));
+    const services = new ServiceContainer(createConfigStores(tempDir));
+    const session = services.workspaceService.getOrCreateSession("bounded-cli-disposal");
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    spyOn(services.backgroundProcessManager, "cleanup").mockImplementationOnce(async () => {
+      entered.resolve();
+      await release.promise;
+    });
+    let nextDependency = false;
+    try {
+      const cleanup = runBestEffortCleanup(
+        [
+          { name: "scope", run: () => closeScopeBounded(services.appFiberScope, 20) },
+          { name: "session", run: () => session.beginDispose() },
+          {
+            name: "dependency",
+            run: () => {
+              nextDependency = true;
+            },
+          },
+        ],
+        () => undefined
+      );
+      await entered.promise;
+      await cleanup;
+      expect(nextDependency).toBe(true);
+    } finally {
+      release.resolve();
+      await session.dispose();
+      await services.dispose();
+      await services.shutdown();
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/cli/workflow.ts
+++ b/src/cli/workflow.ts
@@ -287,7 +287,9 @@ async function disposeWorkflowResources(input: {
             { name: "appFiberScope.close", run: () => closeScopeBounded(services.appFiberScope) },
           ]
         : []),
-      { name: "session.dispose", run: () => input.session?.dispose() },
+      // The service guardian joins disposal inside closeScopeBounded. After a timeout,
+      // only initiate cleanup here: a second unbounded join would prevent CLI exit.
+      { name: "session.dispose", run: () => input.session?.beginDispose() },
       { name: "mcpServerManager.dispose", run: () => services?.mcpServerManager.dispose() },
       { name: "codexOauthService.dispose", run: () => input.codexOauthService?.dispose() },
       { name: "coderOauthService.dispose", run: () => input.coderOauthService?.dispose() },

--- a/src/node/services/agentPlugins/hookService.test.ts
+++ b/src/node/services/agentPlugins/hookService.test.ts
@@ -478,7 +478,7 @@ describe("AgentPluginHookService", () => {
       metadata.mockRestore();
       create.mockRestore();
       await harness.service.disposeWorkspace(WORKSPACE_ID);
-      h.session.dispose();
+      await h.session.dispose();
       await h.cleanup();
     }
   });

--- a/src/node/services/agentSession.autoCompaction.test.ts
+++ b/src/node/services/agentSession.autoCompaction.test.ts
@@ -51,7 +51,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
     const workspaceId = "ws-auto-compaction-snapshot-deferral";
 
     const streamMessage = mock((_history: MuxMessage[]) =>
-      Promise.resolve(Ok(createStartedTurnHandle()))
+      Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal)))
     );
     const { session, historyService, events, backgroundProcessManager } =
       await createSessionHarness({
@@ -146,7 +146,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
     expect(emittedSnapshot).toBe(false);
     expect(cleanupSpy).not.toHaveBeenCalled();
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("tracks a compaction request when a synthetic snapshot follows it", async () => {
@@ -191,7 +191,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
       source: "auto-compaction",
     });
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("does not materialize skill snapshots (or run their directives) on deferred on-send compaction turns", async () => {
@@ -237,7 +237,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
     expect(result.success).toBe(true);
     expect(materializeSkillSnapshots).not.toHaveBeenCalled();
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("stamps on-send auto-compaction requests with the RLM keep-recent tail only when RLM is on", async () => {
@@ -289,7 +289,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
       );
       expect(request).toBeDefined();
 
-      session.dispose();
+      await session.dispose();
       const muxMetadata = request?.metadata?.muxMetadata;
       return muxMetadata?.type === "compaction-request" ? muxMetadata.keepRecentTail : undefined;
     };
@@ -342,7 +342,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
     // Codex P2 (PRRT_kwDOPxxmWM6cIv2E): the re-dispatched follow-up row must
     // stay goal-scoped instead of degrading to a legacy unscoped row.
     expect(followUp.goalId).toBe("goal-compaction-scope");
-    session.dispose();
+    await session.dispose();
   });
 
   test("triggers on-send compaction at threshold even before force buffer", async () => {
@@ -351,7 +351,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
     const streamRequests: unknown[] = [];
     const streamMessage = mock((request: unknown) => {
       streamRequests.push(request);
-      return Promise.resolve(Ok(createStartedTurnHandle()));
+      return Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal)));
     });
     const { session } = await createSessionHarness({
       workspaceId,
@@ -386,7 +386,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
     );
     expect(hasCompactionRequest).toBe(true);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("uses preferred compaction model for on-send auto-compaction requests", async () => {
@@ -395,7 +395,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
     const streamRequests: unknown[] = [];
     const streamMessage = mock((request: unknown) => {
       streamRequests.push(request);
-      return Promise.resolve(Ok(createStartedTurnHandle()));
+      return Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal)));
     });
     const compactionModel = "openai:gpt-4o-mini";
     const config = {
@@ -441,7 +441,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
 
     expect(compactionRequestMessage?.metadata?.muxMetadata?.requestedModel).toBe(compactionModel);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("does not trigger compaction at 200K threshold when 1M context is preserved after agent routing", async () => {
@@ -450,7 +450,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
     const streamRequests: unknown[] = [];
     const streamMessage = mock((request: unknown) => {
       streamRequests.push(request);
-      return Promise.resolve(Ok(createStartedTurnHandle()));
+      return Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal)));
     });
     const { session, historyService } = await createSessionHarness({
       workspaceId,
@@ -504,7 +504,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
     );
     expect(persistedCompactionRequest).toBe(false);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("does trigger compaction at the default beta Anthropic threshold when beta features disable 1M", async () => {
@@ -513,7 +513,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
     const streamRequests: unknown[] = [];
     const streamMessage = mock((request: unknown) => {
       streamRequests.push(request);
-      return Promise.resolve(Ok(createStartedTurnHandle()));
+      return Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal)));
     });
     const { session, historyService } = await createSessionHarness({
       workspaceId,
@@ -566,7 +566,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
     );
     expect(persistedCompactionRequest).toBe(true);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("compaction model inherit uses caller-provided baseOptions.model when no preferred model configured", async () => {
@@ -611,7 +611,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
     expect(compactionRequest.metadata.requestedModel).toBe(inheritedModel);
     expect(compactionRequest.metadata.parsed?.model).toBe(inheritedModel);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("clears strictAgentResolution on the internal compact request", async () => {
@@ -650,7 +650,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
     expect(compactionRequest.sendOptions.agentId).toBe("compact");
     expect(compactionRequest.sendOptions.strictAgentResolution).toBeUndefined();
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("compaction model explicit override takes priority over baseOptions.model", async () => {
@@ -703,7 +703,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
     expect(compactionRequest.metadata.requestedModel).toBe(compactionModel);
     expect(compactionRequest.metadata.parsed?.model).toBe(compactionModel);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("compaction thinking level prefers compact agent default over baseOptions", async () => {
@@ -752,7 +752,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
     // matching desktop /compact (applyCompactionOverrides).
     expect(compactionRequest.sendOptions.thinkingLevel).toBe("high");
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("compaction thinking level falls back to baseOptions when compact default is unset", async () => {
@@ -789,7 +789,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
 
     expect(compactionRequest.sendOptions.thinkingLevel).toBe("medium");
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("threads providers config into pre-send and mid-stream compaction checks", async () => {
@@ -837,7 +837,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
         },
       });
 
-      return Promise.resolve(Ok(createStartedTurnHandle()));
+      return Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal)));
     });
 
     const aiService = Object.assign(aiEmitter, {
@@ -899,7 +899,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
       providersConfig,
     });
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("seeds on-send compaction usage from the active compaction epoch only", async () => {
@@ -953,7 +953,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
 
     const aiEmitter = new EventEmitter();
     const streamMessage = mock((_history: MuxMessage[]) =>
-      Promise.resolve(Ok(createStartedTurnHandle()))
+      Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal)))
     );
     const aiService = Object.assign(aiEmitter, {
       ...createStreamLifecycleMocks(),
@@ -1015,7 +1015,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
     expect(result.success).toBe(true);
     expect(checkBeforeSend).toHaveBeenCalledTimes(1);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("surfaces nested dispatch failures after mid-stream compaction interrupt", async () => {
@@ -1053,7 +1053,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
         });
       }
 
-      return Promise.resolve(Ok(createStartedTurnHandle()));
+      return Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal)));
     });
 
     const stopStream = mock((_workspaceId: string) => {
@@ -1159,7 +1159,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
     expect(streamError?.error).toContain("mid-stream compaction dispatch failed");
     expect(stopStream).toHaveBeenCalledTimes(1);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("hides default follow-up sentinel in mid-stream auto-compaction prompts", async () => {
@@ -1204,7 +1204,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
         });
       }
 
-      return Promise.resolve(Ok(createStartedTurnHandle()));
+      return Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal)));
     });
 
     const stopStream = mock((_workspaceId: string) => {
@@ -1318,7 +1318,7 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
     expect(compactionRequestText).not.toContain("[CONTINUE]");
     expect(stopStream).toHaveBeenCalledTimes(1);
 
-    session.dispose();
+    await session.dispose();
   });
 });
 
@@ -1498,7 +1498,7 @@ describe("AgentSession on-send auto-compaction for synthetic guidance sends", ()
       )
     ).toBe(true);
 
-    fixture.session.dispose();
+    await fixture.session.dispose();
   });
 
   // Characterization: sends carrying preTurnMessages (family-message payloads)
@@ -1542,7 +1542,7 @@ describe("AgentSession on-send auto-compaction for synthetic guidance sends", ()
     }
     expect(historyResult.data.some((message) => message.id === "payload-1")).toBe(true);
 
-    fixture.session.dispose();
+    await fixture.session.dispose();
   });
 
   test("startup retry of an interrupted compaction keeps compaction identity", async () => {
@@ -1609,6 +1609,6 @@ describe("AgentSession on-send auto-compaction for synthetic guidance sends", ()
     });
     expect(boundaryLanded).toBe(true);
 
-    fixture.session.dispose();
+    await fixture.session.dispose();
   });
 });

--- a/src/node/services/agentSession.budgetGate.test.ts
+++ b/src/node/services/agentSession.budgetGate.test.ts
@@ -44,12 +44,14 @@ async function setGoalOk(
   return result.data;
 }
 
-function createAiService(workspaceId: string): AIService {
+function createAiService(workspaceId: string, getClosingSignal: () => AbortSignal): AIService {
   const aiEmitter = new EventEmitter();
   return Object.assign(aiEmitter, {
     isStreaming: mock((_workspaceId: string) => false),
     stopStream: mock((_workspaceId: string) => Promise.resolve(Ok(undefined))),
-    streamMessage: mock((_request: unknown) => Promise.resolve(Ok(createStartedTurnHandle()))),
+    streamMessage: mock((_request: unknown) =>
+      Promise.resolve(Ok(createStartedTurnHandle(getClosingSignal())))
+    ),
     getStreamInfo: mock((_workspaceId: string) => null),
     getProvidersConfig: mock(() => null),
     getWorkspaceMetadata: mock((_workspaceId: string) =>
@@ -92,11 +94,11 @@ async function createSessionHarness(workspaceId: string): Promise<SessionHarness
     setMessageQueued: mock((_workspaceId: string, _queued: boolean) => undefined),
   } as unknown as BackgroundProcessManager;
 
-  const session = new AgentSession({
+  const session: AgentSession = new AgentSession({
     workspaceId,
     config,
     historyService,
-    aiService: createAiService(workspaceId),
+    aiService: createAiService(workspaceId, () => session.closingSignal),
     initStateManager,
     backgroundProcessManager,
     workspaceGoalService: goalService,
@@ -149,7 +151,7 @@ describe("AgentSession.sendMessage budget gate", () => {
         expect(result.error.raw).toContain("Target model has no pricing data");
       }
     }
-    session.dispose();
+    await session.dispose();
   });
 
   test("resumeStream rejects an unpriced model when a budgeted resumable goal exists", async () => {
@@ -172,7 +174,7 @@ describe("AgentSession.sendMessage budget gate", () => {
         expect(result.error.raw).toContain("Target model has no pricing data");
       }
     }
-    session.dispose();
+    await session.dispose();
   });
 
   test("allows an unpriced model when no budgeted goal exists", async () => {
@@ -185,7 +187,7 @@ describe("AgentSession.sendMessage budget gate", () => {
 
     const result = await session.sendMessage("Unpriced", UNPRICED_OPTIONS);
     expect(result.success).toBe(true);
-    session.dispose();
+    await session.dispose();
   });
 
   test("allows an unpriced model when goal has no budget", async () => {
@@ -200,7 +202,7 @@ describe("AgentSession.sendMessage budget gate", () => {
 
     const result = await session.sendMessage("Unpriced", UNPRICED_OPTIONS);
     expect(result.success).toBe(true);
-    session.dispose();
+    await session.dispose();
   });
 
   test("manual rejected send preserves the user message + emits a stream-error event", async () => {
@@ -259,7 +261,7 @@ describe("AgentSession.sendMessage budget gate", () => {
     // intervened (Codex P1 PRRT_kwDOPxxmWM5_tOFt).
     expect(await goalService.getGoal(workspaceId)).toMatchObject({ status: "paused" });
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("rejected queued sends persist authoring metadata and pre-goal rows do not pause the goal", async () => {
@@ -299,7 +301,7 @@ describe("AgentSession.sendMessage budget gate", () => {
     // enqueuedAtMs path.
     expect(await goalService.getGoal(workspaceId)).toMatchObject({ status: "active" });
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("empty manual rejected send does NOT pause an active goal", async () => {
@@ -322,7 +324,7 @@ describe("AgentSession.sendMessage budget gate", () => {
     expect(result.success).toBe(false);
     expect(await goalService.getGoal(workspaceId)).toMatchObject({ status: "active" });
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("synthetic rejected send does NOT pause an active goal", async () => {
@@ -346,7 +348,7 @@ describe("AgentSession.sendMessage budget gate", () => {
     expect(result.success).toBe(false);
     expect(await goalService.getGoal(workspaceId)).toMatchObject({ status: "active" });
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("synthetic rejected send does NOT persist a user message", async () => {
@@ -377,7 +379,7 @@ describe("AgentSession.sendMessage budget gate", () => {
       expect(userMessages.length).toBe(0);
     }
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("queue-dispatch race: setGoal between enqueue and drain still rejects", async () => {
@@ -433,6 +435,6 @@ describe("AgentSession.sendMessage budget gate", () => {
       );
       expect(queuedUserMessage).toBeDefined();
     }
-    session.dispose();
+    await session.dispose();
   });
 });

--- a/src/node/services/agentSession.continueMessageAgentId.test.ts
+++ b/src/node/services/agentSession.continueMessageAgentId.test.ts
@@ -145,7 +145,7 @@ describe("AgentSession continue-message agentId fallback", () => {
 
   afterEach(async () => {
     for (const session of sessions.splice(0)) {
-      session.dispose();
+      await session.dispose();
     }
     await historyCleanup?.();
     historyCleanup = undefined;

--- a/src/node/services/agentSession.continuousCompaction.test.ts
+++ b/src/node/services/agentSession.continuousCompaction.test.ts
@@ -76,7 +76,7 @@ function deferred<T>() {
 describe("AgentSession continuous compaction wiring", () => {
   let harness: AgentSessionHarness | undefined;
   afterEach(async () => {
-    harness?.session.dispose();
+    await harness?.session.dispose();
     await harness?.cleanup();
     harness = undefined;
     mock.restore();
@@ -473,7 +473,7 @@ describe("AgentSession continuous compaction wiring", () => {
       starts++;
       startStream(h);
       if (starts === 2) queuedStarted.resolve();
-      return Promise.resolve(Ok(createStartedTurnHandle()));
+      return Promise.resolve(Ok(createStartedTurnHandle(h.session.closingSignal)));
     });
     spyOn(internals(h.session).continuousCompactor, "observe").mockImplementation(
       async (_percent, context) => {
@@ -625,7 +625,7 @@ describe("AgentSession continuous compaction wiring", () => {
       spyOn(h.aiService, "streamMessage").mockImplementation(() => {
         streaming = true;
         startStream(h);
-        return Promise.resolve(Ok(createStartedTurnHandle()));
+        return Promise.resolve(Ok(createStartedTurnHandle(h.session.closingSignal)));
       });
       const stop = spyOn(h.aiService, "stopStream").mockImplementation(async () => {
         streaming = false;
@@ -727,7 +727,7 @@ describe("AgentSession continuous compaction wiring", () => {
           order.push("resume");
           resumed.resolve();
         }
-        return Promise.resolve(Ok(createStartedTurnHandle()));
+        return Promise.resolve(Ok(createStartedTurnHandle(h.session.closingSignal)));
       });
       spyOn(h.aiService, "stopStream").mockImplementation(async (_id, options) => {
         if (eventType === "prefix-swap-invalidated")
@@ -841,7 +841,7 @@ describe("AgentSession continuous compaction wiring", () => {
       spyOn(h.aiService, "streamMessage").mockImplementation(() => {
         starts++;
         startStream(h);
-        return Promise.resolve(Ok(createStartedTurnHandle()));
+        return Promise.resolve(Ok(createStartedTurnHandle(h.session.closingSignal)));
       });
       spyOn(h.aiService, "stopStream").mockImplementation(() => {
         void runSessionTerminalPolicy(h.session, h.aiEmitter, {
@@ -1151,7 +1151,7 @@ describe("AgentSession continuous compaction wiring", () => {
     h.session.beginShutdown();
     expect(reset).toHaveBeenCalled();
     reset.mockClear();
-    h.session.dispose();
+    h.session.beginDispose();
     expect(reset).toHaveBeenCalled();
     reset.mockClear();
   });

--- a/src/node/services/agentSession.disposeRace.test.ts
+++ b/src/node/services/agentSession.disposeRace.test.ts
@@ -21,6 +21,7 @@ import {
 import { createAgentSessionHarness, createStreamLifecycleMocks } from "./agentSession.testHarness";
 import type { StreamMessageOptions } from "./aiService";
 import type { TurnCompletion } from "./streamManager";
+import type { TurnCoordinator } from "./turnCoordinator";
 
 function createDeferred<T>(): {
   promise: Promise<T>;
@@ -107,7 +108,7 @@ describe("AgentSession disposal race conditions", () => {
     expect(inFlight).toBeDefined();
 
     // Dispose while sendMessage() is awaiting appendToHistory.
-    session.dispose();
+    session.beginDispose();
     appendDeferred.resolve(Ok(undefined));
 
     const result = await (inFlight as Promise<Result<void>>);
@@ -128,6 +129,7 @@ describe("AgentSession disposal race conditions", () => {
         startTime: Date.now(),
       })
     ).not.toThrow();
+    await session.dispose();
     await history.cleanup();
   });
 
@@ -224,10 +226,11 @@ describe("AgentSession disposal race conditions", () => {
 
       // Mirror removeWorkspace: dispose the session, cancel + drain the
       // writer, then delete the session directory.
-      session.dispose();
+      session.beginDispose();
       const clearPromise = clearPendingBranchSummary(workspaceId);
       releaseModel();
       await clearPromise;
+      await session.dispose();
       await fs.rm(sessionDir, { recursive: true, force: true });
 
       const result = await sendPromise;
@@ -531,7 +534,7 @@ describe("AgentSession disposal race conditions", () => {
         handleStreamError: (data: unknown) => Promise<void>;
       };
       const handleStreamErrorSpy = spyOn(errorSink, "handleStreamError");
-      session.dispose();
+      session.beginDispose();
       completion.resolve({
         status: "failed",
         streamError: { messageId: "assistant-post-dispose", error: "boom", errorType: "api" },
@@ -539,6 +542,7 @@ describe("AgentSession disposal race conditions", () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
       expect(handleStreamErrorSpy).not.toHaveBeenCalled();
     } finally {
+      await session.dispose();
       await cleanup();
     }
   });
@@ -563,7 +567,7 @@ describe("AgentSession disposal race conditions", () => {
       });
       // Let the resume park on the pending commitPartial before disposing.
       await new Promise((resolve) => setTimeout(resolve, 10));
-      session.dispose();
+      session.beginDispose();
       commitDeferred.resolve(Err("workspace removed mid-startup"));
 
       const result = await resumePromise;
@@ -574,6 +578,7 @@ describe("AgentSession disposal race conditions", () => {
       expect(handleStreamErrorSpy).not.toHaveBeenCalled();
       expect(autoRetrySpy).not.toHaveBeenCalled();
     } finally {
+      await session.dispose();
       await cleanup();
     }
   });
@@ -649,5 +654,102 @@ describe("AgentSession disposal race conditions", () => {
     // (goal safety uses it to detect messages that predate a fresh goal).
     expect(internal?.synthetic).toBe(true);
     expect(typeof internal?.enqueuedAtMs).toBe("number");
+  });
+});
+
+describe("AgentSession awaitable disposal", () => {
+  test.each([false, true])(
+    "joins stop, background cleanup and original leases; terminal subscriber throws=%s",
+    async (throwSubscriber) => {
+      const stopped = Promise.withResolvers<void>();
+      const background = Promise.withResolvers<void>();
+      const workspaceId = "disposal-fence";
+      const streamManager = {
+        ...createStreamLifecycleMocks(),
+        getStreamInfo: () => ({
+          messageId: "old",
+          model: "openai:gpt-4o",
+          historySequence: 1,
+          startTime: 0,
+          parts: [],
+          currentStepStartIndex: 0,
+          stepStartIndices: [],
+          toolCompletionTimestamps: new Map<string, number>(),
+        }),
+        stopStream: mock(async () => {
+          await stopped.promise;
+          h.aiEmitter.emit("stream-abort", {
+            type: "stream-abort",
+            workspaceId,
+            messageId: "old",
+            abortReason: "system",
+            abandonPartial: true,
+          });
+          return Ok(undefined);
+        }),
+      };
+      const h = await createAgentSessionHarness({
+        workspaceId,
+        streamManager,
+        captureEvents: true,
+        backgroundProcessManagerOverrides: { cleanup: mock(() => background.promise) },
+      });
+      const { coordinator } = h.session as unknown as { coordinator: TurnCoordinator };
+      const originalLease = coordinator.enterExecution();
+      let finished = false;
+      if (throwSubscriber)
+        h.session.onChatEvent(({ message }) => {
+          if (message.type === "stream-abort") throw new Error("terminal subscriber failed");
+        });
+      const disposed = h.session.dispose();
+      const observedDisposal = disposed.then(() => {
+        finished = true;
+      });
+      try {
+        expect(h.session.dispose()).toBe(disposed);
+        expect(coordinator.disposed).toBe(true);
+        expect(h.aiEmitter.listenerCount("stream-abort")).toBeGreaterThan(0);
+        stopped.resolve();
+        await stopped.promise;
+        // The original stop is a separate join from background cleanup and preparation callbacks.
+        expect(finished).toBe(false);
+        background.resolve();
+        await background.promise;
+        expect(finished).toBe(false);
+        originalLease[Symbol.dispose]();
+        await observedDisposal;
+        expect(h.events.filter((event) => event.type === "stream-abort")).toHaveLength(1);
+        expect(h.aiEmitter.listenerCount("stream-abort")).toBe(0);
+        expect(h.initStateManager.listenerCount("init-start")).toBe(0);
+        expect(streamManager.stopStream).toHaveBeenCalledTimes(1);
+      } finally {
+        stopped.resolve();
+        background.resolve();
+        originalLease[Symbol.dispose]();
+        await disposed;
+        await h.cleanup();
+      }
+    }
+  );
+
+  test("leased callback can initiate disposal before releasing itself", async () => {
+    const h = await createAgentSessionHarness({ workspaceId: "callback-disposal" });
+    const { coordinator } = h.session as unknown as { coordinator: TurnCoordinator };
+    const callbackReturned = Promise.withResolvers<void>();
+    const callback = (async () => {
+      using _lease = coordinator.enterExecution();
+      h.session.beginDispose();
+      await callbackReturned.promise;
+    })();
+    try {
+      expect(coordinator.disposed).toBe(true);
+      callbackReturned.resolve();
+      await callback;
+      await h.session.dispose();
+    } finally {
+      callbackReturned.resolve();
+      await h.session.dispose();
+      await h.cleanup();
+    }
   });
 });

--- a/src/node/services/agentSession.drainQueuedMessagesIfIdle.test.ts
+++ b/src/node/services/agentSession.drainQueuedMessagesIfIdle.test.ts
@@ -33,7 +33,7 @@ describe("AgentSession.drainQueuedMessagesIfIdle", () => {
   let session: AgentSession | undefined;
 
   afterEach(async () => {
-    session?.dispose();
+    await session?.dispose();
     session = undefined;
     await cleanup?.();
     cleanup = undefined;

--- a/src/node/services/agentSession.editMessageId.test.ts
+++ b/src/node/services/agentSession.editMessageId.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, mock, afterEach, spyOn } from "bun:test";
 import { EventEmitter } from "events";
-import type { AIService } from "@/node/services/aiService";
+import type { AIService, StreamMessageOptions } from "@/node/services/aiService";
 import type { InitStateManager } from "@/node/services/initStateManager";
 import type { BackgroundProcessManager } from "@/node/services/backgroundProcessManager";
 import type { Config } from "@/node/config";
@@ -37,7 +37,8 @@ describe("AgentSession.sendMessage (editMessageId)", () => {
 
   async function createSessionHarness(
     workspaceId: string,
-    streamHandler: StreamMessageHandler = () => Promise.resolve(Ok(createStartedTurnHandle()))
+    streamHandler: StreamMessageHandler = (opts: StreamMessageOptions) =>
+      Promise.resolve(Ok(createStartedTurnHandle(opts.abortSignal!)))
   ) {
     const { historyService, cleanup } = await createTestHistoryService();
     historyCleanup = cleanup;
@@ -286,7 +287,7 @@ describe("AgentSession.sendMessage (editMessageId)", () => {
     const streamResolves: Array<() => void> = [];
     const streamHandler: StreamMessageHandler = (opts) => {
       return new Promise<Awaited<ReturnType<StreamMessageHandler>>>((resolve) => {
-        const resolveOk = () => resolve(Ok(createStartedTurnHandle()));
+        const resolveOk = () => resolve(Ok(createStartedTurnHandle(opts.abortSignal!)));
         if (opts.abortSignal?.aborted === true) {
           resolveOk();
           return;
@@ -354,10 +355,11 @@ describe("AgentSession.sendMessage (editMessageId)", () => {
       }
       await firstSendPromise;
     } finally {
-      session.dispose();
+      session.beginDispose();
       for (const resolve of streamResolves) {
         resolve();
       }
+      await session.dispose();
     }
   });
 

--- a/src/node/services/agentSession.fileChangeNotification.test.ts
+++ b/src/node/services/agentSession.fileChangeNotification.test.ts
@@ -26,7 +26,7 @@ describe("AgentSession file-change notification (turn start)", () => {
 
   afterEach(async () => {
     for (const session of sessions.splice(0)) {
-      session.dispose();
+      await session.dispose();
     }
     await historyCleanup?.();
     historyCleanup = undefined;
@@ -48,7 +48,7 @@ describe("AgentSession file-change notification (turn start)", () => {
     const capturedRequests: MuxMessage[][] = [];
     const streamMessage = mock((opts: StreamMessageOptions) => {
       capturedRequests.push(opts.messages);
-      return Promise.resolve(Ok(createStartedTurnHandle()));
+      return Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal)));
     });
     const aiService: AIService = {
       ...createStreamLifecycleMocks(),

--- a/src/node/services/agentSession.goalAutoPause.test.ts
+++ b/src/node/services/agentSession.goalAutoPause.test.ts
@@ -48,12 +48,17 @@ async function setGoalOk(
   return result.data;
 }
 
-function createAiService(workspaceId: string): AIService & EventEmitter {
+function createAiService(
+  workspaceId: string,
+  getClosingSignal: () => AbortSignal
+): AIService & EventEmitter {
   const aiEmitter = new EventEmitter();
   return Object.assign(aiEmitter, {
     isStreaming: mock((_workspaceId: string) => false),
     stopStream: mock((_workspaceId: string) => Promise.resolve(Ok(undefined))),
-    streamMessage: mock((_request: unknown) => Promise.resolve(Ok(createStartedTurnHandle()))),
+    streamMessage: mock((_request: unknown) =>
+      Promise.resolve(Ok(createStartedTurnHandle(getClosingSignal())))
+    ),
     getStreamInfo: mock((_workspaceId: string) => null),
     getProvidersConfig: mock(() => null),
     getWorkspaceMetadata: mock((_workspaceId: string) =>
@@ -99,7 +104,7 @@ async function createSessionHarness(workspaceId: string): Promise<SessionHarness
     setMessageQueued: mock((_workspaceId: string, _queued: boolean) => undefined),
   } as unknown as BackgroundProcessManager;
 
-  const aiService = createAiService(workspaceId);
+  const aiService = createAiService(workspaceId, () => session.closingSignal);
   const session = new AgentSession({
     workspaceId,
     config,
@@ -139,7 +144,7 @@ describe("AgentSession goal safety hooks", () => {
       "goal_paused",
       expect.objectContaining({ initiator: "auto" })
     );
-    session.dispose();
+    await session.dispose();
   });
 
   test("manual user messages can explicitly pause active goals", async () => {
@@ -159,7 +164,7 @@ describe("AgentSession goal safety hooks", () => {
       "goal_paused",
       expect.objectContaining({ initiator: "auto" })
     );
-    session.dispose();
+    await session.dispose();
   });
 
   for (const status of [
@@ -191,7 +196,7 @@ describe("AgentSession goal safety hooks", () => {
 
       expect(result.success).toBe(true);
       expect(await goalService.getGoal(workspaceId)).toMatchObject({ status });
-      session.dispose();
+      await session.dispose();
     });
   }
 
@@ -246,7 +251,7 @@ describe("AgentSession goal safety hooks", () => {
       status: "budget_limited",
       budgetLimitOriginKind: "user",
     });
-    session.dispose();
+    await session.dispose();
   });
 
   test("a paused goal vetoes a redispatched compaction follow-up continuation", async () => {
@@ -305,7 +310,7 @@ describe("AgentSession goal safety hooks", () => {
       const meta = tail.data[0]?.metadata?.muxMetadata;
       expect(meta && "pendingFollowUp" in meta ? meta.pendingFollowUp : undefined).toBeUndefined();
     }
-    session.dispose();
+    await session.dispose();
   });
 
   test("a manual message queued during redispatch preflight vetoes the follow-up", async () => {
@@ -368,7 +373,7 @@ describe("AgentSession goal safety hooks", () => {
       const meta = history.data.find((message) => message.id === summary.id)?.metadata?.muxMetadata;
       expect(meta && "pendingFollowUp" in meta ? meta.pendingFollowUp : undefined).toBeUndefined();
     }
-    session.dispose();
+    await session.dispose();
   });
 
   test("a service-level send preflight defers redispatched follow-ups", async () => {
@@ -417,7 +422,7 @@ describe("AgentSession goal safety hooks", () => {
       expect(meta && "pendingFollowUp" in meta ? meta.pendingFollowUp : undefined).toBeUndefined();
     }
     sendSpy.mockRestore();
-    session.dispose();
+    await session.dispose();
   });
 
   test("a service preflight starting mid-redispatch flips the live admission probe", async () => {
@@ -477,7 +482,7 @@ describe("AgentSession goal safety hooks", () => {
         )
       ).toBe(false);
     }
-    session.dispose();
+    await session.dispose();
   });
 
   test("a recovered budget wrap-up follow-up installs its missing reservation", async () => {
@@ -537,7 +542,7 @@ describe("AgentSession goal safety hooks", () => {
       budgetLimitInjectedForGoalId: created.goalId,
     });
     sendSpy.mockRestore();
-    session.dispose();
+    await session.dispose();
   });
 
   test("malformed persisted follow-up goal IDs are discarded during recovery", async () => {
@@ -581,7 +586,7 @@ describe("AgentSession goal safety hooks", () => {
       expect(meta && "pendingFollowUp" in meta ? meta.pendingFollowUp : undefined).toBeUndefined();
     }
     sendSpy.mockRestore();
-    session.dispose();
+    await session.dispose();
   });
 
   test("synthetic messages do not auto-pause active goals", async () => {
@@ -597,7 +602,7 @@ describe("AgentSession goal safety hooks", () => {
 
     expect(result.success).toBe(true);
     expect(await goalService.getGoal(workspaceId)).toMatchObject({ status: "active" });
-    session.dispose();
+    await session.dispose();
   });
 
   test("queued manual messages that predate the goal do not pause it", async () => {
@@ -621,7 +626,7 @@ describe("AgentSession goal safety hooks", () => {
 
     expect(result.success).toBe(true);
     expect(await goalService.getGoal(workspaceId)).toMatchObject({ status: "active" });
-    session.dispose();
+    await session.dispose();
   });
 
   test("same-millisecond activation and message authoring fail closed to pause", async () => {
@@ -643,7 +648,7 @@ describe("AgentSession goal safety hooks", () => {
 
     expect(result.success).toBe(true);
     expect(await goalService.getGoal(workspaceId)).toMatchObject({ status: "paused" });
-    session.dispose();
+    await session.dispose();
   });
 
   test("a legacy goal follow-up without goal identity is discarded", async () => {
@@ -693,7 +698,7 @@ describe("AgentSession goal safety hooks", () => {
       const meta = tail.data[0]?.metadata?.muxMetadata;
       expect(meta && "pendingFollowUp" in meta ? meta.pendingFollowUp : undefined).toBeUndefined();
     }
-    session.dispose();
+    await session.dispose();
   });
 
   test("queued messages predating a model-created goal still pause it", async () => {
@@ -719,7 +724,7 @@ describe("AgentSession goal safety hooks", () => {
 
     expect(result.success).toBe(true);
     expect(await goalService.getGoal(workspaceId)).toMatchObject({ status: "paused" });
-    session.dispose();
+    await session.dispose();
   });
 
   test("a user Resume is consent for messages authored before it", async () => {
@@ -748,7 +753,7 @@ describe("AgentSession goal safety hooks", () => {
 
     expect(result.success).toBe(true);
     expect(await goalService.getGoal(workspaceId)).toMatchObject({ status: "active" });
-    session.dispose();
+    await session.dispose();
   });
 
   test("queued manual messages enqueued after goal creation still pause it", async () => {
@@ -763,7 +768,7 @@ describe("AgentSession goal safety hooks", () => {
 
     expect(result.success).toBe(true);
     expect(await goalService.getGoal(workspaceId)).toMatchObject({ status: "paused" });
-    session.dispose();
+    await session.dispose();
   });
 
   // Shared harness for the candidate-suspension tests: a busy runtime keeps
@@ -812,7 +817,7 @@ describe("AgentSession goal safety hooks", () => {
 
     expect(thrown).toBeInstanceOf(Error);
     expect(candidates.has(workspaceId)).toBe(false);
-    session.dispose();
+    await session.dispose();
   });
 
   test("kickoff candidate is not consumable while a manual send is classified", async () => {
@@ -844,7 +849,7 @@ describe("AgentSession goal safety hooks", () => {
     expect(result.success).toBe(true);
     expect(eligibilityDuringAck).toBe("no_pending_candidate");
     expect(candidates.has(workspaceId)).toBe(false);
-    session.dispose();
+    await session.dispose();
   });
 
   test("delayed pre-stop sends do not clear a newer stop's acknowledgment gate", async () => {
@@ -872,7 +877,7 @@ describe("AgentSession goal safety hooks", () => {
     expect(await goalService.getGoal(workspaceId)).toMatchObject({ status: "active" });
     const goal = await goalService.getGoal(workspaceId);
     expect(goal?.requireUserAcknowledgmentSinceMs).not.toBeNull();
-    session.dispose();
+    await session.dispose();
   });
 
   test("pre-goal queued sends restore the suspended kickoff candidate", async () => {
@@ -897,7 +902,7 @@ describe("AgentSession goal safety hooks", () => {
     expect(result.success).toBe(true);
     expect(candidates.has(workspaceId)).toBe(true);
     expect(await goalService.getGoal(workspaceId)).toMatchObject({ status: "active" });
-    session.dispose();
+    await session.dispose();
   });
 
   test("manual user messages are no-ops when no goal exists", async () => {
@@ -909,7 +914,7 @@ describe("AgentSession goal safety hooks", () => {
 
     expect(result.success).toBe(true);
     expect(await goalService.getGoal(workspaceId)).toBeNull();
-    session.dispose();
+    await session.dispose();
   });
 
   test("manual user messages clear acknowledgment flags while pausing by default", async () => {
@@ -926,7 +931,7 @@ describe("AgentSession goal safety hooks", () => {
       status: "paused",
       requireUserAcknowledgmentSinceMs: null,
     });
-    session.dispose();
+    await session.dispose();
   });
 
   test("synthetic messages do not clear acknowledgment flags", async () => {
@@ -946,7 +951,7 @@ describe("AgentSession goal safety hooks", () => {
       status: "active",
       requireUserAcknowledgmentSinceMs: 66_000,
     });
-    session.dispose();
+    await session.dispose();
   });
 
   test("stream errors restore durable goal snapshot after live cost preview", async () => {
@@ -1047,7 +1052,7 @@ describe("AgentSession goal safety hooks", () => {
       goal: { costCents: 0, budgetCents: 2_000 },
     });
     expect(activitySnapshots.at(-1)?.transientGoalOnly).toBeUndefined();
-    session.dispose();
+    await session.dispose();
   });
 
   test("startup recovery gates goal continuations when an assistant partial is restored", async () => {
@@ -1076,7 +1081,7 @@ describe("AgentSession goal safety hooks", () => {
       "goal_crash_gate_set",
       expect.objectContaining({ workspaceIdLengthBucket: "10-49" })
     );
-    session.dispose();
+    await session.dispose();
   });
 
   test("startup recovery ignores restored assistant partials when no goal exists", async () => {
@@ -1096,7 +1101,7 @@ describe("AgentSession goal safety hooks", () => {
       "goal_crash_gate_set",
       expect.any(Object)
     );
-    session.dispose();
+    await session.dispose();
   });
 
   test("manual acknowledgment clears stale gated continuations after restart", async () => {
@@ -1143,7 +1148,7 @@ describe("AgentSession goal safety hooks", () => {
     await dispatcher.requestDispatch(workspaceId, GOAL_CONTINUATION_IDLE_CONSUMER_NAME);
 
     expect(execute).not.toHaveBeenCalled();
-    session.dispose();
+    await session.dispose();
   });
 
   // Auto-completion fallback for the "agent ended a goal-continuation turn
@@ -1223,7 +1228,7 @@ describe("AgentSession goal safety hooks", () => {
       "goal_completed",
       expect.objectContaining({ initiator: "model" })
     );
-    session.dispose();
+    await session.dispose();
   });
 
   test("stream-end with a dynamic-tool part leaves an active goal active", async () => {
@@ -1256,7 +1261,7 @@ describe("AgentSession goal safety hooks", () => {
     // Give the stream-end handler a tick to settle before asserting "no change".
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(await goalService.getGoal(workspaceId)).toMatchObject({ status: "active" });
-    session.dispose();
+    await session.dispose();
   });
 
   test("text-only stream-end on a manual user message does not auto-complete the goal", async () => {
@@ -1285,7 +1290,7 @@ describe("AgentSession goal safety hooks", () => {
     // auto-completion would have a chance to corrupt the paused state.
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(await goalService.getGoal(workspaceId)).toMatchObject({ status: "paused" });
-    session.dispose();
+    await session.dispose();
   });
 
   test("length-truncated text-only stream-end does not auto-complete the goal", async () => {
@@ -1318,7 +1323,7 @@ describe("AgentSession goal safety hooks", () => {
 
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(await goalService.getGoal(workspaceId)).toMatchObject({ status: "active" });
-    session.dispose();
+    await session.dispose();
   });
 
   test("text-only goal_continuation turn can complete a resumed paused goal", async () => {
@@ -1356,6 +1361,6 @@ describe("AgentSession goal safety hooks", () => {
       status: "complete",
       completionSummary: "All wrapped up.",
     });
-    session.dispose();
+    await session.dispose();
   });
 });

--- a/src/node/services/agentSession.mcpPromptSnapshot.test.ts
+++ b/src/node/services/agentSession.mcpPromptSnapshot.test.ts
@@ -75,7 +75,7 @@ describe("AgentSession MCP prompt snapshots", () => {
       expect(emittedIds.indexOf(snapshotId)).toBeGreaterThanOrEqual(0);
       expect(emittedIds.indexOf(snapshotId)).toBeLessThan(emittedIds.indexOf(userId));
     } finally {
-      harness.session.dispose();
+      await harness.session.dispose();
       await harness.cleanup();
     }
   });
@@ -130,7 +130,7 @@ describe("AgentSession MCP prompt snapshots", () => {
           .map((message) => message.metadata?.mcpPromptSnapshot?.promptName)
       ).toEqual(["first", "second"]);
     } finally {
-      harness.session.dispose();
+      await harness.session.dispose();
       await harness.cleanup();
     }
   });
@@ -159,7 +159,7 @@ describe("AgentSession MCP prompt snapshots", () => {
       if (!history.success) throw new Error(history.error);
       expect(history.data).toHaveLength(0);
     } finally {
-      harness.session.dispose();
+      await harness.session.dispose();
       await harness.cleanup();
     }
   });
@@ -193,7 +193,7 @@ describe("AgentSession MCP prompt snapshots", () => {
       if (!history.success) throw new Error(history.error);
       expect(history.data).toHaveLength(0);
     } finally {
-      harness.session.dispose();
+      await harness.session.dispose();
       await harness.cleanup();
     }
   });
@@ -225,14 +225,14 @@ describe("AgentSession MCP prompt snapshots", () => {
       expect(history.data).toHaveLength(1);
       expect(history.data[0]?.metadata?.mcpPromptSnapshot).toBeUndefined();
     } finally {
-      harness.session.dispose();
+      await harness.session.dispose();
       await harness.cleanup();
     }
   });
 
   test("excludes crash-orphaned snapshots from provider requests", async () => {
     const streamMessage = mock((_args: { messages: MuxMessage[] }) =>
-      Promise.resolve(Ok(createStartedTurnHandle()))
+      Promise.resolve(Ok(createStartedTurnHandle(harness.session.closingSignal)))
     );
     const harness = await createAgentSessionHarness({
       workspaceId: "workspace",
@@ -266,7 +266,7 @@ describe("AgentSession MCP prompt snapshots", () => {
       expect(requestMessages.length).toBeGreaterThan(0);
       expect(requestMessages.map((message) => message.id)).not.toContain("orphan-snap");
     } finally {
-      harness.session.dispose();
+      await harness.session.dispose();
       await harness.cleanup();
     }
   });
@@ -308,7 +308,7 @@ describe("AgentSession MCP prompt snapshots", () => {
       expect(truncateAfterMessage.mock.calls).toHaveLength(1);
       expect(truncateAfterMessage.mock.calls[0][1]).toBe(snapshotId);
     } finally {
-      harness.session.dispose();
+      await harness.session.dispose();
       await harness.cleanup();
     }
   });

--- a/src/node/services/agentSession.memoryContext.test.ts
+++ b/src/node/services/agentSession.memoryContext.test.ts
@@ -122,7 +122,7 @@ describe("AgentSession memory context", () => {
       expect(await priv.resolveMemoryContext("test-model")).toEqual(context);
       expect(buildMemorySessionContext).toHaveBeenCalledTimes(1);
     } finally {
-      session.dispose();
+      await session.dispose();
     }
   });
 
@@ -161,7 +161,7 @@ describe("AgentSession memory context", () => {
       );
       expect(buildMemorySessionContext).toHaveBeenCalledTimes(2);
     } finally {
-      session.dispose();
+      await session.dispose();
     }
   });
 
@@ -195,7 +195,7 @@ describe("AgentSession memory context", () => {
       );
       expect(buildMemorySessionContext).toHaveBeenCalledTimes(2);
     } finally {
-      session.dispose();
+      await session.dispose();
     }
   });
 
@@ -217,7 +217,7 @@ describe("AgentSession memory context", () => {
       expect(await priv.resolveMemoryContext("test-model")).toBeUndefined();
       expect(buildMemorySessionContext).toHaveBeenCalledTimes(1);
     } finally {
-      session.dispose();
+      await session.dispose();
     }
   });
 
@@ -255,7 +255,7 @@ describe("AgentSession memory context", () => {
       );
       expect(buildMemorySessionContext).toHaveBeenCalledTimes(2);
     } finally {
-      session.dispose();
+      await session.dispose();
     }
   });
 });

--- a/src/node/services/agentSession.postCompactionAttachments.test.ts
+++ b/src/node/services/agentSession.postCompactionAttachments.test.ts
@@ -267,7 +267,7 @@ describe("AgentSession post-compaction attachments", () => {
         );
       expect(stateExists).toBe(false);
     } finally {
-      session.dispose();
+      await session.dispose();
     }
   });
 
@@ -318,7 +318,7 @@ describe("AgentSession post-compaction attachments", () => {
       const attachments = await generatePeriodicPostCompactionAttachments(session);
       expect(getEditedFilePaths(attachments)).toEqual(["/tmp/recent-epoch-2.ts"]);
     } finally {
-      session.dispose();
+      await session.dispose();
     }
   });
 
@@ -355,7 +355,7 @@ describe("AgentSession post-compaction attachments", () => {
       const attachments = await generatePeriodicPostCompactionAttachments(session);
       expect(getEditedFilePaths(attachments)).toEqual(["/tmp/recent.ts", "/tmp/stale.ts"]);
     } finally {
-      session.dispose();
+      await session.dispose();
     }
   });
 
@@ -403,7 +403,7 @@ describe("AgentSession post-compaction attachments", () => {
       );
       expect(getEditedFilePaths(attachments)).toEqual(["/tmp/post-compaction.ts"]);
     } finally {
-      session.dispose();
+      await session.dispose();
     }
   });
 
@@ -447,7 +447,7 @@ describe("AgentSession post-compaction attachments", () => {
       );
       expect(getEditedFilePaths(attachments)).toEqual(["/tmp/recent-periodic.ts"]);
     } finally {
-      session.dispose();
+      await session.dispose();
     }
   });
 
@@ -493,7 +493,7 @@ describe("AgentSession post-compaction attachments", () => {
       expect(getLoadedSkillNames(attachments)).toEqual([]);
       expect(getEditedFilePaths(attachments)).toEqual(["/tmp/excluded-skills.ts"]);
     } finally {
-      session.dispose();
+      await session.dispose();
     }
   });
 });

--- a/src/node/services/agentSession.postCompactionRefresh.test.ts
+++ b/src/node/services/agentSession.postCompactionRefresh.test.ts
@@ -114,7 +114,7 @@ describe("AgentSession post-compaction refresh trigger", () => {
     await new Promise((resolve) => setTimeout(resolve, 25));
     expect(onCompactionComplete).toHaveBeenCalledTimes(1);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("reports failed compaction continuation dispatch to lifecycle consumers", async () => {
@@ -167,7 +167,7 @@ describe("AgentSession post-compaction refresh trigger", () => {
 
     expect(await decision).toBe(false);
     expect(internals.dispatchPendingFollowUp).toHaveBeenCalledTimes(1);
-    session.dispose();
+    await session.dispose();
   });
 
   test("triggers callback on file_edit_* tool-call-end", async () => {
@@ -256,6 +256,6 @@ describe("AgentSession post-compaction refresh trigger", () => {
 
     expect(onPostCompactionStateChange).toHaveBeenCalledTimes(2);
 
-    session.dispose();
+    await session.dispose();
   });
 });

--- a/src/node/services/agentSession.postCompactionRetry.test.ts
+++ b/src/node/services/agentSession.postCompactionRetry.test.ts
@@ -114,7 +114,7 @@ describe("AgentSession post-compaction context retry", () => {
       resolveSecondCall?.();
       return Promise.resolve({
         success: true as const,
-        data: createStartedTurnHandle("assistant-retry"),
+        data: createStartedTurnHandle(session.closingSignal, "assistant-retry"),
       });
     });
 
@@ -212,7 +212,7 @@ describe("AgentSession post-compaction context retry", () => {
     }
     expect(exists).toBe(false);
 
-    session.dispose();
+    await session.dispose();
   });
 
   // Waiters (task/workspace-turn stream-error settlement) treat the resolved
@@ -356,7 +356,7 @@ describe("AgentSession post-compaction context retry", () => {
     expect(session.isPreparingTurn()).toBe(false);
     expect(callCount).toBe(2);
 
-    session.dispose();
+    await session.dispose();
   });
 
   // Overlapping recovery episodes: a retry stream can emit its own error
@@ -490,6 +490,6 @@ describe("AgentSession post-compaction context retry", () => {
     ).toBe("terminal");
     expect(callCount).toBe(2);
 
-    session.dispose();
+    await session.dispose();
   });
 });

--- a/src/node/services/agentSession.preStreamError.test.ts
+++ b/src/node/services/agentSession.preStreamError.test.ts
@@ -417,7 +417,7 @@ describe("AgentSession pre-stream errors", () => {
       backgroundProcessManager,
     });
     await sessionWithPersistedPreference.setAutoRetryEnabled(false);
-    sessionWithPersistedPreference.dispose();
+    await sessionWithPersistedPreference.dispose();
 
     const session = new AgentSession({
       workspaceId,
@@ -447,7 +447,7 @@ describe("AgentSession pre-stream errors", () => {
     expect(result.success).toBe(false);
     expect(events.some((event) => event.type === "auto-retry-scheduled")).toBe(false);
 
-    session.dispose();
+    await session.dispose();
   });
 
   it("replays init state for since-mode reconnects", async () => {

--- a/src/node/services/agentSession.preTurnMessages.test.ts
+++ b/src/node/services/agentSession.preTurnMessages.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, mock, afterEach, spyOn } from "bun:test";
 import { EventEmitter } from "events";
-import type { AIService } from "@/node/services/aiService";
+import type { AIService, StreamMessageOptions } from "@/node/services/aiService";
 import type { InitStateManager } from "@/node/services/initStateManager";
 import type { BackgroundProcessManager } from "@/node/services/backgroundProcessManager";
 import type { Config } from "@/node/config";
@@ -29,7 +29,9 @@ describe("AgentSession.sendMessage (preTurnMessages)", () => {
     const { historyService, cleanup } = await createTestHistoryService();
     historyCleanup = cleanup;
 
-    const streamMessage = mock(() => Promise.resolve(Ok(createStartedTurnHandle())));
+    const streamMessage = mock((opts: StreamMessageOptions) =>
+      Promise.resolve(Ok(createStartedTurnHandle(opts.abortSignal!)))
+    );
     const aiService = Object.assign(new EventEmitter(), {
       ...createStreamLifecycleMocks(),
       isStreaming: mock((_workspaceId: string) => false),

--- a/src/node/services/agentSession.preparationAdmission.test.ts
+++ b/src/node/services/agentSession.preparationAdmission.test.ts
@@ -20,7 +20,7 @@ async function harness(workspaceId: string) {
 }
 afterEach(async () => {
   for (const h of harnesses.splice(0)) {
-    h.session.dispose();
+    await h.session.dispose();
     await h.cleanup();
   }
 });
@@ -45,7 +45,7 @@ describe("preparation admission", () => {
     const stream = spyOn(h.aiService, "streamMessage").mockImplementation(async () => {
       started.resolve();
       await release.promise;
-      return Ok(createStartedTurnHandle());
+      return Ok(createStartedTurnHandle(h.session.closingSignal));
     });
     h.session.queueMessage("head", { ...options, muxMetadata: metadata }, { synthetic: true });
     h.session.queueMessage("tail", options);
@@ -79,7 +79,7 @@ describe("preparation admission", () => {
     const started = Promise.withResolvers<void>();
     const stream = spyOn(h.aiService, "streamMessage").mockImplementation(() => {
       started.resolve();
-      return Promise.resolve(Ok(createStartedTurnHandle()));
+      return Promise.resolve(Ok(createStartedTurnHandle(h.session.closingSignal)));
     });
     h.session.queueMessage("removed", options, { synthetic: true, onCanceled: canceled });
     let removed = false;
@@ -185,7 +185,7 @@ describe("preparation admission", () => {
       const stream = spyOn(h.aiService, "streamMessage").mockImplementation(() => {
         expect(cleanups).toBe(2);
         started.resolve();
-        return Promise.resolve(Ok(createStartedTurnHandle()));
+        return Promise.resolve(Ok(createStartedTurnHandle(h.session.closingSignal)));
       });
       h.session.queueMessage("failed", options, {
         synthetic: true,
@@ -279,7 +279,7 @@ describe("preparation admission", () => {
     const stream = spyOn(h.aiService, "streamMessage").mockImplementation(async () => {
       provider.resolve();
       await releaseProvider.promise;
-      return Ok(createStartedTurnHandle());
+      return Ok(createStartedTurnHandle(h.session.closingSignal));
     });
     const oldSend = h.session.sendMessage("old", options);
     await appended.promise;
@@ -355,7 +355,7 @@ describe("preparation admission", () => {
     spyOn(h.aiService, "streamMessage").mockImplementation(async () => {
       provider.resolve();
       await releaseProvider.promise;
-      return Ok(createStartedTurnHandle());
+      return Ok(createStartedTurnHandle(h.session.closingSignal));
     });
     const cancel = spyOn(session.retryManager, "cancel");
     const enable = spyOn(session.retryManager, "setEnabled");
@@ -409,7 +409,7 @@ describe("preparation admission", () => {
     });
     const stream = spyOn(h.aiService, "streamMessage").mockImplementation(() => {
       started.resolve();
-      return Promise.resolve(Ok(createStartedTurnHandle()));
+      return Promise.resolve(Ok(createStartedTurnHandle(h.session.closingSignal)));
     });
     const edit = h.session.sendMessage("edited", { ...options, editMessageId: "original" });
     await entered.promise;
@@ -446,7 +446,7 @@ describe("preparation admission", () => {
       const started = Promise.withResolvers<void>();
       const stream = spyOn(h.aiService, "streamMessage").mockImplementation(() => {
         started.resolve();
-        return Promise.resolve(Ok(createStartedTurnHandle()));
+        return Promise.resolve(Ok(createStartedTurnHandle(h.session.closingSignal)));
       });
       let retire = true;
       const retireEdit = () => {

--- a/src/node/services/agentSession.queueDispatch.test.ts
+++ b/src/node/services/agentSession.queueDispatch.test.ts
@@ -69,7 +69,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
           Err({ type: "api_key_not_found" as const, provider: "anthropic" as const })
         );
       successor.resolve();
-      return Promise.resolve(Ok(createStartedTurnHandle()));
+      return Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal)));
     });
     const { session, cleanup } = await createAgentSessionHarness({
       workspaceId: "queue-provider-startup-failure",
@@ -88,7 +88,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
       expect(calls).toBe(2);
       expect(session.hasQueuedMessages()).toBe(false);
     } finally {
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -102,7 +102,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
       const successorStarted = Promise.withResolvers<void>();
       const streamMessage = mock(() => {
         successorStarted.resolve();
-        return Promise.resolve(Ok(createStartedTurnHandle()));
+        return Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal)));
       });
       const { session, historyService, cleanup } = await createAgentSessionHarness({
         workspaceId,
@@ -160,7 +160,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
       } finally {
         releaseFailure.resolve();
         append.mockRestore();
-        session.dispose();
+        await session.dispose();
         await cleanup();
       }
     }
@@ -187,24 +187,24 @@ describe("AgentSession queued message tool-call dispatch", () => {
         }
       | undefined;
     const streamMessage = mock(() => {
-      const session = sessionHolder.current;
+      const observedSession = sessionHolder.current;
       preparingState = {
-        sameTurn: session?.hasQueuedOrDispatchingEntry(WORKSPACE_TURN_CORRELATION) === true,
+        sameTurn: observedSession?.hasQueuedOrDispatchingEntry(WORKSPACE_TURN_CORRELATION) === true,
         differentTurn:
-          session?.hasQueuedOrDispatchingEntry({
+          observedSession?.hasQueuedOrDispatchingEntry({
             ...WORKSPACE_TURN_CORRELATION,
             turnId: "turn-different",
           }) === true,
-        uncorrelated: session?.hasQueuedOrDispatchingEntry() === true,
+        uncorrelated: observedSession?.hasQueuedOrDispatchingEntry() === true,
         pendingSameTurn:
-          session?.hasPendingWorkspaceTurnContinuation(WORKSPACE_TURN_CORRELATION) === true,
+          observedSession?.hasPendingWorkspaceTurnContinuation(WORKSPACE_TURN_CORRELATION) === true,
         pendingDifferentTurn:
-          session?.hasPendingWorkspaceTurnContinuation({
+          observedSession?.hasPendingWorkspaceTurnContinuation({
             ...WORKSPACE_TURN_CORRELATION,
             turnId: "turn-different",
           }) === true,
       };
-      return Promise.resolve(Ok(createStartedTurnHandle()));
+      return Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal)));
     });
     const { session, cleanup } = await createAgentSessionHarness({
       workspaceId: "queue-dispatch-preparing-predecessor",
@@ -232,7 +232,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
       });
       expect(session.hasQueuedOrDispatchingEntry()).toBe(false);
     } finally {
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -277,7 +277,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
       expect(session.hasQueuedOrDispatchingEntry(differentCorrelation)).toBe(true);
       sendMessage.mockRestore();
     } finally {
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -319,7 +319,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
       expect(engaged?.muxMetadata).toBeUndefined();
       sendMessage.mockRestore();
     } finally {
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -349,7 +349,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
       expect(cutter?.stage).toBe("dispatching");
       expect(cutter?.muxMetadata).toBeUndefined();
     } finally {
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -388,7 +388,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
       );
       sendMessage.mockRestore();
     } finally {
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -435,7 +435,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
     } finally {
       sendQueuedMessages.mockRestore();
       stopStream.mockRestore();
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -472,7 +472,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
     } finally {
       sendQueuedMessages.mockRestore();
       stopStream.mockRestore();
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -521,7 +521,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
       expect(queuedSignals).toEqual([true, false]);
     } finally {
       stopStream.mockRestore();
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -552,7 +552,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
           })
         ).toBe(liveMode);
       } finally {
-        session.dispose();
+        await session.dispose();
         await cleanup();
       }
     }
@@ -606,7 +606,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
       expect(stopStream).toHaveBeenCalledTimes(1);
     } finally {
       stopStream.mockRestore();
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -665,7 +665,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
       expect(session.hasQueuedDedupeKey("heartbeat-request")).toBe(false);
     } finally {
       sendMessage.mockRestore();
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -709,7 +709,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
       expect(setMessageQueued).toHaveBeenLastCalledWith(workspaceId, false);
       expect(session.hasQueuedMessages()).toBe(true);
     } finally {
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -754,7 +754,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
       unsubscribeUser();
       expect(restoredTexts).toEqual(["my own words"]);
     } finally {
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -806,7 +806,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
       expect(canceledReasons).toHaveLength(1);
       expect(session.hasQueuedMessages()).toBe(false);
     } finally {
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -885,7 +885,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
     } finally {
       releaseAppend();
       appendSpy.mockRestore();
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -961,7 +961,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
       releaseAppend();
       deleteMessagesSpy.mockRestore();
       appendSpy.mockRestore();
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -1042,7 +1042,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
       releaseAppend();
       deleteMessagesSpy.mockRestore();
       appendSpy.mockRestore();
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -1121,7 +1121,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
       }
     } finally {
       releaseInitialSync();
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -1150,7 +1150,6 @@ describe("AgentSession queued message tool-call dispatch", () => {
       workspaceGoalService,
     });
 
-    let disposed = false;
     try {
       const controller = new AbortController();
       const cancelState = { canceledBeforeAcceptance: false };
@@ -1170,8 +1169,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
       );
 
       await syncStarted;
-      session.dispose();
-      disposed = true;
+      session.beginDispose();
       releaseSync();
       const result = await sendPromise;
 
@@ -1180,7 +1178,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
       expect(cancelState.canceledBeforeAcceptance).toBe(false);
     } finally {
       releaseSync();
-      if (!disposed) session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -1258,7 +1256,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
       }
     } finally {
       releaseSync();
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -1293,7 +1291,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
     } finally {
       sendQueuedMessages.mockRestore();
       stopStream.mockRestore();
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -1325,7 +1323,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
       expect(failures[0]).toContain("pricing gate exploded");
       sendMessage.mockRestore();
     } finally {
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });

--- a/src/node/services/agentSession.scopedLifetimes.test.ts
+++ b/src/node/services/agentSession.scopedLifetimes.test.ts
@@ -38,7 +38,7 @@ describe("AgentSession scoped turn lifetimes", () => {
       await closing;
     } finally {
       release.resolve();
-      h.session.dispose();
+      await h.session.dispose();
       await h.cleanup();
     }
   });
@@ -74,7 +74,7 @@ describe("AgentSession scoped turn lifetimes", () => {
     } finally {
       release.resolve();
       await recovering;
-      h.session.dispose();
+      await h.session.dispose();
       await h.cleanup();
     }
   });
@@ -123,7 +123,7 @@ describe("AgentSession scoped turn lifetimes", () => {
         expect(spyOn(h.aiService, "streamMessage")).not.toHaveBeenCalled();
       } finally {
         release.resolve();
-        h.session.dispose();
+        await h.session.dispose();
         await h.cleanup();
       }
     }
@@ -162,7 +162,7 @@ describe("AgentSession scoped turn lifetimes", () => {
     } finally {
       release.resolve();
       await send;
-      h.session.dispose();
+      await h.session.dispose();
       await h.cleanup();
     }
   });
@@ -208,7 +208,7 @@ describe("AgentSession scoped turn lifetimes", () => {
     } finally {
       releaseStartup.resolve();
       releaseFailure.resolve();
-      h.session.dispose();
+      await h.session.dispose();
       await h.cleanup();
     }
   });
@@ -231,7 +231,7 @@ describe("AgentSession scoped turn lifetimes", () => {
         await runner.runPromise(Scope.close(appFiberScope, Exit.void));
         expect(spyOn(h.aiService, "streamMessage")).not.toHaveBeenCalled();
       } finally {
-        h.session.dispose();
+        await h.session.dispose();
         await h.cleanup();
       }
     }
@@ -251,7 +251,7 @@ describe("AgentSession scoped turn lifetimes", () => {
       expect(append).not.toHaveBeenCalled();
       expect(spyOn(h.aiService, "streamMessage")).not.toHaveBeenCalled();
     } finally {
-      h.session.dispose();
+      await h.session.dispose();
       await h.cleanup();
     }
   });
@@ -269,7 +269,7 @@ describe("AgentSession scoped turn lifetimes", () => {
     });
     try {
       await entered.promise;
-      h.session.dispose();
+      h.session.beginDispose();
       let closed = false;
       const closing = runner.runPromise(Scope.close(appFiberScope, Exit.void)).then(() => {
         closed = true;
@@ -282,7 +282,7 @@ describe("AgentSession scoped turn lifetimes", () => {
     } finally {
       release.resolve();
       await send;
-      h.session.dispose();
+      await h.session.dispose();
       await h.cleanup();
     }
   });

--- a/src/node/services/agentSession.startupAutoRetry.test.ts
+++ b/src/node/services/agentSession.startupAutoRetry.test.ts
@@ -144,7 +144,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(retryOptions.options.toolPolicy).toEqual([{ regex_match: ".*", action: "disable" }]);
     expect(retryOptions.options.disableWorkspaceAgents).toBe(true);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("startup auto-retry does not dispatch once the workspace is archived on disk", async () => {
@@ -193,7 +193,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     // Completed rather than deferred: nothing reruns the check for an archived workspace.
     expect(privateSession.startupAutoRetryCheckScheduled).toBe(true);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("auto-retry abandons instead of resuming once the workspace is archived on disk", async () => {
@@ -236,12 +236,14 @@ describe("AgentSession startup auto-retry recovery", () => {
       .map((event) => event.reason);
     expect(abandonedReasons).toEqual(["workspace_archived"]);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("beginShutdown cancels the pending retry and stops re-arming or streaming", async () => {
     const workspaceId = "startup-retry-shutdown";
-    const streamMessage = mock(() => Promise.resolve(Ok(createStartedTurnHandle("assistant-1"))));
+    const streamMessage = mock(() =>
+      Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal, "assistant-1")))
+    );
     const { session, historyService, events, cleanup } = await createSessionBundle(workspaceId, {
       streamMessage: streamMessage as unknown as AgentSessionAIService["streamMessage"],
     });
@@ -273,12 +275,14 @@ describe("AgentSession startup auto-retry recovery", () => {
     const history = await historyService.getHistoryFromLatestBoundary(workspaceId);
     expect(history.success ? history.data : ["unexpected"]).toHaveLength(0);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("beginShutdown during pre-stream awaits stops the stream before the provider", async () => {
     const workspaceId = "startup-retry-shutdown-mid-prepare";
-    const streamMessage = mock(() => Promise.resolve(Ok(createStartedTurnHandle("assistant-1"))));
+    const streamMessage = mock(() =>
+      Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal, "assistant-1")))
+    );
     const { session, historyService, cleanup } = await createSessionBundle(workspaceId, {
       streamMessage: streamMessage as unknown as AgentSessionAIService["streamMessage"],
     });
@@ -299,7 +303,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(sendResult.success).toBe(true);
     expect(streamMessage).not.toHaveBeenCalled();
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("visible completed subagent report cards do not schedule startup auto-retry", async () => {
@@ -331,7 +335,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     await startupCheckPromise;
 
     expect(events.some((event) => event.type === "auto-retry-scheduled")).toBe(false);
-    session.dispose();
+    await session.dispose();
   });
 
   test("visible completed subagent report cards do not mask recoverable assistant partials", async () => {
@@ -375,7 +379,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     await startupCheckPromise;
 
     expect(events.some((event) => event.type === "auto-retry-scheduled")).toBe(true);
-    session.dispose();
+    await session.dispose();
   });
 
   test("hidden completed subagent reports preserve the existing startup retry fallback", async () => {
@@ -412,7 +416,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     await startupCheckPromise;
 
     expect(events.some((event) => event.type === "auto-retry-scheduled")).toBe(true);
-    session.dispose();
+    await session.dispose();
   });
 
   test("startup auto-retry reuses workspace-turn metadata from the retry user message", async () => {
@@ -436,7 +440,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(appendResult.success).toBe(true);
     const streamMessageMock = mock(
       (_payload: Parameters<AgentSessionAIService["streamMessage"]>[0]) =>
-        Promise.resolve(Ok(createStartedTurnHandle()))
+        Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal)))
     );
     aiService.streamMessage =
       streamMessageMock as unknown as AgentSessionAIService["streamMessage"];
@@ -455,7 +459,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(streamMessageMock).toHaveBeenCalledTimes(1);
     expect(streamMessageMock.mock.calls[0]?.[0]).toMatchObject({ muxMetadata });
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("startup auto-retry does not stamp workflow-result metadata on assistant streams", async () => {
@@ -482,7 +486,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(appendResult.success).toBe(true);
     const streamMessageMock = mock(
       (_payload: Parameters<AgentSessionAIService["streamMessage"]>[0]) =>
-        Promise.resolve(Ok(createStartedTurnHandle()))
+        Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal)))
     );
     aiService.streamMessage =
       streamMessageMock as unknown as AgentSessionAIService["streamMessage"];
@@ -498,7 +502,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(streamMessageMock).toHaveBeenCalledTimes(1);
     expect(streamMessageMock.mock.calls[0]?.[0].muxMetadata).toBeUndefined();
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("re-runs startup auto-retry check after busy startup state clears", async () => {
@@ -546,7 +550,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(events.some((event) => event.type === "auto-retry-scheduled")).toBe(true);
     expect(privateSession.startupAutoRetryCheckScheduled).toBe(true);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("re-runs startup auto-retry check after transient history read failures", async () => {
@@ -600,7 +604,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(events.some((event) => event.type === "auto-retry-scheduled")).toBe(true);
     expect(privateSession.startupAutoRetryCheckScheduled).toBe(true);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("backs off reruns after repeated startup history read failures", async () => {
@@ -644,7 +648,7 @@ describe("AgentSession startup auto-retry recovery", () => {
 
     expect(getLastMessagesCalls).toBeGreaterThanOrEqual(2);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("runStartupRecovery gives up after repeated deferred history-read failures", async () => {
@@ -686,7 +690,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(privateSession.startupRecoveryScheduled).toBe(false);
     expect(privateSession.startupAutoRetryCheckScheduled).toBe(true);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("waits for AI streaming to settle before rerunning deferred startup checks", async () => {
@@ -740,7 +744,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(scheduleCalls).toBe(2);
     expect(privateSession.startupAutoRetryCheckScheduled).toBe(true);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("restores persisted retry send options for startup auto-retry", async () => {
@@ -805,7 +809,7 @@ describe("AgentSession startup auto-retry recovery", () => {
 
     expect(retryOptions.options.providerOptions?.anthropic?.use1MContext).toBe(true);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("startup auto-retry discards goal attribution when the persisted goal ID is malformed", async () => {
@@ -845,7 +849,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(retryOptions?.goalKind).toBeUndefined();
     expect(retryOptions?.goalId).toBeUndefined();
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("startup auto-retry prefers child workspace agent settings over stale retry metadata", async () => {
@@ -906,7 +910,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(retryOptions.options.model).toBe("openai:gpt-5.5-low");
     expect(retryOptions.options.thinkingLevel).toBe("low");
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("replays pending auto-retry schedule during reconnect catch-up", async () => {
@@ -941,7 +945,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(caughtUpIndex).toBeGreaterThanOrEqual(0);
     expect(scheduledIndex).toBeLessThan(caughtUpIndex);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("respects persisted auto-retry opt-out across restart", async () => {
@@ -966,7 +970,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(appendResult.success).toBe(true);
 
     await firstSession.setAutoRetryEnabled(false);
-    firstSession.dispose();
+    await firstSession.dispose();
 
     const { session: secondSession, events } = await createAgentSessionHarness({
       workspaceId,
@@ -987,7 +991,7 @@ describe("AgentSession startup auto-retry recovery", () => {
 
     expect(events.some((event) => event.type === "auto-retry-scheduled")).toBe(false);
 
-    secondSession.dispose();
+    await secondSession.dispose();
   });
 
   test("respects legacy auto-retry opt-out hint when backend preference is missing", async () => {
@@ -1025,7 +1029,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     };
     expect(persisted.enabled).toBe(false);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("does not persist temporary auto-retry enable across restart", async () => {
@@ -1051,7 +1055,7 @@ describe("AgentSession startup auto-retry recovery", () => {
 
     await firstSession.setAutoRetryEnabled(false);
     await firstSession.setAutoRetryEnabled(true, { persist: false });
-    firstSession.dispose();
+    await firstSession.dispose();
 
     const { session: secondSession, events } = await createAgentSessionHarness({
       workspaceId,
@@ -1072,7 +1076,7 @@ describe("AgentSession startup auto-retry recovery", () => {
 
     expect(events.some((event) => event.type === "auto-retry-scheduled")).toBe(false);
 
-    secondSession.dispose();
+    await secondSession.dispose();
   });
 
   test("does not reschedule startup retries after persisted non-retryable failure", async () => {
@@ -1102,7 +1106,7 @@ describe("AgentSession startup auto-retry recovery", () => {
       }
     ).persistStartupAutoRetryAbandon("runtime_not_ready", "user-1");
 
-    firstSession.dispose();
+    await firstSession.dispose();
 
     const { session: secondSession, events } = await createAgentSessionHarness({
       workspaceId,
@@ -1123,7 +1127,7 @@ describe("AgentSession startup auto-retry recovery", () => {
 
     expect(events.some((event) => event.type === "auto-retry-scheduled")).toBe(false);
 
-    secondSession.dispose();
+    await secondSession.dispose();
   });
 
   test("reports auto-retry as pending while retry resume is starting", async () => {
@@ -1163,7 +1167,7 @@ describe("AgentSession startup auto-retry recovery", () => {
 
     expect(session.hasPendingAutoRetry()).toBe(false);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("clears persisted startup abandon state once retry resumes successfully", async () => {
@@ -1205,7 +1209,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(privateSession.startupAutoRetryAbandon).toBeNull();
     expect(await Bun.file(preferencePath).exists()).toBe(false);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("provider config changes clear credential abandon state without starting a stream", async () => {
@@ -1354,7 +1358,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(resumeStreamMock).toHaveBeenCalledTimes(1);
     expect(scheduledAfter).toBe(scheduledBefore + 1);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("does not re-process retry failures already handled by resumeStream", async () => {
@@ -1391,7 +1395,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(resumeStreamMock).toHaveBeenCalledTimes(1);
     expect(scheduledAfter).toBe(scheduledBefore);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("handles unprocessed resume failures by scheduling the next retry", async () => {
@@ -1427,7 +1431,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(resumeStreamMock).toHaveBeenCalledTimes(1);
     expect(scheduledAfter).toBe(scheduledBefore + 1);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("retryActiveStream resumes the reconstructed follow-up after compaction handoff send fails", async () => {
@@ -1517,7 +1521,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(optionsArg.toolPolicy).toBeUndefined();
     expect(internalArg?.agentInitiated).toBeUndefined();
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("same-session auto-retry preserves ACP correlation fields", async () => {
@@ -1546,7 +1550,7 @@ describe("AgentSession startup auto-retry recovery", () => {
         });
       }
 
-      return Promise.resolve(Ok(createStartedTurnHandle()));
+      return Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal)));
     });
     aiService.streamMessage =
       streamMessageMock as unknown as AgentSessionAIService["streamMessage"];
@@ -1581,7 +1585,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(retryPayload.acpPromptId).toBe(acpPromptId);
     expect(retryPayload.delegatedToolNames).toEqual(delegatedToolNames);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("compaction retry failure preserves the adjusted 1M-context retry request", async () => {
@@ -1701,7 +1705,7 @@ describe("AgentSession startup auto-retry recovery", () => {
     ).toEqual([baseOptions.model]);
     expect(privateSession.lastAutoRetryResumeRequest?.agentInitiated).toBe(true);
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("persists startup abandon marker for pre-stream user aborts", async () => {
@@ -1726,7 +1730,9 @@ describe("AgentSession startup auto-retry recovery", () => {
       isStreaming: mock(() => false),
       getStreamInfo: mock(() => undefined),
       replayStream: mock(() => Promise.resolve()),
-      streamMessage: mock(() => Promise.resolve(Ok(createStartedTurnHandle()))),
+      streamMessage: mock(() =>
+        Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal)))
+      ),
       getWorkspaceMetadata: mock(() => Promise.resolve(Ok(workspaceMetadata))),
     }) as unknown as AgentSessionAIService;
 
@@ -1816,7 +1822,7 @@ describe("AgentSession startup auto-retry recovery", () => {
       userMessageId: "user-1",
     });
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("skips persisting startup abandon marker for non-user abort reasons", async () => {
@@ -1854,7 +1860,7 @@ describe("AgentSession startup auto-retry recovery", () => {
       userMessageId: "user-1",
     });
 
-    session.dispose();
+    await session.dispose();
   });
 
   test("does not schedule startup auto-retry while ask_user_question is waiting", async () => {
@@ -1896,6 +1902,6 @@ describe("AgentSession startup auto-retry recovery", () => {
 
     expect(events.some((event) => event.type === "auto-retry-scheduled")).toBe(false);
 
-    session.dispose();
+    await session.dispose();
   });
 });

--- a/src/node/services/agentSession.testHarness.ts
+++ b/src/node/services/agentSession.testHarness.ts
@@ -20,8 +20,17 @@ import type { MCPServerManager } from "@/node/services/mcpServerManager";
 import { createTestHistoryService } from "@/node/services/testHistoryService";
 import type { StreamErrorType } from "@/common/types/errors";
 
-export function createStartedTurnHandle(messageId = "test-assistant"): TurnStreamHandle {
-  return { messageId, completion: new Promise(() => undefined) };
+export function createStartedTurnHandle(
+  signal: AbortSignal,
+  messageId = "test-assistant"
+): TurnStreamHandle {
+  // Policy-only fixtures have no engine. Their own session shutdown retires this handle;
+  // lifecycle tests supply independent completion gates instead of this convenience helper.
+  const completion = Promise.withResolvers<Awaited<TurnStreamHandle["completion"]>>();
+  const stop = () => completion.resolve({ status: "aborted", abortReason: "user" });
+  if (signal.aborted) stop();
+  else signal.addEventListener("abort", stop, { once: true });
+  return { messageId, completion: completion.promise };
 }
 
 export function createFailedTurnHandle(
@@ -98,7 +107,8 @@ export function createStreamLifecycleMocks() {
   };
 }
 
-function createMockAiService(args?: {
+function createMockAiService(args: {
+  getClosingSignal: () => AbortSignal;
   emitter?: EventEmitter;
   overrides?: Partial<AgentSessionAIService>;
 }): {
@@ -120,7 +130,9 @@ function createMockAiService(args?: {
     isExperimentEnabled: mock((_experimentId) => false),
     ...createStreamLifecycleMocks(),
     streamMessage: mock(() =>
-      Promise.resolve(Ok(createStartedTurnHandle("test-assistant-message")))
+      Promise.resolve(
+        Ok(createStartedTurnHandle(args.getClosingSignal(), "test-assistant-message"))
+      )
     ),
     ...args?.overrides,
   });
@@ -170,6 +182,7 @@ export async function createAgentSessionHarness(
   const { aiEmitter, aiService } = options.aiService
     ? { aiEmitter: options.aiEmitter ?? new EventEmitter(), aiService: options.aiService }
     : createMockAiService({
+        getClosingSignal: () => session.closingSignal,
         emitter: options.aiEmitter,
         overrides: options.aiServiceOverrides,
       });
@@ -179,7 +192,7 @@ export async function createAgentSessionHarness(
     options.backgroundProcessManager ??
     createMockBackgroundProcessManager(options.backgroundProcessManagerOverrides);
 
-  const session = new AgentSession({
+  const session: AgentSession = new AgentSession({
     effectRunner: options.effectRunner,
     appFiberScope: options.appFiberScope,
     workspaceId: options.workspaceId,

--- a/src/node/services/agentSession.thinkingOverride.test.ts
+++ b/src/node/services/agentSession.thinkingOverride.test.ts
@@ -16,7 +16,7 @@ describe("AgentSession.setActiveTurnThinkingLevel", () => {
     try {
       expect(session.setActiveTurnThinkingLevel("high")).toEqual({ accepted: false });
     } finally {
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -38,7 +38,7 @@ describe("AgentSession.setActiveTurnThinkingLevel", () => {
       expect(first).toEqual({ accepted: true });
       expect(second).toEqual({ accepted: true });
       expect(opts.activeTurnThinkingOverride?.pending).toBe("low");
-      return Promise.resolve(Ok(createStartedTurnHandle()));
+      return Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal)));
     });
 
     const { session, cleanup } = await createAgentSessionHarness({
@@ -67,7 +67,7 @@ describe("AgentSession.setActiveTurnThinkingLevel", () => {
       expect(capturedHolders[1]).not.toBe(capturedHolders[0]);
       expect(capturedPendingAtStreamStart[1]).toBeUndefined();
     } finally {
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -76,7 +76,7 @@ describe("AgentSession.setActiveTurnThinkingLevel", () => {
     let pendingSeenByStream: string | undefined;
     const streamMessage = mock((opts: StreamMessageOptions) => {
       pendingSeenByStream = opts.activeTurnThinkingOverride?.pending;
-      return Promise.resolve(Ok(createStartedTurnHandle()));
+      return Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal)));
     });
 
     const { session, cleanup } = await createAgentSessionHarness({
@@ -104,7 +104,7 @@ describe("AgentSession.setActiveTurnThinkingLevel", () => {
       // holder (prepareStep runs before step 1).
       expect(pendingSeenByStream).toBe("high");
     } finally {
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -127,14 +127,14 @@ describe("AgentSession.setActiveTurnThinkingLevel", () => {
       await session.waitForIdle();
       expect(session.setActiveTurnThinkingLevel("high")).toEqual({ accepted: false });
     } finally {
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
 
   it("clears the holder when an onAccepted failure aborts the turn before streaming", async () => {
     const streamMessage = mock((_history: MuxMessage[]) =>
-      Promise.resolve(Ok(createStartedTurnHandle()))
+      Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal)))
     );
     const { session, cleanup } = await createAgentSessionHarness({
       workspaceId: "thinking-override-onaccepted-failure",
@@ -158,7 +158,7 @@ describe("AgentSession.setActiveTurnThinkingLevel", () => {
       expect(streamMessage.mock.calls).toHaveLength(0);
       expect(session.setActiveTurnThinkingLevel("high")).toEqual({ accepted: false });
     } finally {
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -572,10 +572,18 @@ export interface AgentSessionStreamManager {
   getPrefixSwapPreparation?: StreamManager["getPrefixSwapPreparation"];
   stopStream(
     workspaceId: string,
-    options?: { soft?: boolean; abandonPartial?: boolean; abortReason?: StreamAbortReason }
+    options?: {
+      soft?: boolean;
+      abandonPartial?: boolean;
+      abortReason?: StreamAbortReason;
+      emitIfMissing?: boolean;
+    }
   ): Promise<Result<void>>;
   isStreaming(workspaceId: string): boolean;
-  getStreamInfo(workspaceId: string): AgentSessionActiveStreamInfo | undefined;
+  getStreamInfo(
+    workspaceId: string,
+    includeFinalizing?: boolean
+  ): AgentSessionActiveStreamInfo | undefined;
   replayStream(workspaceId: string, options?: { afterTimestamp?: number }): Promise<void>;
   /**
    * The runner the stream manager's clock-driven fibers use; the session's
@@ -593,7 +601,12 @@ export interface AgentSessionAIService extends BranchSummaryAiService {
   streamMessage(options: StreamMessageOptions): Promise<Result<TurnStreamHandle, SendMessageError>>;
   stopStream?(
     workspaceId: string,
-    options?: { soft?: boolean; abandonPartial?: boolean; abortReason?: StreamAbortReason }
+    options?: {
+      soft?: boolean;
+      abandonPartial?: boolean;
+      abortReason?: StreamAbortReason;
+      emitIfMissing?: boolean;
+    }
   ): Promise<Result<void>>;
   isStreaming?(workspaceId: string): boolean;
   getStreamInfo?(workspaceId: string): AgentSessionActiveStreamInfo | undefined;
@@ -1165,43 +1178,93 @@ export class AgentSession {
     this.retryManager.cancel();
   }
 
-  dispose(): void {
-    if (this.coordinator.disposed) {
-      return;
+  get closingSignal(): AbortSignal {
+    return this.coordinator.closingSignal;
+  }
+
+  /** Service guardian owns the whole shutdown inside the app's existing bounded budget. */
+  async finishShutdown(): Promise<void> {
+    this.beginShutdown();
+    // Retain/commit the captured partial before destructive disposal. The engine supervisor
+    // joins this same cancellation; no session policy or scope joins itself here.
+    try {
+      try {
+        await this.streamManager.stopStream(this.workspaceId, {
+          abortReason: "system",
+          emitIfMissing: false,
+        });
+      } catch (error) {
+        log.warn("Session shutdown stop failed", { workspaceId: this.workspaceId, error });
+      }
+      await this.coordinator.drain();
+    } finally {
+      // A failed drain/adapter cannot skip background cleanup or listener teardown.
+      await this.dispose();
     }
-    this.coordinator.dispose();
-    this.continuousCompactor.reset("dispose");
+  }
 
-    this.retryManager.dispose();
+  private disposePromise?: Promise<void>;
+  private disposalMessageId?: string;
 
-    // Stop any active stream (fire and forget - disposal shouldn't block).
-    // Contain rejections: an unhandled rejection during CLI teardown would
-    // flip the process exit code after the run already completed.
-    // Promise.resolve guards test doubles that return non-promises.
-    void Promise.resolve(
-      this.streamManager.stopStream(this.workspaceId, { abandonPartial: true })
-    ).catch((error) => {
-      log.debug(`dispose: stopStream failed: ${getErrorMessage(error)}`);
-    });
-    // Terminate background processes for this workspace (skip when flagged for bench/CI)
-    if (!this.keepBackgroundProcesses) {
-      void Promise.resolve(this.backgroundProcessManager.cleanup(this.workspaceId)).catch(
-        (error) => {
-          log.debug(`dispose: background process cleanup failed: ${getErrorMessage(error)}`);
+  /** Initiation is safe inside a leased callback; its caller must join at an outer boundary. */
+  beginDispose(): void {
+    this.dispose().catch((error: unknown) => log.warn("Session disposal failed", { error }));
+  }
+
+  dispose(): Promise<void> {
+    if (this.disposePromise) return this.disposePromise;
+    const disposed = Promise.withResolvers<void>();
+    this.disposePromise = disposed.promise;
+    // Register before closing the guardian so app teardown also joins stop/background cleanup.
+    const cleanupExecution = this.coordinator.enterExecution();
+    this.disposalMessageId =
+      this.streamManager.getStreamInfo(this.workspaceId, true)?.messageId ??
+      this.coordinator.terminalMessageId;
+    const cleanup = async (label: string, run: () => unknown): Promise<void> => {
+      try {
+        const result = await run();
+        if (result && typeof result === "object" && "success" in result && !result.success) {
+          log.debug(`dispose: ${label} failed`, { result });
         }
-      );
-    }
-
-    for (const { event, handler } of this.aiListeners) {
-      this.aiService.off(event, handler);
-    }
-    this.aiListeners.length = 0;
-    for (const { event, handler } of this.initListeners) {
-      this.initStateManager.off(event, handler as never);
-    }
-    this.initListeners.length = 0;
-    this.emitter.removeAllListeners();
-    eventSpine.emit("session.end", { workspaceId: this.workspaceId });
+      } catch (error) {
+        log.debug(`dispose: ${label} failed: ${getErrorMessage(error)}`);
+      }
+    };
+    // Latch admission without publishing idle before stopStream captures the old attempt.
+    this.coordinator.beginShutdown();
+    const stopped = cleanup("stopStream", () =>
+      this.streamManager.stopStream(this.workspaceId, {
+        abandonPartial: true,
+        emitIfMissing: false,
+      })
+    );
+    const invalidated = cleanup("invalidate", () => this.coordinator.dispose());
+    const compactionStopped = cleanup("compaction", () =>
+      this.continuousCompactor.reset("dispose")
+    );
+    const retryStopped = cleanup("retry", () => this.retryManager.dispose());
+    const backgroundStopped = this.keepBackgroundProcesses
+      ? undefined
+      : cleanup("background processes", () =>
+          this.backgroundProcessManager.cleanup(this.workspaceId)
+        );
+    Promise.all([stopped, invalidated, compactionStopped, retryStopped, backgroundStopped])
+      .then(async () => {
+        cleanupExecution[Symbol.dispose]();
+        await cleanup("drain", () => this.coordinator.drain());
+        // Raw bridges stay attached through the attempt fence. Destructive disposal suppresses
+        // recovery policy, but still presents its captured terminal exactly once below.
+        for (const { event, handler } of this.aiListeners) this.aiService.off(event, handler);
+        this.aiListeners.length = 0;
+        for (const { event, handler } of this.initListeners)
+          this.initStateManager.off(event, handler as never);
+        this.initListeners.length = 0;
+        this.emitter.removeAllListeners();
+        eventSpine.emit("session.end", { workspaceId: this.workspaceId });
+      })
+      .catch((error: unknown) => log.debug("dispose: final cleanup failed", { error }))
+      .finally(() => disposed.resolve());
+    return disposed.promise;
   }
 
   onChatEvent(listener: (event: AgentSessionChatEvent) => void): () => void {
@@ -2483,9 +2546,9 @@ export class AgentSession {
       }
     }
 
-    while (!this.coordinator.disposed) {
+    while (!this.coordinator.closing) {
       await this.waitForIdle();
-      if (!this.isAiStreaming()) {
+      if (this.coordinator.closing || !this.isAiStreaming()) {
         return;
       }
 
@@ -5409,16 +5472,6 @@ export class AgentSession {
       this.activeToolCallIds.clear();
     }
 
-    // For hard interrupts, delete partial BEFORE stopping to prevent abort handler
-    // from committing it. For soft interrupts, defer to stream-abort handler since
-    // the stream continues running and would recreate the partial.
-    if (options?.abandonPartial && !options?.soft) {
-      const deleteResult = await this.historyService.deletePartial(this.workspaceId);
-      if (!deleteResult.success) {
-        return Err(deleteResult.error);
-      }
-    }
-
     const stopResult = await this.streamManager.stopStream(this.workspaceId, {
       ...options,
       abortReason: "user",
@@ -7025,6 +7078,7 @@ export class AgentSession {
     });
     forward("stream-abort", (payload) => {
       if (payload.type !== "stream-abort") return;
+      if (this.forwardDisposalTerminal(payload)) return;
       if (this.coordinator.observeStartupAbort(payload)) return this.handleStartupAbort(payload);
       this.coordinator.rawTerminal("aborted", payload.messageId);
     });
@@ -7037,6 +7091,7 @@ export class AgentSession {
 
     forward("stream-end", (payload) => {
       if (payload.type !== "stream-end") return;
+      if (this.forwardDisposalTerminal(payload)) return;
       this.coordinator.rawTerminal("completed", payload.messageId);
     });
 
@@ -7087,10 +7142,21 @@ export class AgentSession {
     forward("init-end", (payload) => this.emitChatEvent(payload));
   }
 
+  private forwardDisposalTerminal(payload: StreamAbortEvent | StreamEndEvent): boolean {
+    if (!this.disposePromise) return false;
+    if (payload.messageId && payload.messageId === this.disposalMessageId) {
+      this.disposalMessageId = undefined;
+      this.emitter.emit("chat-event", {
+        workspaceId: this.workspaceId,
+        message: payload,
+      } satisfies AgentSessionChatEvent);
+    }
+    return true;
+  }
+
   // Public method to emit chat events (used by init hooks and other workspace events)
   emitChatEvent(message: WorkspaceChatMessage): void {
-    // NOTE: Workspace teardown does not await in-flight async work (sendMessage(), stopStream(), etc).
-    // Those code paths can still try to emit events after dispose; drop them rather than crashing.
+    // Destructive disposal keeps raw terminal presentation separate from late policy work.
     if (this.coordinator.disposed) {
       return;
     }

--- a/src/node/services/agentSession.turnCompletion.test.ts
+++ b/src/node/services/agentSession.turnCompletion.test.ts
@@ -11,7 +11,7 @@ import type { StreamMessageOptions } from "./turnRequestBuilder";
 import type { TurnCompletion } from "./streamManager";
 import type { WorkspaceGoalService } from "./workspaceGoalService";
 import type { AgentSession } from "./agentSession";
-import { createAgentSessionHarness } from "./agentSession.testHarness";
+import { createStartedTurnHandle, createAgentSessionHarness } from "./agentSession.testHarness";
 
 const workspaceId = "session-completion";
 const model = "openai:gpt-4o";
@@ -101,7 +101,7 @@ describe("AgentSession turn completion", () => {
         abortReason: "user",
       });
     } finally {
-      h.session.dispose();
+      await h.session.dispose();
       await h.cleanup();
     }
   });
@@ -149,7 +149,7 @@ describe("AgentSession turn completion", () => {
       expect(coordinator.phase).toBe("preparing");
       expect(coordinator.thinkingOverride).toBe(replacementThinking);
     } finally {
-      h.session.dispose();
+      await h.session.dispose();
       await h.cleanup();
     }
   });
@@ -219,7 +219,7 @@ describe("AgentSession turn completion", () => {
       });
     } finally {
       releaseAccounting.resolve();
-      h.session.dispose();
+      await h.session.dispose();
       await edit;
       await closing;
       errorLog.mockRestore();
@@ -259,7 +259,7 @@ describe("AgentSession turn completion", () => {
       ]);
       expect(h.session.isBusy()).toBe(false);
     } finally {
-      h.session.dispose();
+      await h.session.dispose();
       await h.cleanup();
     }
   });
@@ -317,7 +317,7 @@ describe("AgentSession turn completion", () => {
       } finally {
         releaseEnvelope.resolve();
         await send;
-        h.session.dispose();
+        await h.session.dispose();
         await h.cleanup();
       }
     }
@@ -349,7 +349,9 @@ describe("AgentSession turn completion", () => {
               Ok({
                 messageId,
                 completion:
-                  calls === 1 ? completion.promise : new Promise<TurnCompletion>(() => undefined),
+                  calls === 1
+                    ? completion.promise
+                    : createStartedTurnHandle(h.session.closingSignal).completion,
               })
             );
           }),
@@ -405,7 +407,7 @@ describe("AgentSession turn completion", () => {
       } finally {
         completion.resolve(outcome);
         await edit;
-        h.session.dispose();
+        await h.session.dispose();
         await h.cleanup();
       }
     }
@@ -450,7 +452,7 @@ describe("AgentSession turn completion", () => {
           { abortReason: reason },
         ]);
       } finally {
-        h.session.dispose();
+        await h.session.dispose();
         await h.cleanup();
       }
     }
@@ -474,7 +476,9 @@ describe("AgentSession turn completion", () => {
               Ok({
                 messageId,
                 completion:
-                  calls === 1 ? completion.promise : new Promise<TurnCompletion>(() => undefined),
+                  calls === 1
+                    ? completion.promise
+                    : createStartedTurnHandle(h.session.closingSignal).completion,
               })
             );
           }),
@@ -523,7 +527,7 @@ describe("AgentSession turn completion", () => {
       } finally {
         releaseHistory.resolve();
         await replacement;
-        h.session.dispose();
+        await h.session.dispose();
         await h.cleanup();
       }
     }
@@ -561,7 +565,7 @@ describe("AgentSession turn completion", () => {
       const decision = h.session.waitForPendingCompactionCompletionDecision("assistant-1");
       completion.resolve({ status: "completed", streamEnd: end() });
       await entered.promise;
-      h.session.dispose();
+      h.session.beginDispose();
       expect(await decision).toBe(false);
       expect(await h.session.waitForPendingCompactionCompletionDecision("late-observer")).toBe(
         false
@@ -572,7 +576,7 @@ describe("AgentSession turn completion", () => {
       expect(h.session.isBusy()).toBe(false);
     } finally {
       release.resolve();
-      h.session.dispose();
+      await h.session.dispose();
       await h.cleanup();
     }
   });
@@ -601,7 +605,10 @@ describe("AgentSession turn completion", () => {
           start(emitter, messageId);
           if (calls > 1)
             return Promise.resolve(
-              Ok({ messageId, completion: new Promise<TurnCompletion>(() => undefined) })
+              Ok({
+                messageId,
+                completion: createStartedTurnHandle(h.session.closingSignal).completion,
+              })
             );
           emitter.emit("stream-end", rawEnd);
           return Promise.resolve(
@@ -670,7 +677,7 @@ describe("AgentSession turn completion", () => {
         { type: "text", text: "Continue after summary" },
       ]);
     } finally {
-      h.session.dispose();
+      await h.session.dispose();
       await h.cleanup();
     }
   });
@@ -697,7 +704,9 @@ describe("AgentSession turn completion", () => {
           return Ok({
             messageId,
             completion:
-              calls === 1 ? completion.promise : new Promise<TurnCompletion>(() => undefined),
+              calls === 1
+                ? completion.promise
+                : createStartedTurnHandle(h.session.closingSignal).completion,
           });
         }),
       },
@@ -733,7 +742,7 @@ describe("AgentSession turn completion", () => {
       releaseLookup.resolve();
       await original;
       await edit;
-      h.session.dispose();
+      await h.session.dispose();
       await h.cleanup();
     }
   });
@@ -757,7 +766,9 @@ describe("AgentSession turn completion", () => {
             Ok({
               messageId,
               completion:
-                calls === 1 ? completion.promise : new Promise<TurnCompletion>(() => undefined),
+                calls === 1
+                  ? completion.promise
+                  : createStartedTurnHandle(h.session.closingSignal).completion,
             })
           );
         }),
@@ -791,7 +802,7 @@ describe("AgentSession turn completion", () => {
       expect(h.events.filter((event) => event.type === "stream-abort")).toHaveLength(1);
       expect(h.session.isBusy()).toBe(true);
     } finally {
-      h.session.dispose();
+      await h.session.dispose();
       await h.cleanup();
     }
   });
@@ -845,7 +856,7 @@ describe("AgentSession turn completion", () => {
       emitter.emit("stream-end", end());
       expect(await h.session.waitForPendingCompactionCompletionDecision("assistant-1")).toBe(false);
     } finally {
-      h.session.dispose();
+      await h.session.dispose();
       await h.cleanup();
     }
   });
@@ -887,7 +898,7 @@ describe("AgentSession turn completion", () => {
           return result;
         });
         await stopped.promise;
-        if (mode === "dispose") h.session.dispose();
+        if (mode === "dispose") h.session.beginDispose();
         if (mode === "hard") {
           await new Promise<void>((resolve) => setImmediate(resolve));
           expect(returned).toBe(false);
@@ -899,12 +910,11 @@ describe("AgentSession turn completion", () => {
         await sending;
         await interrupt;
         await policyPromise(consumer);
-        expect(h.events.filter((event) => event.type === "stream-abort")).toHaveLength(
-          mode === "dispose" ? 0 : 1
-        );
+        // Disposal retains the captured attempt's raw terminal even before its handle returns.
+        expect(h.events.filter((event) => event.type === "stream-abort")).toHaveLength(1);
       } finally {
         releaseHandle.resolve();
-        h.session.dispose();
+        await h.session.dispose();
         await sending;
         await interrupt;
         await h.cleanup();
@@ -927,7 +937,7 @@ describe("AgentSession turn completion", () => {
             return Promise.resolve(
               Ok({
                 messageId: "replacement",
-                completion: new Promise<TurnCompletion>(() => undefined),
+                completion: createStartedTurnHandle(h.session.closingSignal).completion,
               })
             );
           }),
@@ -964,7 +974,7 @@ describe("AgentSession turn completion", () => {
         expect(h.session.setActiveTurnThinkingLevel("high")).toEqual({ accepted: true });
       } finally {
         release.resolve();
-        h.session.dispose();
+        await h.session.dispose();
         await h.cleanup();
       }
     }
@@ -1001,14 +1011,14 @@ describe("AgentSession turn completion", () => {
       });
       await preferenceEntered.promise;
       h.session.beginShutdown();
-      h.session.dispose();
+      h.session.beginDispose();
       preference.resolve(true);
       await policyPromise(consumer);
       expect(h.session.hasPendingAutoRetry()).toBe(false);
       expect(h.events.some((event) => event.type === "auto-retry-scheduled")).toBe(false);
     } finally {
       preference.resolve(true);
-      h.session.dispose();
+      await h.session.dispose();
       await h.cleanup();
     }
   });

--- a/src/node/services/agentSession.waitForIdle.test.ts
+++ b/src/node/services/agentSession.waitForIdle.test.ts
@@ -42,7 +42,7 @@ describe("AgentSession.waitForIdle", () => {
       expect(session.isBusy()).toBe(true);
     } finally {
       internalSession.coordinator.finishTurn(internalSession.coordinator.turnId);
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -71,7 +71,7 @@ describe("AgentSession.waitForIdle", () => {
       release();
       expect(session.hasPendingManualFollowUp()).toBe(false);
     } finally {
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -96,7 +96,7 @@ describe("AgentSession.waitForIdle", () => {
       session.queueMessage("now");
       expect(session.hasQueuedMessages("tool-end")).toBe(true);
     } finally {
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -133,7 +133,7 @@ describe("AgentSession.waitForIdle", () => {
       expect(session.isBusy()).toBe(true);
     } finally {
       internalSession.coordinator.finishTurn(internalSession.coordinator.turnId);
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });

--- a/src/node/services/agentSession.workspaceTurnInheritance.test.ts
+++ b/src/node/services/agentSession.workspaceTurnInheritance.test.ts
@@ -142,7 +142,7 @@ describe("AgentSession workspace-turn correlation inheritance", () => {
     let streamedMuxMetadata: StreamMessageOptions["muxMetadata"];
     const streamMessage = mock((opts: StreamMessageOptions) => {
       streamedMuxMetadata = opts.muxMetadata;
-      return Promise.resolve(Ok(createStartedTurnHandle()));
+      return Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal)));
     });
     const { session, cleanup, historyService } = await createAgentSessionHarness({
       workspaceId: "workspace-turn-inheritance",
@@ -167,7 +167,7 @@ describe("AgentSession workspace-turn correlation inheritance", () => {
       expect(streamMessage.mock.calls).toHaveLength(1);
       return streamedMuxMetadata;
     } finally {
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   }
@@ -215,7 +215,7 @@ describe("AgentSession workspace-turn correlation inheritance", () => {
         muxMetadata: correlation,
       });
     } finally {
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });
@@ -268,7 +268,7 @@ describe("AgentSession workspace-turn correlation inheritance", () => {
       expect(requestMeta.parsed.followUpContent?.agentInitiated).toBe(true);
       expect(requestMeta.parsed.followUpContent?.workspaceTurnMetadata).toEqual(correlation);
     } finally {
-      session.dispose();
+      await session.dispose();
       await cleanup();
     }
   });

--- a/src/node/services/aiService.test.ts
+++ b/src/node/services/aiService.test.ts
@@ -536,7 +536,7 @@ describe("AIService turn engine events", () => {
     mock.restore();
   });
 
-  it("forwards stream-abort even when partial cleanup throws", async () => {
+  it("forwards stream-abort without mutating a workspace partial", async () => {
     using harness = createForwardingHarness("ai-service-stream-abort-forwarding");
     const { historyService, service, internals, clearPendingRunMetadataSpy } = harness;
     const cleanupError = new Error("disk full");
@@ -560,7 +560,7 @@ describe("AIService turn engine events", () => {
     await internals.emitEngineEvent(abortEvent);
 
     expect(await forwardedAbortPromise).toEqual(abortEvent);
-    expect(deletePartialSpy).toHaveBeenCalledWith(abortEvent.workspaceId);
+    expect(deletePartialSpy).not.toHaveBeenCalled();
     expect(clearPendingRunMetadataSpy).toHaveBeenCalledWith(abortEvent.workspaceId, "metadata-1");
     expect(internals.pendingDevToolsRunMetadataByMessageId.has(abortEvent.messageId)).toBe(false);
   });

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -355,26 +355,10 @@ export class AIService extends EventEmitter {
 
     if (event.type === "stream-abort") {
       this.clearTrackedPendingDevToolsRunMetadata(event.messageId);
-      return (async () => {
-        try {
-          if (event.abandonPartial) {
-            await this.historyService.deletePartial(event.workspaceId);
-          } else {
-            const partial = await this.historyService.readPartial(event.workspaceId);
-            if (partial) {
-              await this.historyService.commitPartial(event.workspaceId);
-              await this.historyService.deletePartial(event.workspaceId);
-            }
-          }
-        } catch (error) {
-          log.error("Failed partial cleanup during stream-abort", {
-            workspaceId: event.workspaceId,
-            error: getErrorMessage(error),
-          });
-        } finally {
-          this.emit("stream-abort", event);
-        }
-      })();
+      // Persistence belongs to the captured engine attempt. Synthetic/empty startup
+      // terminals have no authority to mutate whichever partial occupies this workspace.
+      this.emit("stream-abort", event);
+      return;
     }
 
     this.emit(event.type, event);

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -2038,23 +2038,29 @@ export class HistoryService {
    * commit of the same partial) would otherwise be appended pre-update and then dropped, or
    * resurrect an already committed partial.
    */
-  async commitPartial(workspaceId: string): Promise<Result<void>> {
+  async commitPartial(workspaceId: string, expectedMessageId?: string): Promise<Result<void>> {
     // Lock-free probe: most stream starts have no partial to commit, and a reader observes either
     // the old or the new atomically written file, never a torn one.
     if ((await this.readPartial(workspaceId)) == null) {
       return Ok(undefined);
     }
     return this.withRecoveredHistoryWriteResultLock(workspaceId, "Failed to commit partial", () =>
-      this.commitPartialUnderWriteLock(workspaceId)
+      this.commitPartialUnderWriteLock(workspaceId, expectedMessageId)
     );
   }
 
-  private async commitPartialUnderWriteLock(workspaceId: string): Promise<Result<void>> {
+  private async commitPartialUnderWriteLock(
+    workspaceId: string,
+    expectedMessageId?: string
+  ): Promise<Result<void>> {
     try {
       let partial = await this.readPartial(workspaceId);
       if (!partial) {
         return Ok(undefined);
       }
+      // Attempt finalization must not commit a replacement's partial. Check inside the
+      // same transaction as the history write and deletion, never in a caller-side probe.
+      if (expectedMessageId != null && partial.id !== expectedMessageId) return Ok(undefined);
 
       const hadErrorMetadata = partial.metadata?.error != null;
 

--- a/src/node/services/mock/mockAiStreamPlayer.test.ts
+++ b/src/node/services/mock/mockAiStreamPlayer.test.ts
@@ -192,13 +192,13 @@ describe("MockAiStreamPlayer", () => {
       aiService: aiServiceStub as unknown as AIService,
     });
 
-    const originalDeletePartial = historyService.deletePartial.bind(historyService);
+    const originalDeletePartial = historyService.commitPartial.bind(historyService);
     let deletePartialCallCount = 0;
     let releaseStopCleanup!: () => void;
     const stopCleanupGate = new Promise<void>((resolve) => {
       releaseStopCleanup = () => resolve();
     });
-    spyOn(historyService, "deletePartial").mockImplementation(async (workspaceIdToDelete) => {
+    spyOn(historyService, "commitPartial").mockImplementation(async (workspaceIdToDelete) => {
       deletePartialCallCount += 1;
       if (deletePartialCallCount === 1) {
         await stopCleanupGate;
@@ -351,7 +351,9 @@ describe("MockAiStreamPlayer", () => {
 
       await waitForCondition(() => writePartialCallCount >= 1, 1000);
 
-      await player.stop(workspaceId);
+      const stop = player.stop(workspaceId, { abandonPartial: true });
+      releaseFirstWrite();
+      await stop;
       expect(player.isStreaming(workspaceId)).toBe(false);
       expect(await historyService.readPartial(workspaceId)).toBeNull();
 
@@ -366,108 +368,44 @@ describe("MockAiStreamPlayer", () => {
     }
   });
 
-  test("does not let stale delayed-write cleanup delete a replacement stream partial", async () => {
-    const aiServiceStub = new EventEmitter();
-
+  test("replacement joins the old delayed write and captured partial finalization", async () => {
+    const emitter = new EventEmitter();
     const player = new MockAiStreamPlayer({
       historyService,
-      aiService: aiServiceStub as unknown as AIService,
+      aiService: emitter as unknown as AIService,
     });
-
-    const originalWritePartial = historyService.writePartial.bind(historyService);
-    let releaseFirstWrite!: () => void;
-    const firstWriteGate = new Promise<void>((resolve) => {
-      releaseFirstWrite = () => resolve();
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const originalWrite = historyService.writePartial.bind(historyService);
+    spyOn(historyService, "writePartial").mockImplementationOnce(async (...args) => {
+      entered.resolve();
+      await release.promise;
+      return originalWrite(...args);
     });
-    let writePartialCallCount = 0;
-    spyOn(historyService, "writePartial").mockImplementation(
-      async (workspaceIdToWrite, message) => {
-        writePartialCallCount += 1;
-        if (writePartialCallCount === 1) {
-          await firstWriteGate;
-        }
-        return await originalWritePartial(workspaceIdToWrite, message);
-      }
-    );
-
-    const originalDeletePartialIfMessageIdMatches =
-      historyService.deletePartialIfMessageIdMatches.bind(historyService);
-    let releaseStaleCleanup!: () => void;
-    const staleCleanupGate = new Promise<void>((resolve) => {
-      releaseStaleCleanup = () => resolve();
-    });
-    let deleteMatchingCallCount = 0;
-    spyOn(historyService, "deletePartialIfMessageIdMatches").mockImplementation(
-      async (workspaceIdToDelete, messageIdToDelete) => {
-        deleteMatchingCallCount += 1;
-        if (deleteMatchingCallCount === 1) {
-          await staleCleanupGate;
-        }
-        return await originalDeletePartialIfMessageIdMatches(
-          workspaceIdToDelete,
-          messageIdToDelete
-        );
-      }
-    );
-
-    const workspaceId = "workspace-stale-delayed-write-cleanup";
-    const streamStartMessageIds: string[] = [];
-    aiServiceStub.on("stream-start", (payload: unknown) => {
-      if (readWorkspaceId(payload) !== workspaceId) {
-        return;
-      }
-      const messageId = (payload as { messageId?: string }).messageId;
-      if (typeof messageId === "string") {
-        streamStartMessageIds.push(messageId);
-      }
-    });
-
-    const firstUserMessage = createMuxMessage(
-      "user-stale-delayed-write-first",
-      "user",
-      "[force] first stream before stale delayed-write cleanup",
-      {
-        timestamp: Date.now(),
-      }
-    );
-
+    const workspaceId = "mock-replacement-write-fence";
+    const user = createMuxMessage("user", "user", "[force] keep streaming");
+    let replacementStarted = false;
     try {
-      const firstPlayResult = await player.play([firstUserMessage], workspaceId);
-      expect(firstPlayResult.success).toBe(true);
-
-      await waitForCondition(() => writePartialCallCount >= 1, 1000);
-
-      const replacementUserMessage = createMuxMessage(
-        "user-stale-delayed-write-second",
-        "user",
-        "[force] replacement stream should keep its partial after stale cleanup",
-        {
-          timestamp: Date.now(),
-        }
-      );
-
-      const replacementPlayResult = await player.play([replacementUserMessage], workspaceId);
-      expect(replacementPlayResult.success).toBe(true);
-
-      await waitForCondition(() => streamStartMessageIds.length >= 2, 1000);
-      const replacementMessageId = streamStartMessageIds[1];
-
-      releaseFirstWrite();
-      await waitForCondition(() => deleteMatchingCallCount >= 1, 1000);
-
-      await waitForCondition(
-        async () => (await historyService.readPartial(workspaceId))?.id === replacementMessageId,
-        2000
-      );
-
-      releaseStaleCleanup();
-      await waitForCondition(
-        async () => (await historyService.readPartial(workspaceId))?.id === replacementMessageId,
-        1000
-      );
+      const first = await player.play([user], workspaceId);
+      if (!first.success || !first.data) throw new Error("Expected handle");
+      await entered.promise;
+      const replacement = player.play([user], workspaceId).then((result) => {
+        replacementStarted = true;
+        return result;
+      });
+      expect(replacementStarted).toBe(false);
+      release.resolve();
+      const next = await replacement;
+      if (!next.success || !next.data) throw new Error("Expected replacement");
+      expect(await first.data.completion).toMatchObject({
+        status: "aborted",
+        abortReason: "system",
+      });
+      const partial = await historyService.readPartial(workspaceId);
+      expect(partial?.id).not.toBe(first.data.messageId);
+      expect(next.data.messageId).not.toBe(first.data.messageId);
     } finally {
-      releaseFirstWrite();
-      releaseStaleCleanup();
+      release.resolve();
       await player.stop(workspaceId);
     }
   });
@@ -812,6 +750,49 @@ describe("MockAiStreamPlayer", () => {
     if (!playResult.success || !playResult.data) throw new Error("expected a stream handle");
     expect(await playResult.data.completion).toMatchObject({ status: "aborted" });
   });
+  test.each(["stream-end", "error"] as const)(
+    "a synchronous stop from %s cannot publish a second terminal",
+    async (eventName) => {
+      const emitter = new EventEmitter();
+      const player = new MockAiStreamPlayer({
+        historyService,
+        aiService: emitter as unknown as AIService,
+      });
+      const workspaceId = `mock-reentrant-${eventName}`;
+      let stop: Promise<void> | undefined;
+      let aborts = 0;
+      emitter.on("stream-abort", () => {
+        aborts++;
+      });
+      emitter.once(eventName, () => {
+        stop = player.stop(workspaceId, { abortReason: "user" });
+        throw new Error("terminal listener failed");
+      });
+      const played = await player.play(
+        [
+          createMuxMessage(
+            "user",
+            "user",
+            eventName === "error"
+              ? "[mock:error:api] Trigger API error"
+              : "[mock:list-languages] List 3 programming languages"
+          ),
+        ],
+        workspaceId
+      );
+      if (!played.success || !played.data) throw new Error("Expected mock handle");
+      try {
+        const completion = await played.data.completion;
+        expect(completion.status).toBe(eventName === "error" ? "failed" : "completed");
+        expect(stop).toBeDefined();
+        await stop;
+        expect(aborts).toBe(0);
+      } finally {
+        await player.stop(workspaceId);
+      }
+    }
+  );
+
   test.each([false, true])(
     "abort completion waits for partial deletion (reject=%s)",
     async (rejectDelete) => {
@@ -831,12 +812,15 @@ describe("MockAiStreamPlayer", () => {
       await delta.promise;
       const entered = Promise.withResolvers<void>();
       const release = Promise.withResolvers<void>();
-      const deletePartial = historyService.deletePartial.bind(historyService);
-      const deletion = spyOn(historyService, "deletePartial").mockImplementationOnce(async (id) => {
+      const deletePartial = historyService.deletePartialIfMessageIdMatches.bind(historyService);
+      const deletion = spyOn(
+        historyService,
+        "deletePartialIfMessageIdMatches"
+      ).mockImplementationOnce(async (id, messageId) => {
         entered.resolve();
         await release.promise;
         if (rejectDelete) throw new Error("partial delete failed");
-        return deletePartial(id);
+        return deletePartial(id, messageId);
       });
       let settled = false;
       const observed = played.data.completion.then(() => {
@@ -846,12 +830,14 @@ describe("MockAiStreamPlayer", () => {
       emitter.once("stream-abort", (payload) => {
         terminal = payload;
       });
-      const stop = player.stop(workspaceId).catch((error) => error as unknown);
+      const stop = player
+        .stop(workspaceId, { abandonPartial: true, abortReason: "user" })
+        .catch((error) => error as unknown);
       try {
         await entered.promise;
-        expect(player.isStreaming(workspaceId)).toBe(false);
+        expect(player.isStreaming(workspaceId)).toBe(true);
         expect(settled).toBe(false);
-        expect(terminal).toBeDefined();
+        expect(terminal).toBeUndefined();
         release.resolve();
         await stop;
         expect(await played.data.completion).toMatchObject({

--- a/src/node/services/mock/mockAiStreamPlayer.ts
+++ b/src/node/services/mock/mockAiStreamPlayer.ts
@@ -9,6 +9,7 @@ import type { AIService } from "@/node/services/aiService";
 import { createErrorEvent } from "@/node/services/utils/sendMessageError";
 import {
   createTurnCompletionController,
+  type StopStreamOptions,
   type TurnCompletion,
   type TurnStreamHandle,
 } from "@/node/services/streamManager";
@@ -140,6 +141,9 @@ interface ActiveStream {
   partialWriteTimer: ReturnType<typeof setTimeout> | null;
   eventQueue: Array<() => Promise<void>>;
   isProcessing: boolean;
+  processing?: ReturnType<typeof Promise.withResolvers<void>>;
+  cancelPromise?: Promise<void>;
+  terminalCompletion?: TurnCompletion;
   cancelled: boolean;
   settleCompletion: (completion: TurnCompletion) => void;
 }
@@ -236,38 +240,52 @@ export class MockAiStreamPlayer {
       }
     });
   }
-  private async stopActiveStream(workspaceId: string): Promise<void> {
+  private stopActiveStream(workspaceId: string, options?: StopStreamOptions): Promise<void> {
     const active = this.activeStreams.get(workspaceId);
-    if (!active) return;
-
-    active.cancelled = true;
-
-    // Emit stream-abort event to mirror real streaming behavior before we await disk cleanup.
+    if (!active) return Promise.resolve();
+    if (active.cancelPromise) return active.cancelPromise;
+    const canceled = Promise.withResolvers<void>();
+    active.cancelPromise = canceled.promise;
+    this.cancelTimers(active);
+    const abortReason = options?.abortReason ?? "system";
     const streamAbort: StreamAbortEvent = {
       type: "stream-abort",
       workspaceId,
       messageId: active.messageId,
-      abortReason: "user",
+      abortReason,
+      abandonPartial: options?.abandonPartial,
     };
-    this.deps.aiService.emit("stream-abort", streamAbort);
-
-    this.cleanup(workspaceId);
-
-    // User-initiated mock interrupts should not leave behind resumable partial state.
-    try {
-      const deletePartialResult = await this.deps.historyService.deletePartial(workspaceId);
-      if (!deletePartialResult.success) {
-        log.error(
-          `Failed to clear mock partial on stop for ${active.messageId}: ${deletePartialResult.error}`
-        );
+    (async () => {
+      // Join the exact running event/write before touching partial.json. A replacement
+      // joins this same cancellation, including persistence and raw delivery.
+      await active.processing?.promise;
+      if (active.terminalCompletion) return;
+      try {
+        const result = options?.abandonPartial
+          ? await this.deps.historyService.deletePartialIfMessageIdMatches(
+              workspaceId,
+              active.messageId
+            )
+          : await this.deps.historyService.commitPartial(workspaceId, active.messageId);
+        if (!result.success)
+          log.error("Failed to finalize mock partial", { workspaceId, error: result.error });
+      } catch (error) {
+        log.error("Failed to finalize mock partial", { workspaceId, error });
       }
-    } finally {
-      active.settleCompletion({ status: "aborted", abortReason: "user", streamAbort });
-    }
+      try {
+        this.deps.aiService.emit("stream-abort", streamAbort);
+      } finally {
+        if (this.activeStreams.get(workspaceId) === active) this.activeStreams.delete(workspaceId);
+        active.settleCompletion({ status: "aborted", abortReason, streamAbort });
+      }
+    })()
+      .catch((error: unknown) => log.error("Mock abort delivery failed", { error }))
+      .finally(canceled.resolve);
+    return canceled.promise;
   }
 
-  async stop(workspaceId: string): Promise<void> {
-    await this.stopActiveStream(workspaceId);
+  stop(workspaceId: string, options?: StopStreamOptions): Promise<void> {
+    return this.stopActiveStream(workspaceId, options);
   }
 
   private async deleteAssistantPlaceholder(workspaceId: string, messageId: string): Promise<void> {
@@ -484,6 +502,8 @@ export class MockAiStreamPlayer {
     if (!active || active.isProcessing) return;
 
     active.isProcessing = true;
+    const processing = Promise.withResolvers<void>();
+    active.processing = processing;
 
     while (active.eventQueue.length > 0) {
       const handler = active.eventQueue.shift();
@@ -497,6 +517,8 @@ export class MockAiStreamPlayer {
     }
 
     active.isProcessing = false;
+    active.processing = undefined;
+    processing.resolve();
   }
 
   private appendTextPart(active: ActiveStream, text: string, timestamp: number): void {
@@ -638,7 +660,7 @@ export class MockAiStreamPlayer {
     workspaceId: string,
     active: ActiveStream
   ): Promise<void> {
-    if (this.isCurrentActiveStream(workspaceId, active)) {
+    if (this.isCurrentActiveStream(workspaceId, active) || active.cancelPromise) {
       return;
     }
 
@@ -813,19 +835,23 @@ export class MockAiStreamPlayer {
           return;
         }
 
-        this.deps.aiService.emit(
-          "error",
-          createErrorEvent(workspaceId, {
-            messageId,
-            error: payload.error,
-            errorType: payload.errorType,
-          })
-        );
-        active.settleCompletion({
+        active.terminalCompletion = {
           status: "failed",
           streamError: { messageId, error: payload.error, errorType: payload.errorType },
-        });
-        this.cleanup(workspaceId);
+        };
+        try {
+          this.deps.aiService.emit(
+            "error",
+            createErrorEvent(workspaceId, {
+              messageId,
+              error: payload.error,
+              errorType: payload.errorType,
+            })
+          );
+        } finally {
+          this.cleanup(workspaceId);
+          active.settleCompletion(active.terminalCompletion);
+        }
         break;
       }
       case "stream-end": {
@@ -888,9 +914,13 @@ export class MockAiStreamPlayer {
 
         if (!this.isCurrentActiveStream(workspaceId, active)) return;
 
-        this.deps.aiService.emit("stream-end", payload);
-        this.cleanup(workspaceId);
-        active.settleCompletion({ status: "completed", streamEnd: payload });
+        active.terminalCompletion = { status: "completed", streamEnd: payload };
+        try {
+          this.deps.aiService.emit("stream-end", payload);
+        } finally {
+          this.cleanup(workspaceId);
+          active.settleCompletion(active.terminalCompletion);
+        }
         break;
       }
     }
@@ -900,6 +930,11 @@ export class MockAiStreamPlayer {
     const active = this.activeStreams.get(workspaceId);
     if (!active) return;
 
+    this.cancelTimers(active);
+    if (this.activeStreams.get(workspaceId) === active) this.activeStreams.delete(workspaceId);
+  }
+
+  private cancelTimers(active: ActiveStream): void {
     active.cancelled = true;
 
     if (active.partialWriteTimer) {
@@ -914,8 +949,6 @@ export class MockAiStreamPlayer {
 
     // Clear event queue to prevent any pending events from processing
     active.eventQueue = [];
-
-    this.activeStreams.delete(workspaceId);
   }
 
   private extractText(message: MuxMessage): string {

--- a/src/node/services/serviceContainer.test.ts
+++ b/src/node/services/serviceContainer.test.ts
@@ -444,7 +444,6 @@ describe("ServiceContainer", () => {
     await housekeeping;
     await disposed;
 
-    expect(disposeRecoverySessions).toHaveBeenCalledTimes(1);
     expect(beginShutdown).toHaveBeenCalledTimes(1);
     expect(heartbeatStart).not.toHaveBeenCalled();
     expect(idleCompactionStart).not.toHaveBeenCalled();
@@ -902,6 +901,82 @@ describe("ServiceContainer", () => {
             part.type === "text" && part.text === "hello from a stream shutdown must not lose"
         )
       ).toBe(true);
+    }
+  );
+
+  it("joins cleanup enqueued by a closing session callback before dependency teardown", async () => {
+    services = new ServiceContainer(stores);
+    const session = services.workspaceService.getOrCreateSession("late-cleanup-owner");
+    const { coordinator } = session as unknown as { coordinator: TurnCoordinator };
+    const lease = coordinator.enterExecution();
+    const cleanupEntered = Promise.withResolvers<void>();
+    const cleanupRelease = Promise.withResolvers<void>();
+    const backgroundEntered = Promise.withResolvers<void>();
+    const backgroundRelease = Promise.withResolvers<void>();
+    spyOn(services.backgroundProcessManager, "cleanup").mockImplementationOnce(async () => {
+      backgroundEntered.resolve();
+      await backgroundRelease.promise;
+    });
+    const bridge = spyOn(services.desktopBridgeServer, "stop").mockResolvedValue(undefined);
+    const disposed = services.dispose();
+    try {
+      // The still-leased producer registers cleanup after the shutdown snapshot.
+      services.workspaceService.deferWorkspaceCleanup(async () => {
+        cleanupEntered.resolve();
+        await cleanupRelease.promise;
+      });
+      lease[Symbol.dispose]();
+      await Promise.all([cleanupEntered.promise, backgroundEntered.promise]);
+      expect(bridge).not.toHaveBeenCalled();
+      backgroundRelease.resolve();
+      await session.dispose();
+      expect(bridge).not.toHaveBeenCalled();
+      cleanupRelease.resolve();
+      await disposed;
+      expect(bridge).toHaveBeenCalledTimes(1);
+    } finally {
+      lease[Symbol.dispose]();
+      backgroundRelease.resolve();
+      cleanupRelease.resolve();
+      await disposed;
+    }
+  });
+
+  it.each(["stop", "drain"] as const)(
+    "a rejected session %s cannot skip held background or deferred cleanup",
+    async (failure) => {
+      services = new ServiceContainer(stores);
+      const session = services.workspaceService.getOrCreateSession(`shutdown-${failure}-failure`);
+      const { coordinator } = session as unknown as { coordinator: TurnCoordinator };
+      if (failure === "stop")
+        spyOn(services.streamManager, "stopStream").mockRejectedValueOnce(
+          new Error("adapter stop failure")
+        );
+      else spyOn(coordinator, "drain").mockRejectedValueOnce(new Error("scope drain failure"));
+      const backgroundEntered = Promise.withResolvers<void>();
+      const backgroundRelease = Promise.withResolvers<void>();
+      const cleanupRelease = Promise.withResolvers<void>();
+      spyOn(services.backgroundProcessManager, "cleanup").mockImplementationOnce(async () => {
+        backgroundEntered.resolve();
+        await backgroundRelease.promise;
+      });
+      services.workspaceService.deferWorkspaceCleanup(() => cleanupRelease.promise);
+      const bridge = spyOn(services.desktopBridgeServer, "stop").mockResolvedValue(undefined);
+      const disposed = services.dispose();
+      try {
+        await backgroundEntered.promise;
+        expect(bridge).not.toHaveBeenCalled();
+        backgroundRelease.resolve();
+        await session.dispose();
+        expect(bridge).not.toHaveBeenCalled();
+        cleanupRelease.resolve();
+        await disposed;
+        expect(bridge).toHaveBeenCalledTimes(1);
+      } finally {
+        backgroundRelease.resolve();
+        cleanupRelease.resolve();
+        await disposed;
+      }
     }
   );
 

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -47,7 +47,7 @@ import type { HistoryService } from "./historyService";
 import { createTestHistoryService } from "./testHistoryService";
 import { makeTestEffectRunner } from "./di/testEffectRunner";
 import { closeScopeBounded } from "./di/appRuntime";
-import { Scope } from "effect";
+import { Effect, Scope } from "effect";
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { countTokens } from "@/node/utils/main/tokenizer";
 import * as tokenizer from "@/node/utils/main/tokenizer";
@@ -1564,7 +1564,7 @@ describe("StreamManager - engine supervision (AppFiberScope occupant)", () => {
         service.off("stream-abort", throwFromRawListener);
         countTokensSpy.mockRestore();
         commitSpy.mockRestore();
-        h.session.dispose();
+        await h.session.dispose();
         await streamManager.stopStream(workspaceId, { abortReason: "system" });
       }
     }
@@ -1793,6 +1793,31 @@ describe("StreamManager - engine supervision (AppFiberScope occupant)", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(terminalEvents(events).map((event) => event.type)).toEqual(["stream-abort"]);
     expect(getWorkspaceStreamsForTests(streamManager).size).toBe(0);
+  });
+
+  test("a resource finalizer defect cannot orphan a completed engine handle", async () => {
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const workspaceId = "completion-finalizer-defect";
+    const { streamManager, events, engineScope } = createSupervisedStreamManagerForTests(() =>
+      (async function* () {
+        yield { type: "text-delta", text: "completed answer" };
+        entered.resolve();
+        await release.promise;
+        yield { type: "finish", finishReason: "stop" };
+      })()
+    );
+    const handle = await startSupervisedStreamForTests(streamManager, workspaceId);
+    await entered.promise;
+    const info = getWorkspaceStreamsForTests(streamManager).get(workspaceId) as {
+      resourceScope: Scope.Closeable;
+    };
+    Effect.runSync(Scope.addFinalizer(info.resourceScope, Effect.die(new Error("cleanup defect"))));
+    release.resolve();
+    expect(await handle.completion).toMatchObject({ status: "completed" });
+    expect(terminalEvents(events).map((event) => event.type)).toEqual(["stream-end"]);
+    expect(getWorkspaceStreamsForTests(streamManager).size).toBe(0);
+    await closeScopeBounded(engineScope);
   });
 
   test("completed streams leave no supervisor residue: closing the scope after 50 completions aborts nothing", async () => {
@@ -2929,6 +2954,91 @@ describe("StreamManager - language model cleanup", () => {
     expect(getCleanupCalls()).toBe(1);
   });
 
+  test("returning the startup envelope cannot bypass a held abort fence or emit a second startup abort", async () => {
+    const workspaceId = "envelope-abort-fence";
+    const events: TurnEngineEvent[] = [];
+    const streamManager = new StreamManager(historyService, undefined, undefined, (event) => {
+      events.push(event);
+    });
+    const envelopeEntered = Promise.withResolvers<void>();
+    const envelopeRelease = Promise.withResolvers<void>();
+    const commitEntered = Promise.withResolvers<void>();
+    const commitRelease = Promise.withResolvers<void>();
+    const originalCommit = historyService.commitPartial.bind(historyService);
+    spyOn(historyService, "commitPartial").mockImplementationOnce(async (...args) => {
+      commitEntered.resolve();
+      await commitRelease.promise;
+      return originalCommit(...args);
+    });
+    const pending = streamManager.beginStreamStart({ workspaceId });
+    const started = streamManager.startStream(
+      testStartOptions({
+        workspaceId,
+        messageId: "constructed-fence",
+        model: createTestLanguageModel(),
+        abortSignal: pending.abortSignal,
+        onStreamConstructed: async () => {
+          envelopeEntered.resolve();
+          await envelopeRelease.promise;
+        },
+      })
+    );
+    await envelopeEntered.promise;
+    const stop = streamManager.stopStream(workspaceId, { abortReason: "user" });
+    await commitEntered.promise;
+    const secondStop = streamManager.stopStream(workspaceId, { abortReason: "system" });
+    let returned = false;
+    const observedStart = started.then(() => {
+      returned = true;
+    });
+    try {
+      envelopeRelease.resolve();
+      await envelopeRelease.promise;
+      await Promise.resolve();
+      expect(events.filter((event) => event.type === "stream-abort")).toHaveLength(0);
+      expect(streamManager.getStreamInfo(workspaceId, true)?.messageId).toBe("constructed-fence");
+      expect(returned).toBe(false);
+      commitRelease.resolve();
+      await Promise.all([stop, secondStop]);
+      const result = await started;
+      await observedStart;
+      if (!result.success) throw new Error("Expected aborted handle");
+      expect(await result.data.completion).toMatchObject({
+        status: "aborted",
+        abortReason: "user",
+      });
+      expect(events.filter((event) => event.type === "stream-abort")).toHaveLength(1);
+    } finally {
+      envelopeRelease.resolve();
+      commitRelease.resolve();
+      pending.finish();
+      await Promise.all([started, stop, secondStop]);
+    }
+  });
+
+  test("throwing startup envelope cleanup preserves a replacement registration", async () => {
+    const workspaceId = "throwing-envelope-replacement";
+    const streamManager = new StreamManager(historyService);
+    const streams = getWorkspaceStreamsForTests(streamManager);
+    const replacement = createStreamInfoForTests({ messageId: "replacement" });
+    const { model, getCleanupCalls } = createCleanupModel("throwing-envelope");
+    const result = await streamManager.startStream(
+      testStartOptions({
+        workspaceId,
+        messageId: "old",
+        model,
+        onStreamConstructed: async () => {
+          await streamManager.stopStream(workspaceId);
+          streams.set(workspaceId, replacement);
+          throw new Error("envelope failure");
+        },
+      })
+    );
+    expect(result.success).toBe(false);
+    expect(streams.get(workspaceId)).toBe(replacement);
+    expect(getCleanupCalls()).toBe(1);
+  });
+
   test("runs model cleanup when stream creation throws before processing", async () => {
     const streamManager = new StreamManager(historyService);
     const { model, getCleanupCalls } = createCleanupModel("cleanup-create-throw-model");
@@ -3008,6 +3118,88 @@ describe("StreamManager - turn completion", () => {
     if (!result.success) throw new Error("Expected stream to start");
     return { streamManager, handle: result.data };
   }
+
+  test("replacement and concurrent stops join the captured attempt's held commit", async () => {
+    const workspaceId = "held-commit-replacement";
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const providerEntered = Promise.withResolvers<void>();
+    const terminals: TurnEngineEvent[] = [];
+    const originalCommit = historyService.commitPartial.bind(historyService);
+    spyOn(historyService, "commitPartial").mockImplementationOnce(async (...args) => {
+      entered.resolve();
+      await release.promise;
+      return originalCommit(...args);
+    });
+    const { streamManager, handle } = await startWithStreamResult({
+      workspaceId,
+      messageId: "attempt-a",
+      events: terminals,
+      createStreamResult: (_request, controller) =>
+        createStreamResultForTests(
+          (async function* () {
+            yield { type: "text-delta", text: "durable interrupted answer" };
+            providerEntered.resolve();
+            if (!controller.signal.aborted)
+              await new Promise<void>((resolve) =>
+                controller.signal.addEventListener("abort", () => resolve(), { once: true })
+              );
+          })()
+        ),
+    });
+    await providerEntered.promise;
+    let stopped = false;
+    let replaced = false;
+    const userStop = streamManager.stopStream(workspaceId, { abortReason: "user" }).then(() => {
+      stopped = true;
+    });
+    await entered.promise;
+    const systemStop = streamManager.stopStream(workspaceId, {
+      abortReason: "system",
+      abandonPartial: true,
+    });
+    const replacement = streamManager
+      .startStream(
+        testStartOptions({
+          workspaceId,
+          messageId: "attempt-b",
+          historySequence: 2,
+          model: createTestLanguageModel(),
+          providedRuntimeTempDir: "",
+          onStreamConstructed: () => appendPartialAssistantForTests(workspaceId, "attempt-b", 2),
+        })
+      )
+      .then((result) => {
+        replaced = true;
+        return result;
+      });
+    try {
+      expect(stopped).toBe(false);
+      expect(replaced).toBe(false);
+      expect(streamManager.getStreamInfo(workspaceId, true)?.messageId).toBe("attempt-a");
+      expect(terminals.filter((event) => event.type === "stream-abort")).toHaveLength(0);
+      release.resolve();
+      await Promise.all([userStop, systemStop]);
+      expect(await handle.completion).toMatchObject({ status: "aborted", abortReason: "user" });
+      const next = await replacement;
+      expect(next.success).toBe(true);
+      expect(streamManager.getStreamInfo(workspaceId)?.messageId).toBe("attempt-b");
+      const history = await historyService.getLastMessages(workspaceId, 10);
+      if (!history.success) throw new Error(history.error);
+      expect(history.data.find((message) => message.id === "attempt-a")?.parts).toMatchObject([
+        { type: "text", text: "durable interrupted answer" },
+      ]);
+      expect(
+        terminals.filter(
+          (event) => event.type === "stream-abort" && event.messageId === "attempt-a"
+        )
+      ).toHaveLength(1);
+    } finally {
+      release.resolve();
+      await replacement;
+      await streamManager.stopStream(workspaceId, { abandonPartial: true });
+    }
+  });
 
   test("pre-start failures return Err while successful startup owns an aborted completion", async () => {
     const streamManager = new StreamManager(historyService);
@@ -3101,7 +3293,7 @@ describe("StreamManager - turn completion", () => {
     });
   });
 
-  test("aborted completion waits for the sink to commit and remove the partial", async () => {
+  test("hard stop and completion wait for raw delivery after attempt persistence", async () => {
     const workspaceId = "completion-abort-workspace";
     const providerBlocked = Promise.withResolvers<void>();
     const abortDeliveryEntered = Promise.withResolvers<void>();
@@ -3125,10 +3317,7 @@ describe("StreamManager - turn completion", () => {
         if (event.type !== "stream-abort") return;
         abortDeliveryEntered.resolve();
         await releaseAbortDelivery.promise;
-        // The facade owns abort persistence. A completion consumer must see its cleanup,
-        // even though stopStream has already released the engine's streaming registration.
-        await historyService.commitPartial(workspaceId);
-        await historyService.deletePartial(workspaceId);
+        expect(await historyService.readPartial(workspaceId)).toBeNull();
       },
     });
 
@@ -3144,12 +3333,10 @@ describe("StreamManager - turn completion", () => {
     try {
       await providerBlocked.promise;
       stopPromise = streamManager.stopStream(workspaceId, { abortReason: "user" });
-      await stopPromise;
       await abortDeliveryEntered.promise;
       expect(streamManager.isStreaming(workspaceId)).toBe(false);
-      expect(await historyService.readPartial(workspaceId)).toMatchObject({
-        parts: [{ type: "text", text: "interrupted answer" }],
-      });
+      expect(await historyService.readPartial(workspaceId)).toBeNull();
+      expect(streamManager.getStreamInfo(workspaceId, true)?.messageId).toBe(handle.messageId);
       expect(settled).toBe(false);
 
       releaseAbortDelivery.resolve();
@@ -6479,7 +6666,7 @@ describe("StreamManager - stopStream", () => {
     expect((await streamManager.stopStream("mock-workspace")).success).toBe(true);
     await streamManager.replayStream("mock-workspace", { afterTimestamp: 10 });
 
-    expect(stop).toHaveBeenCalledWith("mock-workspace");
+    expect(stop).toHaveBeenCalledWith("mock-workspace", undefined);
     expect(replayStream).toHaveBeenCalledWith("mock-workspace");
   });
 
@@ -6538,8 +6725,10 @@ describe("StreamManager - aborted stream usage persistence", () => {
     );
     await cleanupAborted.call(streamManager, workspaceId, createAbortStreamInfo(messageId), "user");
 
-    const partial = await historyService.readPartial(workspaceId);
-    expect(partial?.metadata?.partial).toBe(true);
+    expect(await historyService.readPartial(workspaceId)).toBeNull();
+    const history = await historyService.getLastMessages(workspaceId, 10);
+    if (!history.success) throw new Error(history.error);
+    const partial = history.data.find((message) => message.id === messageId);
     expect(partial?.metadata?.usage).toEqual({
       inputTokens: 120,
       outputTokens: 30,
@@ -6553,6 +6742,66 @@ describe("StreamManager - aborted stream usage persistence", () => {
       outputTokens: 30,
       totalTokens: 150,
     });
+  });
+
+  test.each(["commit-err", "commit-throw", "delete-err", "delete-throw"] as const)(
+    "abort settles once and retains recovery data on %s",
+    async (failure) => {
+      const workspaceId = `partial-finalize-${failure}`;
+      const messageId = "partial-owner";
+      const info = createAbortStreamInfo(messageId);
+      await historyService.writePartial(workspaceId, {
+        id: messageId,
+        role: "assistant",
+        parts: [{ type: "text", text: "recover me" }],
+        metadata: { historySequence: 1 },
+      });
+      const events: TurnEngineEvent[] = [];
+      const streamManager = new StreamManager(historyService, undefined, undefined, (event) => {
+        events.push(event);
+      });
+      const abandon = failure.startsWith("delete");
+      if (abandon) {
+        const deletion = spyOn(historyService, "deletePartialIfMessageIdMatches");
+        if (failure.endsWith("throw"))
+          deletion.mockRejectedValueOnce(new Error("disk unavailable"));
+        else deletion.mockResolvedValueOnce(Err("disk unavailable"));
+      } else {
+        const commit = spyOn(historyService, "commitPartial");
+        if (failure.endsWith("throw")) commit.mockRejectedValueOnce(new Error("disk unavailable"));
+        else commit.mockResolvedValueOnce(Err("disk unavailable"));
+      }
+      const cleanupAborted = getPrivateMethodForTests<CleanupAbortedStreamForTests>(
+        streamManager,
+        "cleanupAbortedStream"
+      );
+      await cleanupAborted.call(streamManager, workspaceId, info, "user", abandon);
+      expect(events.filter((event) => event.type === "stream-abort")).toHaveLength(1);
+      expect(events.at(-1)).toMatchObject({ abortReason: "user", messageId });
+      expect(await historyService.readPartial(workspaceId)).not.toBeNull();
+    }
+  );
+
+  test("identity-checked partial finalization preserves a replacement and empty startup cannot drop it", async () => {
+    const workspaceId = "partial-identity";
+    await historyService.writePartial(workspaceId, {
+      id: "replacement",
+      role: "assistant",
+      parts: [{ type: "text", text: "replacement answer" }],
+      metadata: { historySequence: 1 },
+    });
+    expect((await historyService.commitPartial(workspaceId, "old")).success).toBe(true);
+    expect((await historyService.deletePartialIfMessageIdMatches(workspaceId, "old")).success).toBe(
+      true
+    );
+    const streamManager = new StreamManager(historyService);
+    await streamManager.stopStream(workspaceId, { abandonPartial: true });
+    expect((await historyService.readPartial(workspaceId))?.id).toBe("replacement");
+    expect((await historyService.commitPartial(workspaceId, "replacement")).success).toBe(true);
+    expect(await historyService.readPartial(workspaceId)).toBeNull();
+    const history = await historyService.getLastMessages(workspaceId, 10);
+    if (!history.success) throw new Error(history.error);
+    expect(history.data[0]?.id).toBe("replacement");
   });
 
   test("routes tool-only aborted usage to the headless sidecar (commit would drop it)", async () => {
@@ -6643,9 +6892,13 @@ describe("StreamManager - aborted stream usage persistence", () => {
         "headless-usage.jsonl"
       );
       expect(existsSync(sidecarPath)).toBe(false);
-      // Usage still reaches history via the partial (asserted in the test above).
-      const partial = await hs.readPartial(workspaceId);
-      expect(partial?.metadata?.usage).toBeDefined();
+      const history = await hs.getLastMessages(workspaceId, 10);
+      if (!history.success) throw new Error(history.error);
+      expect(
+        history.data.find((message) => message.id === "abort-commit-worthy-message")?.metadata
+          ?.usage
+      ).toBeDefined();
+      expect(await hs.readPartial(workspaceId)).toBeNull();
     } finally {
       await cleanup();
     }

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -747,6 +747,7 @@ interface WorkspaceStreamInfo {
   // when registration fails. Optional: whitebox test fixtures register stream
   // infos without a resource scope.
   resourceScope?: Scope.Closeable;
+  resourceCleanup?: Promise<void>;
   // Cumulative usage across all steps (for live cost display during streaming)
   cumulativeUsage: LanguageModelV2Usage;
   // Cumulative provider metadata across all steps (for live cost display with cache tokens)
@@ -789,9 +790,17 @@ interface PendingStreamStartHandle {
   finish(): void;
 }
 
+export interface StopStreamOptions {
+  soft?: boolean;
+  abandonPartial?: boolean;
+  abortReason?: StreamAbortReason;
+  /** Teardown of an already-settled attempt must not manufacture a second raw terminal. */
+  emitIfMissing?: boolean;
+}
+
 interface MockStreamLifecycle {
   isStreaming(workspaceId: string): boolean;
-  stop(workspaceId: string): Promise<void>;
+  stop(workspaceId: string, options?: StopStreamOptions): Promise<void>;
   replayStream(workspaceId: string): Promise<void>;
 }
 
@@ -803,6 +812,7 @@ export class StreamManager {
       abortController: AbortController;
       startTime: number;
       syntheticMessageId: string;
+      abortDelivery?: Promise<void>;
       acpPromptId?: string;
     }
   >();
@@ -1901,6 +1911,38 @@ export class StreamManager {
     }
   }
 
+  private closeStreamResources(streamInfo: WorkspaceStreamInfo): Promise<void> {
+    if (streamInfo.resourceCleanup) return streamInfo.resourceCleanup;
+    const closed = Promise.withResolvers<void>();
+    streamInfo.resourceCleanup = closed.promise;
+    (async () => {
+      // Retire scheduled writes before joining their original Promise I/O. Scope close
+      // interrupts debounce fibers; remote temp-directory removal remains best effort
+      // (its registered finalizer only initiates removal, never awaits SSH).
+      streamInfo.partialRetired = true;
+      try {
+        if (streamInfo.resourceScope) {
+          await this.effectRunner.runPromise(Scope.close(streamInfo.resourceScope, Exit.void));
+        }
+      } catch (error) {
+        log.error("Stream resource cleanup failed", { error });
+      }
+      try {
+        this.interruptPartialWriteFiber(streamInfo);
+        await this.awaitPendingPartialWrite(streamInfo);
+      } catch (error) {
+        // A cleanup defect must not orphan a completed/failed handle or skip raw teardown.
+        log.error("Pending partial write cleanup failed", { error });
+      }
+
+      runLanguageModelCleanup(streamInfo.request?.model);
+
+      streamInfo.unlinkAbortSignal?.();
+      streamInfo.unlinkAbortSignal = undefined;
+    })().then(closed.resolve, closed.reject);
+    return closed.promise;
+  }
+
   private async cleanupAbortedStream(
     workspaceId: WorkspaceId,
     streamInfo: WorkspaceStreamInfo,
@@ -1927,6 +1969,12 @@ export class StreamManager {
     if (streamInfo.terminalCompletion !== undefined) {
       return;
     }
+
+    // Also covers registered STARTING attempts: their envelope callback may itself await
+    // stopStream, so join owned resources here without joining that callback back into itself.
+    // The envelope only journals; its original callback/mutex lifetime stays independently
+    // leased. Canceled engine model/temp/debounce resources retire before raw terminal delivery.
+    await this.closeStreamResources(streamInfo);
 
     // For aborts, use our tracked cumulativeUsage directly instead of AI SDK's totalUsage.
     // cumulativeUsage is updated on each finish-step event (before tool execution),
@@ -1976,8 +2024,8 @@ export class StreamManager {
         streamInfo
       );
 
-      // Stamp the aborted turn's usage onto the partial message BEFORE emitting
-      // stream-abort (whose handler commits the partial to chat.jsonl). Analytics
+      // Stamp the aborted turn's usage onto the partial message BEFORE committing
+      // it and delivering stream-abort. Analytics
       // prices history rows from metadata.usage, so without this every
       // interrupted turn — user Esc, queued tool-end preemption, monitor wakes —
       // would ingest as $0 even though the provider billed all completed steps.
@@ -2036,28 +2084,43 @@ export class StreamManager {
     } catch (error) {
       log.error("Failed abort bookkeeping; delivering preserved terminal metadata", { error });
     } finally {
-      // Emit abort asynchronously as before; completion settles only after the facade's
-      // partial cleanup and external stream-abort emission have finished.
-      const abortDelivery = (async () => this.eventSink(streamAbort))();
-
-      // Clean up immediately
-      if (this.workspaceStreams.get(workspaceId) === streamInfo) {
-        this.workspaceStreams.delete(workspaceId);
-      }
-      void abortDelivery
-        .catch((error) => {
-          // Contain sink rejections: .finally alone would re-propagate them as
-          // an unhandled rejection after completion settles.
-          log.error("Stream-abort delivery failed", { error: getErrorMessage(error) });
-        })
-        .finally(() => {
-          streamInfo.completionController?.settle({
-            status: "aborted",
-            abortReason,
-            streamAbort,
-            systemMessageTokens: streamInfo.initialMetadata?.systemMessageTokens,
+      try {
+        // Cancellation owns this attempt through disk cleanup and raw delivery. Keeping
+        // the registration until then makes replacement startup join the same fence.
+        const result = abandonPartial
+          ? await this.historyService.deletePartialIfMessageIdMatches(
+              workspaceId,
+              streamInfo.messageId
+            )
+          : await this.historyService.commitPartial(workspaceId, streamInfo.messageId);
+        // commitPartial already deletes on success. On failure retain recovery data;
+        // an unconditional delete here would silently discard an uncommitted answer.
+        if (!result.success)
+          log.error("Failed partial cleanup during stream-abort", {
+            workspaceId,
+            error: result.error,
           });
-        });
+      } catch (error) {
+        log.error("Failed partial cleanup during stream-abort", { workspaceId, error });
+      }
+      try {
+        await this.eventSink(streamAbort);
+      } catch (error) {
+        log.error("Stream-abort delivery failed", { error: getErrorMessage(error) });
+      } finally {
+        if (this.workspaceStreams.get(workspaceId) === streamInfo) {
+          this.workspaceStreams.delete(workspaceId);
+        }
+        streamInfo.terminalCompletion = {
+          status: "aborted",
+          abortReason,
+          streamAbort,
+          systemMessageTokens: streamInfo.initialMetadata?.systemMessageTokens,
+        };
+        // Session policy consumes this promise separately. It may start a replacement,
+        // so neither this fence nor the raw sink may join that policy.
+        streamInfo.completionController?.settle(streamInfo.terminalCompletion);
+      }
     }
   }
 
@@ -3020,7 +3083,7 @@ export class StreamManager {
     }
   }
 
-  private emitStreamAbort(
+  private async emitStreamAbort(
     workspaceId: WorkspaceId,
     messageId: string,
     metadata: Record<string, unknown>,
@@ -4385,25 +4448,16 @@ export class StreamManager {
     } finally {
       this.mcpServerManager?.releaseLease(workspaceId as string);
 
-      // Guaranteed cleanup in all code paths: close the stream's resource
-      // scope. Finalizers run in reverse acquisition order — the scope-tied
-      // debounce fiber is interrupted first (replaces manual clearTimeout
-      // bookkeeping; a pending partial flush must not fire after the stream
-      // ends and resurrect partial.json), then the temp-dir release runs (the
-      // fire-and-forget rm registered by acquireRelease in startStream; don't
-      // block stream completion on directory deletion — especially on SSH
-      // where rm -rf can take 500ms-2s). Scope.close is idempotent, so the
-      // never-registered path in startStream can never double-release.
-      if (streamInfo.resourceScope) {
-        Effect.runFork(Scope.close(streamInfo.resourceScope, Exit.void));
+      await this.closeStreamResources(streamInfo);
+
+      // Aborts keep their registration until cleanupAbortedStream completes its disk
+      // transaction and raw delivery. A stale finally must never remove a replacement.
+      if (
+        streamInfo.terminalCompletion != null &&
+        this.workspaceStreams.get(workspaceId) === streamInfo
+      ) {
+        this.workspaceStreams.delete(workspaceId);
       }
-
-      runLanguageModelCleanup(streamInfo.request?.model);
-
-      streamInfo.unlinkAbortSignal?.();
-      streamInfo.unlinkAbortSignal = undefined;
-
-      this.workspaceStreams.delete(workspaceId);
 
       // Lifecycle spine event: emitted from the guaranteed-cleanup path so
       // EVERY terminal outcome (completion, abort/Escape, provider failure)
@@ -5103,6 +5157,7 @@ export class StreamManager {
     }
     const mutex = this.streamLocks.get(typedWorkspaceId)!;
 
+    let registeredStream: WorkspaceStreamInfo | undefined;
     try {
       // Acquire lock - guarantees only one startStream per workspace
       // Lock is automatically released when scope exits via Symbol.asyncDispose
@@ -5120,7 +5175,17 @@ export class StreamManager {
       // fiber). Ownership transfers to processStreamWithCleanup once the
       // stream registers; otherwise the finally below closes it.
       const resourceScope = Scope.makeUnsafe();
-      let streamRegistered = false;
+      let processingStarted = false;
+      const cleanupStartup = async (): Promise<void> => {
+        if (registeredStream) return this.closeStreamResources(registeredStream);
+        runLanguageModelCleanup(model);
+        unlinkAbortSignal();
+        try {
+          await this.effectRunner.runPromise(Scope.close(resourceScope, Exit.void));
+        } catch (error) {
+          log.error("Startup resource cleanup failed", { error });
+        }
+      };
 
       try {
         // Step 1: Cancel any existing stream before proceeding
@@ -5133,6 +5198,7 @@ export class StreamManager {
         // If the stream was interrupted while we were waiting on async setup (mutex,
         // temp dir creation, etc), avoid starting the stream entirely.
         if (streamAbortController.signal.aborted) {
+          await cleanupStartup();
           return settleStartupAbort();
         }
 
@@ -5169,6 +5235,7 @@ export class StreamManager {
         );
 
         if (streamAbortController.signal.aborted) {
+          await cleanupStartup();
           return settleStartupAbort();
         }
 
@@ -5181,18 +5248,21 @@ export class StreamManager {
           completionController,
         });
 
+        registeredStream = streamInfo;
+        streamInfo.unlinkAbortSignal = unlinkAbortSignal;
+
         // Guard against a narrow race:
         // - stopStream() may abort while we're between the last aborted-check and stream registration.
         // - If we start processStreamWithCleanup anyway, it would emit stream-start, but no one would
         //   subsequently call stopStream() again (it already ran), so we'd never emit stream-abort/end.
         // In that case, immediately drop the registered stream and rely on the caller to handle UI.
         if (streamAbortController.signal.aborted) {
-          this.workspaceStreams.delete(typedWorkspaceId);
+          if (this.workspaceStreams.get(typedWorkspaceId) === streamInfo)
+            this.workspaceStreams.delete(typedWorkspaceId);
+          await cleanupStartup();
           return settleStartupAbort();
         }
 
-        streamInfo.unlinkAbortSignal = unlinkAbortSignal;
-        streamRegistered = true;
         // Supervise from registration on: a shutdown landing during the envelope
         // write below must find this STARTING stream and cancel it inside the
         // scope close (the hard-interrupt path documented after the await),
@@ -5214,15 +5284,18 @@ export class StreamManager {
           streamAbortController.signal.aborted ||
           this.workspaceStreams.get(typedWorkspaceId) !== streamInfo
         ) {
-          if (this.workspaceStreams.get(typedWorkspaceId) === streamInfo) {
+          // The envelope may return while abort persistence/raw delivery is still held.
+          // Joining its existing fence preserves the first reason and attempt registration.
+          await streamInfo.cancelPromise;
+          await cleanupStartup();
+          if (this.workspaceStreams.get(typedWorkspaceId) === streamInfo)
             this.workspaceStreams.delete(typedWorkspaceId);
-          }
-          streamRegistered = false;
           return settleStartupAbort();
         }
 
         // Step 5: Track the processing promise for guaranteed cleanup
         // This allows cancelStreamSafely to wait for full exit
+        processingStarted = true;
         streamInfo.processingPromise = this.processStreamWithCleanup(
           typedWorkspaceId,
           streamInfo,
@@ -5233,18 +5306,15 @@ export class StreamManager {
 
         return Ok(handle);
       } finally {
-        if (!streamRegistered) {
-          runLanguageModelCleanup(model);
-          unlinkAbortSignal();
-          // Releases the temp dir if it was acquired (no-op otherwise). The
-          // finalizer is synchronous and runFork executes it before returning
-          // control, mirroring the previous direct cleanup call.
-          Effect.runFork(Scope.close(resourceScope, Exit.void));
-        }
+        if (!processingStarted) await cleanupStartup();
       }
     } catch (error) {
-      // Guaranteed cleanup on any failure
-      this.workspaceStreams.delete(typedWorkspaceId);
+      // An envelope failure may arrive after an old stop and replacement registration.
+      // Preserve both the captured cancellation fence and the replacement's map entry.
+      await registeredStream?.cancelPromise;
+      if (registeredStream && this.workspaceStreams.get(typedWorkspaceId) === registeredStream) {
+        this.workspaceStreams.delete(typedWorkspaceId);
+      }
       // No handle is handed out on this path, so the completion is observed only
       // by a supervisor forked at registration: settle it so that fiber exits
       // instead of cancelling this never-started stream at shutdown.
@@ -5264,8 +5334,8 @@ export class StreamManager {
    * during shutdown, cancels the stream through the user-stop path
    * (`cancelStreamSafely`, abort reason `"system"`) and waits for the turn to
    * settle — i.e. for the partial to be flushed with usage, `stream-abort`
-   * delivered (AIService commits the partial into chat.jsonl and deletes
-   * partial.json) and `completion` resolved. `closeScopeBounded` awaits that
+   * delivered after attempt-owned partial persistence, and `completion` resolved.
+   * `closeScopeBounded` awaits that
    * finalizer, so dispose() proceeds to tear down bridges and sessions only once
    * every in-flight stream is durably settled. Supervision starts at
    * registration (before the awaited turn-envelope write), so a STARTING stream
@@ -5299,9 +5369,7 @@ export class StreamManager {
           Effect.promise(async () => {
             const startedAt = performance.now();
             await this.cancelStreamSafely(workspaceId, streamInfo, "system");
-            // Abort delivery (partial commit, downstream stream-abort listeners)
-            // settles the completion asynchronously after cancelStreamSafely
-            // returns; shutdown must not proceed until it has.
+            // The engine fence includes persistence and raw delivery, never session policy.
             await streamInfo.completionController.promise;
             // Per-stream cost inside the AppFiberScope close (shutdownStep style).
             log.debug("[shutdown] streamManager.abortStream", {
@@ -5467,73 +5535,73 @@ export class StreamManager {
    * Stops an active stream for a workspace
    * If soft is true, performs a soft interrupt (cancels at next block boundary)
    */
-  async stopStream(
-    workspaceId: string,
-    options?: { soft?: boolean; abandonPartial?: boolean; abortReason?: StreamAbortReason }
-  ): Promise<Result<void>> {
+  async stopStream(workspaceId: string, options?: StopStreamOptions): Promise<Result<void>> {
     const typedWorkspaceId = workspaceId as WorkspaceId;
+    // Capture every target before abort callbacks or raw startup delivery can reenter and
+    // register a replacement. Never look up a new engine after an asynchronous stop step.
     const pending = this.pendingStreamStarts.get(workspaceId);
-    const isActuallyStreaming = this.mockStreamLifecycle
-      ? this.mockStreamLifecycle.isStreaming(workspaceId)
+    const streamInfo = this.workspaceStreams.get(typedWorkspaceId);
+    const mockLifecycle = this.mockStreamLifecycle;
+    const isActuallyStreaming = mockLifecycle
+      ? mockLifecycle.isStreaming(workspaceId)
       : this.isStreaming(workspaceId);
 
-    if (pending) {
-      pending.abortController.abort(options?.abortReason ?? "startup");
-      if (!isActuallyStreaming) {
-        await this.emitStreamAbort(
-          typedWorkspaceId,
-          pending.syntheticMessageId,
-          { duration: Date.now() - pending.startTime },
-          options?.abortReason ?? "startup",
-          options?.abandonPartial,
-          pending.acpPromptId
-        );
-      }
-    }
-
-    if (this.mockStreamLifecycle) {
-      await this.mockStreamLifecycle.stop(workspaceId);
-      return Ok(undefined);
-    }
-
     try {
-      const streamInfo = this.workspaceStreams.get(typedWorkspaceId);
-      if (!streamInfo) {
-        if (!pending) {
-          void this.emitStreamAbort(
+      // Invoke against the captured mock before pending abort can synchronously start another.
+      const mockStop = mockLifecycle?.stop(workspaceId, options);
+      let engineStop: Promise<void> | undefined;
+      if (!mockLifecycle && streamInfo) {
+        const abortReason = options?.abortReason ?? "system";
+        if (options?.soft) {
+          streamInfo.softInterrupt = {
+            pending: true,
+            abandonPartial: options.abandonPartial ?? false,
+            abortReason,
+          };
+        } else {
+          engineStop = this.cancelStreamSafely(
             typedWorkspaceId,
-            "",
-            {},
-            options?.abortReason ?? "startup",
+            streamInfo,
+            abortReason,
             options?.abandonPartial
-          ).catch((error) => {
-            log.error("Stream-abort delivery failed", { error: getErrorMessage(error) });
-          });
+          );
         }
-        return Ok(undefined);
+      }
+      let startupDelivery: Promise<void> | undefined;
+      if (pending) {
+        if (!isActuallyStreaming && !streamInfo && !pending.abortDelivery) {
+          const delivery = Promise.withResolvers<void>();
+          pending.abortDelivery = delivery.promise;
+          pending.abortController.abort(options?.abortReason ?? "startup");
+          this.emitStreamAbort(
+            typedWorkspaceId,
+            pending.syntheticMessageId,
+            { duration: Date.now() - pending.startTime },
+            this.getStartupAbortReason(pending.abortController.signal),
+            options?.abandonPartial,
+            pending.acpPromptId
+          ).then(delivery.resolve, delivery.reject);
+        } else {
+          pending.abortController.abort(options?.abortReason ?? "startup");
+        }
+        startupDelivery = pending.abortDelivery;
       }
 
-      const abortReason = options?.abortReason ?? "system";
-      const soft = options?.soft ?? false;
-
-      if (soft) {
-        streamInfo.softInterrupt = {
-          pending: true,
-          abandonPartial: options?.abandonPartial ?? false,
-          abortReason,
-        };
-      } else {
-        await this.cancelStreamSafely(
+      if (!mockLifecycle && !streamInfo && !pending && options?.emitIfMissing !== false) {
+        startupDelivery = this.emitStreamAbort(
           typedWorkspaceId,
-          streamInfo,
-          abortReason,
+          "",
+          {},
+          options?.abortReason ?? "startup",
           options?.abandonPartial
         );
       }
+      const outcomes = await Promise.allSettled([startupDelivery, engineStop, mockStop]);
+      const failure = outcomes.find((outcome) => outcome.status === "rejected");
+      if (failure?.status === "rejected") throw failure.reason;
       return Ok(undefined);
     } catch (error) {
-      const message = getErrorMessage(error);
-      return Err("Failed to stop stream: " + message);
+      return Err("Failed to stop stream: " + getErrorMessage(error));
     }
   }
 
@@ -5569,7 +5637,10 @@ export class StreamManager {
    * Returns undefined if no active stream exists
    * Used to re-establish streaming context on frontend reconnection
    */
-  getStreamInfo(workspaceId: string):
+  getStreamInfo(
+    workspaceId: string,
+    includeFinalizing = false
+  ):
     | {
         messageId: string;
         model: string;
@@ -5589,7 +5660,9 @@ export class StreamManager {
     // Only return info if stream is actively running
     if (
       streamInfo &&
-      (streamInfo.state === StreamState.STARTING || streamInfo.state === StreamState.STREAMING)
+      (includeFinalizing ||
+        streamInfo.state === StreamState.STARTING ||
+        streamInfo.state === StreamState.STREAMING)
     ) {
       return {
         messageId: streamInfo.messageId,

--- a/src/node/services/taskWorkspaceSeam.testUtils.ts
+++ b/src/node/services/taskWorkspaceSeam.testUtils.ts
@@ -3,6 +3,9 @@ import type { AgentTaskIntegration, WorkspaceHost } from "@/node/services/taskWo
 
 export function makeWorkspaceHostFake(overrides: Partial<WorkspaceHost> = {}): WorkspaceHost {
   return {
+    deferWorkspaceCleanup: (run) => {
+      run().catch(() => undefined);
+    },
     sendMessage: () => Promise.resolve(Ok(undefined)),
     resumeStream: () => Promise.resolve(Ok({ started: true })),
     clearQueue: () => Ok(undefined),

--- a/src/node/services/taskWorkspaceSeam.ts
+++ b/src/node/services/taskWorkspaceSeam.ts
@@ -472,6 +472,8 @@ export interface WorkspaceLifecycleHost {
     options?: { beforeRemove?: () => Promise<boolean> }
   ): Promise<Result<void>>;
   removeWhileTaskTreeLocked(workspaceId: string, force?: boolean): Promise<Result<void>>;
+  /** Own cleanup outside the originating session callback and inside bounded app shutdown. */
+  deferWorkspaceCleanup(run: () => Promise<void>): void;
 }
 
 export interface WorkspaceProvisioningHost {

--- a/src/node/services/turnCoordinator.ts
+++ b/src/node/services/turnCoordinator.ts
@@ -404,7 +404,7 @@ class TurnExecution {
     else this.runner.runFork(Effect.promise(() => this.close()));
   }
 
-  private close(): Promise<void> {
+  close(): Promise<void> {
     if (this.closePromise) return this.closePromise;
     const closed = Promise.withResolvers<void>();
     // Publish the close latch before interrupting fibers: their finalizers can reenter disposal.
@@ -476,6 +476,10 @@ class TurnExecution {
  */
 export class TurnCoordinator {
   private state = initialCoordinatorState(Symbol("idle"));
+  private readonly closingController = new AbortController();
+  get closingSignal(): AbortSignal {
+    return this.closingController.signal;
+  }
   private readonly settlements = new Map<
     OperationId,
     ReturnType<typeof Promise.withResolvers<void>>
@@ -502,6 +506,11 @@ export class TurnCoordinator {
     return this.execution.lease();
   }
 
+  /** Physical completion, distinct from semantic idle and operation policy settlement. */
+  drain(): Promise<void> {
+    return this.execution.close();
+  }
+
   get phase(): TurnPhase {
     return this.state.turn.phase;
   }
@@ -510,6 +519,10 @@ export class TurnCoordinator {
   }
   get operationId(): OperationId | undefined {
     return this.state.turn.operation?.id;
+  }
+  get terminalMessageId(): string | undefined {
+    const operation = this.state.turn.operation;
+    return operation?.messageId ?? operation?.startupMessageId;
   }
   get disposed(): boolean {
     return this.state.lifetime === "disposed";
@@ -724,8 +737,15 @@ export class TurnCoordinator {
   }
   beginShutdown(): void {
     this.dispatch({ type: "shutdown" });
+    this.closingController.abort();
+    // Lifetime waits must retire before physical leases: a leased retry/startup callback
+    // can be waiting for idle itself. This does not publish semantic idle or drain jobs.
+    const waiters = this.idleWaiters;
+    this.idleWaiters = new Set();
+    for (const finish of waiters) finish();
   }
   dispose(): void {
+    this.beginShutdown();
     try {
       this.dispatch({ type: "dispose" });
     } finally {
@@ -760,7 +780,7 @@ export class TurnCoordinator {
       "waitForIdle signal must be an AbortSignal"
     );
     if (signal?.aborted) return Promise.reject(new Error("Waiting for session idle canceled."));
-    if (this.phase === "idle") return Promise.resolve();
+    if (this.phase === "idle" || this.closing) return Promise.resolve();
     return new Promise<void>((resolve, reject) => {
       const batch = this.idleWaiters;
       let canceled = false;

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -1,4 +1,6 @@
 import type { TurnCompletion } from "./streamManager";
+import type { TurnCoordinator } from "./turnCoordinator";
+import { MutexMap } from "@/node/utils/concurrency/mutexMap";
 import { describe, expect, test, mock, beforeEach, afterEach, spyOn, type Mock } from "bun:test";
 import { WorkspaceService, generateForkBranchName, generateForkTitle } from "./workspaceService";
 import { registerInProcessWorkflowRun } from "@/node/services/workflows/workflowArchiveAdmission";
@@ -4206,7 +4208,7 @@ describe("WorkspaceService workflow invocation events", () => {
         );
       } finally {
         unsubscribe();
-        workspaceService.disposeSession(workspaceId);
+        await workspaceService.disposeSession(workspaceId);
       }
     } finally {
       await cleanup();
@@ -4272,7 +4274,7 @@ describe("WorkspaceService workflow invocation events", () => {
       );
 
       expect(await workspaceService.isWorkflowInvocationCurrent(workspaceId, runId)).toBe(false);
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -4362,7 +4364,7 @@ describe("WorkspaceService workflow invocation events", () => {
       );
 
       expect(await workspaceService.isWorkflowInvocationCurrent(workspaceId, runId)).toBe(true);
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -4470,7 +4472,7 @@ describe("WorkspaceService workflow invocation events", () => {
         afterBoundaryMessageId: "workflow-result",
       });
       expect(await workspaceService.isWorkflowInvocationCurrent(workspaceId, runId)).toBe(true);
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -4515,7 +4517,7 @@ describe("WorkspaceService workflow invocation events", () => {
       });
 
       expect(await workspaceService.isWorkflowInvocationCurrent(workspaceId, runId)).toBe(false);
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -4580,7 +4582,7 @@ describe("WorkspaceService workflow invocation events", () => {
         })
       );
       expect(await workspaceService.isWorkflowInvocationCurrent(workspaceId, runId)).toBe(false);
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -4637,7 +4639,7 @@ describe("WorkspaceService workflow invocation events", () => {
       const clearResult = await workspaceService.truncateHistory(workspaceId, 1.0);
       expect(clearResult.success).toBe(true);
       expect(await workspaceService.isWorkflowInvocationCurrent(workspaceId, runId)).toBe(false);
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -4701,7 +4703,7 @@ describe("WorkspaceService workflow invocation events", () => {
         carryoverSpy.mockRestore();
       }
       expect(await workspaceService.isWorkflowInvocationCurrent(workspaceId, runId)).toBe(false);
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -4777,7 +4779,7 @@ describe("WorkspaceService workflow invocation events", () => {
       expect(
         existsSync(path.join(config.sessionsDir, workspaceId, "agent-workflow-runs.json"))
       ).toBe(false);
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -4833,7 +4835,7 @@ describe("WorkspaceService workflow invocation events", () => {
       expect(
         existsSync(path.join(config.sessionsDir, workspaceId, "agent-workflow-runs.json"))
       ).toBe(false);
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -4905,7 +4907,7 @@ describe("WorkspaceService workflow invocation events", () => {
       expect(
         existsSync(path.join(config.sessionsDir, workspaceId, "agent-workflow-runs.json"))
       ).toBe(false);
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -4974,7 +4976,7 @@ describe("WorkspaceService workflow invocation events", () => {
       expect(
         existsSync(path.join(config.sessionsDir, workspaceId, "agent-workflow-runs.json"))
       ).toBe(true);
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -5052,7 +5054,7 @@ describe("WorkspaceService workflow invocation events", () => {
       expect(
         existsSync(path.join(config.sessionsDir, workspaceId, "agent-workflow-runs.json"))
       ).toBe(false);
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -5125,7 +5127,7 @@ describe("WorkspaceService workflow invocation events", () => {
       if (history.success) {
         expect(history.data.length).toBeGreaterThan(0);
       }
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -5195,7 +5197,7 @@ describe("WorkspaceService workflow invocation events", () => {
       if (history.success) {
         expect(history.data).toHaveLength(6);
       }
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -5257,7 +5259,7 @@ describe("WorkspaceService workflow invocation events", () => {
       expect(
         existsSync(path.join(config.sessionsDir, workspaceId, "agent-workflow-runs.json"))
       ).toBe(false);
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -5336,7 +5338,7 @@ describe("WorkspaceService workflow invocation events", () => {
       if (history.success) {
         expect(history.data).toHaveLength(1);
       }
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -5391,7 +5393,7 @@ describe("WorkspaceService workflow invocation events", () => {
       expect(
         existsSync(path.join(config.sessionsDir, workspaceId, "agent-workflow-runs.json"))
       ).toBe(false);
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -5453,7 +5455,7 @@ describe("WorkspaceService workflow invocation events", () => {
       expect(
         existsSync(path.join(config.sessionsDir, workspaceId, "agent-workflow-runs.json"))
       ).toBe(true);
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -5522,7 +5524,7 @@ describe("WorkspaceService workflow invocation events", () => {
       expect(
         existsSync(path.join(config.sessionsDir, workspaceId, "agent-workflow-runs.json"))
       ).toBe(true);
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -5604,7 +5606,7 @@ describe("WorkspaceService workflow invocation events", () => {
         )
       );
       expect(await workspaceService.isWorkflowInvocationCurrent(workspaceId, runId)).toBe(false);
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -5662,7 +5664,7 @@ describe("WorkspaceService workflow invocation events", () => {
         })
       );
       expect(await workspaceService.isWorkflowInvocationCurrent(workspaceId, runId)).toBe(false);
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -5725,7 +5727,7 @@ describe("WorkspaceService workflow invocation events", () => {
       expect(await workspaceService.getWorkflowInvocationCurrentness(workspaceId, runId)).toBe(
         "not_current"
       );
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -5797,7 +5799,7 @@ describe("WorkspaceService workflow invocation events", () => {
       expect(await workspaceService.getWorkflowInvocationCurrentness(workspaceId, runId)).toBe(
         "current"
       );
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -5866,7 +5868,7 @@ describe("WorkspaceService workflow invocation events", () => {
       expect(await workspaceService.getWorkflowInvocationCurrentness(workspaceId, runId)).toBe(
         "current"
       );
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -5924,7 +5926,7 @@ describe("WorkspaceService workflow invocation events", () => {
         );
 
         expect(await workspaceService.isWorkflowInvocationCurrent(workspaceId, runId)).toBe(false);
-        workspaceService.disposeSession(workspaceId);
+        await workspaceService.disposeSession(workspaceId);
       } finally {
         await cleanup();
       }
@@ -5994,7 +5996,7 @@ describe("WorkspaceService workflow invocation events", () => {
       );
 
       expect(await workspaceService.isWorkflowInvocationCurrent(workspaceId, runId)).toBe(true);
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -6056,7 +6058,7 @@ describe("WorkspaceService workflow invocation events", () => {
       );
 
       expect(await workspaceService.isWorkflowInvocationCurrent(workspaceId, runId)).toBe(false);
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -6109,7 +6111,7 @@ describe("WorkspaceService workflow invocation events", () => {
       );
 
       expect(await workspaceService.isWorkflowInvocationCurrent(workspaceId, runId)).toBe(true);
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -6167,7 +6169,7 @@ describe("WorkspaceService workflow invocation events", () => {
       );
 
       expect(await workspaceService.isWorkflowInvocationCurrent(workspaceId, runId)).toBe(false);
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -6275,7 +6277,7 @@ describe("WorkspaceService workflow invocation events", () => {
       );
 
       expect(await workspaceService.isWorkflowInvocationCurrent(workspaceId, runId)).toBe(false);
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -6339,7 +6341,7 @@ describe("WorkspaceService workflow invocation events", () => {
       );
 
       expect(await workspaceService.isWorkflowInvocationCurrent(workspaceId, runId)).toBe(false);
-      workspaceService.disposeSession(workspaceId);
+      await workspaceService.disposeSession(workspaceId);
     } finally {
       await cleanup();
     }
@@ -6454,6 +6456,7 @@ describe("WorkspaceService truncateHistory goal acknowledgment", () => {
       message: { type: string };
     }
     const session = {
+      closingSignal: new AbortController().signal,
       isBusy: mock(() => busy),
       hasQueuedMessages: mock(() => false),
       hasPendingAutoRetry: mock(() => pendingAutoRetry),
@@ -6636,7 +6639,7 @@ describe("WorkspaceService truncateHistory goal acknowledgment", () => {
     const { config, historyService, workspaceService, cleanup } = await createServices();
     const workspaceId = "start-here-clears-usage-state";
     const streamMessage = mock((..._args: unknown[]) =>
-      Promise.resolve(Ok(createStartedTurnHandle()))
+      Promise.resolve(Ok(createStartedTurnHandle(harness.session.closingSignal)))
     );
     const harness = await createAgentSessionHarness({
       workspaceId,
@@ -6712,7 +6715,7 @@ describe("WorkspaceService truncateHistory goal acknowledgment", () => {
       });
       expect(streamMessage).toHaveBeenCalledTimes(1);
     } finally {
-      harness.session.dispose();
+      await harness.session.dispose();
       await cleanup();
     }
   });
@@ -8508,12 +8511,14 @@ describe("WorkspaceService initialize", () => {
     expect(startStartupRecoverySpy).toHaveBeenCalledTimes(1);
   });
 
-  test("beginShutdown disposes transient recovery sessions and halts the rest", () => {
-    const dispose = mock(() => undefined);
+  test("beginShutdown disposes transient recovery sessions and halts the rest", async () => {
+    const release = Promise.withResolvers<void>();
+    const dispose = mock(() => release.promise);
     const beginShutdown = mock(() => undefined);
     const startupAccess = workspaceService as unknown as {
       transientStartupRecoverySessions: Map<string, AgentSession>;
       sessions: Map<string, AgentSession>;
+      pendingWorkspaceCleanup: Set<Promise<void>>;
     };
     startupAccess.transientStartupRecoverySessions.set("ws-a", {
       dispose,
@@ -8531,6 +8536,9 @@ describe("WorkspaceService initialize", () => {
     workspaceService.beginShutdown();
 
     expect(dispose).toHaveBeenCalledTimes(2);
+    expect(startupAccess.transientStartupRecoverySessions.size).toBe(2);
+    release.resolve();
+    await Promise.all(startupAccess.pendingWorkspaceCleanup);
     expect(startupAccess.transientStartupRecoverySessions.size).toBe(0);
     expect(beginShutdown).toHaveBeenCalledTimes(1);
     startupAccess.sessions.delete("ws-promoted");
@@ -9174,7 +9182,7 @@ describe("WorkspaceService sendMessage status clearing", () => {
       // Fully settled: no residual reservation leaks.
       expect(probe!()).toBe(false);
     } finally {
-      realSession.dispose();
+      await realSession.dispose();
     }
   });
 
@@ -9216,7 +9224,7 @@ describe("WorkspaceService sendMessage status clearing", () => {
       // Fully settled: no residual reservation leaks.
       expect(probe!()).toBe(false);
     } finally {
-      realSession.dispose();
+      await realSession.dispose();
     }
   });
 
@@ -9261,7 +9269,7 @@ describe("WorkspaceService sendMessage status clearing", () => {
       // Fully settled: no residual reservation leaks.
       expect(probe!()).toBe(false);
     } finally {
-      realSession.dispose();
+      await realSession.dispose();
     }
   });
 
@@ -12789,6 +12797,8 @@ describe("WorkspaceService remove timing rollup", () => {
     const parentWorkspaceId = "parent-ws";
 
     const tempRoot = await fsPromises.mkdtemp(path.join(tmpdir(), "mux-remove-"));
+    const stopEntered = Promise.withResolvers<void>();
+    const stopRelease = Promise.withResolvers<void>();
     try {
       const sessionRoot = path.join(tempRoot, "sessions");
       await fsPromises.mkdir(path.join(sessionRoot, workspaceId), { recursive: true });
@@ -12799,20 +12809,19 @@ describe("WorkspaceService remove timing rollup", () => {
       class FakeAIService extends EventEmitter {
         isStreaming = mock(() => true);
 
-        stopStream = mock(() => {
-          setTimeout(() => {
-            abortEmitted = true;
-            this.emit("stream-abort", {
-              type: "stream-abort",
-              workspaceId,
-              messageId: "msg",
-              abortReason: "system",
-              metadata: { duration: 123 },
-              abandonPartial: true,
-            });
-          }, 0);
-
-          return Promise.resolve({ success: true as const, data: undefined });
+        stopStream = mock(async () => {
+          stopEntered.resolve();
+          await stopRelease.promise;
+          abortEmitted = true;
+          this.emit("stream-abort", {
+            type: "stream-abort",
+            workspaceId,
+            messageId: "msg",
+            abortReason: "system",
+            metadata: { duration: 123 },
+            abandonPartial: true,
+          });
+          return { success: true as const, data: undefined };
         });
 
         getWorkspaceMetadata = mock(() =>
@@ -12861,11 +12870,16 @@ describe("WorkspaceService remove timing rollup", () => {
         timingService as SessionTimingService
       );
 
-      const removeResult = await workspaceService.remove(workspaceId, true);
+      const removing = workspaceService.remove(workspaceId, true);
+      await stopEntered.promise;
+      expect(timingService.rollUpTimingIntoParent).not.toHaveBeenCalled();
+      stopRelease.resolve();
+      const removeResult = await removing;
       expect(removeResult.success).toBe(true);
       expect(mockInitStateManager.clearInMemoryState).toHaveBeenCalledWith(workspaceId);
       expect(rollUpSawAbort).toBe(true);
     } finally {
+      stopRelease.resolve();
       await fsPromises.rm(tempRoot, { recursive: true, force: true });
     }
   });
@@ -18418,7 +18432,7 @@ describe("WorkspaceService interruptStream", () => {
               completion:
                 streamCount === 1
                   ? completion.promise
-                  : new Promise<TurnCompletion>(() => undefined),
+                  : createStartedTurnHandle(h.session.closingSignal).completion,
             })
           );
         }),
@@ -18477,7 +18491,7 @@ describe("WorkspaceService interruptStream", () => {
     } finally {
       releaseAccounting.resolve();
       await interrupt;
-      h.session.dispose();
+      await h.session.dispose();
       await h.cleanup();
     }
   });
@@ -20101,6 +20115,147 @@ describe("WorkspaceService.fork branch-summary rollback ordering", () => {
       void realGuardedAppend;
       await fsPromises.rm(projectDir, { recursive: true, force: true });
       await cleanup();
+    }
+  });
+});
+
+describe("WorkspaceService disposal ownership", () => {
+  test.each([false, true])(
+    "leased cleanup removes real session files without a task-tree self-join (external=%s)",
+    async (externalRemoval) => {
+      const h = await createAgentSessionHarness({ workspaceId: "leased-removal" });
+      const workspaceId = "leased-removal";
+      const service = createWorkspaceServiceForTest({
+        config: h.config,
+        historyService: h.historyService,
+        extensionMetadata: new ExtensionMetadataService(
+          path.join(h.config.rootDir, "extensionMetadata.json")
+        ),
+        aiService: createMockAIService({
+          getWorkspaceMetadata: mock(() => Promise.resolve(Err("not found"))),
+        }),
+      });
+      const tree = new MutexMap<string>();
+      service.setAgentTaskIntegration(
+        makeAgentTaskIntegrationFake({
+          withTaskTreeLifecycleLock: (_id, run) => tree.withLock("tree", run),
+        })
+      );
+      service.registerSession(workspaceId, h.session);
+      await h.historyService.appendToHistory(
+        workspaceId,
+        createMuxMessage("user", "user", "remove after callback")
+      );
+      const sessionDir = path.join(h.config.sessionsDir, workspaceId);
+      const { coordinator } = h.session as unknown as { coordinator: TurnCoordinator };
+      const lease = coordinator.enterExecution();
+      const disposalEntered = Promise.withResolvers<void>();
+      const originalDispose = h.session.dispose.bind(h.session);
+      spyOn(h.session, "dispose").mockImplementation(() => {
+        disposalEntered.resolve();
+        return originalDispose();
+      });
+      const removed = Promise.withResolvers<Result<void>>();
+      let external: Promise<Result<void>> | undefined;
+      try {
+        if (externalRemoval) {
+          external = service.remove(workspaceId, true);
+          await disposalEntered.promise;
+          expect(existsSync(sessionDir)).toBe(true);
+        }
+        // This is the leased continuation callback's tail: schedule removal without
+        // awaiting it, then return/release. The service owns the actual remove and join.
+        service.deferWorkspaceCleanup(async () => {
+          removed.resolve(await service.remove(workspaceId, true));
+        });
+        lease[Symbol.dispose]();
+        if (external) expect((await external).success).toBe(true);
+        expect((await removed.promise).success).toBe(true);
+        expect(existsSync(sessionDir)).toBe(false);
+      } finally {
+        lease[Symbol.dispose]();
+        await external;
+        await h.session.dispose();
+        await h.cleanup();
+      }
+    }
+  );
+
+  test.each(["workspace-busy", "queue-busy", "queue-only"] as const)(
+    "shutdown cancels %s wait without pretending the physical lease drained",
+    async (kind) => {
+      const h = await createAgentSessionHarness({ workspaceId: "closing-idle-wait" });
+      const service = createWorkspaceServiceForTest({
+        config: h.config,
+        historyService: h.historyService,
+      });
+      service.registerSession("closing-idle-wait", h.session);
+      const { coordinator } = h.session as unknown as { coordinator: TurnCoordinator };
+      const lease = coordinator.enterExecution();
+      if (kind === "queue-only") h.session.queueMessage("pending");
+      else {
+        const admitted = coordinator.prepare({
+          kind: "fresh",
+          intent: "handoff",
+          expectedTurnId: coordinator.turnId,
+        });
+        expect(admitted.status).toBe("admitted");
+      }
+      const waiting = (
+        kind === "workspace-busy"
+          ? service.waitForWorkspaceIdle("closing-idle-wait")
+          : service.waitForIdleAndNoQueuedMessages("closing-idle-wait")
+      ).then(
+        () => undefined,
+        (error: unknown) => error
+      );
+      h.session.beginShutdown();
+      let drained = false;
+      const drain = coordinator.drain().then(() => {
+        drained = true;
+      });
+      try {
+        expect(await waiting).toBeInstanceOf(Error);
+        expect(drained).toBe(false);
+        if (kind !== "queue-only") expect(coordinator.phase).toBe("preparing");
+      } finally {
+        lease[Symbol.dispose]();
+        await drain;
+        await service.disposeSession("closing-idle-wait");
+        await h.cleanup();
+      }
+    }
+  );
+
+  test("an old disposal cannot remove replacement session subscriptions", async () => {
+    const h = await createAgentSessionHarness({ workspaceId: "dispose-replacement" });
+    const replacement = await createAgentSessionHarness({ workspaceId: "dispose-replacement" });
+    const service = createWorkspaceServiceForTest({
+      config: h.config,
+      historyService: h.historyService,
+    });
+    service.registerSession("dispose-replacement", h.session);
+    const internals = service as unknown as {
+      sessions: Map<string, AgentSession>;
+      sessionSubscriptions: Map<string, { chat: () => void; metadata: () => void }>;
+    };
+    const { coordinator } = h.session as unknown as { coordinator: TurnCoordinator };
+    const lease = coordinator.enterExecution();
+    const disposal = service.disposeSession("dispose-replacement");
+    try {
+      internals.sessions.delete("dispose-replacement");
+      service.registerSession("dispose-replacement", replacement.session);
+      const subscriptions = internals.sessionSubscriptions.get("dispose-replacement");
+      lease[Symbol.dispose]();
+      await disposal;
+      expect(internals.sessions.get("dispose-replacement")).toBe(replacement.session);
+      expect(internals.sessionSubscriptions.get("dispose-replacement")).toBe(subscriptions);
+    } finally {
+      lease[Symbol.dispose]();
+      await disposal;
+      await service.disposeSession("dispose-replacement");
+      await h.cleanup();
+      await replacement.cleanup();
     }
   });
 });

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -1,5 +1,5 @@
 import type { RestartBlocker } from "@/common/orpc/types";
-import type { Scope } from "effect";
+import { Effect, type Scope } from "effect";
 import { defaultEffectRunner, type EffectRunner } from "./di/effectRunner";
 import {
   DesktopInputCoordinator,
@@ -1812,6 +1812,8 @@ const DELEGATED_TURN_CONTINUATION_OPTIONS_SCHEMA = SendMessageOptionsSchema.pick
 export class WorkspaceService extends EventEmitter implements WorkspaceHost {
   private readonly sessions = new Map<string, AgentSession>();
   private shuttingDown = false;
+  private readonly shutdownSessions = new Set<AgentSession>();
+  private readonly pendingWorkspaceCleanup = new Set<Promise<void>>();
   private readonly providerConfigChangedListener = (): void => {
     const liveSessions = new Map([
       ...this.sessions.entries(),
@@ -2453,6 +2455,39 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
     healRemovalTombstonesForRegisteredWorkspaces(this.config).catch((error: unknown) => {
       log.debug("Removal tombstone self-heal failed at startup", { error });
     });
+    if (this.appFiberScope) {
+      // A sibling of session guardians, never a child of a session being disposed. Producers
+      // can enqueue destructive cleanup while their final callbacks release physical leases.
+      this.effectRunner.runSync(
+        Effect.forkIn(
+          Effect.never.pipe(
+            Effect.onInterrupt(() =>
+              Effect.suspend(() => {
+                this.beginShutdown();
+                // Empty graph rollback must stay synchronous so constructor failures retain
+                // their original error instead of becoming an async runSync failure.
+                if (this.shutdownSessions.size === 0 && this.pendingWorkspaceCleanup.size === 0)
+                  return Effect.void;
+                return Effect.promise(async () => {
+                  await Promise.all(
+                    [...this.shutdownSessions].map((session) =>
+                      session.finishShutdown().catch((error: unknown) => {
+                        log.warn("Session shutdown failed", { error });
+                      })
+                    )
+                  );
+                  while (this.pendingWorkspaceCleanup.size > 0) {
+                    await Promise.all([...this.pendingWorkspaceCleanup]);
+                  }
+                });
+              })
+            )
+          ),
+          this.appFiberScope,
+          { startImmediately: true }
+        )
+      );
+    }
   }
 
   private async recoverBashMonitorRegistryPass(): Promise<boolean> {
@@ -4012,14 +4047,39 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
    * on) may own a live stream whose partial the next startup needs, so they only stop dispatching.
    */
   beginShutdown(): void {
+    if (this.shuttingDown) return;
     this.shuttingDown = true;
-    for (const [workspaceId, session] of this.transientStartupRecoverySessions) {
-      this.transientStartupRecoverySessions.delete(workspaceId);
-      session.dispose();
+    // Capture before disposal can remove transient instances from either registry.
+    for (const session of [
+      ...this.sessions.values(),
+      ...this.transientStartupRecoverySessions.values(),
+    ]) {
+      this.shutdownSessions.add(session);
     }
-    for (const session of this.sessions.values()) {
-      session.beginShutdown();
-    }
+    for (const [workspaceId] of this.transientStartupRecoverySessions)
+      this.disposeSession(workspaceId).catch((error: unknown) =>
+        log.warn("Transient session disposal failed", { workspaceId, error })
+      );
+    for (const session of this.sessions.values()) session.beginShutdown();
+  }
+
+  /** Transfer destructive cleanup out of a callback that still owns a session lease. */
+  deferWorkspaceCleanup(run: () => Promise<void>): void {
+    this.trackWorkspaceCleanup(run).catch((error: unknown) =>
+      log.warn("Deferred workspace cleanup failed", { error })
+    );
+  }
+
+  private trackWorkspaceCleanup(run: () => Promise<void>): Promise<void> {
+    const settled = Promise.withResolvers<void>();
+    this.pendingWorkspaceCleanup.add(settled.promise);
+    (async () => run())()
+      .catch((error: unknown) => log.warn("Workspace cleanup failed", { error }))
+      .finally(() => {
+        this.pendingWorkspaceCleanup.delete(settled.promise);
+        settled.resolve();
+      });
+    return settled.promise;
   }
 
   /**
@@ -4044,23 +4104,21 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
 
     void session
       .runStartupRecovery()
-      .then(() => {
+      .then(async () => {
         if (this.transientStartupRecoverySessions.get(trimmed) !== session) {
           return;
         }
 
-        this.transientStartupRecoverySessions.delete(trimmed);
-        if (session.shouldRetainAfterStartupRecovery()) {
+        if (!this.shuttingDown && session.shouldRetainAfterStartupRecovery()) {
           this.registerSession(trimmed, session);
           return;
         }
 
-        session.dispose();
+        await this.disposeSession(trimmed);
       })
-      .catch((error) => {
+      .catch(async (error) => {
         if (this.transientStartupRecoverySessions.get(trimmed) === session) {
-          this.transientStartupRecoverySessions.delete(trimmed);
-          session.dispose();
+          await this.disposeSession(trimmed);
         }
 
         log.warn("Failed to run startup recovery for workspace", {
@@ -4186,6 +4244,7 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
 
         const session =
           this.sessions.get(trimmed) ?? this.transientStartupRecoverySessions.get(trimmed);
+        if (session?.closingSignal.aborted) throw new Error(WORKSPACE_IDLE_WAIT_CANCELED_MESSAGE);
         if (session?.isBusy() !== true) {
           return;
         }
@@ -4231,34 +4290,29 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
     return this.sessions.get(trimmed)?.countQueuedAgentPeerMessages() ?? 0;
   }
 
-  public disposeSession(workspaceId: string): void {
+  public disposeSession(workspaceId: string): Promise<void> {
     const trimmed = workspaceId.trim();
     const transientSession = this.transientStartupRecoverySessions.get(trimmed);
-    if (transientSession) {
-      transientSession.dispose();
-      this.transientStartupRecoverySessions.delete(trimmed);
-    }
-
     const session = this.sessions.get(trimmed);
+    const subscriptions = this.sessionSubscriptions.get(trimmed);
     const refreshTimer = this.postCompactionRefreshTimers.get(trimmed);
     if (refreshTimer) {
       clearTimeout(refreshTimer);
       this.postCompactionRefreshTimers.delete(trimmed);
     }
-
-    if (!session) {
-      return;
-    }
-
-    const subscriptions = this.sessionSubscriptions.get(trimmed);
-    if (subscriptions) {
-      subscriptions.chat();
-      subscriptions.metadata();
-      this.sessionSubscriptions.delete(trimmed);
-    }
-
-    session.dispose();
-    this.sessions.delete(trimmed);
+    return this.trackWorkspaceCleanup(async () => {
+      // Start both synchronous admission latches before the first await. Registry identity
+      // remains visible through terminal delivery and prevents a late old disposer removing B.
+      await Promise.all([transientSession?.dispose(), session?.dispose()]);
+      if (this.transientStartupRecoverySessions.get(trimmed) === transientSession) {
+        this.transientStartupRecoverySessions.delete(trimmed);
+      }
+      subscriptions?.chat();
+      subscriptions?.metadata();
+      if (this.sessionSubscriptions.get(trimmed) === subscriptions)
+        this.sessionSubscriptions.delete(trimmed);
+      if (this.sessions.get(trimmed) === session) this.sessions.delete(trimmed);
+    });
   }
 
   private async getPersistedPostCompactionDiffPaths(workspaceId: string): Promise<string[] | null> {
@@ -5050,7 +5104,7 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
             initAbortController.abort();
             this.initAbortControllers.delete(workspaceId);
             this.initStateManager.clearInMemoryState(workspaceId);
-            this.disposeSession(workspaceId);
+            await this.disposeSession(workspaceId);
             initLogger.logComplete(-1);
             return Err(
               rolledBack
@@ -5613,50 +5667,7 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
         return Err(DESCENDANT_WORKSPACE_REMOVE_ERROR);
       }
 
-      // Stop any active stream before deleting metadata/config to avoid tool calls racing with removal.
-      //
-      // IMPORTANT: AIService forwards "stream-abort" asynchronously after partial cleanup. If we roll up
-      // session timing (or delete session files) immediately after stopStream(), we can race the final
-      // abort timing write.
-      const wasStreaming = this.aiService.isStreaming(workspaceId);
-      const streamStoppedEvent: Promise<"abort" | "end" | undefined> | undefined = wasStreaming
-        ? new Promise((resolve) => {
-            const aiService = this.aiService;
-            const targetWorkspaceId = workspaceId;
-            const timeoutMs = 5000;
-
-            let settled = false;
-            let timer: ReturnType<typeof setTimeout> | undefined;
-
-            const cleanup = (result: "abort" | "end" | undefined) => {
-              if (settled) return;
-              settled = true;
-              if (timer) {
-                clearTimeout(timer);
-                timer = undefined;
-              }
-              aiService.off("stream-abort", onAbort);
-              aiService.off("stream-end", onEnd);
-              resolve(result);
-            };
-
-            function onAbort(data: StreamAbortEvent): void {
-              if (data.workspaceId !== targetWorkspaceId) return;
-              cleanup("abort");
-            }
-
-            function onEnd(data: StreamEndEvent): void {
-              if (data.workspaceId !== targetWorkspaceId) return;
-              cleanup("end");
-            }
-
-            aiService.on("stream-abort", onAbort);
-            aiService.on("stream-end", onEnd);
-
-            timer = setTimeout(() => cleanup(undefined), timeoutMs);
-          })
-        : undefined;
-
+      // The captured engine stop joins partial finalization and raw terminal delivery.
       try {
         const stopPromise = this.aiService.stopStream(workspaceId, { abandonPartial: true });
         const stopOutcome = await raceWithAbortAndTimeout(stopPromise, {
@@ -5681,20 +5692,8 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
         log.debug("Failed to stop stream during workspace removal (threw)", { workspaceId, error });
       }
 
-      if (streamStoppedEvent) {
-        const stopEvent = await streamStoppedEvent;
-        if (!stopEvent) {
-          log.debug("Timed out waiting for stream to stop during workspace removal", {
-            workspaceId,
-          });
-        }
-
-        // If session timing is enabled, make sure no pending writes can recreate session files after
-        // we delete the session directory.
-        if (this.sessionTimingService) {
-          await this.sessionTimingService.waitForIdle(workspaceId);
-        }
-      }
+      // Raw terminal listeners may enqueue timing writes; join those before rollup/removal.
+      await this.sessionTimingService?.waitForIdle(workspaceId);
 
       let parentWorkspaceId: string | null = null;
       let childTaskModelString: string | undefined;
@@ -6066,7 +6065,7 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       // Dispose the session before deleting its directory: disposal aborts the active stream, and
       // the resulting stream-abort event would otherwise be recorded on the timeline after the
       // delete, recreating the session directory for a workspace the user removed.
-      this.disposeSession(workspaceId);
+      await this.disposeSession(workspaceId);
 
       // Same for in-flight dream/harvest consolidation (r60): abort + drain
       // before the session directory disappears (idempotent; normally
@@ -8798,8 +8797,7 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       // scheduling loop creates later sees the archived entry and is never started.
       const transientRecoverySession = this.transientStartupRecoverySessions.get(workspaceId);
       if (transientRecoverySession) {
-        this.transientStartupRecoverySessions.delete(workspaceId);
-        transientRecoverySession.dispose();
+        await this.disposeSession(workspaceId);
       }
 
       if (!needsSnapshotCapture) {
@@ -10264,12 +10262,12 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
                   });
                 });
             }
+            await this.disposeSession(newWorkspaceId);
             await fsPromises
               .rm(newSessionDir, { recursive: true, force: true })
               .catch(() => undefined);
             this.initAbortControllers.delete(newWorkspaceId);
             this.initStateManager.clearInMemoryState(newWorkspaceId);
-            this.disposeSession(newWorkspaceId);
             initLogger.logComplete(-1);
             return Err(
               rolledBack
@@ -12048,7 +12046,9 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       return;
     }
 
+    if (session.closingSignal.aborted) throw new Error(WORKSPACE_IDLE_WAIT_CANCELED_MESSAGE);
     while (session.isBusy() || session.hasQueuedMessages() || session.hasPendingAutoRetry()) {
+      if (session.closingSignal.aborted) throw new Error(WORKSPACE_IDLE_WAIT_CANCELED_MESSAGE);
       if (session.isBusy()) {
         await session.waitForIdle();
         continue;
@@ -12062,6 +12062,7 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
           }
           settled = true;
           unsubscribe();
+          session.closingSignal.removeEventListener("abort", finish);
           resolve();
         };
         const unsubscribe = session.onChatEvent((event) => {
@@ -12078,11 +12079,16 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
             finish();
           }
         });
-        if (!session.hasQueuedMessages() && !session.hasPendingAutoRetry()) {
+        session.closingSignal.addEventListener("abort", finish, { once: true });
+        if (
+          session.closingSignal.aborted ||
+          (!session.hasQueuedMessages() && !session.hasPendingAutoRetry())
+        ) {
           finish();
         }
       });
     }
+    if (session.closingSignal.aborted) throw new Error(WORKSPACE_IDLE_WAIT_CANCELED_MESSAGE);
   }
 
   hasPendingQueuedOrPreparingTurn(workspaceId: string): boolean {

--- a/src/node/services/workspaceTurnManager.test.ts
+++ b/src/node/services/workspaceTurnManager.test.ts
@@ -3053,6 +3053,48 @@ describe("WorkspaceTurnManager", () => {
     expect(createWorkspace).not.toHaveBeenCalled();
   });
 
+  test.each([false, true])(
+    "continuation failure transfers disposable cleanup after lock and notification (throws=%s)",
+    async (throwNotification) => {
+      const remove = mock(() => Promise.resolve(Ok(undefined)));
+      const { parentId, taskService, workspaceMocks } = await startWorkspaceTurnForTest({
+        disposable: true,
+        remove,
+      });
+      const jobs: Array<() => Promise<void>> = [];
+      workspaceMocks.workspaceService.deferWorkspaceCleanup = (run) => {
+        jobs.push(run);
+      };
+      if (throwNotification)
+        spyOn(
+          taskService as unknown as {
+            deliverPersistentChildWorkspaceTurnResult(
+              record: WorkspaceTurnTaskHandleRecord
+            ): Promise<void>;
+          },
+          "deliverPersistentChildWorkspaceTurnResult"
+        ).mockRejectedValueOnce(new Error("notification unavailable"));
+      const outcome = await taskService
+        .settleWorkspaceTurnContinuationFailure(
+          "childworkspace",
+          workspaceTurnMuxMetadata(parentId),
+          "error",
+          "preparation failed"
+        )
+        .then(
+          () => undefined,
+          (error: unknown) => error
+        );
+      expect(outcome instanceof Error).toBe(throwNotification);
+      const snapshot = await workspaceTurnSnapshot(taskService, parentId);
+      expect(snapshot?.status).toBe("error");
+      expect(remove).not.toHaveBeenCalled();
+      expect(jobs).toHaveLength(1);
+      await jobs[0]();
+      expect(remove).toHaveBeenCalledWith("childworkspace", true);
+    }
+  );
+
   test("createWorkspaceTurn marks accepted pre-stream failures as handle errors", async () => {
     const sendMessage = mock(
       async (...args: unknown[]): Promise<Result<void, SendMessageError>> => {

--- a/src/node/services/workspaceTurnManager.ts
+++ b/src/node/services/workspaceTurnManager.ts
@@ -2423,7 +2423,11 @@ export class WorkspaceTurnManager {
           params.record.ownerWorkspaceId
         );
         this.taskHost.markTaskForegroundRelevant(params.record.handleId);
-        await this.cleanupDisposableWorkspaceTurn(nextRecord);
+        // A preparation/queue failure callback still owns the target session's physical
+        // lease. Removing that session here would join this very callback under the lock.
+        if (params.cause.kind !== "continuation-failure") {
+          await this.cleanupDisposableWorkspaceTurn(nextRecord);
+        }
         this.taskHost.scheduleMaybeStartQueuedTasks();
 
         // Suppress the owner-scoped wake only when the owner itself received this terminal result.
@@ -2466,78 +2470,88 @@ export class WorkspaceTurnManager {
       settledRecord,
       foregroundWaiterWorkspaceIds = new Set<string>(),
     } = settlementResult;
-    if (settledRecord != null) {
-      await this.deliverPersistentChildWorkspaceTurnResult(
-        settledRecord,
-        foregroundWaiterWorkspaceIds
-      );
-    }
-    if (pendingNotify == null) {
-      return;
-    }
-    if (pendingNotify.kind === "drain_pending") {
-      this.taskHost.scheduleTerminalAttentionDrain(params.record.ownerWorkspaceId);
-      return;
-    }
-
-    // Enqueue the terminal wake-up outside the lock. The persisted notification is the restart-safe
-    // record of intent; only after it is accepted do we set terminalAttentionNotifiedAt on the
-    // handle so a duplicate settlement / stale recovery cannot double-wake.
-    if (pendingNotify.resettled) {
-      const shouldEnqueueCorrectedAttention =
-        settledRecord != null &&
-        (await this.workspaceTurnSettlementLocks.withLock(params.record.handleId, async () => {
-          const current = await this.taskHandleStore.getWorkspaceTurn(
-            params.record.ownerWorkspaceId,
-            params.record.handleId
-          );
-          if (
-            current == null ||
-            current.status !== settledRecord.status ||
-            current.updatedAt !== settledRecord.updatedAt ||
-            current.terminalAttentionNotifiedAt != null
-          ) {
-            return false;
-          }
-          // Delete the stale generation while holding the same lock used by direct-parent
-          // consumption. If consumption wins next, it installs a delivered tombstone before this
-          // method's enqueueIfAbsent; if it already won, the marker above prevents this deletion.
-          if (pendingNotify.staleAttentionRecord != null) {
-            await this.deleteWorkspaceTurnTerminalAttention(pendingNotify.staleAttentionRecord);
-          }
-          return true;
-        }));
-      if (!shouldEnqueueCorrectedAttention) {
+    try {
+      if (settledRecord != null) {
+        await this.deliverPersistentChildWorkspaceTurnResult(
+          settledRecord,
+          foregroundWaiterWorkspaceIds
+        );
+      }
+      if (pendingNotify == null) {
         return;
       }
-    }
-    await this.taskHost.enqueueTerminalAttention({
-      ownerWorkspaceId: params.record.ownerWorkspaceId,
-      sourceKind: "workspace_turn",
-      terminalOutcome: terminalAttentionOutcome(settlementResult.winningStatus),
-      sourceId: params.record.handleId,
-      ...(settledRecord != null
-        ? { generationId: this.workspaceTurnTerminalAttentionGenerationId(settledRecord) }
-        : {}),
-    });
-    await this.workspaceTurnSettlementLocks.withLock(params.record.handleId, async () => {
-      const terminal = await this.taskHandleStore.getWorkspaceTurn(
-        params.record.ownerWorkspaceId,
-        params.record.handleId
-      );
-      if (
-        terminal != null &&
-        (settledRecord == null ||
-          (terminal.status === settledRecord.status &&
-            terminal.updatedAt === settledRecord.updatedAt)) &&
-        terminal.terminalAttentionNotifiedAt == null
-      ) {
-        await this.taskHandleStore.upsertWorkspaceTurn({
-          ...terminal,
-          terminalAttentionNotifiedAt: getIsoNow(),
-        });
+      if (pendingNotify.kind === "drain_pending") {
+        this.taskHost.scheduleTerminalAttentionDrain(params.record.ownerWorkspaceId);
+        return;
       }
-    });
+
+      // Enqueue the terminal wake-up outside the lock. The persisted notification is the restart-safe
+      // record of intent; only after it is accepted do we set terminalAttentionNotifiedAt on the
+      // handle so a duplicate settlement / stale recovery cannot double-wake.
+      if (pendingNotify.resettled) {
+        const shouldEnqueueCorrectedAttention =
+          settledRecord != null &&
+          (await this.workspaceTurnSettlementLocks.withLock(params.record.handleId, async () => {
+            const current = await this.taskHandleStore.getWorkspaceTurn(
+              params.record.ownerWorkspaceId,
+              params.record.handleId
+            );
+            if (
+              current == null ||
+              current.status !== settledRecord.status ||
+              current.updatedAt !== settledRecord.updatedAt ||
+              current.terminalAttentionNotifiedAt != null
+            ) {
+              return false;
+            }
+            // Delete the stale generation while holding the same lock used by direct-parent
+            // consumption. If consumption wins next, it installs a delivered tombstone before this
+            // method's enqueueIfAbsent; if it already won, the marker above prevents this deletion.
+            if (pendingNotify.staleAttentionRecord != null) {
+              await this.deleteWorkspaceTurnTerminalAttention(pendingNotify.staleAttentionRecord);
+            }
+            return true;
+          }));
+        if (!shouldEnqueueCorrectedAttention) {
+          return;
+        }
+      }
+      await this.taskHost.enqueueTerminalAttention({
+        ownerWorkspaceId: params.record.ownerWorkspaceId,
+        sourceKind: "workspace_turn",
+        terminalOutcome: terminalAttentionOutcome(settlementResult.winningStatus),
+        sourceId: params.record.handleId,
+        ...(settledRecord != null
+          ? { generationId: this.workspaceTurnTerminalAttentionGenerationId(settledRecord) }
+          : {}),
+      });
+      await this.workspaceTurnSettlementLocks.withLock(params.record.handleId, async () => {
+        const terminal = await this.taskHandleStore.getWorkspaceTurn(
+          params.record.ownerWorkspaceId,
+          params.record.handleId
+        );
+        if (
+          terminal != null &&
+          (settledRecord == null ||
+            (terminal.status === settledRecord.status &&
+              terminal.updatedAt === settledRecord.updatedAt)) &&
+          terminal.terminalAttentionNotifiedAt == null
+        ) {
+          await this.taskHandleStore.upsertWorkspaceTurn({
+            ...terminal,
+            terminalAttentionNotifiedAt: getIsoNow(),
+          });
+        }
+      });
+    } finally {
+      // Register after lock release even when notification bookkeeping throws. The service
+      // owns the original job independently; cleanup rechecks live successor ownership.
+      if (params.cause.kind === "continuation-failure" && settledRecord?.disposableWorkspace) {
+        this.workspaceService.deferWorkspaceCleanup(() =>
+          this.cleanupDisposableWorkspaceTurn(settledRecord)
+        );
+      }
+    }
   }
 
   async waitForWorkspaceTurn(


### PR DESCRIPTION
Cancellation now finishes the captured stream attempt's partial persistence and terminal delivery before a replacement starts. Session and workspace disposal await in-flight work, while application and CLI shutdown keep their existing bounded teardown budget.

Abort persistence moves from AIService event forwarding into StreamManager and its mock counterpart. The first cancellation owns its reason and completion; identity checks prevent old cleanup from touching a replacement, and failed commits retain recoverable partial data. Startup cancellation joins the same completion barrier without waiting on an envelope callback that may itself await stop.

AgentSession separates synchronous closing from awaitable disposal. WorkspaceService tracks destructive cleanup outside continuation callbacks to avoid joining the callback that requested removal, keeps subscriptions through captured terminal delivery, and joins cleanup within the app scope. Closing cancels idle and queue waits separately from physical cleanup. Empty service-graph rollback remains synchronous so constructor failures retain their original error.

Test fixtures now await teardown. Policy-only fake handles retire on their own session's closing signal; lifecycle tests retain independent completion barriers.

Validation: 512 session/coordinator/queue/hooks tests, 421 engine/history/AI/mock tests, 1,162 workspace/task/container tests, and 20 CLI/edit tests passed. The full static check and main-process build passed. Isolated UI suites passed for interruption (1 test) and send-mode/queue behavior (5 tests). Deterministic regressions hold disk writes, envelope callbacks, session work and task-tree locks to exercise concurrent stop, replacement, cleanup errors, reentrant disposal, and shutdown bounds.

Risk: incorrect cleanup ordering could stall interruption or workspace removal, or lose interrupted output. Raw engine events retain their role, and session policy settlement stays separate from engine completion to avoid circular waits. Compaction policy and retry ownership remain for later phases.

---

_Generated with `xum` • Model: `unavailable` • Thinking: `unavailable` • Cost: `$unavailable`_

<!-- mux-attribution: model=unavailable thinking=unavailable costs=unavailable -->
