### PR TITLE
🤖 fix: restore live chat streaming after reconnect

### DIFF
--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -1,3 +1,12 @@
+import { EventEmitter } from "node:events";
+// This integration regression drives the real server replay into the real renderer store.
+// eslint-disable-next-line local/no-cross-boundary-imports -- test-only server fixture, never bundled into the renderer
+import { createAgentSessionHarness } from "@/node/services/agentSession.testHarness";
+// eslint-disable-next-line local/no-cross-boundary-imports -- exercise the actual IPC replay boundary in this store fixture
+import { subscribeWorkspaceChat } from "@/node/orpc/routerSubscriptions";
+import type { ORPCContext } from "@/node/orpc/context";
+import type { TurnCoordinator, OperationId } from "@/node/services/turnCoordinator";
+import { Ok } from "@/common/types/result";
 import { GlobalWindow } from "happy-dom";
 import {
   describe,
@@ -821,6 +830,186 @@ describe("WorkspaceStore", () => {
 
   afterEach(() => {
     store.dispose();
+  });
+
+  it.each([
+    ["stream-abort", "full"],
+    ["error", "full"],
+    ["stream-abort", "since"],
+    ["error", "since"],
+    ["stream-abort", "live"],
+    ["error", "live"],
+  ])("keeps the successor streaming after %s during %s replay", async (terminal, mode) => {
+    const workspaceId = `replay-successor-${terminal}`;
+    const emitter = new EventEmitter();
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    let messageId = "engine-A";
+    const info = () => ({
+      messageId,
+      model: "anthropic:claude-test",
+      historySequence: 1,
+      startTime: 1,
+      parts: [],
+      currentStepStartIndex: 0,
+      stepStartIndices: [0],
+      toolCompletionTimestamps: new Map<string, number>(),
+    });
+    const publish = (replay = false) => {
+      emitter.emit("stream-start", { ...info(), type: "stream-start", workspaceId, replay });
+      emitter.emit("stream-delta", {
+        type: "stream-delta",
+        workspaceId,
+        messageId,
+        delta: "successor text",
+        timestamp: 30,
+        replay,
+      });
+      emitter.emit("reasoning-delta", {
+        type: "reasoning-delta",
+        workspaceId,
+        messageId,
+        delta: "successor reasoning",
+        timestamp: 30,
+        replay,
+      });
+      emitter.emit("tool-call-start", {
+        type: "tool-call-start",
+        workspaceId,
+        messageId,
+        toolCallId: "tool-B",
+        toolName: "bash",
+        args: { script: "pwd" },
+        tokens: 1,
+        timestamp: 31,
+        replay,
+      });
+      emitter.emit("tool-call-end", {
+        type: "tool-call-end",
+        workspaceId,
+        messageId,
+        toolCallId: "tool-B",
+        toolName: "bash",
+        result: "result-B",
+        timestamp: 32,
+        replay,
+      });
+    };
+    const h = await createAgentSessionHarness({
+      workspaceId,
+      aiEmitter: emitter,
+      aiServiceOverrides: {
+        isStreaming: () => true,
+        getStreamInfo: info,
+        replayStream: async () => {
+          if (mode === "live") {
+            entered.resolve();
+            await release.promise;
+          }
+          publish(true);
+        },
+      },
+      initStateManagerOverrides: { replayInit: () => Promise.resolve() },
+    });
+    await h.historyService.appendToHistory(workspaceId, createMuxMessage("seed", "user", "seed"));
+    const read = h.historyService.readPartial.bind(h.historyService);
+    spyOn(h.historyService, "readPartial").mockImplementationOnce(async (...args) => {
+      entered.resolve();
+      await release.promise;
+      return read(...args);
+    });
+    const coordinator = (h.session as unknown as { coordinator: TurnCoordinator }).coordinator;
+    let operation: OperationId | undefined;
+    const send = spyOn(h.session, "sendMessage").mockImplementation(() => {
+      operation = coordinator.registerOperation(coordinator.turnId);
+      messageId = "engine-B";
+      publish();
+      return Promise.resolve(Ok(undefined));
+    });
+    const context = {
+      workspaceService: { getOrCreateSession: () => h.session },
+    } as unknown as ORPCContext;
+    const trace: WorkspaceChatMessage[] = [];
+    const consumed = Promise.withResolvers<void>();
+    mockOnChat.mockImplementation(async function* (_input, options) {
+      for await (const event of subscribeWorkspaceChat(
+        context,
+        {
+          workspaceId,
+          mode:
+            mode === "live"
+              ? { type: "live" }
+              : mode === "since"
+                ? {
+                    type: "since",
+                    cursor: {
+                      history: { messageId: "seed", historySequence: 0 },
+                      stream: { messageId: "engine-A", lastTimestamp: 10 },
+                    },
+                  }
+                : undefined,
+        },
+        options?.signal
+      )) {
+        trace.push(event);
+        yield event;
+        if (event.type === "caught-up") consumed.resolve();
+      }
+    });
+    try {
+      createAndAddWorkspace(store, workspaceId);
+      await entered.promise;
+      h.session.queueMessage("queued successor");
+      emitter.emit(terminal, {
+        type: terminal,
+        workspaceId,
+        messageId: "engine-A",
+        error: "failed A",
+        errorType: "unknown",
+        abortReason: "user",
+        metadata: {},
+        parts: [],
+      });
+      expect(send).toHaveBeenCalledTimes(1);
+      release.resolve();
+      expect(await waitUntil(() => trace.some((event) => event.type === "caught-up"))).toBe(true);
+      await consumed.promise;
+      const aggregator = store.getAggregator(workspaceId)!;
+      expect(store.getWorkspaceState(workspaceId).canInterrupt).toBe(true);
+      expect(aggregator.getActiveStreamMessageId()).toBe("engine-B");
+      expect(aggregator.getStreamLifecycle()?.phase).toBe("streaming");
+      const successor = aggregator.getAllMessages().find((message) => message.id === "engine-B")!;
+      expect(
+        successor.parts.filter((part) => part.type === "text").map((part) => part.text)
+      ).toEqual(["successor text"]);
+      expect(
+        successor.parts.filter((part) => part.type === "reasoning").map((part) => part.text)
+      ).toEqual(["successor reasoning"]);
+      expect(successor.parts.filter((part) => part.type === "dynamic-tool")).toHaveLength(1);
+      expect(successor.parts.find((part) => part.type === "dynamic-tool")).toMatchObject({
+        state: "output-available",
+        output: "result-B",
+      });
+      emitter.emit("stream-delta", {
+        type: "stream-delta",
+        workspaceId,
+        messageId: "engine-B",
+        delta: " still live",
+        timestamp: 40,
+      });
+      expect(
+        await waitUntil(() =>
+          JSON.stringify(aggregator.getDisplayedMessages()).includes("still live")
+        )
+      ).toBe(true);
+    } finally {
+      release.resolve();
+      store.dispose();
+      if (operation) coordinator.finishStartup(operation);
+      h.session.clearQueue();
+      await h.session.dispose();
+      await h.cleanup();
+    }
   });
 
   describe("provider config changes", () => {

--- a/src/node/orpc/replayOwnership.test.ts
+++ b/src/node/orpc/replayOwnership.test.ts
@@ -1,0 +1,262 @@
+import { expect, test, spyOn } from "bun:test";
+import type { AsyncLocalStorage } from "node:async_hooks";
+import { EventEmitter } from "node:events";
+import { createAgentSessionHarness } from "../services/agentSession.testHarness";
+import { subscribeWorkspaceChat } from "./routerSubscriptions";
+import type { ORPCContext } from "./context";
+import { createMuxMessage } from "@/common/types/message";
+import type { OnChatMode, WorkspaceChatMessage } from "@/common/orpc/types";
+import { StreamingMessageAggregator } from "@/browser/utils/messages/StreamingMessageAggregator";
+import { Ok } from "@/common/types/result";
+
+async function setup(onReplayResumed?: () => void) {
+  const workspaceId = "observed-engine";
+  const emitter = new EventEmitter();
+  const info = {
+    messageId: "engine-A",
+    model: "anthropic:claude-test",
+    historySequence: 1,
+    startTime: 1,
+    parts: [{ type: "text" as const, text: "earlier", timestamp: 30 }],
+    currentStepStartIndex: 0,
+    stepStartIndices: [0],
+    toolCompletionTimestamps: new Map<string, number>(),
+  };
+  const start = { ...info, type: "stream-start" as const, workspaceId, replay: true };
+  const gates: Array<{
+    entered: ReturnType<typeof Promise.withResolvers<void>>;
+    release: ReturnType<typeof Promise.withResolvers<void>>;
+  }> = [];
+  let invocation = 0;
+  const replayOffsets: Array<number | undefined> = [];
+  const harness = await createAgentSessionHarness({
+    workspaceId,
+    aiEmitter: emitter,
+    aiServiceOverrides: {
+      isStreaming: () => true,
+      getStreamInfo: () => info,
+      replayStream: async (_workspaceId, options) => {
+        replayOffsets.push(options?.afterTimestamp);
+        const index = invocation++;
+        emitter.emit("stream-start", start);
+        const gate = gates[index];
+        gate?.entered.resolve();
+        if (gate) await gate.release.promise;
+        onReplayResumed?.();
+        emitter.emit("stream-delta", {
+          type: "stream-delta",
+          workspaceId,
+          messageId: info.messageId,
+          delta: `window-${index}`,
+          timestamp: index + 10,
+          replay: true,
+        });
+      },
+    },
+    initStateManagerOverrides: { replayInit: () => Promise.resolve() },
+  });
+  await harness.historyService.appendToHistory(
+    workspaceId,
+    createMuxMessage("seed", "user", "seed")
+  );
+  const context = {
+    workspaceService: { getOrCreateSession: () => harness.session },
+  } as unknown as ORPCContext;
+  const clients: Array<{ stop: () => Promise<void> }> = [];
+  const subscribe = (mode?: OnChatMode) => {
+    const abort = new AbortController();
+    const caught = Promise.withResolvers<void>();
+    const queued = Promise.withResolvers<void>();
+    const live = Promise.withResolvers<void>();
+    const aggregator = new StreamingMessageAggregator("2024-01-01T00:00:00.000Z");
+    const events: WorkspaceChatMessage[] = [];
+    const done = (async () => {
+      for await (const event of subscribeWorkspaceChat(
+        context,
+        { workspaceId, mode },
+        abort.signal
+      )) {
+        events.push(event);
+        if (event.type === "stream-start") aggregator.handleStreamStart(event);
+        if (event.type === "queued-message-changed") {
+          aggregator.setActiveQueuedFollowUp(event.hasQueuedMessages === true);
+          if (event.hasQueuedMessages) queued.resolve();
+        }
+        if (event.type === "caught-up") caught.resolve();
+        if (event.type === "stream-delta" && event.delta === "live") live.resolve();
+      }
+    })();
+    const stop = async () => {
+      abort.abort();
+      await done;
+    };
+    clients.push({ stop });
+    return {
+      caught: caught.promise,
+      queued: queued.promise,
+      live: live.promise,
+      events,
+      aggregator,
+      stop,
+    };
+  };
+  return {
+    ...harness,
+    workspaceId,
+    emitter,
+    gates,
+    replayOffsets,
+    subscribe,
+    close: async () => {
+      for (const gate of gates) gate?.release.resolve();
+      await Promise.all(clients.map((client) => client.stop()));
+      harness.session.clearQueue();
+      await harness.session.dispose();
+      await harness.cleanup();
+    },
+  };
+}
+
+test.each(["stream-end", "stream-abort", "error"])(
+  "operationless replay holds manual input until its exact %s",
+  async (terminal) => {
+    const h = await setup();
+    const send = spyOn(h.session, "sendMessage").mockResolvedValue(Ok(undefined));
+    try {
+      const client = h.subscribe();
+      await client.caught;
+      expect(h.session.isBusy()).toBe(true);
+      h.session.queueMessage("manual follow-up");
+      h.session.drainQueuedMessagesIfIdle();
+      expect(send).not.toHaveBeenCalled();
+      h.emitter.emit(terminal, {
+        type: terminal === "error" ? "stream-error" : terminal,
+        error: "provider failed",
+        errorType: "unknown",
+        abortReason: "user",
+        workspaceId: h.workspaceId,
+        messageId: "stale",
+        parts: [],
+        metadata: {},
+      });
+      expect(h.session.isBusy()).toBe(true);
+      h.emitter.emit(terminal, {
+        type: terminal === "error" ? "stream-error" : terminal,
+        error: "provider failed",
+        errorType: "unknown",
+        abortReason: "user",
+        workspaceId: h.workspaceId,
+        messageId: "engine-A",
+        parts: [],
+        metadata: {},
+      });
+      expect(send).toHaveBeenCalledTimes(1);
+      expect(send.mock.calls[0][0]).toBe("manual follow-up");
+    } finally {
+      await h.close();
+    }
+  }
+);
+
+test("overlapping replays preserve an existing client's queue and isolate each replay window", async () => {
+  const h = await setup();
+  try {
+    const existing = h.subscribe();
+    await existing.caught;
+    h.session.queueMessage("follow-up");
+    await existing.queued;
+    expect(existing.aggregator.getActiveStreams()[0]?.hasQueuedFollowUp).toBe(true);
+    h.gates[1] = { entered: Promise.withResolvers<void>(), release: Promise.withResolvers<void>() };
+    h.gates[2] = { entered: Promise.withResolvers<void>(), release: Promise.withResolvers<void>() };
+    const caughtUp = existing.events.find((event) => event.type === "caught-up");
+    const history = caughtUp?.cursor?.history;
+    if (!history) throw new Error("Expected history cursor");
+    const a = h.subscribe({
+      type: "since",
+      cursor: { history, stream: { messageId: "engine-A", lastTimestamp: 10 } },
+    });
+    await h.gates[1].entered.promise;
+    const b = h.subscribe({
+      type: "since",
+      cursor: { history, stream: { messageId: "engine-A", lastTimestamp: 20 } },
+    });
+    await h.gates[2].entered.promise;
+    h.emitter.emit("stream-delta", {
+      type: "stream-delta",
+      workspaceId: h.workspaceId,
+      messageId: "engine-A",
+      delta: "live",
+      timestamp: 100,
+    });
+    await existing.live;
+    h.gates[2].release.resolve();
+    await b.caught;
+    h.gates[1].release.resolve();
+    await a.caught;
+    await Promise.all([a.live, b.live]);
+    expect(existing.aggregator.getActiveStreams()[0]?.hasQueuedFollowUp).toBe(true);
+    const windows = (events: WorkspaceChatMessage[]) =>
+      events.filter((event) => event.type === "stream-delta").map((event) => event.delta);
+    expect(windows(existing.events)).toEqual(["window-0", "live"]);
+    expect(windows(a.events)).toEqual(["window-1", "live"]);
+    expect(windows(b.events)).toEqual(["window-2", "live"]);
+    expect(h.replayOffsets).toEqual([undefined, 10, 20]);
+  } finally {
+    await h.close();
+  }
+});
+
+test("an aborted replay cannot publish its delayed window to another subscriber", async () => {
+  const h = await setup();
+  try {
+    const existing = h.subscribe();
+    await existing.caught;
+    h.gates[1] = { entered: Promise.withResolvers<void>(), release: Promise.withResolvers<void>() };
+    const abandoned = h.subscribe();
+    await h.gates[1].entered.promise;
+    await abandoned.stop();
+    const before = abandoned.events.length;
+    h.gates[1].release.resolve();
+    // A succeeding replay is an explicit barrier past the abandoned replay's release.
+    const next = h.subscribe();
+    await next.caught;
+    expect(abandoned.events).toHaveLength(before);
+    expect(
+      existing.events.filter((event) => event.type === "stream-delta").map((event) => event.delta)
+    ).toEqual(["window-0"]);
+  } finally {
+    await h.close();
+  }
+});
+
+test("disposing a held replay releases its async context without affecting a sibling session", async () => {
+  const resumed = Promise.withResolvers<unknown>();
+  const h = await setup(() => resumed.resolve(publication.getStore()));
+  const publication = (h.session as unknown as { replayPublication: AsyncLocalStorage<unknown> })
+    .replayPublication;
+  const sibling = await setup();
+  let held: ReturnType<typeof h.subscribe> | undefined;
+  try {
+    h.gates[0] = { entered: Promise.withResolvers<void>(), release: Promise.withResolvers<void>() };
+    held = h.subscribe();
+    await h.gates[0].entered.promise;
+    await h.session.dispose();
+    h.gates[0].release.resolve();
+    expect(await resumed.promise).toBeUndefined();
+    await held.caught;
+    expect(held.events.some((event) => event.type === "stream-delta")).toBe(false);
+    const surviving = sibling.subscribe();
+    await surviving.caught;
+    expect(
+      surviving.events.filter((event) => event.type === "stream-delta").map((event) => event.delta)
+    ).toEqual(["window-0"]);
+    expect(surviving.aggregator.hasInterruptibleActiveStream()).toBe(true);
+  } finally {
+    // The disposed session rejects queue APIs; its subscription and disk fixture are
+    // still independently owned by the test while the delayed replay finishes.
+    for (const gate of h.gates) gate?.release.resolve();
+    await held?.stop();
+    await h.cleanup();
+    await sibling.close();
+  }
+});

--- a/src/node/orpc/replayOwnership.test.ts
+++ b/src/node/orpc/replayOwnership.test.ts
@@ -7,9 +7,15 @@ import type { ORPCContext } from "./context";
 import { createMuxMessage } from "@/common/types/message";
 import type { OnChatMode, WorkspaceChatMessage } from "@/common/orpc/types";
 import { StreamingMessageAggregator } from "@/browser/utils/messages/StreamingMessageAggregator";
+import type { TurnCoordinator, OperationId } from "../services/turnCoordinator";
 import { Ok } from "@/common/types/result";
 
-async function setup(onReplayResumed?: () => void) {
+async function setup(
+  onReplayResumed?: () => void,
+  beforeReplayStart?: () => Promise<void>,
+  initiallyActive = true
+) {
+  let active = initiallyActive;
   const workspaceId = "observed-engine";
   const emitter = new EventEmitter();
   const info = {
@@ -33,11 +39,12 @@ async function setup(onReplayResumed?: () => void) {
     workspaceId,
     aiEmitter: emitter,
     aiServiceOverrides: {
-      isStreaming: () => true,
-      getStreamInfo: () => info,
+      isStreaming: () => active,
+      getStreamInfo: () => (active ? { ...info } : undefined),
       replayStream: async (_workspaceId, options) => {
         replayOffsets.push(options?.afterTimestamp);
         const index = invocation++;
+        await beforeReplayStart?.();
         emitter.emit("stream-start", start);
         const gate = gates[index];
         gate?.entered.resolve();
@@ -68,6 +75,7 @@ async function setup(onReplayResumed?: () => void) {
     const caught = Promise.withResolvers<void>();
     const queued = Promise.withResolvers<void>();
     const live = Promise.withResolvers<void>();
+    const terminal = Promise.withResolvers<void>();
     const aggregator = new StreamingMessageAggregator("2024-01-01T00:00:00.000Z");
     const events: WorkspaceChatMessage[] = [];
     const done = (async () => {
@@ -83,6 +91,7 @@ async function setup(onReplayResumed?: () => void) {
           if (event.hasQueuedMessages) queued.resolve();
         }
         if (event.type === "caught-up") caught.resolve();
+        if (event.type === "stream-end") terminal.resolve();
         if (event.type === "stream-delta" && event.delta === "live") live.resolve();
       }
     })();
@@ -95,6 +104,7 @@ async function setup(onReplayResumed?: () => void) {
       caught: caught.promise,
       queued: queued.promise,
       live: live.promise,
+      terminal: terminal.promise,
       events,
       aggregator,
       stop,
@@ -106,6 +116,14 @@ async function setup(onReplayResumed?: () => void) {
     emitter,
     gates,
     replayOffsets,
+    startReplacement: () => {
+      active = true;
+      info.messageId = "engine-B";
+      emitter.emit("stream-start", { ...info, workspaceId, type: "stream-start" });
+    },
+    setActive: (value: boolean) => {
+      active = value;
+    },
     subscribe,
     close: async () => {
       for (const gate of gates) gate?.release.resolve();
@@ -258,5 +276,142 @@ test("disposing a held replay releases its async context without affecting a sib
     await held?.stop();
     await h.cleanup();
     await sibling.close();
+  }
+});
+
+test.each([
+  ["history", "full"],
+  ["history", "since"],
+  ["before-start", "full"],
+  ["before-start", "since"],
+  ["before-start", "live"],
+])("replay owns the active engine before %s awaits in %s mode", async (boundary, modeName) => {
+  const entered = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<void>();
+  const hold = async () => {
+    entered.resolve();
+    await release.promise;
+  };
+  const h = await setup(undefined, boundary === "before-start" ? hold : undefined, false);
+  h.setActive(true);
+  if (boundary === "history") {
+    const read = h.historyService.readPartial.bind(h.historyService);
+    spyOn(h.historyService, "readPartial").mockImplementationOnce(async (...args) => {
+      await hold();
+      return read(...args);
+    });
+  }
+  const coordinator = (h.session as unknown as { coordinator: TurnCoordinator }).coordinator;
+  let replacementOperation: OperationId | undefined;
+  const send = spyOn(h.session, "sendMessage").mockImplementation(() => {
+    // Queue dispatch has already claimed B's real preparation owner. Only its
+    // provider boundary is controlled here; start and replay use session ingress.
+    replacementOperation = coordinator.registerOperation(coordinator.turnId);
+    h.startReplacement();
+    return Promise.resolve(Ok(undefined));
+  });
+  try {
+    const mode: OnChatMode | undefined =
+      modeName === "live"
+        ? { type: "live" }
+        : modeName === "since"
+          ? {
+              type: "since",
+              cursor: {
+                history: { messageId: "seed", historySequence: 0 },
+                stream: { messageId: "engine-A", lastTimestamp: 10 },
+              },
+            }
+          : undefined;
+    const client = h.subscribe(mode);
+    await entered.promise;
+    expect(h.session.isBusy()).toBe(true);
+    h.session.queueMessage("manual during replay");
+    h.session.drainQueuedMessagesIfIdle();
+    expect(send).not.toHaveBeenCalled();
+    h.emitter.emit("stream-end", {
+      type: "stream-end",
+      workspaceId: h.workspaceId,
+      messageId: "stale",
+      parts: [],
+      metadata: {},
+    });
+    expect(h.session.isBusy()).toBe(true);
+    h.setActive(false);
+    expect(h.session.isBusy()).toBe(true);
+    expect(send).not.toHaveBeenCalled();
+    h.emitter.emit("stream-end", {
+      type: "stream-end",
+      workspaceId: h.workspaceId,
+      messageId: "engine-A",
+      parts: [],
+      metadata: {},
+    });
+    expect(send).toHaveBeenCalledTimes(1);
+    const replacementTurn = coordinator.turnId;
+    expect(coordinator.phase).toBe("streaming");
+    release.resolve();
+    await client.caught;
+    await client.terminal;
+    expect(client.events.filter((event) => event.type === "stream-end")).toHaveLength(1);
+    expect(
+      client.events.some((event) => event.type === "stream-start" && event.messageId === "engine-A")
+    ).toBe(false);
+    expect(coordinator.turnId).toBe(replacementTurn);
+    expect(coordinator.phase).toBe("streaming");
+    expect(client.events.find((event) => event.type === "caught-up")).toMatchObject({
+      cursor: { stream: { messageId: "engine-B" } },
+    });
+  } finally {
+    release.resolve();
+    if (replacementOperation) coordinator.finishStartup(replacementOperation);
+    await h.close();
+  }
+});
+
+test("a constructed session reserves an existing engine before a lazy subscription is pulled", async () => {
+  const h = await setup();
+  const send = spyOn(h.session, "sendMessage").mockResolvedValue(Ok(undefined));
+  try {
+    const context = {
+      workspaceService: { getOrCreateSession: () => h.session },
+    } as unknown as ORPCContext;
+    const subscription = subscribeWorkspaceChat(context, { workspaceId: h.workspaceId });
+    expect(h.session.isBusy()).toBe(true);
+    h.session.queueMessage("manual before first pull");
+    h.session.drainQueuedMessagesIfIdle();
+    expect(send).not.toHaveBeenCalled();
+    h.setActive(false);
+    h.emitter.emit("stream-end", {
+      type: "stream-end",
+      workspaceId: h.workspaceId,
+      messageId: "engine-A",
+      parts: [],
+      metadata: {},
+    });
+    expect(send).toHaveBeenCalledTimes(1);
+    await subscription.return(undefined);
+  } finally {
+    await h.close();
+  }
+});
+
+test("a later observed engine is reserved before replay lifecycle listeners can submit input", async () => {
+  const h = await setup(undefined, undefined, false);
+  const send = spyOn(h.session, "sendMessage").mockResolvedValue(Ok(undefined));
+  try {
+    h.setActive(true);
+    let busyAtFirstPublication: boolean | undefined;
+    await h.session.replayHistory(({ message }) => {
+      if (message.type === "stream-lifecycle" && busyAtFirstPublication === undefined) {
+        busyAtFirstPublication = h.session.isBusy();
+        h.session.queueMessage("reentrant manual");
+        h.session.drainQueuedMessagesIfIdle();
+      }
+    });
+    expect(busyAtFirstPublication).toBe(true);
+    expect(send).not.toHaveBeenCalled();
+  } finally {
+    await h.close();
   }
 });

--- a/src/node/orpc/routerSubscriptions.ts
+++ b/src/node/orpc/routerSubscriptions.ts
@@ -297,8 +297,9 @@ export function subscribeWorkspaceChat(
     },
     initialize: async () => {
       await session.replayHistory(
-        ({ message }) => replayRelay.handleSessionMessage(message),
-        input.mode
+        ({ message }) => replayRelay.handleReplayMessage(message),
+        input.mode,
+        replayRelay.finishReplay
       );
       replayRelay.finishReplay();
       session.scheduleStartupRecovery();

--- a/src/node/orpc/routerSubscriptions.ts
+++ b/src/node/orpc/routerSubscriptions.ts
@@ -295,8 +295,11 @@ export function subscribeWorkspaceChat(
       replayRelay = createReplayBufferedStreamMessageRelay(emit.push);
       return session.onChatEvent(({ message }) => replayRelay.handleSessionMessage(message));
     },
-    initialize: async (emit) => {
-      await session.replayHistory(({ message }) => emit.push(message), input.mode);
+    initialize: async () => {
+      await session.replayHistory(
+        ({ message }) => replayRelay.handleSessionMessage(message),
+        input.mode
+      );
       replayRelay.finishReplay();
       session.scheduleStartupRecovery();
     },

--- a/src/node/orpc/routerWorkspaceChat.test.ts
+++ b/src/node/orpc/routerWorkspaceChat.test.ts
@@ -1,0 +1,141 @@
+import { test, expect, mock, spyOn } from "bun:test";
+import { StreamManager } from "../services/streamManager";
+import type { TurnCoordinator } from "../services/turnCoordinator";
+import { EventEmitter } from "node:events";
+import { subscribeWorkspaceChat } from "./routerSubscriptions";
+import type { ORPCContext } from "./context";
+import { createAgentSessionHarness } from "../services/agentSession.testHarness";
+import { createMuxMessage } from "@/common/types/message";
+import type { WorkspaceChatMessage } from "@/common/orpc/types";
+
+test("active-operation reconnect replays the stream envelope and live deltas before terminal", async () => {
+  const workspaceId = "live-replay-smoke";
+  const messageId = "assistant-active";
+  const emitter = new EventEmitter();
+  const replayEntered = Promise.withResolvers<void>();
+  const releaseReplay = Promise.withResolvers<void>();
+  const caughtUp = Promise.withResolvers<void>();
+  const overlappingDelta = Promise.withResolvers<void>();
+  const subsequentDelta = Promise.withResolvers<void>();
+  let active = true;
+  const streamInfo = {
+    messageId,
+    model: "anthropic:claude-test",
+    historySequence: 1,
+    currentStepStartIndex: 0,
+    stepStartIndices: [0],
+    startTime: 100,
+    parts: [],
+    toolCompletionTimestamps: new Map<string, number>(),
+  };
+  const delta = (text: string, timestamp: number, replay = false) => ({
+    type: "stream-delta",
+    workspaceId,
+    messageId,
+    delta: text,
+    timestamp,
+    replay,
+  });
+  const harness = await createAgentSessionHarness({
+    workspaceId,
+    aiEmitter: emitter,
+    captureEvents: true,
+    aiServiceOverrides: {
+      isStreaming: mock(() => active),
+      getStreamInfo: mock(() => (active ? streamInfo : undefined)),
+      replayStream: mock(async () => {
+        emitEngineStart(true);
+        emitter.emit("stream-delta", delta("replayed", 101, true));
+        replayEntered.resolve();
+        await releaseReplay.promise;
+      }),
+    },
+    initStateManagerOverrides: { replayInit: mock(() => Promise.resolve()) },
+  });
+  const engine = new StreamManager(harness.historyService, undefined, undefined, (event) => {
+    emitter.emit(event.type, event);
+  });
+  const actualEmit = (
+    engine as unknown as {
+      emitStreamStart: (
+        workspaceId: string,
+        info: object,
+        sequence: number,
+        options: { replay: boolean }
+      ) => void;
+    }
+  ).emitStreamStart;
+  const emitEngineStart = (replay: boolean) =>
+    actualEmit.call(engine, workspaceId, { ...streamInfo, model: "anthropic:claude-test" }, 1, {
+      replay,
+    });
+  const coordinator = (harness.session as unknown as { coordinator: TurnCoordinator }).coordinator;
+  const startPolicy = spyOn(coordinator, "streamStarted");
+  const operation = coordinator.registerOperation(coordinator.turnId);
+  emitEngineStart(false);
+  await harness.historyService.appendToHistory(
+    workspaceId,
+    createMuxMessage("user", "user", "hello")
+  );
+  const controller = new AbortController();
+  const events: WorkspaceChatMessage[] = [];
+  const context = {
+    workspaceService: { getOrCreateSession: () => harness.session },
+  } as unknown as ORPCContext;
+  const consumed = (async () => {
+    for await (const event of subscribeWorkspaceChat(context, { workspaceId }, controller.signal)) {
+      events.push(event);
+      if (event.type === "caught-up") caughtUp.resolve();
+      if (event.type === "stream-delta" && event.delta === "overlap") overlappingDelta.resolve();
+      if (event.type === "stream-delta" && event.delta === "after") subsequentDelta.resolve();
+    }
+  })();
+  try {
+    await replayEntered.promise;
+    emitter.emit("stream-delta", delta("overlap", 102));
+    releaseReplay.resolve();
+    await Promise.all([caughtUp.promise, overlappingDelta.promise]);
+    emitter.emit("stream-delta", delta("after", 103));
+    await subsequentDelta.promise;
+    // The same envelope must not become a second live admission or resurrect a
+    // terminal operation; mismatched engine identity is also rejected.
+    const startsBefore = harness.events.filter((event) => event.type === "stream-start").length;
+    expect(startsBefore).toBe(2);
+    expect(startPolicy).toHaveBeenCalledTimes(1);
+    emitEngineStart(false);
+    emitter.emit("stream-start", {
+      type: "stream-start",
+      ...streamInfo,
+      workspaceId,
+      messageId: "stale",
+      replay: true,
+    });
+    expect(harness.events.filter((event) => event.type === "stream-start")).toHaveLength(
+      startsBefore
+    );
+    expect(startPolicy).toHaveBeenCalledTimes(2);
+    coordinator.rawTerminal("completed", messageId);
+    emitEngineStart(true);
+    expect(harness.events.filter((event) => event.type === "stream-start")).toHaveLength(
+      startsBefore
+    );
+    const envelopeIndex = events.findIndex((event) => event.type === "stream-start");
+    expect(envelopeIndex).toBeGreaterThanOrEqual(0);
+    expect(envelopeIndex).toBeLessThan(events.findIndex((event) => event.type === "stream-delta"));
+    expect(envelopeIndex).toBeLessThan(events.findIndex((event) => event.type === "caught-up"));
+    expect(
+      events.some((event) => event.type === "stream-end" || event.type === "stream-abort")
+    ).toBe(false);
+    expect(events.find((event) => event.type === "caught-up")).toMatchObject({
+      cursor: { stream: { messageId } },
+    });
+  } finally {
+    releaseReplay.resolve();
+    controller.abort();
+    await consumed;
+    active = false;
+    coordinator.finishStartup(operation);
+    await harness.session.dispose();
+    await harness.cleanup();
+  }
+}, 5000);

--- a/src/node/orpc/routerWorkspaceChat.test.ts
+++ b/src/node/orpc/routerWorkspaceChat.test.ts
@@ -100,7 +100,7 @@ test("active-operation reconnect replays the stream envelope and live deltas bef
     // The same envelope must not become a second live admission or resurrect a
     // terminal operation; mismatched engine identity is also rejected.
     const startsBefore = harness.events.filter((event) => event.type === "stream-start").length;
-    expect(startsBefore).toBe(2);
+    expect(startsBefore).toBe(1);
     expect(startPolicy).toHaveBeenCalledTimes(1);
     emitEngineStart(false);
     emitter.emit("stream-start", {

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { TurnStreamHandle } from "./streamManager";
 import type { StreamManager } from "./streamManager";
 import * as path from "path";
@@ -766,6 +767,10 @@ interface PreparationAttempt {
 }
 
 export class AgentSession {
+  private readonly replayPublication = new AsyncLocalStorage<{
+    listener: (event: AgentSessionChatEvent) => void;
+    emittedStreamEvents: boolean;
+  }>();
   private readonly workspaceId: string;
   private readonly config: Config;
   private readonly historyService: HistoryService;
@@ -1250,7 +1255,15 @@ export class AgentSession {
         emitIfMissing: false,
       })
     );
-    const invalidated = cleanup("invalidate", () => this.coordinator.dispose());
+    const invalidated = cleanup("invalidate", () => {
+      try {
+        this.coordinator.dispose();
+      } finally {
+        // Release Node's async-context registration only after late replay events
+        // are suppressed; disabling while merely closing could broadcast them live.
+        if (this.coordinator.disposed) this.replayPublication.disable();
+      }
+    });
     const compactionStopped = cleanup("compaction", () =>
       this.continuousCompactor.reset("dispose")
     );
@@ -1300,7 +1313,7 @@ export class AgentSession {
     assert(typeof listener === "function", "listener must be a function");
 
     const unsubscribe = this.onChatEvent(listener);
-    await this.emitHistoricalEvents(listener);
+    await this.replayHistory(listener);
 
     this.scheduleStartupRecovery();
 
@@ -1313,7 +1326,9 @@ export class AgentSession {
   ): Promise<void> {
     this.assertNotDisposed("replayHistory");
     assert(typeof listener === "function", "listener must be a function");
-    await this.emitHistoricalEvents(listener, mode);
+    await this.replayPublication.run({ listener, emittedStreamEvents: false }, () =>
+      this.emitHistoricalEvents(listener, mode)
+    );
   }
 
   emitMetadata(metadata: FrontendWorkspaceMetadata | null): void {
@@ -2721,25 +2736,6 @@ export class AgentSession {
       }
     };
 
-    let emittedReplayStreamEvents = false;
-    const replayStreamEventTracker = (event: AgentSessionChatEvent) => {
-      if (event.workspaceId !== this.workspaceId) {
-        return;
-      }
-
-      const message = event.message;
-      if (typeof message !== "object" || message === null) {
-        return;
-      }
-
-      if (!("replay" in message) || message.replay !== true) {
-        return;
-      }
-
-      emittedReplayStreamEvents = true;
-    };
-    this.emitter.on("chat-event", replayStreamEventTracker);
-
     const shouldReplayTerminalState = mode?.type !== "live";
 
     // try/catch/finally guarantees caught-up is always sent, even if replay fails.
@@ -2992,7 +2988,11 @@ export class AgentSession {
       // Keep append/live semantics when we've already emitted incremental payload.
       // Downgrading to full at that point would make the frontend apply replace-mode to
       // a partial replay buffer and temporarily hide older transcript rows.
-      if (replayMode !== "full" && !emittedReplayMessages && !emittedReplayStreamEvents) {
+      if (
+        replayMode !== "full" &&
+        !emittedReplayMessages &&
+        !this.replayPublication.getStore()?.emittedStreamEvents
+      ) {
         replayMode = "full";
       }
       if (mode?.type === "since" && replayMode === "full") {
@@ -3002,8 +3002,6 @@ export class AgentSession {
       // Replay failed, so do not advertise a trustworthy reconnect cursor.
       serverCursor = undefined;
     } finally {
-      this.emitter.off("chat-event", replayStreamEventTracker);
-
       if (shouldReplayTerminalState) {
         // Replay the latest terminal/preparing state one last time before caught-up in case the
         // stream changed while history was replaying (for example PREPARING -> failed/idle).
@@ -6815,7 +6813,7 @@ export class AgentSession {
         // admitted. Replay must not rerun start policy or revive a retired attempt.
         if (
           this.streamManager.getStreamInfo(this.workspaceId)?.messageId === payload.messageId &&
-          this.coordinator.canReplayStreamStart(payload.messageId)
+          this.coordinator.observeStreamReplay(payload.messageId)
         )
           this.emitChatEvent(payload);
         return;
@@ -7021,6 +7019,7 @@ export class AgentSession {
     forward("stream-abort", (payload) => {
       if (payload.type !== "stream-abort") return;
       if (this.forwardDisposalTerminal(payload)) return;
+      if (this.finishObservedStream(payload.messageId, payload)) return;
       if (this.coordinator.observeStartupAbort(payload)) return this.handleStartupAbort(payload);
       this.coordinator.rawTerminal("aborted", payload.messageId);
     });
@@ -7034,6 +7033,7 @@ export class AgentSession {
     forward("stream-end", (payload) => {
       if (payload.type !== "stream-end") return;
       if (this.forwardDisposalTerminal(payload)) return;
+      if (this.finishObservedStream(payload.messageId, payload)) return;
       this.coordinator.rawTerminal("completed", payload.messageId);
     });
 
@@ -7048,6 +7048,14 @@ export class AgentSession {
         return;
       }
       const data = raw as StreamErrorPayload & { workspaceId: string };
+      if (
+        this.finishObservedStream(data.messageId, {
+          ...data,
+          type: "stream-error",
+          errorType: data.errorType ?? "unknown",
+        })
+      )
+        return;
       // Begin synchronously at event emission so completion waiters always find
       // this attempt's decision before they run.
       this.coordinator.beginErrorDecision(data.messageId);
@@ -7096,6 +7104,10 @@ export class AgentSession {
     return true;
   }
 
+  private finishObservedStream(messageId: string, payload: WorkspaceChatMessage): boolean {
+    return this.coordinator.finishObservedStream(messageId, () => this.emitChatEvent(payload));
+  }
+
   // Public method to emit chat events (used by init hooks and other workspace events)
   emitChatEvent(message: WorkspaceChatMessage): void {
     // Destructive disposal keeps raw terminal presentation separate from late policy work.
@@ -7103,10 +7115,16 @@ export class AgentSession {
       return;
     }
 
-    this.emitter.emit("chat-event", {
-      workspaceId: this.workspaceId,
-      message,
-    } satisfies AgentSessionChatEvent);
+    const event = { workspaceId: this.workspaceId, message } satisfies AgentSessionChatEvent;
+    const replay = this.replayPublication.getStore();
+    if (replay && "replay" in message && message.replay === true) {
+      // Async-local routing isolates concurrent reconnects without redirecting live
+      // provider events or resetting another subscriber's active-stream queue state.
+      replay.emittedStreamEvents = true;
+      replay.listener(event);
+      return;
+    }
+    this.emitter.emit("chat-event", event);
   }
 
   private publishTurnPhase(next: TurnPhase, isCurrent: () => boolean): void {

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -6810,6 +6810,16 @@ export class AgentSession {
     };
 
     forward("stream-start", (payload) => {
+      if (payload.type === "stream-start" && payload.replay === true) {
+        // Reconnect needs the stream envelope even when its live start was already
+        // admitted. Replay must not rerun start policy or revive a retired attempt.
+        if (
+          this.streamManager.getStreamInfo(this.workspaceId)?.messageId === payload.messageId &&
+          this.coordinator.canReplayStreamStart(payload.messageId)
+        )
+          this.emitChatEvent(payload);
+        return;
+      }
       if (payload.type === "stream-start" && this.coordinator.streamStarted(payload)) {
         this.emitChatEvent(payload);
       }

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -1326,12 +1326,13 @@ export class AgentSession {
 
   async replayHistory(
     listener: (event: AgentSessionChatEvent) => void,
-    mode?: OnChatMode
+    mode?: OnChatMode,
+    beforeReplayCompletion?: () => void
   ): Promise<void> {
     this.assertNotDisposed("replayHistory");
     assert(typeof listener === "function", "listener must be a function");
     await this.replayPublication.run({ listener, emittedStreamEvents: false }, () =>
-      this.emitHistoricalEvents(listener, mode)
+      this.emitHistoricalEvents(listener, mode, beforeReplayCompletion)
     );
   }
 
@@ -2673,7 +2674,8 @@ export class AgentSession {
 
   private async emitHistoricalEvents(
     listener: (event: AgentSessionChatEvent) => void,
-    mode?: OnChatMode
+    mode?: OnChatMode,
+    beforeReplayCompletion?: () => void
   ): Promise<void> {
     let replayMode: "full" | "since" | "live" = "full";
     let hasOlderHistory: boolean | undefined;
@@ -3010,6 +3012,8 @@ export class AgentSession {
       // Replay failed, so do not advertise a trustworthy reconnect cursor.
       serverCursor = undefined;
     } finally {
+      // Flush overlapping live events before authoritative final snapshots, including on replay failure.
+      beforeReplayCompletion?.();
       if (shouldReplayTerminalState) {
         // Replay the latest terminal/preparing state one last time before caught-up in case the
         // stream changed while history was replaying (for example PREPARING -> failed/idle).

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -1181,6 +1181,10 @@ export class AgentSession {
 
     this.attachAiListeners();
     this.attachInitListeners();
+    // A subscription is lazy: protect an existing engine before any caller can
+    // send through this new session, even before replay is first pulled.
+    const existingStream = this.streamManager.getStreamInfo(this.workspaceId);
+    if (existingStream) this.coordinator.observeStreamReplay(existingStream.messageId);
     eventSpine.emit("session.start", { workspaceId: this.workspaceId });
   }
 
@@ -2741,6 +2745,10 @@ export class AgentSession {
     // try/catch/finally guarantees caught-up is always sent, even if replay fails.
     // Without caught-up, the frontend stays in "Loading workspace..." forever.
     try {
+      // Reserve the observed engine before history/tokenization awaits or the first
+      // lifecycle publication can reenter a manual send. The envelope arrives later.
+      const initialStreamInfo = this.streamManager.getStreamInfo(this.workspaceId);
+      if (initialStreamInfo) this.coordinator.observeStreamReplay(initialStreamInfo.messageId);
       if (shouldReplayTerminalState) {
         // Rehydrate the current terminal/preparing state immediately so reconnect clients do not
         // regress to transcript heuristics while the rest of replay is still streaming in.
@@ -2753,7 +2761,7 @@ export class AgentSession {
         // Live mode still needs stream context when a response is currently active.
         // Replay only stream-start (no historical deltas/tool updates) so clients can
         // attach future live events to the correct message.
-        const liveStreamInfo = this.streamManager.getStreamInfo(this.workspaceId);
+        const liveStreamInfo = initialStreamInfo;
         if (liveStreamInfo) {
           const streamLastTimestamp = this.getStreamLastTimestamp(liveStreamInfo);
           await this.streamManager.replayStream(this.workspaceId, {
@@ -2782,7 +2790,7 @@ export class AgentSession {
 
       // Read partial BEFORE iterating history so we can skip the corresponding
       // placeholder message (which has empty parts). The partial has the real content.
-      const streamInfo = this.streamManager.getStreamInfo(this.workspaceId);
+      const streamInfo = initialStreamInfo;
       const partial = await this.historyService.readPartial(this.workspaceId);
       const partialHistorySequence = partial?.metadata?.historySequence;
 

--- a/src/node/services/replayBufferedStreamMessageRelay.test.ts
+++ b/src/node/services/replayBufferedStreamMessageRelay.test.ts
@@ -3,6 +3,66 @@ import type { WorkspaceChatMessage } from "@/common/orpc/types";
 import { createReplayBufferedStreamMessageRelay } from "./replayBufferedStreamMessageRelay";
 
 describe("createReplayBufferedStreamMessageRelay", () => {
+  test("keeps early live successor events ordered across independent replay windows", () => {
+    const outputs: WorkspaceChatMessage[][] = [[], []];
+    const relays = outputs.map((output) =>
+      createReplayBufferedStreamMessageRelay((message) => output.push(message))
+    );
+    const start: WorkspaceChatMessage = {
+      type: "stream-start",
+      workspaceId: "workspace",
+      messageId: "B",
+      model: "model",
+      historySequence: 1,
+      startTime: 1,
+    };
+    const delta: WorkspaceChatMessage = {
+      type: "stream-delta",
+      workspaceId: "workspace",
+      messageId: "B",
+      delta: "live text",
+      tokens: 1,
+      timestamp: 20,
+    };
+    for (const relay of relays) {
+      relay.handleSessionMessage({
+        type: "stream-abort",
+        workspaceId: "workspace",
+        messageId: "A",
+        abortReason: "user",
+      });
+      relay.handleSessionMessage(start);
+      relay.handleSessionMessage(delta);
+      relay.handleReplayMessage({
+        type: "stream-lifecycle",
+        workspaceId: "workspace",
+        phase: "streaming",
+        hadAnyOutput: true,
+      });
+    }
+    expect(outputs.map((output) => output.map((message) => message.type))).toEqual([
+      ["stream-lifecycle"],
+      ["stream-lifecycle"],
+    ]);
+    relays[0].handleReplayMessage({ ...start, replay: true });
+    relays[0].handleReplayMessage({ ...delta, replay: true });
+    relays[0].finishReplay();
+    // The second replay has its own cursor window and has not reached B's snapshot yet.
+    expect(outputs[1]).toHaveLength(1);
+    relays[1].handleReplayMessage({ ...start, replay: true });
+    relays[1].finishReplay();
+    for (const output of outputs) {
+      expect(output.map((message) => message.type)).toEqual([
+        "stream-lifecycle",
+        "stream-abort",
+        "stream-start",
+        "stream-start",
+        "stream-delta",
+      ]);
+      expect(output.filter((message) => message.type === "stream-delta")).toHaveLength(1);
+    }
+  });
+
   test("buffers live init events until replay finishes", () => {
     const pushed: WorkspaceChatMessage[] = [];
     const relay = createReplayBufferedStreamMessageRelay((message) => {

--- a/src/node/services/replayBufferedStreamMessageRelay.ts
+++ b/src/node/services/replayBufferedStreamMessageRelay.ts
@@ -1,53 +1,23 @@
 import type { WorkspaceChatMessage } from "@/common/orpc/types";
 
-type ReplayBufferedSessionMessage = Extract<
-  WorkspaceChatMessage,
-  {
-    type:
-      | "stream-delta"
-      | "reasoning-delta"
-      | "stream-end"
-      | "stream-abort"
-      | "stream-error"
-      | "init-start"
-      | "init-output"
-      | "init-end";
-  }
->;
-
 type ReplayBufferedDeltaMessage = Extract<
-  ReplayBufferedSessionMessage,
+  WorkspaceChatMessage,
   { type: "stream-delta" | "reasoning-delta" }
 >;
 
-function isReplayBufferedSessionMessage(
-  message: WorkspaceChatMessage
-): message is ReplayBufferedSessionMessage {
-  return (
-    message.type === "stream-delta" ||
-    message.type === "reasoning-delta" ||
-    message.type === "stream-end" ||
-    message.type === "stream-abort" ||
-    message.type === "stream-error" ||
-    message.type === "init-start" ||
-    message.type === "init-output" ||
-    message.type === "init-end"
-  );
-}
-
 function isReplayBufferedDeltaMessage(
-  message: ReplayBufferedSessionMessage
+  message: WorkspaceChatMessage
 ): message is ReplayBufferedDeltaMessage {
   return message.type === "stream-delta" || message.type === "reasoning-delta";
 }
 
 type ReplayBufferedInitMessage = Extract<
-  ReplayBufferedSessionMessage,
+  WorkspaceChatMessage,
   { type: "init-start" | "init-output" | "init-end" }
 >;
 
 function isReplayBufferedInitMessage(
-  message: ReplayBufferedSessionMessage
+  message: WorkspaceChatMessage
 ): message is ReplayBufferedInitMessage {
   return (
     message.type === "init-start" || message.type === "init-output" || message.type === "init-end"
@@ -88,10 +58,11 @@ export function createReplayBufferedStreamMessageRelay(
   push: (message: WorkspaceChatMessage) => void
 ): {
   handleSessionMessage: (message: WorkspaceChatMessage) => void;
+  handleReplayMessage: (message: WorkspaceChatMessage) => void;
   finishReplay: () => void;
 } {
   let isReplaying = true;
-  const bufferedLiveSessionMessages: ReplayBufferedSessionMessage[] = [];
+  const bufferedLiveSessionMessages: WorkspaceChatMessage[] = [];
 
   // Counters (not Sets) so we don't drop more buffered events than were replayed.
   const replayedDeltaKeyCounts = new Map<string, number>();
@@ -135,39 +106,43 @@ export function createReplayBufferedStreamMessageRelay(
     return true;
   };
 
-  const handleSessionMessage = (message: WorkspaceChatMessage) => {
-    if (isReplaying && isReplayBufferedSessionMessage(message)) {
-      if (!isReplayMessage(message)) {
-        // Preserve live ordering during replay buffering. Init events need the same isolation as
-        // stream events so reconnect replay cannot blank the row or drop lines due to reordering.
-        bufferedLiveSessionMessages.push(message);
-        return;
-      }
-
-      // Track replayed deltas/init events so buffered live events from the same window do not
-      // double-apply after `caught-up`.
-      if (isReplayBufferedDeltaMessage(message)) {
-        noteReplayedDelta(message);
-      } else if (isReplayBufferedInitMessage(message)) {
-        noteReplayedInit(message);
-      }
+  const flushBuffered = (count = bufferedLiveSessionMessages.length) => {
+    for (const message of bufferedLiveSessionMessages.splice(0, count)) {
+      if (isReplayBufferedDeltaMessage(message) && shouldDropBufferedDelta(message)) continue;
+      if (isReplayBufferedInitMessage(message) && shouldDropBufferedInit(message)) continue;
+      push(message);
     }
+  };
 
+  const handleReplayMessage = (message: WorkspaceChatMessage) => {
+    if (isReplaying) {
+      if (message.type === "stream-start") {
+        const startIndex = bufferedLiveSessionMessages.findIndex(
+          (event) => event.type === "stream-start" && event.messageId === message.messageId
+        );
+        // Deliver the predecessor terminal and successor's normal start before its replay
+        // snapshot. A normal start delivered later would erase the replayed successor content.
+        if (startIndex >= 0) flushBuffered(startIndex + 1);
+      }
+      if (isReplayBufferedDeltaMessage(message)) noteReplayedDelta(message);
+      else if (isReplayBufferedInitMessage(message)) noteReplayedInit(message);
+    }
     push(message);
   };
 
-  const finishReplay = () => {
-    // Flush buffered live session messages after replay (`caught-up` already queued by replayHistory).
-    for (const message of bufferedLiveSessionMessages) {
-      if (isReplayBufferedDeltaMessage(message) && shouldDropBufferedDelta(message)) {
-        continue;
-      }
-      if (isReplayBufferedInitMessage(message) && shouldDropBufferedInit(message)) {
-        continue;
-      }
+  const handleSessionMessage = (message: WorkspaceChatMessage) => {
+    if (isReplayMessage(message)) {
+      handleReplayMessage(message);
+    } else if (isReplaying) {
+      // Buffer the whole live event family so terminals cannot overtake starts or tools.
+      bufferedLiveSessionMessages.push(message);
+    } else {
       push(message);
     }
+  };
 
+  const finishReplay = () => {
+    flushBuffered();
     isReplaying = false;
 
     // Avoid retaining replay keys for the lifetime of the subscription.
@@ -176,5 +151,5 @@ export function createReplayBufferedStreamMessageRelay(
     bufferedLiveSessionMessages.length = 0;
   };
 
-  return { handleSessionMessage, finishReplay };
+  return { handleSessionMessage, handleReplayMessage, finishReplay };
 }

--- a/src/node/services/turnCoordinator.test.ts
+++ b/src/node/services/turnCoordinator.test.ts
@@ -63,6 +63,34 @@ function reduce(events: CoordinatorEvent[]) {
 }
 
 describe("TurnCoordinator", () => {
+  test("replay eligibility observes existing streams without starting or reviving operations", () => {
+    const streamStarted = mock(() => undefined);
+    const { coordinator, callbacks } = setup({ streamStarted });
+    expect(coordinator.canReplayStreamStart("existing-engine")).toBe(true);
+    expect(coordinator.phase).toBe("idle");
+    expect(callbacks.phaseChanged).not.toHaveBeenCalled();
+    expect(streamStarted).not.toHaveBeenCalled();
+    const op = coordinator.registerOperation(prepare(coordinator));
+    expect(coordinator.canReplayStreamStart("active")).toBe(false);
+    coordinator.streamStarted(startEvent("active"));
+    expect(coordinator.canReplayStreamStart("active")).toBe(true);
+    expect(coordinator.canReplayStreamStart("stale")).toBe(false);
+    expect(streamStarted).toHaveBeenCalledTimes(1);
+    coordinator.rawTerminal("completed", "active");
+    expect(coordinator.canReplayStreamStart("active")).toBe(false);
+    coordinator.finishStartup(op);
+    coordinator.dispose();
+
+    const closing = setup().coordinator;
+    const closingOp = closing.registerOperation(prepare(closing));
+    closing.streamStarted(startEvent("closing"));
+    expect(closing.canReplayStreamStart("closing")).toBe(true);
+    closing.beginShutdown();
+    expect(closing.canReplayStreamStart("closing")).toBe(false);
+    closing.finishStartup(closingOp);
+    closing.dispose();
+  });
+
   test("session scope releases thinking and idle listeners even without another idle event", async () => {
     const scope = Scope.makeUnsafe("parallel");
     const { coordinator } = setup();

--- a/src/node/services/turnCoordinator.test.ts
+++ b/src/node/services/turnCoordinator.test.ts
@@ -63,6 +63,34 @@ function reduce(events: CoordinatorEvent[]) {
 }
 
 describe("TurnCoordinator", () => {
+  test("observed terminal publishes before idle/drain and cannot retire a reentrant replacement", () => {
+    const order: string[] = [];
+    const { coordinator, callbacks } = setup({
+      phaseChanged: () => {
+        order.push(coordinator.phase);
+      },
+      drainQueue: () => {
+        order.push("drain");
+      },
+    });
+    expect(coordinator.observeStreamReplay("A")).toBe(true);
+    expect(coordinator.isBusy()).toBe(true);
+    order.length = 0;
+    expect(coordinator.finishObservedStream("stale", () => order.push("wrong"))).toBe(false);
+    expect(coordinator.finishObservedStream("A", () => order.push("terminal"))).toBe(true);
+    expect(order).toEqual(["terminal", "idle", "drain"]);
+    expect(callbacks.policy).not.toHaveBeenCalled();
+    expect(coordinator.observeStreamReplay("B")).toBe(true);
+    let replacement: TurnId | undefined;
+    coordinator.finishObservedStream("B", () => {
+      replacement = prepare(coordinator);
+    });
+    expect(replacement).toBeDefined();
+    expect(replacement === coordinator.turnId).toBe(true);
+    expect(coordinator.phase).toBe("preparing");
+    coordinator.dispose();
+  });
+
   test("replay eligibility observes existing streams without starting or reviving operations", () => {
     const streamStarted = mock(() => undefined);
     const { coordinator, callbacks } = setup({ streamStarted });

--- a/src/node/services/turnCoordinator.ts
+++ b/src/node/services/turnCoordinator.ts
@@ -841,6 +841,20 @@ export class TurnCoordinator {
   streamStarting(id: OperationId, messageId: string): void {
     this.dispatch({ type: "starting", id, messageId });
   }
+  canReplayStreamStart(messageId: string): boolean {
+    if (this.closing) return false;
+    const operation = this.state.turn.operation;
+    // A newly constructed session can observe an existing engine without owning
+    // its operation. The caller also verifies the engine's current message ID.
+    if (!operation) return this.phase === "idle" || this.phase === "streaming";
+    return (
+      this.phase === "streaming" &&
+      operation.stage === "started" &&
+      operation.delivery === "waiting" &&
+      operation.messageId === messageId
+    );
+  }
+
   streamStarted(payload: StreamStartEvent): boolean {
     const previous = this.state;
     const turn = this.turnId;

--- a/src/node/services/turnCoordinator.ts
+++ b/src/node/services/turnCoordinator.ts
@@ -39,10 +39,16 @@ type Operation = {
 );
 
 type Turn =
-  | { readonly phase: "idle"; readonly id: TurnId; readonly operation?: Operation }
+  | {
+      readonly phase: "idle";
+      readonly id: TurnId;
+      readonly observedMessageId?: string;
+      readonly operation?: Operation;
+    }
   | {
       readonly phase: Exclude<TurnPhase, "idle">;
       readonly id: TurnId;
+      readonly observedMessageId?: string;
       readonly operation?: Operation;
     };
 interface Decision {
@@ -69,6 +75,8 @@ export type CoordinatorEvent =
   | { type: "configure-operation"; id: OperationId; compaction: boolean }
   | { type: "starting"; id: OperationId; messageId: string }
   | { type: "started"; payload: StreamStartEvent }
+  | { type: "observe-stream"; messageId: string }
+  | { type: "finish-observed-stream"; id: TurnId; messageId: string }
   | { type: "raw-terminal"; kind: "completed" | "aborted"; messageId: string }
   | { type: "startup-abort"; messageId: string }
   | { type: "completion"; id: OperationId; messageId: string; outcome: TurnCompletion }
@@ -246,6 +254,25 @@ export function transition(
       break;
     case "starting":
       if (current?.id === event.id) operation({ ...current, startupMessageId: event.messageId });
+      break;
+    case "observe-stream":
+      if (
+        state.lifetime === "open" &&
+        !current &&
+        state.turn.observedMessageId == null &&
+        (state.turn.phase === "idle" || state.turn.phase === "streaming")
+      )
+        phase({ ...state.turn, phase: "streaming", observedMessageId: event.messageId });
+      break;
+    case "finish-observed-stream":
+      if (
+        !current &&
+        state.turn.id === event.id &&
+        state.turn.observedMessageId === event.messageId
+      ) {
+        phase({ id: state.turn.id, phase: "idle" });
+        commands.push({ type: "drain", turnId: state.turn.id });
+      }
       break;
     case "started":
       if (current && (current.delivery !== "waiting" || current.stage === "started")) break;
@@ -841,12 +868,35 @@ export class TurnCoordinator {
   streamStarting(id: OperationId, messageId: string): void {
     this.dispatch({ type: "starting", id, messageId });
   }
+  observeStreamReplay(messageId: string): boolean {
+    if (!this.canReplayStreamStart(messageId)) return false;
+    this.dispatch({ type: "observe-stream", messageId });
+    return this.canReplayStreamStart(messageId);
+  }
+
+  finishObservedStream(messageId: string, publish: () => void): boolean {
+    const turn = this.state.turn;
+    if (turn.operation || turn.observedMessageId !== messageId) return false;
+    try {
+      publish();
+    } finally {
+      this.dispatch({ type: "finish-observed-stream", id: turn.id, messageId });
+    }
+    return true;
+  }
+
   canReplayStreamStart(messageId: string): boolean {
     if (this.closing) return false;
     const operation = this.state.turn.operation;
     // A newly constructed session can observe an existing engine without owning
     // its operation. The caller also verifies the engine's current message ID.
-    if (!operation) return this.phase === "idle" || this.phase === "streaming";
+    if (!operation)
+      return (
+        this.phase === "idle" ||
+        (this.phase === "streaming" &&
+          (this.state.turn.observedMessageId == null ||
+            this.state.turn.observedMessageId === messageId))
+      );
     return (
       this.phase === "streaming" &&
       operation.stage === "started" &&


### PR DESCRIPTION
## Summary

Opening or reconnecting to a chat during an active response could show “Stream interrupted” while the backend continued working, with the UI recovering only when the turn finished. Restore each subscriber's stream initialization, preserve admission safety while observing an existing engine, and isolate simultaneous replay deliveries.

## Cause and fix

The coordinator integration in #4109 suppressed `stream-start` whenever the current operation had already started. That also suppressed replayed starts, although subsequent replayed and live text/tool events still reached subscribers. The frontend therefore received response events without their stream initialization.

- Forward matching replayed starts without admitting the backend operation again. Reject mismatched, completed, or closing operation replays.
- When a session observes an existing engine without owning its operation, reserve busy state during construction and at replay entry, before callbacks or history/tokenization awaits. Hold it until the matching completion, interruption, or error is published. Queued input then drains normally; stale terminals cannot release a replacement.
- Route replay-only events and cursor/error bookkeeping through a separate async context for each subscription. The requesting relay still deduplicates overlapping live events. Reconnecting one client no longer resets another client's queued-follow-up state or mixes concurrent replay windows.
- Keep the complete overlapping live-event sequence ordered with targeted replay. Deliver the predecessor terminal and successor's normal start before its replay snapshot, then flush remaining live events before final lifecycle/queue snapshots and catch-up. An old abort/error cannot clear a newly active successor, and a delayed normal start cannot erase replayed content.

## Validation

- Direct localhost WebSocket subscriptions to the affected running main build reproduced the missing start with active-stream cursors, replayed response content, heartbeats, and subsequent live tool events. This bypassed the Coder proxy and browser.
- A differential test using the real StreamManager start-event producer, AgentSession, disk-backed HistoryService, and chat router failed on main `373257bbc` and passed before the refactor at `5cca5bf5f`.
- The permanent regression verifies the replayed envelope precedes response deltas and `caught-up`, with live deltas arriving before terminal completion. Additional tests cover exact terminal queue release, stale/reentrant lifecycle events, three simultaneous subscribers with distinct cursors, preserved queue state in real aggregators, and canceled replay isolation.
- 1,938 tests pass: 434 session/router/relay, 190 stream engine, 153 frontend store/subscription transport, and 1,161 workspace/task/container. Full canonical `make static-check` passes. Disposal coverage verifies a held replay releases its async context, suppresses late deltas, and leaves sibling sessions working.
- Six actual WorkspaceStore regressions exercise abort/error across full/since/live replay through the real AgentSession, history, and chat router. They verify successor lifecycle and exact-once text, reasoning, and completed tool output after replay delivery.
- Full, since, and live replay tests hold history/token setup through engine termination and a queued successor's admission. Losing the active snapshot alone cannot release the queue; the exact terminal does, and delayed old replay cannot replace the successor's ownership or reconnect cursor. Separate regressions cover lazy subscription construction and reentrant lifecycle callbacks.

## Risks

Replay delivery now has explicit subscription scope, and passively observed engines have lifecycle identity without operation policy. The main risks are losing replay/live ordering, releasing admission too early, or retaining a stale observed stream; deterministic concurrency and terminal tests cover these boundaries.

---

_Generated with `xum` • Model: `unavailable` • Thinking: `unavailable` • Cost: `$unavailable`_

<!-- mux-attribution: model=unavailable thinking=unavailable costs=unavailable -->
