### PR TITLE
🤖 fix: enable GPT-6 Astra Pro mode through Coder

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -995,6 +995,7 @@ function AppInner() {
     getEffectiveComposerModel: getModelForWorkspace,
     providersConfig,
     getRouteForModel,
+    getEffectiveRouteForModel: (modelString) => routing.resolveEffectiveRoute(modelString),
     getMinThinkingOverride,
     onStartScratchCreation: openNewScratchFromPalette,
     onStartWorkspaceCreation: openNewWorkspaceFromPalette,

--- a/src/browser/components/ThinkingSelector/ThinkingSelector.tsx
+++ b/src/browser/components/ThinkingSelector/ThinkingSelector.tsx
@@ -129,7 +129,7 @@ export const ThinkingSelectorControl: React.FC<ThinkingSelectorControlProps> = (
           props.allowProMode !== false &&
           openaiProModeAvailable(props.modelString, {
             providersConfig,
-            resolvedRouteProvider: resolvedRoute,
+            effectiveRouteProvider: routing.resolveEffectiveRoute(props.modelString),
           }),
         fastModeProvider:
           props.allowFastMode !== false && providersConfig != null

--- a/src/browser/features/Settings/Sections/ExperimentsSection.advisor.test.tsx
+++ b/src/browser/features/Settings/Sections/ExperimentsSection.advisor.test.tsx
@@ -1,6 +1,8 @@
 import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import * as ActualMinThinkingLevelsModule from "@/browser/hooks/useMinThinkingLevels";
+import * as ActualRoutingModule from "@/browser/hooks/useRouting";
 import * as ActualSelectPrimitiveModule from "@/browser/components/SelectPrimitive/SelectPrimitive";
 import { ThemeProvider } from "@/browser/contexts/ThemeContext";
 import type { ProvidersConfigMap } from "@/common/orpc/types";
@@ -38,6 +40,10 @@ interface MockAPIClient {
     saveConfig: (input: SaveConfigInput) => Promise<void>;
   };
 }
+
+// Capture before installing module mocks; mock.restore() does not undo them.
+const actualMinThinkingLevelsModule = { ...ActualMinThinkingLevelsModule };
+const actualRoutingModule = { ...ActualRoutingModule };
 
 let mockApi: MockAPIClient;
 let providersConfig: ProvidersConfigMap | null = null;
@@ -105,7 +111,10 @@ void mock.module("@/browser/hooks/useProvidersConfig", () => ({
   useProvidersConfig: () => ({ config: providersConfig }),
 }));
 void mock.module("@/browser/hooks/useRouting", () => ({
-  useRouting: () => ({ resolveRoute: () => ({ route: "direct" }) }),
+  useRouting: () => ({
+    resolveRoute: () => ({ route: "direct" }),
+    resolveEffectiveRoute: () => "direct",
+  }),
 }));
 
 import { ExperimentsSection } from "./ExperimentsSection";
@@ -157,6 +166,11 @@ function createMockAPI(configOverrides: Partial<MockConfig> = {}) {
 
 describe("ExperimentsSection advisor config", () => {
   let cleanupDom: (() => void) | null = null;
+
+  afterAll(async () => {
+    await mock.module("@/browser/hooks/useMinThinkingLevels", () => actualMinThinkingLevelsModule);
+    await mock.module("@/browser/hooks/useRouting", () => actualRoutingModule);
+  });
 
   beforeEach(() => {
     cleanupDom = installDom();

--- a/src/browser/features/Settings/Sections/ProvidersSection.test.tsx
+++ b/src/browser/features/Settings/Sections/ProvidersSection.test.tsx
@@ -1,11 +1,12 @@
 import type React from "react";
 import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { installDom } from "../../../../../tests/ui/dom";
 import { createSelectPrimitiveDouble } from "../../../../../tests/ui/selectPrimitiveDouble";
 import type { APIClient } from "@/browser/contexts/API";
 import * as ActualSelectPrimitiveModule from "@/browser/components/SelectPrimitive/SelectPrimitive";
+import * as ActualRoutingModule from "@/browser/hooks/useRouting";
 import * as SettingsContextModule from "@/browser/contexts/SettingsContext";
 import type * as WorkspaceStoreModule from "@/browser/stores/WorkspaceStore";
 import type * as WorkspaceContextModule from "@/browser/contexts/WorkspaceContext";
@@ -64,11 +65,17 @@ void mock.module("@/browser/hooks/useProvidersConfig", () => ({
   }),
 }));
 
+const actualRoutingModule = { ...ActualRoutingModule };
+afterAll(async () => {
+  await mock.module("@/browser/hooks/useRouting", () => actualRoutingModule);
+});
+
 void mock.module("@/browser/hooks/useRouting", () => ({
   useRouting: () => ({
     routePriority: ["direct"],
     routeOverrides: {},
     resolveRoute: () => ({ route: "direct", isAuto: true, displayName: "Direct" }),
+    resolveEffectiveRoute: () => "direct",
     availableRoutes: () => [],
     setRoutePreferences: () => undefined,
     setRoutePriority: () => undefined,

--- a/src/browser/hooks/useModelsFromSettings.test.ts
+++ b/src/browser/hooks/useModelsFromSettings.test.ts
@@ -86,6 +86,7 @@ const useRoutingMock = mock(() => ({
   routePriority,
   routeOverrides,
   resolveRoute: () => ({ route: "direct", isAuto: true, displayName: "Direct" }),
+  resolveEffectiveRoute: () => "direct",
   availableRoutes: () => [],
   setRoutePreferences: () => {
     /* noop */

--- a/src/browser/hooks/useModelsFromSettings.test.ts
+++ b/src/browser/hooks/useModelsFromSettings.test.ts
@@ -575,6 +575,29 @@ describe("useModelsFromSettings OpenAI Codex OAuth gating", () => {
     expect(result.current.models).not.toContain("openai:gpt-5.2-pro");
   });
 
+  test("policy-hidden Coder metadata does not expose Coder models or routes", () => {
+    providersConfig = {
+      openai: { apiKeySet: true, isEnabled: true, isConfigured: true },
+      coder: {
+        apiKeySet: false,
+        isEnabled: false,
+        isConfigured: false,
+        discoveredProviders: [{ name: "prod-openai", type: "openai" }],
+      },
+    };
+    routePriority = ["coder", "direct"];
+    enforcedPolicy = buildEnforcedPolicy([{ id: "openai", allowedModels: null }]);
+    const { result } = renderHook(() => useModelsFromSettings());
+    expect(result.current.models).toContain(KNOWN_MODELS.GPT_6_ASTRA.id);
+    expect(result.current.models.some((model) => model.startsWith("coder:"))).toBe(false);
+    expect(getSuggestedModels(providersConfig).some((model) => model.startsWith("coder:"))).toBe(
+      false
+    );
+    expect(result.current.isAllowedByPolicyOnActiveRoute("coder:prod-openai/gpt-6-astra")).toBe(
+      false
+    );
+  });
+
   test("a gateway-only policy keeps models whose active route is that gateway", () => {
     providersConfig = {
       openai: {

--- a/src/browser/hooks/useRouting.test.ts
+++ b/src/browser/hooks/useRouting.test.ts
@@ -256,6 +256,53 @@ describe("useRouting", () => {
     ).toBe(false);
   });
 
+  test.each(["direct", "mux-gateway"])(
+    "policy-hidden Coder metadata preserves the %s fallback for Pro",
+    async (fallback) => {
+      const model = "coder:prod-openai/gpt-6-astra";
+      providersConfig = {
+        openai: { apiKeySet: true, isEnabled: true, isConfigured: true },
+        "mux-gateway": { apiKeySet: true, isEnabled: true, isConfigured: true },
+        coder: {
+          apiKeySet: false,
+          isEnabled: false,
+          isConfigured: false,
+          discoveredProviders: [{ name: "prod-openai", type: "openai" }],
+        },
+      };
+      routePriority = ["coder", fallback];
+      policyResponse = {
+        source: "env",
+        status: { state: "enforced" },
+        policy: {
+          policyFormatVersion: "0.1",
+          providerAccess: [
+            { id: "openai", allowedModels: null },
+            { id: "mux-gateway", allowedModels: null },
+          ],
+          mcp: { allowUserDefined: { stdio: true, remote: true } },
+          runtimes: null,
+        },
+      };
+      getProvidersConfigStore().setClient(stubClient);
+      getAppConfigStore().setClient(stubClient);
+      const { result } = renderHook(() => useRouting(), { wrapper });
+      await waitFor(() => expect(result.current.routePriority).toEqual(routePriority));
+      expect(result.current.resolveEffectiveRoute(model)).toBe(fallback);
+      expect(
+        result.current
+          .availableRoutes("openai:gpt-6-astra")
+          .some((route) => route.route === "coder")
+      ).toBe(false);
+      expect(
+        openaiProModeAvailable(model, {
+          providersConfig,
+          effectiveRouteProvider: result.current.resolveEffectiveRoute(model),
+        })
+      ).toBe(fallback === "direct");
+    }
+  );
+
   test("hook instances share one config fetch via the AppConfigStore", async () => {
     routeOverrides = { "openai:gpt-5.4": "mux-gateway" };
     let configFetchCount = 0;

--- a/src/browser/hooks/useRouting.test.ts
+++ b/src/browser/hooks/useRouting.test.ts
@@ -11,6 +11,7 @@ import { getAppConfigStore } from "@/browser/stores/AppConfigStore";
 import { getProvidersConfigStore } from "@/browser/stores/ProvidersConfigStore";
 
 import { useRouting } from "./useRouting";
+import { openaiProModeAvailable } from "@/common/utils/ai/proMode";
 
 let providersConfig: ProvidersConfigMap | null = null;
 let routePriority: string[] = ["direct"];
@@ -167,6 +168,92 @@ describe("useRouting", () => {
       expect(viaGateway(KNOWN_MODELS.GPT.id)).toBe(true);
       expect(result.current.resolveRoute(KNOWN_MODELS.GPT.id).route).toBe("mux-gateway");
     });
+  });
+
+  const coderFallbackCases: Array<{
+    availability: Partial<NonNullable<ProvidersConfigMap["coder"]>>;
+    override?: string;
+    expected: string;
+  }> = [
+    { availability: { isEnabled: false }, override: undefined, expected: "mux-gateway" },
+    {
+      availability: { discoveredModels: [], models: [] },
+      override: undefined,
+      expected: "mux-gateway",
+    },
+    {
+      availability: { removedModels: ["prod-openai/gpt-6-astra"] },
+      override: undefined,
+      expected: "mux-gateway",
+    },
+    { availability: { isEnabled: false }, override: "direct", expected: "direct" },
+    { availability: {}, override: "direct", expected: "coder" },
+  ];
+  test.each(coderFallbackCases)(
+    "resolves Pro's effective custom-instance route: %j",
+    async (testCase) => {
+      const model = "coder:prod-openai/gpt-6-astra";
+      providersConfig = {
+        openai: { apiKeySet: true, isEnabled: true, isConfigured: true },
+        "mux-gateway": { apiKeySet: true, isEnabled: true, isConfigured: true },
+        coder: {
+          apiKeySet: false,
+          isEnabled: true,
+          isConfigured: true,
+          discoveredProviders: [{ name: "prod-openai", type: "openai" }],
+          // Capability overrides must not change the fallback's provider or route key.
+          models: [{ id: "prod-openai/gpt-6-astra", mappedToModel: "anthropic:claude-opus-4-6" }],
+          ...testCase.availability,
+        },
+      };
+      routePriority = ["mux-gateway", "direct"];
+      if (testCase.override) routeOverrides = { "openai:gpt-6-astra": testCase.override };
+      getProvidersConfigStore().setClient(stubClient);
+      getAppConfigStore().setClient(stubClient);
+      const { result } = renderHook(() => useRouting(), { wrapper });
+      await waitFor(() => expect(result.current.routePriority).toEqual(routePriority));
+      expect(result.current.resolveEffectiveRoute(model)).toBe(testCase.expected);
+    }
+  );
+
+  test("Pro honors policy rejection even when Coder's catalog lists the model", async () => {
+    const model = "coder:openai/gpt-6-astra";
+    providersConfig = {
+      openai: { apiKeySet: true, isEnabled: true, isConfigured: true },
+      "mux-gateway": { apiKeySet: true, isEnabled: true, isConfigured: true },
+      coder: {
+        apiKeySet: false,
+        isEnabled: true,
+        isConfigured: true,
+        models: ["openai/gpt-6-astra"],
+        discoveredModels: ["openai/gpt-6-astra"],
+      },
+    };
+    routePriority = ["coder", "mux-gateway", "direct"];
+    policyResponse = {
+      source: "env",
+      status: { state: "enforced" },
+      policy: {
+        policyFormatVersion: "0.1",
+        providerAccess: [
+          { id: "openai", allowedModels: null },
+          { id: "coder", allowedModels: [] },
+          { id: "mux-gateway", allowedModels: null },
+        ],
+        mcp: { allowUserDefined: { stdio: true, remote: true } },
+        runtimes: null,
+      },
+    };
+    getProvidersConfigStore().setClient(stubClient);
+    getAppConfigStore().setClient(stubClient);
+    const { result } = renderHook(() => useRouting(), { wrapper });
+    await waitFor(() => expect(result.current.resolveEffectiveRoute(model)).toBe("mux-gateway"));
+    expect(
+      openaiProModeAvailable(model, {
+        providersConfig,
+        effectiveRouteProvider: result.current.resolveEffectiveRoute(model),
+      })
+    ).toBe(false);
   });
 
   test("hook instances share one config fetch via the AppConfigStore", async () => {

--- a/src/browser/hooks/useRouting.ts
+++ b/src/browser/hooks/useRouting.ts
@@ -11,6 +11,8 @@ import {
 import { usePolicy } from "@/browser/contexts/PolicyContext";
 import { isGatewayModelAccessibleForUi } from "@/browser/utils/policyUi";
 import { normalizeToCanonical } from "@/common/utils/ai/models";
+import { resolveCoderGatewayMetadataModel } from "@/common/utils/providers/coderGatewayMetadata";
+import { isCustomProviderConfig } from "@/common/utils/providers/customProviders";
 
 import { useProvidersConfig } from "./useProvidersConfig";
 
@@ -42,6 +44,9 @@ export interface RoutingState {
     isAuto: boolean;
     displayName: string;
   };
+
+  /** Actual route for a raw selection, including policy-aware explicit gateway fallback. */
+  resolveEffectiveRoute: (modelString: string) => string;
 
   /** What route would be used if all per-model overrides were cleared? */
   resolveAutoRoute(canonicalModel: string): {
@@ -172,6 +177,32 @@ export function useRouting(): RoutingState {
     [isConfigured, isGatewayModelAccessible, routeOverrides, routePriority]
   );
 
+  const resolveEffectiveRoute = (modelString: string): string => {
+    const [prefix] = modelString.split(":", 1);
+    if (isCustomProviderConfig(providersConfig?.[prefix])) return "direct";
+
+    let routeModel = modelString;
+    if (modelString.startsWith("coder:")) {
+      if (
+        isConfigured("coder") &&
+        isGatewayModelAccessible("coder", modelString.slice("coder:".length))
+      ) {
+        return "coder";
+      }
+      // Mirror the backend's type-derived fallback. Treat-as aliases describe
+      // capabilities only; they must never redirect a request to another provider.
+      routeModel = resolveCoderGatewayMetadataModel(modelString, providersConfig) ?? modelString;
+    }
+    const resolved = resolveRouteForModel(
+      routeModel,
+      routePriority,
+      routeOverrides,
+      isConfigured,
+      isGatewayModelAccessible
+    );
+    return resolved.routeProvider === resolved.origin ? "direct" : resolved.routeProvider;
+  };
+
   // Resolve ignoring per-model overrides — answers "what would Auto pick?"
   const resolveAutoRoute = useCallback(
     (canonicalModel: string) => {
@@ -204,6 +235,7 @@ export function useRouting(): RoutingState {
     routePriority,
     routeOverrides,
     resolveRoute,
+    resolveEffectiveRoute,
     resolveAutoRoute,
     availableRoutes,
     setRoutePreferences,

--- a/src/browser/stories/App.astraPro.stories.tsx
+++ b/src/browser/stories/App.astraPro.stories.tsx
@@ -1,0 +1,69 @@
+import { expect, userEvent, within } from "@storybook/test";
+import { appMeta, AppWithMocks, type AppStory } from "./meta.js";
+import { setupSimpleChatStory } from "./helpers/chatSetup";
+import { collapseLeftSidebar } from "./helpers/uiState";
+import { blurActiveElement, waitForChatInputAutofocusDone } from "./storyPlayHelpers";
+import { readPersistedState, updatePersistedState } from "@/browser/hooks/usePersistedState";
+import { getModelKey, getReasoningModeKey, getThinkingLevelKey } from "@/common/constants/storage";
+
+export default { ...appMeta, title: "App/Astra Pro" };
+
+const workspaceId = "ws-astra-pro";
+
+export const CoderGateway: AppStory = {
+  globals: { viewport: { value: "mobile1", isRotated: false } },
+  parameters: { pixel: { matrix: { themes: ["dark", "light"], viewports: ["phone"] } } },
+  render: () => (
+    <AppWithMocks
+      setup={() => {
+        collapseLeftSidebar();
+        updatePersistedState(getModelKey(workspaceId), "coder:openai/gpt-6-astra");
+        updatePersistedState(getThinkingLevelKey(workspaceId), "high");
+        updatePersistedState(getReasoningModeKey(workspaceId), "standard");
+        return setupSimpleChatStory({
+          workspaceId,
+          messages: [],
+          routePriority: ["coder"],
+          providersConfig: {
+            coder: {
+              apiKeySet: false,
+              isEnabled: true,
+              isConfigured: true,
+              models: ["openai/gpt-6-astra"],
+            },
+          },
+        });
+      }}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const root = document.getElementById("storybook-root") ?? canvasElement;
+    const canvas = within(root);
+    await waitForChatInputAutofocusDone(root);
+    blurActiveElement();
+    const trigger = canvas.getByRole("button", { name: /Thinking:/ });
+    await userEvent.click(trigger);
+    const pro = canvas.getByRole("button", { name: /Pro mode/ });
+    await expect(pro).toHaveAttribute("aria-pressed", "false");
+    await userEvent.click(pro);
+    await expect(pro).toHaveAttribute("aria-pressed", "true");
+    await expect(readPersistedState(getReasoningModeKey(workspaceId), "standard")).toBe("pro");
+    await expect(trigger).toHaveAccessibleName("Thinking: high, pro mode");
+    // Keyboard activation must also disable Pro without changing reasoning effort.
+    pro.focus();
+    await userEvent.keyboard(" ");
+    await expect(pro).toHaveAttribute("aria-pressed", "false");
+    await expect(trigger).toHaveAccessibleName("Thinking: high");
+    await userEvent.click(pro);
+    const menu = canvas.getByRole("listbox", { name: "Reasoning effort" });
+    await expect(menu.getBoundingClientRect().right).toBeLessThanOrEqual(window.innerWidth);
+    await expect(menu.getBoundingClientRect().left).toBeGreaterThanOrEqual(0);
+  },
+};
+
+export const Desktop: AppStory = {
+  ...CoderGateway,
+  globals: { viewport: { value: "desktop", isRotated: false } },
+  parameters: { pixel: { matrix: { themes: ["dark", "light"], viewports: ["laptop"] } } },
+  play: async (context) => CoderGateway.play!(context),
+};

--- a/src/browser/stories/App.astraPro.stories.tsx
+++ b/src/browser/stories/App.astraPro.stories.tsx
@@ -9,10 +9,25 @@ import { getModelKey, getReasoningModeKey, getThinkingLevelKey } from "@/common/
 export default { ...appMeta, title: "App/Astra Pro" };
 
 const workspaceId = "ws-astra-pro";
+const phoneViewport = { name: "Phone", styles: { width: "390px", height: "844px" } };
 
 export const CoderGateway: AppStory = {
-  globals: { viewport: { value: "mobile1", isRotated: false } },
-  parameters: { pixel: { matrix: { themes: ["dark", "light"], viewports: ["phone"] } } },
+  // The test-runner ignores viewport globals, so enforce the narrow container there too.
+  decorators: [
+    (Story) => (
+      <div
+        data-testid="astra-pro-phone"
+        style={{ width: `min(${phoneViewport.styles.width}, 100%)`, height: "100%" }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  globals: { viewport: { value: "astraPhone", isRotated: false } },
+  parameters: {
+    viewport: { options: { astraPhone: phoneViewport } },
+    pixel: { matrix: { themes: ["dark", "light"], viewports: ["phone"] } },
+  },
   render: () => (
     <AppWithMocks
       setup={() => {
@@ -56,13 +71,15 @@ export const CoderGateway: AppStory = {
     await expect(trigger).toHaveAccessibleName("Thinking: high");
     await userEvent.click(pro);
     const menu = canvas.getByRole("listbox", { name: "Reasoning effort" });
-    await expect(menu.getBoundingClientRect().right).toBeLessThanOrEqual(window.innerWidth);
-    await expect(menu.getBoundingClientRect().left).toBeGreaterThanOrEqual(0);
+    const bounds = (canvas.queryByTestId("astra-pro-phone") ?? root).getBoundingClientRect();
+    await expect(menu.getBoundingClientRect().right).toBeLessThanOrEqual(bounds.right);
+    await expect(menu.getBoundingClientRect().left).toBeGreaterThanOrEqual(bounds.left);
   },
 };
 
 export const Desktop: AppStory = {
   ...CoderGateway,
+  decorators: [],
   globals: { viewport: { value: "desktop", isRotated: false } },
   parameters: { pixel: { matrix: { themes: ["dark", "light"], viewports: ["laptop"] } } },
   play: async (context) => CoderGateway.play!(context),

--- a/src/browser/utils/commands/sources.test.ts
+++ b/src/browser/utils/commands/sources.test.ts
@@ -1414,3 +1414,33 @@ test("toggle hide sub-agents command flips the persisted sidebar setting", () =>
     globalThis.document = originalDocument;
   }
 });
+
+test.each(["coder", "mux-gateway", "direct"])(
+  "Pro palette uses the effective %s route instead of stale settings routing",
+  async (route) =>
+    withTestWindow(() => {
+      const model = "coder:prod-openai/gpt-6-astra";
+      const resolveEffectiveRoute = mock((selection: string) => {
+        expect(selection).toBe(model);
+        return route;
+      });
+      const actions = getActions({
+        getEffectiveComposerModel: () => model,
+        providersConfig: {
+          openai: { apiKeySet: true, isEnabled: true, isConfigured: true },
+          coder: {
+            apiKeySet: false,
+            isEnabled: true,
+            isConfigured: true,
+            discoveredProviders: [{ name: "prod-openai", type: "openai" }],
+          },
+        },
+        getRouteForModel: () => "direct",
+        getEffectiveRouteForModel: resolveEffectiveRoute,
+      });
+      expect(actions.some((action) => action.id === "thinking:toggle-pro-reasoning")).toBe(
+        route !== "mux-gateway"
+      );
+      expect(resolveEffectiveRoute).toHaveBeenCalled();
+    })
+);

--- a/src/browser/utils/commands/sources.ts
+++ b/src/browser/utils/commands/sources.ts
@@ -113,6 +113,7 @@ export interface BuildSourcesParams {
   providersConfig?: ProvidersConfigMap | null;
   /** Settings-resolved route for a canonical model ("direct" = no gateway). */
   getRouteForModel?: (canonicalModel: string) => string;
+  getEffectiveRouteForModel?: (modelString: string) => string;
   /**
    * Explicit per-model minimum thinking override (undefined → built-in default floor).
    * Used to hide off/low from the "Set Thinking Effort" picker, matching the selector.
@@ -1403,8 +1404,8 @@ export function buildCoreSources(p: BuildSourcesParams): Array<() => CommandActi
       }
 
       // Pro reasoning mode is only meaningful for models that support it
-      // (GPT-5.6 family) on routes that deliver the native provider option
-      // (direct OpenAI) with the Responses wire format; hide the action
+      // on routes that deliver the native provider option (direct OpenAI or
+      // Coder OpenAI instances) with the Responses wire format; hide the action
       // elsewhere to avoid inert toggles. Gate on the chat input's persisted selection —
       // that is the model the NEXT send will use — and only fall back to the
       // activity snapshot's currentModel (last streamed model, stale after a
@@ -1417,6 +1418,9 @@ export function buildCoreSources(p: BuildSourcesParams): Array<() => CommandActi
         openaiProModeAvailable(proGateModelString ?? "", {
           providersConfig: p.providersConfig,
           resolvedRouteProvider: currentModelRoute,
+          effectiveRouteProvider: proGateModelString
+            ? p.getEffectiveRouteForModel?.(proGateModelString)
+            : undefined,
         })
       ) {
         const proActive = p.getReasoningMode(workspaceId) === "pro";

--- a/src/common/utils/ai/openaiProviderOptionsAvailability.ts
+++ b/src/common/utils/ai/openaiProviderOptionsAvailability.ts
@@ -17,15 +17,12 @@ export interface OpenAIDirectProviderOptionsAvailability {
   openaiWireFormat?: OpenAIWireFormat | null;
 }
 
-export function openaiDirectProviderOptionsAvailable(
+/** Share explicit-gateway precedence between direct-only options and Pro mode. */
+export function resolveProviderOptionsRoute(
   modelString: string,
   options?: OpenAIDirectProviderOptionsAvailability
-): boolean {
-  const normalized = normalizeToCanonical(modelString);
-  const [origin] = normalized.split(":", 2);
-  if (origin !== "openai") {
-    return false;
-  }
+): string {
+  const [origin] = normalizeToCanonical(modelString).split(":", 2);
 
   // Explicit gateway selections only win while that gateway is configured and
   // enabled. Otherwise the backend falls through to the settings-resolved route.
@@ -38,14 +35,23 @@ export function openaiDirectProviderOptionsAvailable(
       (gatewayConfig?.isConfigured === true &&
         gatewayConfig.isEnabled !== false &&
         gatewayDefinition.kind === "gateway" &&
-        (gatewayDefinition.routes as readonly string[]).includes("openai"));
+        (origin === explicitGateway ||
+          (gatewayDefinition.routes as readonly string[]).includes(origin)));
     if (gatewayWinsRoute) {
-      return false;
+      return explicitGateway;
     }
   }
 
-  const resolvedRouteProvider = options?.resolvedRouteProvider;
-  if (resolvedRouteProvider != null && resolvedRouteProvider !== "direct") {
+  return options?.resolvedRouteProvider ?? "direct";
+}
+
+export function openaiDirectProviderOptionsAvailable(
+  modelString: string,
+  options?: OpenAIDirectProviderOptionsAvailability
+): boolean {
+  const normalized = normalizeToCanonical(modelString);
+  const [origin] = normalized.split(":", 2);
+  if (origin !== "openai" || resolveProviderOptionsRoute(modelString, options) !== "direct") {
     return false;
   }
 

--- a/src/common/utils/ai/openaiProviderOptionsAvailability.ts
+++ b/src/common/utils/ai/openaiProviderOptionsAvailability.ts
@@ -7,6 +7,7 @@ import type { OpenAIWireFormat } from "@/common/types/providerOptions";
 import { PROVIDER_DEFINITIONS } from "@/common/constants/providers";
 import { getExplicitGatewayPrefix, normalizeToCanonical } from "@/common/utils/ai/models";
 import { wouldRouteOpenAIThroughCodexOauth } from "@/common/utils/providers/codexOauthRouting";
+import { isGatewayModelAccessibleFromAuthoritativeCatalog } from "@/common/utils/providers/gatewayModelCatalog";
 
 export interface OpenAIDirectProviderOptionsAvailability {
   /** Settings-resolved route for the canonical model ("direct" = no gateway). */
@@ -36,7 +37,17 @@ export function resolveProviderOptionsRoute(
         gatewayConfig.isEnabled !== false &&
         gatewayDefinition.kind === "gateway" &&
         (origin === explicitGateway ||
-          (gatewayDefinition.routes as readonly string[]).includes(origin)));
+          (gatewayDefinition.routes as readonly string[]).includes(origin)) &&
+        // A removed/catalog-excluded Coder model must use the resolved fallback,
+        // even while the gateway itself remains connected.
+        (explicitGateway !== "coder" ||
+          isGatewayModelAccessibleFromAuthoritativeCatalog(
+            explicitGateway,
+            modelString.slice(modelString.indexOf(":") + 1),
+            gatewayConfig.models,
+            gatewayConfig.discoveredModels,
+            gatewayConfig.removedModels
+          )));
     if (gatewayWinsRoute) {
       return explicitGateway;
     }

--- a/src/common/utils/ai/proMode.ts
+++ b/src/common/utils/ai/proMode.ts
@@ -5,8 +5,8 @@
  * cannot affect the request:
  * - model must be pro-capable (see openaiSupportsProMode);
  * - pro mode is a Responses API field, so `wireFormat: "chatCompletions"` disables it;
- * - only the direct `openai:` route delivers the mode. Gateways hide it:
- *   non-passthrough ones use another provider schema, and mux-gateway currently
+ * - direct OpenAI and Coder's OpenAI Responses instances deliver the mode.
+ *   Other gateways hide it: non-passthrough ones use another provider schema, and mux-gateway currently
  *   drops `providerOptions.openai.reasoningMode` server-side (verified empirically —
  *   the Responses API echoed `mode: "standard"`), so it fails closed until the
  *   gateway forwards the field;
@@ -18,10 +18,13 @@
  * modelEntries → models); adding it to models.ts would create a cycle.
  */
 
+import { resolveCoderWireCanonicalModel } from "@/common/constants/coderOAuth";
 import { openaiSupportsProMode } from "@/common/types/thinking";
+import { isCustomProviderConfig } from "@/common/utils/providers/customProviders";
 import { normalizeToCanonical } from "@/common/utils/ai/models";
 import {
   openaiDirectProviderOptionsAvailable,
+  resolveProviderOptionsRoute,
   type OpenAIDirectProviderOptionsAvailability,
 } from "@/common/utils/ai/openaiProviderOptionsAvailability";
 import { resolveModelForMetadata } from "@/common/utils/providers/modelEntries";
@@ -32,6 +35,20 @@ export function openaiProModeAvailable(
   modelString: string,
   options?: ProModeAvailabilityOptions
 ): boolean {
+  if (resolveProviderOptionsRoute(modelString, options) === "coder") {
+    if (isCustomProviderConfig(options?.providersConfig?.coder)) {
+      return false;
+    }
+    // Coder forwards native Responses bodies, unlike mux-gateway's SDK proxy.
+    // Resolve the actual instance type before name-based canonicalization; the
+    // direct OpenAI wire format and Codex credentials do not govern this route.
+    const gatewayModelId = modelString.startsWith("coder:")
+      ? modelString.slice("coder:".length)
+      : normalizeToCanonical(modelString).replace(":", "/");
+    const wire = resolveCoderWireCanonicalModel(gatewayModelId, options?.providersConfig?.coder);
+    return wire?.providerType === "openai" && openaiSupportsProMode(`openai:${wire.modelId}`);
+  }
+
   const wireFormat =
     options?.openaiWireFormat ?? options?.providersConfig?.openai?.wireFormat ?? "responses";
   if (wireFormat === "chatCompletions") {

--- a/src/common/utils/ai/proMode.ts
+++ b/src/common/utils/ai/proMode.ts
@@ -21,6 +21,7 @@
 import { resolveCoderWireCanonicalModel } from "@/common/constants/coderOAuth";
 import { openaiSupportsProMode } from "@/common/types/thinking";
 import { isCustomProviderConfig } from "@/common/utils/providers/customProviders";
+import { resolveCoderGatewayMetadataModel } from "@/common/utils/providers/coderGatewayMetadata";
 import { normalizeToCanonical } from "@/common/utils/ai/models";
 import {
   openaiDirectProviderOptionsAvailable,
@@ -35,7 +36,8 @@ export function openaiProModeAvailable(
   modelString: string,
   options?: ProModeAvailabilityOptions
 ): boolean {
-  if (resolveProviderOptionsRoute(modelString, options) === "coder") {
+  const route = resolveProviderOptionsRoute(modelString, options);
+  if (route === "coder") {
     if (isCustomProviderConfig(options?.providersConfig?.coder)) {
       return false;
     }
@@ -46,7 +48,12 @@ export function openaiProModeAvailable(
       ? modelString.slice("coder:".length)
       : normalizeToCanonical(modelString).replace(":", "/");
     const wire = resolveCoderWireCanonicalModel(gatewayModelId, options?.providersConfig?.coder);
-    return wire?.providerType === "openai" && openaiSupportsProMode(`openai:${wire.modelId}`);
+    return (
+      wire?.providerType === "openai" &&
+      openaiSupportsProMode(
+        resolveModelForMetadata(`openai:${wire.modelId}`, options?.providersConfig ?? null)
+      )
+    );
   }
 
   const wireFormat =
@@ -54,7 +61,11 @@ export function openaiProModeAvailable(
   if (wireFormat === "chatCompletions") {
     return false;
   }
-  const normalized = normalizeToCanonical(modelString);
+  // An unavailable custom-named Coder instance can fall back to its real upstream.
+  // Keep unknown/compatible instances scoped rather than guessing from their name.
+  const normalized = modelString.startsWith("coder:")
+    ? (resolveCoderGatewayMetadataModel(modelString, options?.providersConfig) ?? modelString)
+    : normalizeToCanonical(modelString);
   const [origin] = normalized.split(":", 2);
   if (origin !== "openai") {
     return false;
@@ -67,5 +78,8 @@ export function openaiProModeAvailable(
     return false;
   }
 
-  return openaiDirectProviderOptionsAvailable(modelString, options);
+  return openaiDirectProviderOptionsAvailable(normalized, {
+    ...options,
+    resolvedRouteProvider: route,
+  });
 }

--- a/src/common/utils/ai/proMode.ts
+++ b/src/common/utils/ai/proMode.ts
@@ -30,13 +30,19 @@ import {
 } from "@/common/utils/ai/openaiProviderOptionsAvailability";
 import { resolveModelForMetadata } from "@/common/utils/providers/modelEntries";
 
-export type ProModeAvailabilityOptions = OpenAIDirectProviderOptionsAvailability;
+export type ProModeAvailabilityOptions = OpenAIDirectProviderOptionsAvailability & {
+  /** Authoritative raw-selection route, including explicit gateways, policy and catalog fallback. */
+  effectiveRouteProvider?: string | null;
+};
 
 export function openaiProModeAvailable(
   modelString: string,
   options?: ProModeAvailabilityOptions
 ): boolean {
-  const route = resolveProviderOptionsRoute(modelString, options);
+  // Policy-aware callers already resolved explicit gateway precedence. Do not
+  // resurrect a rejected Coder route from its persisted (policy-unfiltered) catalog.
+  const route =
+    options?.effectiveRouteProvider ?? resolveProviderOptionsRoute(modelString, options);
   if (route === "coder") {
     if (isCustomProviderConfig(options?.providersConfig?.coder)) {
       return false;
@@ -51,7 +57,10 @@ export function openaiProModeAvailable(
     return (
       wire?.providerType === "openai" &&
       openaiSupportsProMode(
-        resolveModelForMetadata(`openai:${wire.modelId}`, options?.providersConfig ?? null)
+        resolveModelForMetadata(
+          modelString.startsWith("coder:") ? modelString : `openai:${wire.modelId}`,
+          options?.providersConfig ?? null
+        )
       )
     );
   }

--- a/src/common/utils/ai/providerOptions.test.ts
+++ b/src/common/utils/ai/providerOptions.test.ts
@@ -1302,6 +1302,49 @@ describe("buildProviderOptions - OpenAI", () => {
       ).toBe(false);
     });
 
+    test.each([
+      { scoped: "openai:gpt-6-astra", upstream: "openai:gpt-5.2", type: "openai", pro: true },
+      { scoped: "openai:gpt-5.2", upstream: "openai:gpt-6-astra", type: "openai", pro: false },
+      {
+        scoped: "openai:gpt-6-astra",
+        upstream: "openai:gpt-6-astra",
+        type: "openai-compat",
+        pro: false,
+      },
+    ])("scoped aliases control capabilities, not Coder's wire: %j", (testCase) => {
+      const model = "coder:prod-openai/team-astra";
+      const config: ProvidersConfigMap = {
+        openai: {
+          apiKeySet: true,
+          isEnabled: true,
+          isConfigured: true,
+          models: [{ id: "team-astra", mappedToModel: testCase.upstream }],
+        },
+        coder: {
+          apiKeySet: false,
+          isEnabled: true,
+          isConfigured: true,
+          discoveredProviders: [{ name: "prod-openai", type: testCase.type }],
+          models: [{ id: "prod-openai/team-astra", mappedToModel: testCase.scoped }],
+        },
+      };
+      expect(openaiProModeAvailable(model, { providersConfig: config })).toBe(testCase.pro);
+      const options = buildProviderOptions(
+        model,
+        "high",
+        undefined,
+        undefined,
+        { openai: { wireFormat: "responses" } },
+        undefined,
+        undefined,
+        config,
+        "coder",
+        undefined,
+        "pro"
+      );
+      expect(getOpenAIOptions(options)?.reasoningMode).toBe(testCase.pro ? "pro" : undefined);
+    });
+
     const fallbackAvailability: Array<Partial<NonNullable<ProvidersConfigMap["coder"]>>> = [
       { isEnabled: false, isConfigured: true },
       { isEnabled: true, isConfigured: false },

--- a/src/common/utils/ai/providerOptions.test.ts
+++ b/src/common/utils/ai/providerOptions.test.ts
@@ -1249,6 +1249,7 @@ describe("buildProviderOptions - OpenAI", () => {
         isConfigured: true,
         codexOauthSet: true,
         wireFormat: "chatCompletions",
+        models: [{ id: "team-astra", mappedToModel: "openai:gpt-6-astra" }],
       },
       coder: {
         apiKeySet: false,
@@ -1266,6 +1267,8 @@ describe("buildProviderOptions - OpenAI", () => {
       ["coder:openai/gpt-6-astra", true],
       ["coder:prod-openai/gpt-6-astra", true],
       ["openai:gpt-6-astra", true],
+      ["openai:team-astra", true],
+      ["coder:prod-openai/team-astra", true],
       ["coder:openai/gpt-5.6-sol", true],
       ["coder:openai/gpt-6-astra-mini", false],
       ["coder:compat/gpt-6-astra", false],
@@ -1298,6 +1301,65 @@ describe("buildProviderOptions - OpenAI", () => {
         })
       ).toBe(false);
     });
+
+    const fallbackAvailability: Array<Partial<NonNullable<ProvidersConfigMap["coder"]>>> = [
+      { isEnabled: false, isConfigured: true },
+      { isEnabled: true, isConfigured: false },
+      { isEnabled: true, isConfigured: true, discoveredModels: [] },
+      { isEnabled: true, isConfigured: true, removedModels: ["prod-openai/gpt-6-astra"] },
+    ];
+    test.each(fallbackAvailability)(
+      "preserves Pro on custom-instance direct fallback (%j)",
+      (availability) => {
+        const config: ProvidersConfigMap = {
+          ...providersConfig,
+          openai: { apiKeySet: true, isEnabled: true, isConfigured: true },
+          coder: { ...providersConfig.coder, ...availability },
+        };
+        const model = "coder:prod-openai/gpt-6-astra";
+        expect(
+          openaiProModeAvailable(model, {
+            providersConfig: config,
+            resolvedRouteProvider: "direct",
+          })
+        ).toBe(true);
+        expect(
+          openaiProModeAvailable(model, {
+            providersConfig: config,
+            resolvedRouteProvider: "mux-gateway",
+          })
+        ).toBe(false);
+        expect(
+          openaiProModeAvailable(model, {
+            providersConfig: config,
+            resolvedRouteProvider: "direct",
+            openaiWireFormat: "chatCompletions",
+          })
+        ).toBe(false);
+        expect(
+          openaiProModeAvailable(model, {
+            providersConfig: { ...config, openai: { ...config.openai, codexOauthSet: true } },
+            resolvedRouteProvider: "direct",
+          })
+        ).toBe(false);
+      }
+    );
+
+    test.each(["compat", "unknown"])(
+      "does not invent an upstream for %s on fallback",
+      (instance) => {
+        expect(
+          openaiProModeAvailable(`coder:${instance}/gpt-6-astra`, {
+            providersConfig: {
+              ...providersConfig,
+              openai: { apiKeySet: true, isEnabled: true, isConfigured: true },
+              coder: { ...providersConfig.coder, isEnabled: false },
+            },
+            resolvedRouteProvider: "direct",
+          })
+        ).toBe(false);
+      }
+    );
 
     test.each(["anthropic", "openai-compat"])(
       "does not trust an OpenAI-named instance whose type is %s",

--- a/src/common/utils/ai/providerOptions.test.ts
+++ b/src/common/utils/ai/providerOptions.test.ts
@@ -1240,6 +1240,96 @@ describe("buildProviderOptions - OpenAI", () => {
     });
   });
 
+  describe("Coder Pro mode", () => {
+    const providersConfig: ProvidersConfigMap = {
+      // Direct OpenAI settings must not disable Coder's independent Responses route.
+      openai: {
+        apiKeySet: false,
+        isEnabled: true,
+        isConfigured: true,
+        codexOauthSet: true,
+        wireFormat: "chatCompletions",
+      },
+      coder: {
+        apiKeySet: false,
+        isEnabled: true,
+        isConfigured: true,
+        discoveredProviders: [
+          { name: "prod-openai", type: "openai" },
+          { name: "compat", type: "openai-compat" },
+        ],
+      },
+      openrouter: { apiKeySet: true, isEnabled: true, isConfigured: true },
+    };
+
+    test.each([
+      ["coder:openai/gpt-6-astra", true],
+      ["coder:prod-openai/gpt-6-astra", true],
+      ["openai:gpt-6-astra", true],
+      ["coder:openai/gpt-5.6-sol", true],
+      ["coder:openai/gpt-6-astra-mini", false],
+      ["coder:compat/gpt-6-astra", false],
+      ["coder:unknown/gpt-6-astra", false],
+      ["openrouter:openai/gpt-6-astra", false],
+    ] as const)("gates the picker and request consistently for %s", (model, available) => {
+      expect(
+        openaiProModeAvailable(model, { providersConfig, resolvedRouteProvider: "coder" })
+      ).toBe(available);
+      // The request builder pins wireFormat to the Coder instance's protocol.
+      const options = buildProviderOptions(
+        model,
+        "high",
+        undefined,
+        undefined,
+        { openai: { wireFormat: "responses" } },
+        undefined,
+        undefined,
+        providersConfig,
+        "coder",
+        undefined,
+        "pro"
+      );
+      expect(getOpenAIOptions(options)?.reasoningMode).toBe(available ? "pro" : undefined);
+      // Pro eligibility must not broaden the shared direct-only Fast mode gate.
+      expect(
+        openaiDirectProviderOptionsAvailable(model, {
+          providersConfig,
+          resolvedRouteProvider: "coder",
+        })
+      ).toBe(false);
+    });
+
+    test.each(["anthropic", "openai-compat"])(
+      "does not trust an OpenAI-named instance whose type is %s",
+      (type) => {
+        const config = {
+          ...providersConfig,
+          coder: {
+            ...providersConfig.coder,
+            discoveredProviders: [{ name: "openai", type }],
+          },
+        };
+        expect(
+          openaiProModeAvailable("coder:openai/gpt-6-astra", { providersConfig: config })
+        ).toBe(false);
+      }
+    );
+
+    test("does not treat a custom provider shadowing coder as the gateway", () => {
+      expect(
+        openaiProModeAvailable("coder:openai/gpt-6-astra", {
+          providersConfig: {
+            coder: {
+              ...providersConfig.coder,
+              providerType: "openai-responses",
+            },
+          },
+          resolvedRouteProvider: "coder",
+        })
+      ).toBe(false);
+    });
+  });
+
   describe("native pro reasoning mode", () => {
     const buildWithMode = (
       model: string,
@@ -1316,9 +1406,13 @@ describe("buildProviderOptions - OpenAI", () => {
       );
     });
 
-    test.each(["gpt-5.6-sol", "gpt-6-astra"])(
-      "serializes native max and pro for %s through the OpenAI SDK",
-      async (model) => {
+    test.each([
+      ["gpt-5.6-sol", "openai"],
+      ["gpt-6-astra", "openai"],
+      ["gpt-6-astra", "coder"],
+    ] as const)(
+      "serializes native max and pro for %s via %s through the OpenAI SDK",
+      async (model, routeProvider) => {
         const capturedBodies: Array<Record<string, unknown>> = [];
         const captureFetch = Object.assign(
           (
@@ -1368,9 +1462,11 @@ describe("buildProviderOptions - OpenAI", () => {
           baseURL: "https://example.test/v1",
           fetch: captureFetch,
         });
-        const responsesOptions = buildWithMode(`openai:${model}`, "pro", {
-          thinkingLevel: "max",
-        });
+        const responsesOptions = buildWithMode(
+          routeProvider === "coder" ? `coder:openai/${model}` : `openai:${model}`,
+          "pro",
+          { thinkingLevel: "max", routeProvider }
+        );
         if (!responsesOptions) {
           throw new Error("Expected OpenAI Responses provider options");
         }
@@ -2278,8 +2374,8 @@ describe("buildRequestHeaders", () => {
   });
 
   describe("openaiProModeAvailable", () => {
-    // UI gating must mirror provider-option delivery: only direct OpenAI routes
-    // surface the toggle while gateways still drop or reject the field.
+    // UI gating must mirror provider-option delivery: direct OpenAI and Coder
+    // Responses surface the toggle; other gateways still drop or reject it.
     const cases: Array<[string, boolean]> = [
       ["openai:gpt-5.6-sol", true],
       ["openai:gpt-5.6-terra", true],
@@ -2290,7 +2386,7 @@ describe("buildRequestHeaders", () => {
       ["openai:gpt-6-astra-2026-09-03", true],
       ["mux-gateway:openai/gpt-6-astra", false],
       ["openai:gpt-6-astra-mini", false],
-      // All gateways fail closed — mux-gateway drops the field server-side.
+      // Other gateways fail closed — mux-gateway drops the field server-side.
       ["mux-gateway:openai/gpt-5.6-sol", false],
       ["openrouter:openai/gpt-5.6-sol", false],
       ["github-copilot:gpt-5.6-sol", false],

--- a/src/common/utils/ai/providerOptions.ts
+++ b/src/common/utils/ai/providerOptions.ts
@@ -481,14 +481,16 @@ export function buildProviderOptions(
     const routeIsDirect = routeProvider == null || routeProvider === origin;
     const shouldUseProMode =
       isResponses &&
-      (routeIsDirect ||
-        (routeProvider === "coder" &&
+      reasoningMode === "pro" &&
+      (routeIsDirect
+        ? openaiSupportsProMode(capabilityModel)
+        : routeProvider === "coder" &&
+          // The route-aware gate preserves scoped aliases without treating an
+          // alias's capability identity as the Coder instance's wire type.
           openaiProModeAvailable(modelString, {
             providersConfig,
             resolvedRouteProvider: routeProvider,
-          }))) &&
-      reasoningMode === "pro" &&
-      openaiSupportsProMode(capabilityModel);
+          }));
     const truncationMode = openaiTruncationMode ?? "disabled";
     const shouldSendReasoningSummary = supportsOpenAIReasoningSummary(capModelName);
 

--- a/src/common/utils/ai/providerOptions.ts
+++ b/src/common/utils/ai/providerOptions.ts
@@ -39,6 +39,7 @@ import {
   isGeminiFlashThinkingLevelModelName,
 } from "@/common/utils/thinking/policy";
 import { openaiExplicitPromptCachingAvailable } from "@/common/utils/ai/cacheStrategy";
+import { openaiProModeAvailable } from "./proMode";
 import { resolveModelForMetadata } from "@/common/utils/providers/modelEntries";
 import { log } from "@/node/services/log";
 import type { MuxMessage } from "@/common/types/message";
@@ -480,7 +481,12 @@ export function buildProviderOptions(
     const routeIsDirect = routeProvider == null || routeProvider === origin;
     const shouldUseProMode =
       isResponses &&
-      routeIsDirect &&
+      (routeIsDirect ||
+        (routeProvider === "coder" &&
+          openaiProModeAvailable(modelString, {
+            providersConfig,
+            resolvedRouteProvider: routeProvider,
+          }))) &&
       reasoningMode === "pro" &&
       openaiSupportsProMode(capabilityModel);
     const truncationMode = openaiTruncationMode ?? "disabled";
@@ -506,8 +512,8 @@ export function buildProviderOptions(
           // Default to disabled; allow auto truncation for compaction to avoid context errors
           truncation: truncationMode,
           // Pro mode is a native Responses option in @ai-sdk/openai 4.0.11.
-          // Keep the existing direct-route capability gate because mux-gateway
-          // currently drops this provider option and Codex OAuth strips it.
+          // Direct OpenAI and Coder Responses forward it; mux-gateway drops
+          // this provider option and Codex OAuth strips it.
           ...(shouldUseProMode && { reasoningMode: "pro" as const }),
           // Stable prompt cache key to improve OpenAI cache hit rates
           // See: https://sdk.vercel.ai/providers/ai-sdk-providers/openai#responses-models

--- a/src/common/utils/tools/tools.ts
+++ b/src/common/utils/tools/tools.ts
@@ -356,13 +356,9 @@ export interface ToolConfiguration {
     /** Returns the frozen same-step capture snapshot for a specific advisor tool call, if available. */
     takeToolCallSnapshot: (toolCallId: string) => AdvisorToolCallSnapshot | undefined;
     /**
-     * Creates a LanguageModel from a model string (delegates to
-     * providerModelFactory). Also returns the wire-resolved identity for
-     * provider option construction, derived from the SAME config snapshot
-     * that created the model: a raw coder:<instance>/<model> string carries
-     * no wire information on its own, so building options from it would emit
-     * the wrong (or no) provider namespace for custom-named or cross-typed
-     * instances.
+     * Creates a model and pins its request identity, route, and config together.
+     * Coder identities retain their actual instance and scoped aliases; option
+     * construction resolves their wire from this snapshot, never live config.
      */
     createModel: (modelString: string) => Promise<{
       model: LanguageModel;
@@ -375,7 +371,7 @@ export interface ToolConfiguration {
        * alias metadata from the raw custom identity.
        */
       optionsProvidersConfig: ProvidersConfigMap | null;
-      /** Pinned wire/route options keep Pro restricted to supported direct Responses requests. */
+      /** Pinned wire/route options keep Pro restricted to supported Responses routes. */
       optionsMuxProviderOptions?: MuxProviderOptions;
       optionsRouteProvider?: ProviderName;
     }>;

--- a/src/node/services/agentPlugins/hookService.test.ts
+++ b/src/node/services/agentPlugins/hookService.test.ts
@@ -420,8 +420,17 @@ describe("AgentPluginHookService", () => {
       },
     });
     attachLanguageModelCleanup(sdkModel, cleanup);
-    const create = spyOn(h.aiService, "createModelWithPinnedMetadata").mockResolvedValue(
-      Ok({ model: sdkModel, metadataModel: "openai:gpt-4o" })
+    const create = spyOn(h.aiService, "createModelWithPinnedOptions").mockResolvedValue(
+      Ok({
+        model: sdkModel,
+        metadataModel: "openai:gpt-4o",
+        effectiveModelString: "openai:gpt-4o",
+        wireProviderName: "openai",
+        optionsModelString: "openai:gpt-4o",
+        optionsProvidersConfig: {},
+        optionsMuxProviderOptions: {},
+        optionsRouteProvider: "openai",
+      })
     );
     const record = mock(() => Promise.resolve(undefined));
     try {

--- a/src/node/services/agentSession.continuousCompaction.test.ts
+++ b/src/node/services/agentSession.continuousCompaction.test.ts
@@ -981,6 +981,19 @@ describe("AgentSession continuous compaction wiring", () => {
     };
   }
 
+  function pinnedSummaryModel(sdkModel: MockLanguageModelV3, metadataModel: string) {
+    return {
+      model: sdkModel,
+      metadataModel,
+      effectiveModelString: metadataModel,
+      wireProviderName: "openai",
+      optionsModelString: metadataModel,
+      optionsProvidersConfig: {},
+      optionsMuxProviderOptions: {},
+      optionsRouteProvider: "openai" as const,
+    };
+  }
+
   function modelChunks(): LanguageModelV3StreamPart[] {
     return [
       { type: "text-start", id: "summary" },
@@ -1024,8 +1037,8 @@ describe("AgentSession continuous compaction wiring", () => {
         return Promise.resolve({ stream: simulateReadableStream({ chunks: modelChunks() }) });
       },
     });
-    const create = spyOn(h.aiService, "createModelWithPinnedMetadata").mockResolvedValue(
-      Ok({ model: sdkModel, metadataModel: "openai:gpt-4.1" })
+    const create = spyOn(h.aiService, "createModelWithPinnedOptions").mockResolvedValue(
+      Ok(pinnedSummaryModel(sdkModel, "openai:gpt-4.1"))
     );
     const record = mock<SessionUsageService["recordHeadlessUsage"]>(() =>
       Promise.resolve(undefined)
@@ -1064,6 +1077,62 @@ describe("AgentSession continuous compaction wiring", () => {
     expect(await rows(h)).toHaveLength(0);
   });
 
+  test.each([
+    { route: "coder", alias: true, wire: "responses", pro: true },
+    { route: "mux-gateway", alias: false, wire: "responses", pro: false },
+    { route: "openai", alias: false, wire: "responses", pro: true },
+    { route: "openai", alias: false, wire: "chatCompletions", pro: false },
+  ] as const)(
+    "summary consumes the pinned route/wire rather than raw Coder intent: %j",
+    async (testCase) => {
+      const { h, args } = await summarySetup();
+      const rawModel = `coder:prod-openai/${testCase.alias ? "team-astra" : "gpt-6-astra"}`;
+      const requests: LanguageModelV3CallOptions[] = [];
+      const sdkModel = new MockLanguageModelV3({
+        doStream: (request) => {
+          requests.push(request);
+          return Promise.resolve({ stream: simulateReadableStream({ chunks: modelChunks() }) });
+        },
+      });
+      spyOn(h.aiService, "getProvidersConfig").mockReturnValue({
+        coder: {
+          apiKeySet: false,
+          isEnabled: true,
+          isConfigured: true,
+          discoveredProviders: [{ name: "prod-openai", type: "anthropic" }],
+        },
+      });
+      spyOn(h.aiService, "createModelWithPinnedOptions").mockResolvedValue(
+        Ok({
+          ...pinnedSummaryModel(sdkModel, "openai:gpt-6-astra"),
+          effectiveModelString:
+            testCase.route === "coder" ? rawModel : `${testCase.route}:gpt-6-astra`,
+          optionsModelString: testCase.route === "coder" ? rawModel : "openai:gpt-6-astra",
+          optionsRouteProvider: testCase.route,
+          optionsMuxProviderOptions: { openai: { wireFormat: testCase.wire } },
+          optionsProvidersConfig: {
+            coder: {
+              apiKeySet: false,
+              isEnabled: true,
+              isConfigured: true,
+              discoveredProviders: [{ name: "prod-openai", type: "openai" }],
+              models: [{ id: "prod-openai/team-astra", mappedToModel: "openai:gpt-6-astra" }],
+            },
+          },
+        })
+      );
+      await summarizeContinuousCompaction({
+        ...args,
+        compactOptions: { ...args.compactOptions, model: rawModel, reasoningMode: "pro" },
+        baseOptions: { ...args.baseOptions, model: rawModel, reasoningMode: "pro" },
+      });
+      expect(requests[0].providerOptions?.openai?.reasoningMode).toBe(
+        testCase.pro ? "pro" : undefined
+      );
+      expect(requests[0].providerOptions?.anthropic).toBeUndefined();
+    }
+  );
+
   test("a compact model too small for the head falls back to the configured parent route without truncating", async () => {
     const { h, args } = await summarySetup();
     spyOn(h.aiService, "getProvidersConfig").mockReturnValue({
@@ -1078,8 +1147,8 @@ describe("AgentSession continuous compaction wiring", () => {
       doStream: () =>
         Promise.resolve({ stream: simulateReadableStream({ chunks: modelChunks() }) }),
     });
-    const create = spyOn(h.aiService, "createModelWithPinnedMetadata").mockResolvedValue(
-      Ok({ model: sdkModel, metadataModel: model })
+    const create = spyOn(h.aiService, "createModelWithPinnedOptions").mockResolvedValue(
+      Ok(pinnedSummaryModel(sdkModel, model))
     );
     const result = await summarizeContinuousCompaction({
       ...args,
@@ -1099,7 +1168,7 @@ describe("AgentSession continuous compaction wiring", () => {
         models: [{ id: "gpt-4.1-mini", contextWindowTokens: 100 }],
       },
     });
-    const create = spyOn(h.aiService, "createModelWithPinnedMetadata");
+    const create = spyOn(h.aiService, "createModelWithPinnedOptions");
     const result = await summarizeContinuousCompaction({
       ...args,
       context: { ...args.context, contextWindowTokens: 100 },
@@ -1126,8 +1195,8 @@ describe("AgentSession continuous compaction wiring", () => {
         });
       },
     });
-    spyOn(h.aiService, "createModelWithPinnedMetadata").mockResolvedValue(
-      Ok({ model: sdkModel, metadataModel: model })
+    spyOn(h.aiService, "createModelWithPinnedOptions").mockResolvedValue(
+      Ok(pinnedSummaryModel(sdkModel, model))
     );
     const result = summarizeContinuousCompaction({ ...args, signal: controller.signal }).catch(
       (error: unknown) => error

--- a/src/node/services/agentSession.testHarness.ts
+++ b/src/node/services/agentSession.testHarness.ts
@@ -124,6 +124,11 @@ function createMockAiService(args: {
         Err({ type: "unknown" as const, raw: "Test AI service cannot create models" })
       )
     ),
+    createModelWithPinnedOptions: mock(() =>
+      Promise.resolve(
+        Err({ type: "unknown" as const, raw: "Test AI service cannot create models" })
+      )
+    ),
     getWorkspaceMetadata: mock(() =>
       Promise.resolve(Err("Test AI service has no workspace metadata"))
     ),

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -1,3 +1,4 @@
+import type { AIService } from "./aiService";
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { GoalRecordV1 } from "@/common/types/goal";
 import type { PreparedStreamMessage } from "./turnRequestBuilder";
@@ -651,6 +652,7 @@ export interface AgentSessionStreamManager {
 
 /** Keeps AgentSession coupled only to the AI operations and events it consumes. */
 export interface AgentSessionAIService extends BranchSummaryAiService {
+  createModelWithPinnedOptions: AIService["createModelWithPinnedOptions"];
   on(event: string, listener: (...args: unknown[]) => void): void;
   off(event: string, listener: (...args: unknown[]) => void): void;
   streamMessage(options: StreamMessageOptions): Promise<Result<TurnStreamHandle, SendMessageError>>;

--- a/src/node/services/aiService.test.ts
+++ b/src/node/services/aiService.test.ts
@@ -2567,6 +2567,10 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
     await startAdvisorStream(harness, workspaceId);
     const runtime = harness.getToolsForModelSpy.mock.calls[0]?.[1].advisorRuntime;
     if (!runtime) throw new Error("Expected advisor runtime");
+    const factory = Reflect.get(harness.service, "providerModelFactory") as ProviderModelFactory;
+    spyOn(factory, "resolveAndCreateModel").mockImplementation(
+      ProviderModelFactory.prototype.resolveAndCreateModel.bind(factory)
+    );
     const created = await runtime.createModel(testCase.model);
     providersStore.saveProvidersConfig({
       openai: { apiKey: "changed-key", wireFormat: "responses" },
@@ -2619,17 +2623,32 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
       await startAdvisorStream(harness, workspaceId);
       // Avoid an OAuth exchange; the real option/route adapter below must retain
       // the selected instance instead of re-resolving the unrelated "openai" instance.
-      spyOn(harness.service, "createModel").mockImplementation((_model, options, creation) => {
-        expect(creation?.providersConfig?.coder).toMatchObject({
-          discoveredProviders: [
-            { name: "prod-openai", type: "openai" },
-            { name: "openai", type: "openai-compat" },
-          ],
-        });
-        if (!options) throw new Error("Expected the adapter's provider-options target");
-        options.openai = { wireFormat: "responses" };
-        return Promise.resolve({ success: true, data: Object.create(null) as LanguageModel });
-      });
+      const factory = Reflect.get(harness.service, "providerModelFactory") as ProviderModelFactory;
+      spyOn(factory, "resolveAndCreateModel").mockImplementation(
+        (_model, _thinking, options, creation) => {
+          expect(creation?.providersConfig?.coder).toMatchObject({
+            discoveredProviders: [
+              { name: "prod-openai", type: "openai" },
+              { name: "openai", type: "openai-compat" },
+            ],
+          });
+          if (!options) throw new Error("Expected the adapter's provider-options target");
+          options.openai = { wireFormat: "responses" };
+          return Promise.resolve({
+            success: true,
+            data: {
+              model: Object.create(null) as LanguageModel,
+              effectiveModelString: model,
+              canonicalModelString: "openai:gpt-6-astra",
+              canonicalProviderName: "openai",
+              canonicalModelId: "gpt-6-astra",
+              wireProviderName: "openai",
+              routeProvider: "coder",
+              routedThroughGateway: false,
+            },
+          });
+        }
+      );
       const runtime = harness.getToolsForModelSpy.mock.calls[0]?.[1].advisorRuntime;
       if (!runtime) throw new Error("Expected advisor runtime");
       if (testCase.refresh !== "none") {
@@ -3095,12 +3114,8 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
       const resolveModel = spyOn(factory, "resolveAndCreateModel").mockImplementation(
         ProviderModelFactory.prototype.resolveAndCreateModel.bind(factory)
       );
-      const createModel = spyOn(harness.service, "createModel");
       const created = await runtime.createModel(KNOWN_MODELS.GPT_53_CODEX.id);
-      const creationOptions =
-        toolName === "advisor"
-          ? createModel.mock.calls.at(-1)?.[2]
-          : resolveModel.mock.calls.at(-1)?.[3];
+      const creationOptions = resolveModel.mock.calls.at(-1)?.[3];
       expect(creationOptions).toMatchObject({
         agentInitiated: true,
         workspaceId,

--- a/src/node/services/aiService.test.ts
+++ b/src/node/services/aiService.test.ts
@@ -2579,9 +2579,14 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
     }
   });
 
-  it.each(["gpt-6-astra", "team-astra"])(
-    "preserves the actual Coder instance and scoped alias for advisor Pro: %s",
-    async (modelId) => {
+  it.each([
+    { modelId: "gpt-6-astra", refresh: "none" },
+    { modelId: "team-astra", refresh: "none" },
+    { modelId: "team-astra", refresh: "retyped" },
+    { modelId: "team-astra", refresh: "removed" },
+  ])(
+    "preserves the actual Coder instance and scoped alias for advisor Pro: %j",
+    async (testCase) => {
       using xumHome = new DisposableTempDir("ai-service-advisor-coder-pro");
       const projectPath = path.join(xumHome.path, "project");
       await fs.mkdir(projectPath, { recursive: true });
@@ -2590,7 +2595,7 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
         xumHome.path,
         createLocalWorkspaceMetadata(workspaceId, projectPath)
       );
-      const model = `coder:prod-openai/${modelId}`;
+      const model = `coder:prod-openai/${testCase.modelId}`;
       await writeProvidersConfig(xumHome.path, {
         coder: {
           coderOauth: {
@@ -2614,13 +2619,36 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
       await startAdvisorStream(harness, workspaceId);
       // Avoid an OAuth exchange; the real option/route adapter below must retain
       // the selected instance instead of re-resolving the unrelated "openai" instance.
-      spyOn(harness.service, "createModel").mockImplementation((_model, options) => {
+      spyOn(harness.service, "createModel").mockImplementation((_model, options, creation) => {
+        expect(creation?.providersConfig?.coder).toMatchObject({
+          discoveredProviders: [
+            { name: "prod-openai", type: "openai" },
+            { name: "openai", type: "openai-compat" },
+          ],
+        });
         if (!options) throw new Error("Expected the adapter's provider-options target");
         options.openai = { wireFormat: "responses" };
         return Promise.resolve({ success: true, data: Object.create(null) as LanguageModel });
       });
       const runtime = harness.getToolsForModelSpy.mock.calls[0]?.[1].advisorRuntime;
       if (!runtime) throw new Error("Expected advisor runtime");
+      if (testCase.refresh !== "none") {
+        const snapshot = new ProvidersConfigStore(harness.config.rootDir).loadProvidersConfig();
+        if (!snapshot) throw new Error("Expected the initial Coder configuration");
+        // Model creation gets the first read; an independent options-view read
+        // would see a catalog refresh with incompatible or missing metadata.
+        spyOn(ProvidersConfigStore.prototype, "loadProvidersConfig")
+          .mockReturnValue({
+            ...snapshot,
+            coder: {
+              ...snapshot.coder,
+              discoveredProviders:
+                testCase.refresh === "retyped" ? [{ name: "prod-openai", type: "anthropic" }] : [],
+              models: [],
+            },
+          })
+          .mockReturnValueOnce(snapshot);
+      }
       const created = await runtime.createModel(model);
       expect(created.optionsRouteProvider).toBe("coder");
       const options = buildProviderOptions(

--- a/src/node/services/aiService.test.ts
+++ b/src/node/services/aiService.test.ts
@@ -69,6 +69,7 @@ import * as toolAssembly from "./toolAssembly";
 import type { ToolModelUsageEvent } from "@/common/utils/tools/tools";
 import { createDisplayUsage } from "@/common/utils/tokens/displayUsage";
 import { normalizeToCanonical } from "@/common/utils/ai/models";
+import { buildProviderOptions } from "@/common/utils/ai/providerOptions";
 import * as toolsModule from "@/common/utils/tools/tools";
 import * as systemMessageModule from "./systemMessage";
 
@@ -2577,6 +2578,67 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
       expect(created.optionsMuxProviderOptions?.openai?.wireFormat).toBe(testCase.wireFormat);
     }
   });
+
+  it.each(["gpt-6-astra", "team-astra"])(
+    "preserves the actual Coder instance and scoped alias for advisor Pro: %s",
+    async (modelId) => {
+      using xumHome = new DisposableTempDir("ai-service-advisor-coder-pro");
+      const projectPath = path.join(xumHome.path, "project");
+      await fs.mkdir(projectPath, { recursive: true });
+      const workspaceId = "workspace-advisor-coder-pro";
+      const harness = createHarness(
+        xumHome.path,
+        createLocalWorkspaceMetadata(workspaceId, projectPath)
+      );
+      const model = `coder:prod-openai/${modelId}`;
+      await writeProvidersConfig(xumHome.path, {
+        coder: {
+          coderOauth: {
+            type: "oauth",
+            sessionId: "test",
+            deploymentUrl: "https://coder.example.com",
+            access: "test-access",
+            refresh: "test-refresh",
+            expires: Date.now() + 3_600_000,
+            clientId: "test",
+            clientSecret: "test",
+          },
+          discoveredProviders: [
+            { name: "prod-openai", type: "openai" },
+            { name: "openai", type: "openai-compat" },
+          ],
+          models: [{ id: "prod-openai/team-astra", mappedToModel: "openai:gpt-6-astra" }],
+        },
+      });
+      await enableAdvisorForHarness(harness, model);
+      await startAdvisorStream(harness, workspaceId);
+      // Avoid an OAuth exchange; the real option/route adapter below must retain
+      // the selected instance instead of re-resolving the unrelated "openai" instance.
+      spyOn(harness.service, "createModel").mockImplementation((_model, options) => {
+        if (!options) throw new Error("Expected the adapter's provider-options target");
+        options.openai = { wireFormat: "responses" };
+        return Promise.resolve({ success: true, data: Object.create(null) as LanguageModel });
+      });
+      const runtime = harness.getToolsForModelSpy.mock.calls[0]?.[1].advisorRuntime;
+      if (!runtime) throw new Error("Expected advisor runtime");
+      const created = await runtime.createModel(model);
+      expect(created.optionsRouteProvider).toBe("coder");
+      const options = buildProviderOptions(
+        created.optionsModelString,
+        "high",
+        undefined,
+        undefined,
+        created.optionsMuxProviderOptions,
+        undefined,
+        undefined,
+        created.optionsProvidersConfig,
+        created.optionsRouteProvider,
+        undefined,
+        "pro"
+      );
+      expect(options).toMatchObject({ openai: { reasoningMode: "pro" } });
+    }
+  );
 
   it("freezes advisor tool-call snapshots at the tool-call boundary", async () => {
     using xumHome = new DisposableTempDir("ai-service-advisor-step-snapshot-boundary");

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -223,8 +223,6 @@ export class AIService extends EventEmitter {
       durableEventJournalFor: (workspaceId) => this.durableEventJournalFor(workspaceId),
       shouldAllowLegacyInvalidWorkflowAgentOutputSchema: (metadata) =>
         this.shouldAllowLegacyInvalidWorkflowAgentOutputSchema(metadata),
-      createModel: (modelString, providerOptions, options) =>
-        this.createModel(modelString, providerOptions, options),
       isStreaming: (workspaceId) => this.streamManager.isStreaming(workspaceId),
       trackPendingDevToolsRunMetadata: (messageId, workspaceId, metadataId) =>
         this.trackPendingDevToolsRunMetadata(messageId, workspaceId, metadataId),
@@ -593,6 +591,13 @@ export class AIService extends EventEmitter {
       model: result.data,
       metadataModel: resolveModelForMetadata(metadataSeed, providersConfig),
     });
+  }
+
+  createModelWithPinnedOptions(
+    modelString: string,
+    opts?: Parameters<ProviderModelFactory["createModelWithPinnedOptions"]>[1]
+  ): ReturnType<ProviderModelFactory["createModelWithPinnedOptions"]> {
+    return this.providerModelFactory.createModelWithPinnedOptions(modelString, opts);
   }
 
   private wrapToolsForDelegation(

--- a/src/node/services/continuousCompactionSummary.ts
+++ b/src/node/services/continuousCompactionSummary.ts
@@ -11,7 +11,6 @@ import assert from "@/common/utils/assert";
 import type { SendMessageOptions } from "@/common/orpc/types";
 import type { MuxMessage } from "@/common/types/message";
 import { coerceThinkingLevel } from "@/common/types/thinking";
-import { getExplicitGatewayPrefix } from "@/common/utils/ai/models";
 import {
   buildProviderOptions,
   buildRequestHeaders,
@@ -67,7 +66,7 @@ export async function summarizeContinuousCompaction(args: {
     if (headTokens > args.context.contextWindowTokens * SUMMARIZER_INPUT_FRACTION) return null;
   }
   const modelString = options.model;
-  const thinkingLevel = enforceThinkingPolicy(
+  const initialThinkingLevel = enforceThinkingPolicy(
     modelString,
     coerceThinkingLevel(options.thinkingLevel) ?? "off",
     undefined,
@@ -115,16 +114,24 @@ export async function summarizeContinuousCompaction(args: {
     }
   );
   args.signal.throwIfAborted();
-  const created = await args.aiService.createModelWithPinnedMetadata(modelString, {
+  const created = await args.aiService.createModelWithPinnedOptions(modelString, {
     workspaceId: args.workspaceId,
     agentInitiated: true,
+    thinkingLevel: initialThinkingLevel,
+    providerOptions: options.providerOptions,
   });
   if (!created.success) throw new Error(`Cannot create compact model: ${created.error.type}`);
   try {
     args.signal.throwIfAborted();
+    const thinkingLevel = enforceThinkingPolicy(
+      created.data.optionsModelString,
+      coerceThinkingLevel(options.thinkingLevel) ?? "off",
+      undefined,
+      created.data.optionsProvidersConfig
+    );
     const prepared = prepareProviderRequestMessages(
       args.head,
-      created.data.metadataModel.split(":", 1)[0],
+      created.data.wireProviderName,
       thinkingLevel
     );
     const messages = await prepareMessagesForProvider({
@@ -132,10 +139,10 @@ export async function summarizeContinuousCompaction(args: {
       effectiveAgentId: "compact",
       toolNamesForSentinel: [],
       postCompactionAttachments: null,
-      providerForMessages: created.data.metadataModel.split(":", 1)[0],
+      providerForMessages: created.data.wireProviderName,
       effectiveThinkingLevel: thinkingLevel,
-      modelString,
-      providersConfig,
+      modelString: created.data.optionsModelString,
+      providersConfig: created.data.optionsProvidersConfig,
       workspaceId: args.workspaceId,
     });
     messages.push({
@@ -178,24 +185,24 @@ export async function summarizeContinuousCompaction(args: {
       messages,
       abortSignal: args.signal,
       providerOptions: buildProviderOptions(
-        modelString,
+        created.data.optionsModelString,
         thinkingLevel,
         args.head,
         undefined,
-        options.providerOptions,
+        created.data.optionsMuxProviderOptions,
         args.workspaceId,
         undefined,
-        providersConfig,
-        getExplicitGatewayPrefix(modelString),
+        created.data.optionsProvidersConfig,
+        created.data.optionsRouteProvider,
         undefined,
         options.reasoningMode
       ) as NonNullable<Parameters<typeof streamText>[0]["providerOptions"]>,
       headers: buildRequestHeaders(
-        modelString,
-        options.providerOptions,
+        created.data.optionsModelString,
+        created.data.optionsMuxProviderOptions,
         args.workspaceId,
-        providersConfig,
-        getExplicitGatewayPrefix(modelString)
+        created.data.optionsProvidersConfig,
+        created.data.optionsRouteProvider
       ),
     });
     const text = (await stream.text).trim();

--- a/src/node/services/providerModelFactory.test.ts
+++ b/src/node/services/providerModelFactory.test.ts
@@ -12,7 +12,10 @@ import { KNOWN_MODELS } from "@/common/constants/knownModels";
 import { CODEX_ENDPOINT, CODEX_OAUTH_ROUTED_HEADER } from "@/common/constants/codexOAuth";
 import { PROVIDER_REGISTRY } from "@/common/constants/providers";
 import { CUSTOM_PROVIDER_TYPES } from "@/common/utils/providers/customProviders";
-import { resolveProviderOptionsNamespaceKey } from "@/common/utils/ai/providerOptions";
+import {
+  buildProviderOptions,
+  resolveProviderOptionsNamespaceKey,
+} from "@/common/utils/ai/providerOptions";
 import { Ok } from "@/common/types/result";
 import {
   ProviderModelFactory,
@@ -2387,6 +2390,215 @@ describe("ProviderModelFactory Coder", () => {
         ),
     } as unknown as CoderOauthService;
   }
+
+  it.each([
+    {
+      available: true,
+      excluded: false,
+      fallback: "mux-gateway",
+      wire: "chatCompletions",
+      alias: true,
+      pro: true,
+    },
+    {
+      available: false,
+      excluded: false,
+      fallback: "mux-gateway",
+      wire: "responses",
+      alias: false,
+      pro: false,
+    },
+    {
+      available: true,
+      excluded: true,
+      fallback: "mux-gateway",
+      wire: "responses",
+      alias: false,
+      pro: false,
+    },
+    {
+      available: false,
+      excluded: false,
+      fallback: "direct",
+      wire: "responses",
+      alias: false,
+      pro: true,
+    },
+    {
+      available: true,
+      excluded: true,
+      fallback: "direct",
+      wire: "responses",
+      alias: false,
+      pro: true,
+    },
+    {
+      available: false,
+      excluded: false,
+      fallback: "direct",
+      wire: "chatCompletions",
+      alias: false,
+      pro: false,
+    },
+  ] as const)("pins request options to the created Coder/fallback route: %j", async (testCase) => {
+    await withTempConfig(async (config, factory, oauth) => {
+      const modelId = testCase.alias ? "team-astra" : "gpt-6-astra";
+      saveCoderConfig(config, {
+        enabled: testCase.available,
+        discoveredProviders: [{ name: "prod-openai", type: "openai" }],
+        ...(testCase.excluded ? { discoveredModels: [] } : {}),
+        models: testCase.alias
+          ? [{ id: "prod-openai/team-astra", mappedToModel: "openai:gpt-6-astra" }]
+          : [],
+      });
+      const store = new ProvidersConfigStore(config.rootDir);
+      store.saveProvidersConfig({
+        ...store.loadProvidersConfig(),
+        openai: { apiKey: "test-key", wireFormat: testCase.wire },
+        "mux-gateway": { couponCode: "test" },
+      });
+      oauth.coderOauthService = stubCoderOauthService();
+      await saveRoutePriority(config, [testCase.fallback], { muxGatewayEnabled: true });
+      const result = await factory.createModelWithPinnedOptions(`coder:prod-openai/${modelId}`, {
+        thinkingLevel: "high",
+        agentInitiated: true,
+        providerOptions: { openai: { wireFormat: "chatCompletions" } },
+      });
+      expect(result.success).toBe(true);
+      if (!result.success) throw new Error(result.error.type);
+      expect(result.data.optionsRouteProvider).toBe(
+        testCase.available && !testCase.excluded
+          ? "coder"
+          : testCase.fallback === "direct"
+            ? "openai"
+            : "mux-gateway"
+      );
+      expect(result.data.metadataModel).toBe("openai:gpt-6-astra");
+      const options = buildProviderOptions(
+        result.data.optionsModelString,
+        "high",
+        undefined,
+        undefined,
+        result.data.optionsMuxProviderOptions,
+        undefined,
+        undefined,
+        result.data.optionsProvidersConfig,
+        result.data.optionsRouteProvider,
+        undefined,
+        "pro"
+      );
+      if (!("openai" in options)) throw new Error("Expected OpenAI request options");
+      expect(options.openai.reasoningMode).toBe(testCase.pro ? "pro" : undefined);
+    });
+  });
+
+  it("pins compatible Coder instances to Chat Completions despite a Responses override", async () => {
+    await withTempConfig(async (config, factory, oauth) => {
+      saveCoderConfig(config, {
+        discoveredProviders: [{ name: "compat", type: "openai-compat" }],
+        models: [{ id: "compat/team-astra", mappedToModel: "openai:gpt-6-astra" }],
+      });
+      oauth.coderOauthService = stubCoderOauthService();
+      const result = await factory.createModelWithPinnedOptions("coder:compat/team-astra", {
+        providerOptions: { openai: { wireFormat: "responses" } },
+      });
+      if (!result.success) throw new Error(result.error.type);
+      const options = buildProviderOptions(
+        result.data.optionsModelString,
+        "high",
+        undefined,
+        undefined,
+        result.data.optionsMuxProviderOptions,
+        undefined,
+        undefined,
+        result.data.optionsProvidersConfig,
+        result.data.optionsRouteProvider,
+        undefined,
+        "pro"
+      );
+      if (!("openai" in options)) throw new Error("Expected OpenAI request options");
+      expect(options.openai.reasoningMode).toBeUndefined();
+      expect(options.openai.truncation).toBeUndefined();
+    });
+  });
+
+  it.each(["openai:gpt-6-astra", "coder:prod-openai/team-astra"])(
+    "does not rebuild the receipt from changed route/config state after creating %s",
+    async (modelString) => {
+      await withTempConfig(async (config, factory, oauth) => {
+        saveCoderConfig(config, {
+          discoveredProviders: [{ name: "prod-openai", type: "openai" }],
+          models: [{ id: "prod-openai/team-astra", mappedToModel: "openai:gpt-6-astra" }],
+        });
+        const store = new ProvidersConfigStore(config.rootDir);
+        store.saveProvidersConfig({
+          ...store.loadProvidersConfig(),
+          openai: { apiKey: "test-key" },
+          "mux-gateway": { couponCode: "test" },
+        });
+        await saveRoutePriority(config, ["direct"], { muxGatewayEnabled: true });
+        oauth.coderOauthService = stubCoderOauthService();
+        const resolve = factory.resolveAndCreateModel.bind(factory);
+        spyOn(factory, "resolveAndCreateModel").mockImplementation(async (...args) => {
+          const created = await resolve(...args);
+          store.saveProvidersConfig({
+            openai: { apiKey: "test-key" },
+            "mux-gateway": { couponCode: "test" },
+            coder: {
+              discoveredProviders: [{ name: "prod-openai", type: "anthropic" }],
+              models: [],
+            },
+          });
+          await saveRoutePriority(config, ["mux-gateway"]);
+          return created;
+        });
+        const result = await factory.createModelWithPinnedOptions(modelString, {
+          thinkingLevel: "high",
+        });
+        if (!result.success) throw new Error(result.error.type);
+        expect(result.data.optionsRouteProvider).toBe(
+          modelString.startsWith("coder:") ? "coder" : "openai"
+        );
+        expect(result.data.wireProviderName).toBe("openai");
+        expect(result.data.metadataModel).toBe("openai:gpt-6-astra");
+        const options = buildProviderOptions(
+          result.data.optionsModelString,
+          "high",
+          undefined,
+          undefined,
+          result.data.optionsMuxProviderOptions,
+          undefined,
+          undefined,
+          result.data.optionsProvidersConfig,
+          result.data.optionsRouteProvider,
+          undefined,
+          "pro"
+        );
+        expect(options).toMatchObject({ openai: { reasoningMode: "pro" } });
+      });
+    }
+  );
+
+  it.each([
+    { thinkingLevel: undefined, expected: "grok-4-1-fast" },
+    { thinkingLevel: "off", expected: "grok-4-1-fast-non-reasoning" },
+    { thinkingLevel: "high", expected: "grok-4-1-fast-reasoning" },
+  ] as const)(
+    "preserves unset-thinking variant semantics in pinned receipts: %j",
+    async (testCase) => {
+      await withTempConfig(async (config, factory) => {
+        new ProvidersConfigStore(config.rootDir).saveProvidersConfig({
+          xai: { apiKey: "test-key" },
+        });
+        const created = await factory.createModelWithPinnedOptions("xai:grok-4-1-fast", {
+          thinkingLevel: testCase.thinkingLevel,
+        });
+        if (!created.success) throw new Error(created.error.type);
+        expect(created.data.effectiveModelString).toBe(`xai:${testCase.expected}`);
+        expect(created.data.metadataModel).toBe(`xai:${testCase.expected}`);
+      });
+    }
+  );
 
   it("creates Anthropic-origin models against the deployment's AI Bridge", async () => {
     await withTempConfig(async (config, factory, oauth) => {

--- a/src/node/services/providerModelFactory.ts
+++ b/src/node/services/providerModelFactory.ts
@@ -23,6 +23,7 @@ import { parseCodexOauthAuth } from "@/node/utils/codexOauthAuth";
 import type { Config, ProviderConfig, ProvidersConfig } from "@/node/config";
 import { ProvidersConfigStore } from "@/node/config";
 import type { MuxProviderOptions } from "@/common/types/providerOptions";
+import type { ProvidersConfigMap } from "@/common/orpc/types";
 import type { ServiceTier, XAIServiceTier } from "@/common/config/schemas/providersConfig";
 import { resolveConfigBaseUrl } from "@/common/utils/providers/baseUrl";
 import { isProviderDisabledInConfig } from "@/common/utils/providers/isProviderDisabled";
@@ -1103,6 +1104,18 @@ export interface ResolveAndCreateModelResult {
   routedThroughGateway: boolean;
   /** Route provider chosen by backend routing (direct provider or gateway). */
   routeProvider?: ProviderName;
+}
+
+/** Creation-time request receipt; routing and wire data must not be reconstructed after awaits. */
+export interface PinnedModelOptions extends Pick<
+  ResolveAndCreateModelResult,
+  "model" | "effectiveModelString" | "wireProviderName"
+> {
+  metadataModel: string;
+  optionsModelString: string;
+  optionsProvidersConfig: ProvidersConfigMap;
+  optionsMuxProviderOptions: MuxProviderOptions;
+  optionsRouteProvider?: ProviderName;
 }
 
 interface CreateModelOptions {
@@ -2531,6 +2544,63 @@ export class ProviderModelFactory {
     );
   }
 
+  /** Create a model and its complete request options from one config/route decision. */
+  async createModelWithPinnedOptions(
+    modelString: string,
+    opts?: {
+      thinkingLevel?: ThinkingLevel;
+      providerOptions?: MuxProviderOptions;
+      agentInitiated?: boolean;
+      workspaceId?: string;
+    }
+  ): Promise<Result<PinnedModelOptions, SendMessageError>> {
+    const providersConfig = this.providersConfigStore.loadProvidersConfig() ?? {};
+    const optionsProvidersConfig = this.providerService.getConfig(providersConfig);
+    const optionsMuxProviderOptions = structuredClone(opts?.providerOptions ?? {});
+    const result = await this.resolveAndCreateModel(
+      modelString,
+      opts?.thinkingLevel,
+      optionsMuxProviderOptions,
+      {
+        agentInitiated: opts?.agentInitiated,
+        workspaceId: opts?.workspaceId,
+        providersConfig,
+      }
+    );
+    if (!result.success) return result;
+
+    if (result.data.coderWire?.origin === "openai") {
+      // Coder's SDK protocol comes from the selected instance, not direct
+      // OpenAI preferences (or a caller's requested wire format).
+      optionsMuxProviderOptions.openai = {
+        ...optionsMuxProviderOptions.openai,
+        wireFormat:
+          result.data.coderWire.providerType === "openai" ? "responses" : "chatCompletions",
+      };
+    }
+
+    const onCoderRoute = result.data.effectiveModelString.startsWith("coder:");
+    const custom = isCustomProviderConfig(providersConfig[modelString.split(":", 1)[0]]);
+    // Preserve scoped aliases on Coder/custom routes, but fallback options and
+    // pricing must follow the provider that actually created the model.
+    const fallbackModel = normalizeToCanonical(result.data.effectiveModelString);
+    const optionsModelString =
+      modelString.startsWith("coder:") && !custom && !onCoderRoute ? fallbackModel : modelString;
+    return Ok({
+      model: result.data.model,
+      effectiveModelString: result.data.effectiveModelString,
+      wireProviderName: result.data.wireProviderName,
+      metadataModel: resolveModelForMetadata(
+        custom || onCoderRoute ? modelString : fallbackModel,
+        providersConfig
+      ),
+      optionsModelString,
+      optionsProvidersConfig,
+      optionsMuxProviderOptions,
+      optionsRouteProvider: result.data.routeProvider,
+    });
+  }
+
   /**
    * Resolve model string (xAI variant mapping + gateway routing) and create the model.
    *
@@ -2542,7 +2612,7 @@ export class ProviderModelFactory {
    */
   resolveAndCreateModel(
     modelString: string,
-    thinkingLevel: ThinkingLevel,
+    thinkingLevel: ThinkingLevel | undefined,
     muxProviderOptions?: MuxProviderOptions,
     opts?: Pick<CreateModelOptions, "agentInitiated" | "workspaceId" | "providersConfig">
   ): Promise<Result<ResolveAndCreateModelResult, SendMessageError>> {
@@ -2553,7 +2623,7 @@ export class ProviderModelFactory {
 
   private resolveAndCreateModelEffect(
     modelString: string,
-    thinkingLevel: ThinkingLevel,
+    thinkingLevel: ThinkingLevel | undefined,
     muxProviderOptions?: MuxProviderOptions,
     opts?: Pick<CreateModelOptions, "agentInitiated" | "workspaceId" | "providersConfig">
   ): Effect.Effect<Result<ResolveAndCreateModelResult, SendMessageError>> {
@@ -2584,8 +2654,13 @@ export class ProviderModelFactory {
       const [canonicalProviderName, canonicalModelId] = parseModelString(canonicalModelString);
 
       // xAI Grok: swap between reasoning and non-reasoning variants based on thinking level.
+      // An unset level preserves createModel's no-variant-selection behavior for headless callers.
       // xAI only supports full reasoning (no medium/low).
-      if (canonicalProviderName === "xai" && canonicalModelId === "grok-4-1-fast") {
+      if (
+        thinkingLevel != null &&
+        canonicalProviderName === "xai" &&
+        canonicalModelId === "grok-4-1-fast"
+      ) {
         const variant =
           thinkingLevel !== "off" ? "grok-4-1-fast-reasoning" : "grok-4-1-fast-non-reasoning";
         effectiveModelString = `xai:${variant}`;

--- a/src/node/services/providerService.test.ts
+++ b/src/node/services/providerService.test.ts
@@ -14,6 +14,9 @@ import { Config } from "@/node/config";
 import { log } from "@/node/services/log";
 import { PolicyService } from "@/node/services/policyService";
 import { ProviderService } from "./providerService";
+import { openaiProModeAvailable } from "@/common/utils/ai/proMode";
+import { resolveCoderGatewayMetadataModel } from "@/common/utils/providers/coderGatewayMetadata";
+import { getAllowedProvidersForUi, isGatewayModelAccessibleForUi } from "@/browser/utils/policyUi";
 
 const OPENAI_API_KEY = "sk-test";
 const LOCAL_VLLM_BASE_URL = "http://localhost:8000/v1";
@@ -754,6 +757,109 @@ describe("ProviderService.getConfig", () => {
         // Without a stored credential the denied provider stays fully hidden.
         new ProvidersConfigStore(config.rootDir).saveProvidersConfig({
           coder: { deploymentUrl: "https://coder.example.com" },
+        });
+        expect(service.getConfig().coder).toBeUndefined();
+      }
+    );
+  });
+
+  it("retains only non-routable Coder instance metadata for policy-allowed upstream fallback", async () => {
+    await withTempPolicyProviderService(
+      { policy_format_version: "0.1", provider_access: [{ id: "openai" }] },
+      (config, service, policyService) => {
+        const store = new ProvidersConfigStore(config.rootDir);
+        store.saveProvidersConfig({
+          openai: { apiKey: OPENAI_API_KEY },
+          coder: {
+            deploymentUrl: "https://private.coder.example.com",
+            apiKey: "private-key",
+            baseUrl: "https://private.example.com",
+            coderOauth: {
+              type: "oauth",
+              sessionId: "test",
+              deploymentUrl: "https://private.coder.example.com",
+              access: "private-access",
+              refresh: "private-refresh",
+              expires: Date.now() + 3_600_000,
+              clientId: "private-client",
+              clientSecret: "private-secret",
+            },
+            models: ["prod-openai/gpt-6-astra"],
+            discoveredModels: ["prod-openai/gpt-6-astra"],
+            discoveredProviders: [
+              { name: "prod-openai", type: "openai" },
+              { name: "openai", type: "openai" },
+            ],
+            additionalProviders: [{ name: "openai", type: "openai-compat" }],
+          },
+        });
+        const view = service.getConfig();
+        // This allowlist is a redaction boundary, not an exhaustive config projection.
+        expect(view.coder).toEqual({
+          apiKeySet: false,
+          isEnabled: false,
+          isConfigured: false,
+          coderOauthCredentialStored: true,
+          discoveredProviders: [
+            { name: "prod-openai", type: "openai" },
+            { name: "openai", type: "openai" },
+          ],
+          additionalProviders: [{ name: "openai", type: "openai-compat" }],
+        });
+        const selection = "coder:prod-openai/gpt-6-astra";
+        expect(resolveCoderGatewayMetadataModel(selection, view)).toBe("openai:gpt-6-astra");
+        expect(
+          openaiProModeAvailable(selection, {
+            providersConfig: view,
+            effectiveRouteProvider: "direct",
+          })
+        ).toBe(true);
+        expect(
+          openaiProModeAvailable(selection, {
+            providersConfig: view,
+            effectiveRouteProvider: "mux-gateway",
+          })
+        ).toBe(false);
+        // Keep cross-typed overrides: dropping them would invent an OpenAI fallback.
+        expect(
+          openaiProModeAvailable("coder:openai/gpt-6-astra", {
+            providersConfig: view,
+            effectiveRouteProvider: "direct",
+          })
+        ).toBe(false);
+        expect(
+          openaiProModeAvailable("coder:unknown/gpt-6-astra", {
+            providersConfig: view,
+            effectiveRouteProvider: "direct",
+          })
+        ).toBe(false);
+        expect(service.list()).not.toContain("coder");
+        expect(getAllowedProvidersForUi(policyService.getEffectivePolicy(), view)).not.toContain(
+          "coder"
+        );
+        expect(
+          isGatewayModelAccessibleForUi(
+            policyService.getEffectivePolicy(),
+            view,
+            "coder",
+            "prod-openai/gpt-6-astra"
+          )
+        ).toBe(false);
+        const snapshot = store.loadProvidersConfig();
+        store.saveProvidersConfig({
+          ...snapshot,
+          coder: { ...snapshot?.coder, coderOauth: undefined },
+        });
+        expect(resolveCoderGatewayMetadataModel(selection, service.getConfig())).toBe(
+          "openai:gpt-6-astra"
+        );
+        expect(service.getConfig().coder.coderOauthCredentialStored).toBeUndefined();
+        store.saveProvidersConfig({
+          coder: {
+            providerType: "openai-responses",
+            baseUrl: "https://custom.example.com",
+            discoveredProviders: [{ name: "prod-openai", type: "openai" }],
+          },
         });
         expect(service.getConfig().coder).toBeUndefined();
       }

--- a/src/node/services/providerService.ts
+++ b/src/node/services/providerService.ts
@@ -649,25 +649,25 @@ export class ProviderService {
       );
     }
 
-    // A policy that denies coder hides the provider entirely (above), but a
-    // stored OAuth credential is still live on its deployment. Surface its
-    // PRESENCE so the Disconnect command stays reachable — otherwise the
-    // full-privilege credential would have no revocation path until the
-    // policy broadens. Presence only: no URL/models/config leaks, the entry
-    // is unconfigured/disabled, and the policy-filtered Providers UI still
-    // hides the card (this map key is consumed by the palette command's
-    // visibility gate). Skipped when a custom provider shadows "coder" —
-    // that entry owns the key and has no OAuth flow.
+    // Policy-hidden Coder selections still need instance types to resolve an
+    // allowed upstream fallback, and credential presence for Disconnect. Keep
+    // this view non-routable: no models, endpoint settings or authentication data.
+    // A custom provider shadowing "coder" owns the key and has no gateway metadata.
     if (!result.coder && !shadowedCustomProviderIds.has("coder")) {
-      const coderOauth = parseCoderOauthAuth(
-        (providersConfig.coder as { coderOauth?: unknown } | undefined)?.coderOauth
-      );
-      if (coderOauth !== null) {
+      const coderConfig = providersConfig.coder as
+        | { coderOauth?: unknown; discoveredProviders?: unknown; additionalProviders?: unknown }
+        | undefined;
+      const coderOauth = parseCoderOauthAuth(coderConfig?.coderOauth);
+      const discoveredProviders = parseCoderGatewayProviders(coderConfig?.discoveredProviders);
+      const additionalProviders = parseCoderGatewayProviders(coderConfig?.additionalProviders);
+      if (coderOauth !== null || discoveredProviders.length > 0 || additionalProviders.length > 0) {
         result.coder = {
           apiKeySet: false,
           isEnabled: false,
           isConfigured: false,
-          coderOauthCredentialStored: true,
+          ...(coderOauth !== null && { coderOauthCredentialStored: true }),
+          ...(discoveredProviders.length > 0 && { discoveredProviders }),
+          ...(additionalProviders.length > 0 && { additionalProviders }),
         };
       }
     }

--- a/src/node/services/providerService.ts
+++ b/src/node/services/providerService.ts
@@ -22,7 +22,7 @@
  */
 import { EventEmitter } from "events";
 import { Effect, Schema } from "effect";
-import type { Config, ProjectsConfig } from "@/node/config";
+import type { Config, ProjectsConfig, ProvidersConfig } from "@/node/config";
 import { FileLeaseManager, ProvidersConfigStore } from "@/node/config";
 import {
   PROVIDER_DEFINITIONS,
@@ -363,8 +363,10 @@ export class ProviderService {
   /**
    * Get the full providers config with safe info (no actual API keys)
    */
-  public getConfig(): ProvidersConfigMap {
-    const providersConfig = this.providersConfigStore.loadProvidersConfig() ?? {};
+  public getConfig(snapshot?: ProvidersConfig): ProvidersConfigMap {
+    // Request builders can project their creation-time snapshot without racing
+    // a second disk read that changes instance types or scoped model aliases.
+    const providersConfig = snapshot ?? this.providersConfigStore.loadProvidersConfig() ?? {};
     const mainConfig = this.config.loadConfigOrDefault();
     const result: ProvidersConfigMap = {};
     const shadowedCustomProviderIds = this.detectAndLogShadowedProviders(providersConfig);

--- a/src/node/services/tools/advisor.test.ts
+++ b/src/node/services/tools/advisor.test.ts
@@ -217,10 +217,13 @@ describe("advisor tool", () => {
   });
 
   it.each([
-    { optionsRouteProvider: "coder" },
-    { optionsRouteProvider: "mux-gateway" },
-    { optionsMuxProviderOptions: { openai: { wireFormat: "chatCompletions" } } },
-  ] as const)("does not emit advisor Pro on unsupported routes/wires: %j", async (modelOptions) => {
+    { modelOptions: { optionsRouteProvider: "coder" }, expectedMode: "pro" },
+    { modelOptions: { optionsRouteProvider: "mux-gateway" }, expectedMode: undefined },
+    {
+      modelOptions: { optionsMuxProviderOptions: { openai: { wireFormat: "chatCompletions" } } },
+      expectedMode: undefined,
+    },
+  ] as const)("gates advisor Pro by the effective route/wire: %j", async (testCase) => {
     using tempDir = new TestTempDir("advisor-reasoning-route");
     const { config } = createToolConfig(tempDir.path);
     const streamTextSpy = mockStreamTextSuccess({
@@ -238,12 +241,14 @@ describe("advisor tool", () => {
             model: Object.create(null) as LanguageModel,
             optionsModelString: "openai:gpt-5.6",
             optionsProvidersConfig: null,
-            ...modelOptions,
+            ...testCase.modelOptions,
           }),
       },
     });
     await tool.execute!({}, mockToolCallOptions);
-    expect(getStreamTextArgs(streamTextSpy).providerOptions?.openai?.reasoningMode).toBeUndefined();
+    expect(getStreamTextArgs(streamTextSpy).providerOptions?.openai?.reasoningMode).toBe(
+      testCase.expectedMode
+    );
   });
 
   it("reports model usage after a successful advisor call", async () => {

--- a/src/node/services/tools/advisor.ts
+++ b/src/node/services/tools/advisor.ts
@@ -260,10 +260,9 @@ export function createAdvisorTool(config: ToolConfiguration): Tool {
           optionsMuxProviderOptions,
           optionsRouteProvider,
         } = await runtime.createModel(advisorModelString);
-        // Provider options from the wire-resolved identity captured at model
-        // creation (same snapshot): a raw coder: string would resolve to the
-        // wrong (or no) provider namespace for custom-named or cross-typed
-        // instances. buildProviderOptions returns provider SDK option types;
+        // Keep the creation-time identity, including the actual Coder instance
+        // and scoped aliases. buildProviderOptions resolves its wire namespace
+        // from the same captured config and returns provider SDK option types;
         // streamText accepts the same JSON-shaped values through its shared
         // providerOptions slot.
         // eslint-disable-next-line local/no-chained-type-assertions -- grandfathered when the rule was introduced; fix the underlying type instead of copying this pattern

--- a/src/node/services/turnRequestBuilder.test.ts
+++ b/src/node/services/turnRequestBuilder.test.ts
@@ -70,7 +70,6 @@ async function createPreparationHarness() {
       throw new Error("not used by request preparation tests");
     },
     shouldAllowLegacyInvalidWorkflowAgentOutputSchema: () => Promise.resolve(false),
-    createModel: () => Promise.reject(new Error("not used by request preparation tests")),
     isStreaming: () => false,
     trackPendingDevToolsRunMetadata: () => undefined,
   });

--- a/src/node/services/turnRequestBuilder.ts
+++ b/src/node/services/turnRequestBuilder.ts
@@ -2040,10 +2040,10 @@ export class TurnRequestBuilder {
       // on one wire while recording usage under another type.
       const toolProvidersConfig =
         this.dependencies.providersConfigStore.loadProvidersConfig() ?? {};
-      // View snapshot captured at creation time for option
-      // building (buildProviderOptions takes the oRPC view, not
-      // the raw config shape).
-      const toolOptionsProvidersConfig = this.dependencies.providerService.getConfig();
+      // Project that same snapshot for option building; raw Coder identities
+      // must not resolve against refreshed instance types or alias metadata.
+      const toolOptionsProvidersConfig =
+        this.dependencies.providerService.getConfig(toolProvidersConfig);
       // Let the factory pin provider-level defaults (especially the OpenAI wire
       // format) without inheriting any options from the parent chat.
       const toolMuxProviderOptions: MuxProviderOptions = {};

--- a/src/node/services/turnRequestBuilder.ts
+++ b/src/node/services/turnRequestBuilder.ts
@@ -2091,36 +2091,16 @@ export class TurnRequestBuilder {
         toolOnCoderRoute ? toolModelString : normalizeToCanonical(toolEffectiveModelString),
         toolProvidersConfig
       );
-      // Wire-resolved identity for option construction, same
-      // snapshot: a raw coder: string carries no wire info, so
-      // buildProviderOptions would emit the wrong (or no)
-      // namespace for custom-named/cross-typed instances. Mirrors
-      // resolveOptionsCanonicalModel's shadow + wire rules.
-      const toolOptionsModelString = (() => {
-        // Custom providers keep their RAW identity: with the
-        // pinned snapshot below, buildProviderOptions remaps the
-        // wire namespace itself while still resolving
-        // mappedToModel alias metadata from the custom entry.
-        if (!toolModelString.startsWith("coder:")) {
-          return toolModelString;
-        }
-        const coderSection = toolProvidersConfig.coder;
-        if (isCustomProviderConfig(coderSection)) {
-          return toolModelString;
-        }
-        if (!toolOnCoderRoute) {
-          // Fallback-away: options must target the route that
-          // actually serves the request, not the instance's wire.
-          return normalizeToCanonical(toolEffectiveModelString);
-        }
-        const wire = resolveCoderWireCanonicalModel(
-          toolModelString.slice("coder:".length),
-          coderSection as
-            | { discoveredProviders?: unknown; additionalProviders?: unknown }
-            | undefined
-        );
-        return wire ? `${wire.origin}:${wire.modelId}` : toolModelString;
-      })();
+      // Keep the raw Coder instance and scoped aliases for option construction;
+      // the builder resolves the wire itself. A normalized openai: identity would
+      // make Pro inspect the unrelated default-named instance. Only fallback-away
+      // requests must switch to the identity of the provider actually serving them.
+      const toolOptionsModelString =
+        toolModelString.startsWith("coder:") &&
+        !isCustomProviderConfig(toolProvidersConfig.coder) &&
+        !toolOnCoderRoute
+          ? normalizeToCanonical(toolEffectiveModelString)
+          : toolModelString;
       return {
         model: toolModel.data.model,
         metadataModel,

--- a/src/node/services/turnRequestBuilder.ts
+++ b/src/node/services/turnRequestBuilder.ts
@@ -582,11 +582,6 @@ interface TurnRequestBuilderDependencies {
   shouldAllowLegacyInvalidWorkflowAgentOutputSchema: (
     metadata: WorkspaceMetadata
   ) => Promise<boolean>;
-  createModel: (
-    modelString: string,
-    muxProviderOptions?: MuxProviderOptions,
-    opts?: { agentInitiated?: boolean; workspaceId?: string; providersConfig?: ProvidersConfig }
-  ) => Promise<Result<LanguageModel, SendMessageError>>;
   isStreaming: (workspaceId: string) => boolean;
   trackPendingDevToolsRunMetadata: (
     messageId: string,
@@ -2034,87 +2029,14 @@ export class TurnRequestBuilder {
         toolModelString.length > 0,
         "tool model string must be non-empty when creating a tool model"
       );
-      // ONE config snapshot for both SDK model creation and the
-      // pinned pricing identity: two independent reads would let
-      // a catalog refresh land between them, running the request
-      // on one wire while recording usage under another type.
-      const toolProvidersConfig =
-        this.dependencies.providersConfigStore.loadProvidersConfig() ?? {};
-      // Project that same snapshot for option building; raw Coder identities
-      // must not resolve against refreshed instance types or alias metadata.
-      const toolOptionsProvidersConfig =
-        this.dependencies.providerService.getConfig(toolProvidersConfig);
-      // Let the factory pin provider-level defaults (especially the OpenAI wire
-      // format) without inheriting any options from the parent chat.
-      const toolMuxProviderOptions: MuxProviderOptions = {};
-      const creationOptions = {
-        workspaceId,
-        providersConfig: toolProvidersConfig,
-        agentInitiated: true,
-      };
-      // Intuition's effort can select a different model variant, not just provider
-      // options. Preserve the same provider snapshot for resolution and creation.
-      const toolModel =
-        toolThinkingLevel === undefined
-          ? await this.dependencies
-              .createModel(toolModelString, toolMuxProviderOptions, creationOptions)
-              .then((result) =>
-                result.success
-                  ? Ok({ model: result.data, effectiveModelString: undefined })
-                  : result
-              )
-          : await this.dependencies.providerModelFactory.resolveAndCreateModel(
-              toolModelString,
-              toolThinkingLevel,
-              toolMuxProviderOptions,
-              creationOptions
-            );
-      if (!toolModel.success) {
-        throw new Error(`Failed to create tool model: ${getErrorMessage(toolModel.error)}`);
-      }
-      // Same effective-route rule as createModelWithPinnedMetadata:
-      // a coder: selection whose gateway is unavailable falls away
-      // to a direct provider inside createModel, and identity or
-      // options derived from the raw selection (instance type)
-      // would diverge from the model actually created.
-      const toolEffectiveModelString =
-        toolModel.data.effectiveModelString ??
-        this.dependencies.providerModelFactory.resolveEffectiveModelString(
-          toolModelString,
-          undefined,
-          toolProvidersConfig
-        );
-      const toolOnCoderRoute = toolEffectiveModelString.startsWith("coder:");
-      // Carry pricing with each creation: parallel tools can select different
-      // variants or provider snapshots for the same raw model string.
-      const metadataModel = resolveModelForMetadata(
-        toolOnCoderRoute ? toolModelString : normalizeToCanonical(toolEffectiveModelString),
-        toolProvidersConfig
+      const created = await this.dependencies.providerModelFactory.createModelWithPinnedOptions(
+        toolModelString,
+        { thinkingLevel: toolThinkingLevel, workspaceId, agentInitiated: true }
       );
-      // Keep the raw Coder instance and scoped aliases for option construction;
-      // the builder resolves the wire itself. A normalized openai: identity would
-      // make Pro inspect the unrelated default-named instance. Only fallback-away
-      // requests must switch to the identity of the provider actually serving them.
-      const toolOptionsModelString =
-        toolModelString.startsWith("coder:") &&
-        !isCustomProviderConfig(toolProvidersConfig.coder) &&
-        !toolOnCoderRoute
-          ? normalizeToCanonical(toolEffectiveModelString)
-          : toolModelString;
-      return {
-        model: toolModel.data.model,
-        metadataModel,
-        optionsModelString: toolOptionsModelString,
-        optionsProvidersConfig: toolOptionsProvidersConfig,
-        optionsMuxProviderOptions: toolMuxProviderOptions,
-        optionsRouteProvider: (() => {
-          const provider = toolEffectiveModelString.split(":", 1)[0];
-          return !isCustomProviderConfig(toolProvidersConfig[provider]) &&
-            Object.hasOwn(PROVIDER_DEFINITIONS, provider)
-            ? (provider as ProviderName)
-            : undefined;
-        })(),
-      };
+      if (!created.success) {
+        throw new Error(`Failed to create tool model: ${getErrorMessage(created.error)}`);
+      }
+      return created.data;
     };
     // Hoisted so refusal fallback can rebuild tools without changing their context.
     const toolsForModelConfig: ToolConfiguration = {


### PR DESCRIPTION
## Summary

Enable Pro mode for GPT-6 Astra through Coder's OpenAI Responses route. Astra was already Pro-capable, but the shared direct-only gate hid the toggle and the request builder dropped the selection for every gateway.

## Implementation

- Allow Coder's actual OpenAI Responses instances, including custom-named instances, using their provider type rather than the instance name.
- Retain only instance name/type metadata in the existing disabled policy-hidden Coder shell, so allowed fallbacks work without exposing endpoints, models, or credentials.
- Preserve explicit gateway precedence and fallback behavior, the direct-only Fast mode gate, and restrictions for incompatible gateways, Chat Completions, and Codex OAuth.
- Use the policy-aware effective route in the picker and palette. Keep scoped Treat-as mappings capability-only, and preserve actual Coder instance identity for nested advisors.
- Share one creation-time model result across nested tools and continuous compaction, carrying the effective route, scoped identity, actual wire format, and provider-config snapshot into request construction.
- Send the existing native OpenAI reasoning mode option without changing the selected reasoning effort.

## Validation

- 1,063 targeted provider-options, agent-settings, thinking-policy, routing, palette, AI-service, advisor, model-factory, continuous-compaction, Intuition, provider-service, and Settings UI tests passed, including capture of the real SDK's outgoing `reasoning.mode: "pro"` field.
- All 13 isolated CI-prefix suites passed (440 tests), including the corrected plugin-compaction fixture; an API/MutexMap coverage rerun passed 31 tests.
- Both full-app Storybook interactions passed with `--failOnConsole` after rebasing onto current main.
- Manually verified pointer and keyboard toggles in Storybook manager at 375×667, 390×844, and 1280×800; High remains selected, Pro persists, and the menu stays within bounds.
- `make static-check` passed. Final local self-review found no remaining actionable issues after addressing all independent-review findings.
- Verification was offline; no billable model requests were sent.

<details>
<summary>Dogfood screenshots and recording</summary>

![Desktop: Astra with Pro mode checked](https://github.com/user-attachments/assets/eb7e0023-db7c-43e7-b335-9e3afd044efd)

![Phone: Astra with Pro mode checked](https://github.com/user-attachments/assets/af11c522-3dac-4d8b-99da-2fcce731edb5)

https://github.com/user-attachments/assets/caa22716-48cf-44c8-81b8-08d0109a5791

</details>

## Validation limitation

The full local shared-coverage run was inconclusive: one unchanged reconnect assertion failed (then passed narrowly), and the batch produced no terminal Bun summary. Final-head CI subsequently passed the complete shared-unit run, all required checks, and visual-test execution.

## Risks

The change affects Pro eligibility and request-option assembly for Coder Responses, nested tools, and continuous compaction. Existing metadata-only status/dream/refine callers retain their behavior. Instance-type, unsupported-model, custom-provider-shadowing, gateway, and wire-format regression cases guard against exposing a toggle that cannot affect requests.

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `coder:openai/gpt-6-astra` • Thinking: `high` • Cost: `$177.56`_

<!-- mux-attribution: model=coder:openai/gpt-6-astra thinking=high costs=177.56 -->

