### PR TITLE
🤖 fix: retain eager compaction execution through reset

### DIFF
--- a/src/node/services/agentSession.continuousCompaction.test.ts
+++ b/src/node/services/agentSession.continuousCompaction.test.ts
@@ -24,6 +24,7 @@ import {
   type AgentSessionHarness,
 } from "./agentSession.testHarness";
 import type { ContinuousCompactor } from "./continuousCompactor";
+import type { TurnCoordinator } from "./turnCoordinator";
 
 const workspaceId = "continuous-session";
 const model = "openai:gpt-4o";
@@ -126,6 +127,128 @@ describe("AgentSession continuous compaction wiring", () => {
     );
     expect(result.success).toBe(true);
   }
+
+  describe("eager compaction physical lifetime", () => {
+    async function setupEager() {
+      const h = await setup();
+      for (const row of [
+        createMuxMessage("old-user", "user", "Investigate the regression"),
+        createMuxMessage("old-answer", "assistant", "earlier investigation ".repeat(4_000)),
+        createMuxMessage("recent-user", "user", "Implement the fix"),
+        createMuxMessage("recent-answer", "assistant", "The fix is ready for review."),
+      ]) {
+        expect((await h.historyService.appendToHistory(workspaceId, row)).success).toBe(true);
+      }
+      const compactor = internals(h.session).continuousCompactor;
+      const deps = Reflect.get(compactor, "deps") as ConstructorParameters<
+        typeof ContinuousCompactor
+      >[0];
+      const { coordinator } = h.session as unknown as { coordinator: TurnCoordinator };
+      const enterExecution = coordinator.enterExecution.bind(coordinator);
+      const releases: Array<ReturnType<typeof mock<() => void>>> = [];
+      // Track disposal while retaining the real coordinator leases and shutdown drain.
+      spyOn(coordinator, "enterExecution").mockImplementation(() => {
+        const execution = enterExecution();
+        const release = mock(() => execution[Symbol.dispose]());
+        releases.push(release);
+        return { [Symbol.dispose]: release };
+      });
+      deps.prepare = () => Promise.resolve();
+      deps.estimateAttachmentTokens = () => Promise.resolve(0);
+      deps.summarize = () => Promise.resolve({ text: "Earlier work summarized", model });
+      async function start() {
+        await compactor.observe(60, {
+          enabled: true,
+          model,
+          contextWindowTokens: 100_000,
+          thresholdPercent: 70,
+          phase: "stream-end",
+        });
+        const job = Reflect.get(compactor, "job") as { done: Promise<void> };
+        return { done: job.done };
+      }
+      return { h, compactor, deps, coordinator, releases, start };
+    }
+
+    for (const phase of ["prepare", "summarize"] as const) {
+      test.each(["complete", "reject", "reset", "shutdown"] as const)(
+        `retains eager ${phase} execution until the original Promise settles: %s`,
+        async (outcome) => {
+          const { h, compactor, deps, coordinator, releases, start } = await setupEager();
+          const entered = deferred<void>();
+          const release = deferred<void>();
+          async function work() {
+            entered.resolve();
+            await release.promise;
+            if (outcome === "reject") throw new Error("eager work failed");
+          }
+          if (phase === "prepare") deps.prepare = work;
+          else
+            deps.summarize = async () => {
+              await work();
+              return { text: "Earlier work summarized", model };
+            };
+          const job = await start();
+          let shutdown: Promise<void> | undefined;
+          try {
+            await entered.promise;
+            expect(releases).toHaveLength(1);
+            const eagerRelease = releases[0];
+            expect(eagerRelease).not.toHaveBeenCalled();
+            // Physical ownership must leave normal turn admission and semantic idle intact.
+            expect(coordinator.phase).toBe("idle");
+            expect(coordinator.admissionBlocked).toBe(false);
+            if (outcome === "reset") h.session.setAutoCompactionThreshold(0.8);
+            if (outcome === "shutdown") {
+              h.session.beginShutdown();
+              shutdown = h.session.finishShutdown();
+              expect(coordinator.closing).toBe(true);
+            }
+            await compactor.waitForIdle();
+            expect(eagerRelease).not.toHaveBeenCalled();
+            release.resolve();
+            await job.done;
+            expect(eagerRelease).toHaveBeenCalledTimes(1);
+            // A settled eager job must never strand the real shutdown drain.
+            await (shutdown ?? h.session.finishShutdown());
+            expect(eagerRelease).toHaveBeenCalledTimes(1);
+          } finally {
+            release.resolve();
+            await job.done;
+            await shutdown;
+          }
+        }
+      );
+    }
+
+    test("reset permits replacement work without releasing either job's physical ownership", async () => {
+      const { h, deps, releases, start } = await setupEager();
+      const first = deferred<void>();
+      const second = deferred<void>();
+      let preparations = 0;
+      deps.prepare = () => (preparations++ === 0 ? first.promise : second.promise);
+      const original = await start();
+      h.session.setAutoCompactionThreshold(0.8);
+      const replacement = await start();
+      try {
+        expect(releases).toHaveLength(2);
+        expect(releases[0]).not.toHaveBeenCalled();
+        expect(releases[1]).not.toHaveBeenCalled();
+        first.resolve();
+        await original.done;
+        expect(releases[0]).toHaveBeenCalledTimes(1);
+        expect(releases[1]).not.toHaveBeenCalled();
+        second.resolve();
+        await replacement.done;
+        expect(releases[1]).toHaveBeenCalledTimes(1);
+        await h.session.finishShutdown();
+      } finally {
+        first.resolve();
+        second.resolve();
+        await Promise.all([original.done, replacement.done]);
+      }
+    });
+  });
 
   test.each([
     "startup",

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -1198,6 +1198,7 @@ export class AgentSession {
 
     this.continuousCompactor = new ContinuousCompactor({
       workspaceId: this.workspaceId,
+      enterExecution: () => this.coordinator.enterExecution(),
       historyService: this.historyService,
       compactionHandler: this.compactionHandler,
       streamManager: {
@@ -6271,8 +6272,7 @@ export class AgentSession {
     observe: () => Promise<T>
   ): Promise<T | undefined> {
     if (this.coordinator.closing) return undefined;
-    // Own the actual apply and its continuation; the compactor's detached eager summary job
-    // retains its existing cancellation contract until the later compaction migration.
+    // Own the actual apply and its continuation; the compactor separately owns detached eager work.
     using _execution = this.coordinator.enterExecution();
     if (this.continuousCompactionObservation) {
       await this.continuousCompactionObservation;

--- a/src/node/services/continuousCompactor.ts
+++ b/src/node/services/continuousCompactor.ts
@@ -46,6 +46,7 @@ interface StreamSnapshot {
 }
 interface Dependencies {
   workspaceId: string;
+  enterExecution?(): Disposable;
   historyService: HistoryService;
   compactionHandler: CompactionHandler;
   streamManager: {
@@ -263,6 +264,9 @@ export class ContinuousCompactor {
         done: Promise.resolve(),
       };
       this.job = job;
+      // Reset may retire this job before non-cooperative preparation or summary I/O settles.
+      // Keep physical ownership on the original Promise, independent of semantic job identity.
+      const execution = this.deps.enterExecution?.();
       job.done = this.startEagerJob(job, context)
         .catch((error: unknown) => {
           if (!job.abort.signal.aborted)
@@ -270,6 +274,7 @@ export class ContinuousCompactor {
         })
         .finally(() => {
           if (this.job === job) this.job = null;
+          execution?.[Symbol.dispose]();
         });
     }
     return usagePercent >= context.thresholdPercent + FORCE_COMPACTION_BUFFER_PERCENT


### PR DESCRIPTION
Reset can clear the active eager-compaction job while its preparation or summary request is still running. Session shutdown then loses track of that detached work and can finish too early.

Acquire the existing coordinator execution lease when the eager job starts, and release it in that same promise's `finally`. Semantic reset and normal turn admission retain their existing behavior.

This is the first small replacement for closed #4121. It only fixes physical lifetime ownership; coordinator extraction and persistence hardening are separate changes.

Validation covers held preparation and summary work across completion, rejection, reset, shutdown, and replacement by another eager job. The tests retain real coordinator leases and HistoryService storage.

Risk: shutdown now correctly waits for eager work that ignores cancellation until it settles. Existing cancellation and semantic idle behavior are preserved.

---

_Generated with `xum` • Model: `unavailable` • Thinking: `unavailable` • Cost: `$unavailable`_

<!-- mux-attribution: model=unavailable thinking=unavailable costs=unavailable -->
