### PR TITLE
🤖 fix: inherit workspace MCP overrides in sub-agent and forked workspaces

### DIFF
--- a/src/node/config/index.ts
+++ b/src/node/config/index.ts
@@ -2924,7 +2924,8 @@ export class Config {
   private async addPathsToMetadata(
     metadata: WorkspaceMetadata,
     workspacePath: string,
-    _projectPath: string
+    _projectPath: string,
+    probeCheckout = true
   ): Promise<FrontendWorkspaceMetadata> {
     const result: FrontendWorkspaceMetadata = {
       ...metadata,
@@ -2941,10 +2942,16 @@ export class Config {
     // Mark worktree workspaces with missing checkout directories as transcript-only.
     // Queued/starting agent tasks can briefly exist without a provisioned checkout, so keep
     // those workspaces interactive until the checkout is created.
-    const workspacePathExists = await fs.promises
-      .access(workspacePath)
-      .then(() => true)
-      .catch(() => false);
+    // The probe is filesystem I/O per registered workspace (a stalled mount
+    // blocks it indefinitely); callers that only need registry data skip it
+    // (see getAllWorkspaceMetadata's probeCheckouts) and get no
+    // transcriptOnly classification.
+    const workspacePathExists = probeCheckout
+      ? await fs.promises
+          .access(workspacePath)
+          .then(() => true)
+          .catch(() => false)
+      : true;
     if (
       isWorktreeRuntime(metadata.runtimeConfig) &&
       metadata.taskStatus !== "queued" &&
@@ -3175,7 +3182,17 @@ export class Config {
      * delete activity data findWorkspace still vouches for.
      */
     legacyAliasIds?: Set<string>;
+    /**
+     * Probe each worktree checkout's existence (fs.access) to classify
+     * transcript-only workspaces. Default true. Callers that only need the
+     * registry (ids, paths, runtime, parent links) pass false: one stalled
+     * mount would otherwise block the whole enumeration, and per-request
+     * callers (workspace MCP override resolution) would pay one probe per
+     * registered workspace on every request.
+     */
+    probeCheckouts?: boolean;
   }): Promise<FrontendWorkspaceMetadata[]> {
+    const probeCheckouts = options?.probeCheckouts ?? true;
     const config = this.loadConfigOrDefault({ throwOnError: options?.throwOnError });
     const workspaceMetadata: FrontendWorkspaceMetadata[] = [];
     // Read-time migrations recorded here are re-applied to a FRESH config snapshot inside
@@ -3326,7 +3343,7 @@ export class Config {
             }
 
             workspaceMetadata.push(
-              await this.addPathsToMetadata(metadata, workspace.path, projectPath)
+              await this.addPathsToMetadata(metadata, workspace.path, projectPath, probeCheckouts)
             );
             continue; // Skip metadata file lookup
           }
@@ -3533,7 +3550,7 @@ export class Config {
             }
 
             workspaceMetadata.push(
-              await this.addPathsToMetadata(metadata, workspace.path, projectPath)
+              await this.addPathsToMetadata(metadata, workspace.path, projectPath, probeCheckouts)
             );
             metadataFound = true;
           }
@@ -3605,7 +3622,7 @@ export class Config {
             });
 
             workspaceMetadata.push(
-              await this.addPathsToMetadata(metadata, workspace.path, projectPath)
+              await this.addPathsToMetadata(metadata, workspace.path, projectPath, probeCheckouts)
             );
           }
         } catch (error) {
@@ -3667,7 +3684,7 @@ export class Config {
           };
 
           workspaceMetadata.push(
-            await this.addPathsToMetadata(metadata, workspace.path, projectPath)
+            await this.addPathsToMetadata(metadata, workspace.path, projectPath, probeCheckouts)
           );
         }
       }

--- a/src/node/runtime/RemoteRuntime.test.ts
+++ b/src/node/runtime/RemoteRuntime.test.ts
@@ -33,7 +33,9 @@ class CanonicalPathRemoteRuntime extends RecordingRemoteRuntime {
   override exec(command: string, _options: ExecOptions): Promise<ExecStream> {
     this.commands.push(command);
     return Promise.resolve({
-      stdout: createStream(command.startsWith("stat ") ? "1 2 regular file\n" : "contents"),
+      stdout: createStream(
+        command.startsWith("LC_ALL=C stat ") ? "1 2 regular file\n" : "contents"
+      ),
       stderr: createStream(""),
       stdin: new WritableStream<Uint8Array>(),
       exitCode: Promise.resolve(0),
@@ -85,7 +87,7 @@ describe("RemoteRuntime file path canonicalization", () => {
     expect(runtime.commands.some((command) => command.includes("'/home/test/write.txt'"))).toBe(
       true
     );
-    expect(runtime.commands).toContain("stat -L -c '%s %Y %F' '/workspace/stat.txt'");
+    expect(runtime.commands).toContain("LC_ALL=C stat -L -c '%s %Y %F' '/workspace/stat.txt'");
     expect(runtime.commands).toContain("mkdir -p '/home/test/dir'");
   });
 });

--- a/src/node/runtime/execFileIO.ts
+++ b/src/node/runtime/execFileIO.ts
@@ -176,8 +176,11 @@ export async function ensureDirViaExec(
   }
 }
 
-// -L follows symlinks so symlinked paths report the target's type.
-export const STAT_VIA_EXEC_COMMAND = "stat -L -c '%s %Y %F'";
+// -L follows symlinks so symlinked paths report the target's type. LC_ALL=C
+// pins stat(1)'s diagnostics to English: callers classify "No such file or
+// directory" from stderr (workspace MCP override probes), which a localized
+// remote host would otherwise render unrecognizable.
+export const STAT_VIA_EXEC_COMMAND = "LC_ALL=C stat -L -c '%s %Y %F'";
 
 /**
  * Get file statistics via exec; parses STAT_VIA_EXEC_COMMAND output.

--- a/src/node/services/agentPlugins/installService.test.ts
+++ b/src/node/services/agentPlugins/installService.test.ts
@@ -51,7 +51,7 @@ function overridesServiceStub(
   prune: (
     workspaceId: string,
     keyPrefix: string,
-    options?: { publish?: (persisted: unknown) => Promise<void> }
+    options?: { publish?: (persisted: unknown, workspaceId: string) => Promise<void> }
   ) => Promise<void>
 ): WorkspaceMcpOverridesService {
   const stub: Pick<WorkspaceMcpOverridesService, "prunePluginOverrideKeysForWorkspaces"> = {
@@ -60,9 +60,8 @@ function overridesServiceStub(
       for (const workspaceId of workspaceIds) {
         try {
           await prune(workspaceId, keyPrefix, {
-            publish: (persisted) =>
-              options?.publish?.(workspaceId, persisted as WorkspaceMCPOverrides) ??
-              Promise.resolve(),
+            publish: (persisted, target) =>
+              options?.publish?.(persisted as WorkspaceMCPOverrides, target) ?? Promise.resolve(),
           });
         } catch (error) {
           failures.push({ workspaceId, error });
@@ -2070,16 +2069,16 @@ describe("AgentPluginInstallService", () => {
     // persisted overrides inside the same (stubbed) write step.
     const overridesStub = overridesServiceStub(
       async (
-        _id: string,
+        id: string,
         keyPrefix: string,
-        options?: { publish?: (persisted: unknown) => Promise<void> }
+        options?: { publish?: (persisted: unknown, workspaceId: string) => Promise<void> }
       ) => {
         storedOverrides = {
           enabledServers: storedOverrides.enabledServers.filter(
             (key) => !key.startsWith(keyPrefix)
           ),
         };
-        await options?.publish?.(storedOverrides);
+        await options?.publish?.(storedOverrides, id);
       }
     );
     const applied: Array<{ workspaceId: string; overrides: unknown }> = [];

--- a/src/node/services/agentPlugins/installService.ts
+++ b/src/node/services/agentPlugins/installService.ts
@@ -43,7 +43,10 @@ import { parseSkillMarkdown } from "@/node/services/agentSkills/parseSkillMarkdo
 import { log } from "@/node/services/log";
 import type { MCPServerInfo } from "@/common/types/mcp";
 import type { MCPServerManager } from "@/node/services/mcpServerManager";
-import type { WorkspaceMcpOverridesService } from "@/node/services/workspaceMcpOverridesService";
+import {
+  ALL_WORKSPACES_TARGET,
+  type WorkspaceMcpOverridesService,
+} from "@/node/services/workspaceMcpOverridesService";
 import { MAX_FILE_SIZE } from "@/node/services/tools/fileCommon";
 import { ensurePathContained, hasErrorCode } from "@/node/services/tools/skillFileUtils";
 import { raceWithAbortAndTimeout } from "@/node/utils/concurrency/withTimeout";
@@ -3345,8 +3348,14 @@ export class AgentPluginInstallService {
         serverKeyPrefix,
         mcpServerManager
           ? {
-              publish: (workspaceId, persisted) =>
-                mcpServerManager.applyWorkspaceOverrides(workspaceId, persisted),
+              publish: (persisted, target) =>
+                persisted === null
+                  ? Promise.resolve(
+                      target === ALL_WORKSPACES_TARGET
+                        ? mcpServerManager.forgetAllWorkspaceOverrides()
+                        : mcpServerManager.forgetWorkspaceOverrides(target)
+                    )
+                  : mcpServerManager.applyWorkspaceOverrides(target, persisted),
             }
           : undefined
       );

--- a/src/node/services/agentPlugins/workspacePluginOperations.test.ts
+++ b/src/node/services/agentPlugins/workspacePluginOperations.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { ORPCContext } from "@/node/orpc/context";
 import { Ok } from "@/common/types/result";
-import { listWorkspaceMcpPrompts } from "./workspacePluginOperations";
+import { getWorkspaceMcpOverrides, listWorkspaceMcpPrompts } from "./workspacePluginOperations";
 
 const workspaceId = "ws-mcp-prompts";
 const metadata = {
@@ -39,6 +39,35 @@ function createContext(options: {
   } as unknown as ORPCContext;
   return { context, waitForInit, ensureReady, getPromptsForWorkspace };
 }
+
+describe("getWorkspaceMcpOverrides", () => {
+  test("the settings read is bounded and reports an unestablished state as unavailable", async () => {
+    // An inheriting workspace resolves through its ancestors' documents; the
+    // settings view must not hang on an unreachable parent, and must not show
+    // a guess when the state could not be established.
+    const fixture = createContext({
+      admission: undefined,
+      getPromptsForWorkspace: () => Promise.resolve([]),
+    });
+    const context = fixture.context as unknown as {
+      policyService: { getEffectivePolicy: () => undefined; isEnforced: () => boolean };
+      workspaceMcpOverridesService: { getOverridesForWorkspace: ReturnType<typeof mock> };
+    };
+    context.policyService = { getEffectivePolicy: () => undefined, isEnforced: () => false };
+    const read = context.workspaceMcpOverridesService.getOverridesForWorkspace;
+    read.mockImplementation(
+      (_workspaceId: string, options?: { mode?: string; timeoutMs?: number }) =>
+        options?.timeoutMs !== undefined && options.mode === "strict"
+          ? Promise.reject(new Error("workspace MCP override resolution timed out"))
+          : new Promise(() => undefined)
+    );
+
+    expect(await getWorkspaceMcpOverrides(fixture.context, workspaceId)).toEqual({
+      overrides: {},
+      revision: "unavailable",
+    });
+  });
+});
 
 describe("listWorkspaceMcpPrompts archive admission", () => {
   test("refused discovery returns an empty catalog without readying the runtime", async () => {
@@ -84,6 +113,43 @@ describe("listWorkspaceMcpPrompts archive admission", () => {
 
     releaseStartup();
     expect(await discovery).toEqual([]);
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
+  test("the inherited override read is bounded and cancelled with discovery's signal", async () => {
+    // A child whose SSH/Docker parent is unreachable must not pin discovery
+    // (and its archive admission) on a remote read after the caller gave up.
+    const dispose = mock(() => undefined);
+    const fixture = createContext({
+      admission: { [Symbol.dispose]: dispose },
+      getPromptsForWorkspace: () => Promise.reject(new Error("should not start servers")),
+    });
+    const controller = new AbortController();
+    const getOverrides = (
+      fixture.context.workspaceMcpOverridesService as unknown as {
+        getOverridesForWorkspace: ReturnType<typeof mock>;
+      }
+    ).getOverridesForWorkspace;
+    getOverrides.mockImplementation(
+      (_workspaceId: string, options?: { timeoutMs?: number; signal?: AbortSignal }) =>
+        new Promise((resolve) => {
+          const settle = () => resolve({ overrides: {}, revision: "r", authoritative: false });
+          if (options?.signal?.aborted) settle();
+          options?.signal?.addEventListener("abort", settle, { once: true });
+        })
+    );
+
+    const discovery = listWorkspaceMcpPrompts(fixture.context, workspaceId, controller.signal);
+    controller.abort();
+    expect(await discovery).toEqual([]);
+
+    const [, readOptions] = getOverrides.mock.calls[0] as [
+      string,
+      { timeoutMs?: number; signal?: AbortSignal },
+    ];
+    expect(readOptions.signal).toBe(controller.signal);
+    expect(typeof readOptions.timeoutMs).toBe("number");
+    expect(fixture.getPromptsForWorkspace).not.toHaveBeenCalled();
     expect(dispose).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/node/services/agentPlugins/workspacePluginOperations.ts
+++ b/src/node/services/agentPlugins/workspacePluginOperations.ts
@@ -2,6 +2,11 @@ import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import { formatSendMessageError } from "@/common/utils/errors/formatSendError";
 import { isMultiProject } from "@/common/utils/multiProject";
 import { secretsToRecord } from "@/common/types/secrets";
+import {
+  ALL_WORKSPACES_TARGET,
+  MCP_OVERRIDES_READ_TIMEOUT_MS,
+  MCP_OVERRIDES_REVISION_UNAVAILABLE,
+} from "@/node/services/workspaceMcpOverridesService";
 import type { ORPCContext } from "@/node/orpc/context";
 import { createRuntimeForWorkspace, resolveWorkspaceRootPath } from "@/node/runtime/runtimeHelpers";
 import { isProjectTrusted, isWorkspaceProjectTrusted } from "@/node/utils/projectTrust";
@@ -59,9 +64,18 @@ export async function getWorkspaceMcpOverrides(context: ORPCContext, workspaceId
     return { overrides: {}, revision: "mcp-disabled-by-policy" };
   }
   try {
-    return await context.workspaceMcpOverridesService.getOverridesForWorkspace(workspaceId);
+    // Bounded and strict like every other request-path read: an inheriting
+    // workspace resolves through its ancestors' documents (remote reads allow
+    // minutes per level), and the settings view must either show the
+    // established state or report it unavailable — never hang, never guess.
+    return await context.workspaceMcpOverridesService.getOverridesForWorkspace(workspaceId, {
+      mode: "strict",
+      timeoutMs: MCP_OVERRIDES_READ_TIMEOUT_MS,
+    });
   } catch {
-    return { overrides: {}, revision: "unavailable" };
+    // The sentinel revision makes the dialog's save a repair of the unreadable
+    // document (see writeOverridesLocked) rather than a permanent conflict.
+    return { overrides: {}, revision: MCP_OVERRIDES_REVISION_UNAVAILABLE };
   }
 }
 
@@ -85,8 +99,18 @@ export async function listWorkspaceMcpPrompts(
   const { runtime, workspacePath, hostCheckoutRoot } = runtimeResult.data;
   const ready = await runtime.ensureReady(signal ? { signal } : undefined);
   if (!ready.ready) throw new Error(ready.error);
-  const { overrides } =
-    await context.workspaceMcpOverridesService.getOverridesForWorkspace(workspaceId);
+  // Forward the authority too: a snapshot the service could not establish
+  // must make the manager re-read disk (and fail closed), not start servers.
+  // Bounded and cancellable like the send path: an inheriting child's
+  // resolution reads through an SSH/Docker parent (minutes per remote op),
+  // and discovery holds its archive admission for the duration.
+  const overridesReadStartedAt = Date.now();
+  const { overrides, authoritative } =
+    await context.workspaceMcpOverridesService.getOverridesForWorkspace(workspaceId, {
+      timeoutMs: MCP_OVERRIDES_READ_TIMEOUT_MS,
+      ...(signal !== undefined ? { signal } : {}),
+    });
+  if (signal?.aborted) return [];
   const projectSecrets = await secretsToRecord(
     isMultiProject(metadata)
       ? mergeMultiProjectSecrets(metadata, context.secretsStore)
@@ -102,6 +126,13 @@ export async function listWorkspaceMcpPrompts(
       workspacePath,
       trusted: isWorkspaceProjectTrusted(context.config, metadata),
       overrides,
+      overridesAuthoritative: authoritative,
+      // Like the send path: a non-authoritative read that exhausted its
+      // budget must not be followed by a second full-length attempt inside
+      // the manager while discovery holds its archive admission.
+      ...(authoritative
+        ? {}
+        : { overridesReadDeadlineAt: overridesReadStartedAt + MCP_OVERRIDES_READ_TIMEOUT_MS }),
       projectSecrets,
       agentPlugins: hostCheckoutRoot
         ? resolveAgentPluginsMcpContext(metadata, hostCheckoutRoot)
@@ -144,8 +175,16 @@ export async function setWorkspaceMcpOverrides(
           );
           return new Set(Object.keys(servers).filter((key) => key.startsWith("plugin:")));
         }),
-        publish: (persisted) =>
-          context.mcpServerManager.applyWorkspaceOverrides(input.workspaceId, persisted),
+        // `target` differs from input.workspaceId for affected sharers/descendants;
+        // null = state not establishable, drop the cache instead of guessing.
+        publish: (persisted, target) =>
+          persisted === null
+            ? Promise.resolve(
+                target === ALL_WORKSPACES_TARGET
+                  ? context.mcpServerManager.forgetAllWorkspaceOverrides()
+                  : context.mcpServerManager.forgetWorkspaceOverrides(target)
+              )
+            : context.mcpServerManager.applyWorkspaceOverrides(target, persisted),
       }
     );
     return { success: true as const, data: undefined };

--- a/src/node/services/di/layers/core.ts
+++ b/src/node/services/di/layers/core.ts
@@ -67,7 +67,11 @@ import { TerminalAttentionStore } from "@/node/services/terminalAttentionStore";
 import type { TurnRequestBuilderBindings } from "@/node/services/turnRequestBuilder";
 import { mergeMultiProjectSecrets } from "@/node/services/utils/multiProjectSecrets";
 import { WorkspaceGoalService } from "@/node/services/workspaceGoalService";
-import { WorkspaceMcpOverridesService } from "@/node/services/workspaceMcpOverridesService";
+import {
+  MCP_OVERRIDES_READ_TIMEOUT_MS,
+  readWorkspaceOverridesEpochToken,
+  WorkspaceMcpOverridesService,
+} from "@/node/services/workspaceMcpOverridesService";
 import { WorkspaceService } from "@/node/services/workspaceService";
 import { WorkspaceTurnManager } from "@/node/services/workspaceTurnManager";
 import { StoresFromCoreOptionsLive } from "./stores";
@@ -123,10 +127,20 @@ export const MemoryMetaLive: Layer.Layer<MemoryMeta, never, ConfigTag> = Layer.e
 export const WorkspaceMcpOverridesDefaultLive: Layer.Layer<
   WorkspaceMcpOverrides,
   never,
-  ConfigTag
+  ConfigTag | CoreOptionsTag
 > = Layer.effect(
   WorkspaceMcpOverrides,
-  Effect.map(ConfigTag, (config) => new WorkspaceMcpOverridesService(config))
+  Effect.gen(function* () {
+    const config = yield* ConfigTag;
+    const opts = yield* CoreOptionsTag;
+    // The override epoch and writer locks must live where a sibling backend
+    // looks for them: `xum run` registers under a disposable root while its
+    // MCP configuration (and the desktop/server backend's) is the persistent
+    // home, so coordinate under the latter.
+    return new WorkspaceMcpOverridesService(config, {
+      coordinationRootDir: (opts.mcpConfig ?? config).rootDir,
+    });
+  })
 );
 
 // ---------------------------------------------------------------------------
@@ -360,8 +374,24 @@ export const MCPServerManagerLive = Layer.effect(
         pluginInvalidation: {
           keyPrefix: PLUGIN_SERVER_KEY_PREFIX,
           readToken: () => readMutationEpochToken(path.join(mcpConfig.rootDir, STAGING_DIR_NAME)),
-          readWorkspaceOverrides: async (workspaceId: string) =>
-            (await workspaceMcpOverridesService.getOverridesForWorkspace(workspaceId)).overrides,
+          // Bounded/cancellable like the send path's own read: a distrusted or
+          // cold serve re-reads through here, and an unreachable SSH/Docker
+          // parent must not pin the send for the remote command timeout.
+          readWorkspaceOverrides: async (workspaceId, options) => {
+            const read = await workspaceMcpOverridesService.getOverridesForWorkspace(workspaceId, {
+              timeoutMs: options?.timeoutMs ?? MCP_OVERRIDES_READ_TIMEOUT_MS,
+              ...(options?.signal !== undefined ? { signal: options.signal } : {}),
+            });
+            // undefined = not disk-authoritative; the manager keeps its fallbacks.
+            return read.authoritative ? read.overrides : undefined;
+          },
+          // A sibling backend's override save/prune bumps this; the manager
+          // refreshes or evicts its cached snapshots on the next serve.
+          readOverridesEpoch: () => readWorkspaceOverridesEpochToken(mcpConfig.rootDir),
+          // Served tool calls fence their dispatch against sibling-process
+          // override writes with the writer's own lock.
+          acquireOverridesLock: (options) =>
+            workspaceMcpOverridesService.acquireExclusiveLock(options),
         },
         ...opts.mcpServerManagerOptions,
       },

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -18,6 +18,7 @@ import {
   prepareStdioLaunch,
   runMCPToolWithDeadline,
   wrapMCPTools,
+  type MCPWorkspaceRequestOptions,
 } from "./mcpServerManager";
 import { MCPConfigService } from "./mcpConfigService";
 import { Config } from "@/node/config";
@@ -34,18 +35,30 @@ interface MCPServerManagerTestAccess {
   cleanupIdleServers: () => void;
   ensureWorkspaceServers: (
     ...args: unknown[]
-  ) => Promise<{ tools: Record<string, Tool>; stats: unknown }>;
+  ) => Promise<{ tools: Record<string, Tool>; stats: unknown; enablementDerivedFrom?: unknown }>;
   startServers: (...args: unknown[]) => Promise<{
     instances: Map<string, unknown>;
     failedServerNames: string[];
     timedOutServerNames?: string[];
   }>;
   startSingleServer: (...args: unknown[]) => Promise<unknown>;
+  runWithStablePluginEpoch: (operation: () => Promise<unknown>) => Promise<unknown>;
   startSingleServerImpl: (...args: unknown[]) => Promise<unknown>;
 }
 
 const PROJECT_PATH = "/tmp/project";
 const WORKSPACE_PATH = "/tmp/workspace";
+
+/** Poll a synchronous predicate until it holds (bounded), yielding real time between checks. */
+async function waitFor(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error("waitFor: condition not met in time");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+}
 // Tests use only Runtime identity for workspace request plumbing.
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 const TEST_RUNTIME = {} as Runtime;
@@ -1333,6 +1346,203 @@ describe("MCPServerManager", () => {
     expect(stderrCancel).toHaveBeenCalledTimes(1);
   });
 
+  test("stdio spawn holds the override writer's lock and refuses a launch once the epoch moved", async () => {
+    // The read-only pre-start check leaves a gap between its read and the
+    // spawn; the exec that runs the repository-configured command is fenced
+    // like a tool dispatch: a sibling's revocation either commits before the
+    // fenced read (launch refused) or waits until the process exists.
+    manager.dispose();
+    let epoch = "epoch-1";
+    let lockHeld = false;
+    let gateLock: Promise<void> = Promise.resolve();
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("plugins-1"),
+        readOverridesEpoch: () => Promise.resolve(epoch),
+        readWorkspaceOverrides: () => Promise.resolve({}),
+        acquireOverridesLock: async () => {
+          await gateLock;
+          lockHeld = true;
+          return () => {
+            lockHeld = false;
+            return Promise.resolve();
+          };
+        },
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    // Establish the epoch baseline (first preflight).
+    configService.listServers = mock(() => Promise.resolve({}));
+    await manager.getToolsForWorkspace(workspaceRequest("ws-spawn-fence-baseline"));
+
+    const controller = new AbortController();
+    let heldAtExec: boolean | undefined;
+    const exec = mock((_command: string) => {
+      heldAtExec = lockHeld;
+      // Abort right after the spawn so the startup stops there.
+      controller.abort();
+      return Promise.resolve({
+        stdin: new WritableStream<Uint8Array>({ close: () => Promise.resolve(undefined) }),
+        stdout: new ReadableStream<Uint8Array>({ cancel: () => Promise.resolve(undefined) }),
+        stderr: new ReadableStream<Uint8Array>({ cancel: () => Promise.resolve(undefined) }),
+        exitCode: Promise.resolve(0),
+        duration: Promise.resolve(0),
+      });
+    });
+    const start = () =>
+      access.startSingleServerImpl(
+        "fenced",
+        stdioConfig("never"),
+        { exec } as unknown as Runtime,
+        PROJECT_PATH,
+        WORKSPACE_PATH,
+        undefined,
+        () => undefined,
+        controller.signal
+      );
+    expect(await start()).toBeNull();
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(heldAtExec).toBe(true);
+    expect(lockHeld).toBe(false);
+
+    // A sibling revocation holding the writer's lock commits its epoch before
+    // releasing: the fenced read sees it and nothing is spawned.
+    let releaseSibling!: () => void;
+    gateLock = new Promise<void>((resolve) => {
+      releaseSibling = resolve;
+    });
+    const controller2 = new AbortController();
+    const racing = access.startSingleServerImpl(
+      "fenced",
+      stdioConfig("never"),
+      { exec } as unknown as Runtime,
+      PROJECT_PATH,
+      WORKSPACE_PATH,
+      undefined,
+      () => undefined,
+      controller2.signal
+    );
+    racing.catch(() => undefined);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    epoch = "epoch-2";
+    gateLock = Promise.resolve();
+    releaseSibling();
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(racing).rejects.toThrow("about to start");
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(lockHeld).toBe(false);
+  });
+
+  test("a remote launch fence releases the writer's lock at its initiation deadline while the handshake is pending", async () => {
+    // Every settings save and prune would otherwise queue behind an
+    // endpoint-controlled handshake for the whole startup deadline.
+    manager.dispose();
+    let lockHeld = false;
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("plugins-1"),
+        readOverridesEpoch: () => Promise.resolve("epoch-1"),
+        readWorkspaceOverrides: () => Promise.resolve({}),
+        acquireOverridesLock: () => {
+          lockHeld = true;
+          return Promise.resolve(() => {
+            lockHeld = false;
+            return Promise.resolve();
+          });
+        },
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() => Promise.resolve({}));
+    await manager.getToolsForWorkspace(workspaceRequest("ws-remote-fence-baseline"));
+    const fence = access as unknown as {
+      launchUnderOverrideFence: <T>(
+        launch: () => Promise<T>,
+        signal: AbortSignal,
+        options?: { releaseAfterMs?: number }
+      ) => Promise<T>;
+    };
+    const handshake = Promise.withResolvers<string>();
+    let heldAtLaunch: boolean | undefined;
+    const launched = fence.launchUnderOverrideFence(
+      () => {
+        heldAtLaunch = lockHeld;
+        return handshake.promise;
+      },
+      new AbortController().signal,
+      { releaseAfterMs: 10 }
+    );
+    expect(heldAtLaunch).toBeUndefined();
+    await waitFor(() => !lockHeld && heldAtLaunch === true);
+    // The handshake is still pending; the lock is already released.
+    handshake.resolve("connected");
+    expect(await launched).toBe("connected");
+  });
+
+  test("a stdio launch still awaiting its exec at the fence deadline is aborted, not released", async () => {
+    // Releasing would let an SSH exec still acquiring its connection send the
+    // repository-configured command after a sibling's revocation committed.
+    manager.dispose();
+    let lockHeld = false;
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("plugins-1"),
+        readOverridesEpoch: () => Promise.resolve("epoch-1"),
+        readWorkspaceOverrides: () => Promise.resolve({}),
+        acquireOverridesLock: () => {
+          lockHeld = true;
+          return Promise.resolve(() => {
+            lockHeld = false;
+            return Promise.resolve();
+          });
+        },
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() => Promise.resolve({}));
+    await manager.getToolsForWorkspace(workspaceRequest("ws-stdio-fence-baseline"));
+    const fence = access as unknown as {
+      launchUnderOverrideFence: <T>(
+        launch: (launchSignal: AbortSignal) => Promise<T>,
+        signal: AbortSignal,
+        options?: { abortAfterMs?: { ms: number; serverName: string } }
+      ) => Promise<T>;
+    };
+    let launchSignal: AbortSignal | undefined;
+    let heldWhilePending: boolean | undefined;
+    const launched = fence.launchUnderOverrideFence(
+      (signal) => {
+        launchSignal = signal;
+        heldWhilePending = lockHeld;
+        // Mirrors RemoteRuntime.exec: settles only through the abort.
+        return new Promise<never>((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(new Error("Operation aborted")), {
+            once: true,
+          });
+        });
+      },
+      new AbortController().signal,
+      { abortAfterMs: { ms: 10, serverName: "slow-ssh" } }
+    );
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(launched).rejects.toThrow("MCP server 'slow-ssh' timed out after 10ms");
+    expect(heldWhilePending).toBe(true);
+    expect(launchSignal?.aborted).toBe(true);
+    expect(lockHeld).toBe(false);
+
+    // A launch that hands back its stream in time is unaffected and released.
+    const quick = await fence.launchUnderOverrideFence(
+      (signal) => Promise.resolve(signal.aborted ? "aborted" : "spawned"),
+      new AbortController().signal,
+      { abortAfterMs: { ms: 1_000, serverName: "quick" } }
+    );
+    expect(quick).toBe("spawned");
+    expect(lockHeld).toBe(false);
+  });
+
   test("startSingleServerImpl cleans up client that resolves after abort", async () => {
     const controller = new AbortController();
     const stdinClose = mock(() => Promise.resolve(undefined));
@@ -2152,8 +2362,16 @@ describe("MCPServerManager", () => {
         ]);
         expect(started[0].close).not.toHaveBeenCalled();
         expect(started[1].close).not.toHaveBeenCalled();
-        expect(result.tools.plugin_existing_echo).toBe(first.tools.plugin_existing_echo);
-        expect(result.tools.ordinary_echo).toBe(first.tools.ordinary_echo);
+        // Served tools are per-serve gate wrappers (see gateServedToolOnEnablement),
+        // so the retained clients show through the instance map, not tool identity.
+        expect(Object.keys(first.tools).sort()).toEqual(["ordinary_echo", "plugin_existing_echo"]);
+        const retained = access.workspaceServers.get(workspaceId) as {
+          instances: Map<string, unknown>;
+        };
+        expect(retained.instances.get("plugin_existing")).toBe(started[1]);
+        expect(retained.instances.get("ordinary")).toBe(started[0]);
+        expect(result.tools.plugin_existing_echo).toBeDefined();
+        expect(result.tools.ordinary_echo).toBeDefined();
         expect(result.tools[`${pluginKey}_echo`]).toBeDefined();
         expect(result.stats.startedServerCount).toBe(3);
         expect(result.promptDescriptors.map((prompt) => prompt.serverName).sort()).toEqual(
@@ -2291,12 +2509,25 @@ describe("MCPServerManager", () => {
       oldReadEntered.resolve();
       return oldReadFinished.promise;
     });
-    const older = manager.getToolsForWorkspace(request);
+    // The older request's re-read (taken because a newer publication landed
+    // during its config read) must keep the caller's abort signal: an
+    // interrupted turn cancels the disk re-read on every recursion level.
+    const originalEnsure = access.ensureWorkspaceServers.bind(manager);
+    const readSignals: unknown[] = [];
+    access.ensureWorkspaceServers = (...args: unknown[]) => {
+      readSignals.push(args[2]);
+      return originalEnsure(...args);
+    };
+    const olderSignal = new AbortController().signal;
+    const older = manager.getToolsForWorkspace(request, { signal: olderSignal });
     await oldReadEntered.promise;
     startupFinished.resolve();
     await newer;
     oldReadFinished.resolve({ stable: configs.stable, added: stdioConfig("added") });
     await older;
+    access.ensureWorkspaceServers = originalEnsure;
+    expect(readSignals.length).toBeGreaterThanOrEqual(2);
+    expect(readSignals.every((signal) => signal === olderSignal)).toBe(true);
     expect(startup).toHaveBeenCalledTimes(2);
     expect(stable.close).not.toHaveBeenCalled();
     expect((await manager.getToolsForWorkspace(request)).stats.startedServerCount).toBe(3);
@@ -2870,7 +3101,12 @@ describe("MCPServerManager", () => {
         enabledServerNames: new Set(["coder"]),
         instances: new Map([["coder", testInstance("coder", { prompts: [{ name: "status" }] })]]),
       });
-      return Promise.resolve({ tools: {}, stats: cachedStats() });
+      // Mirrors serveResult: a serve that vouches for its enablement.
+      return Promise.resolve({
+        tools: {},
+        stats: cachedStats(),
+        enablementDerivedFrom: options as MCPWorkspaceRequestOptions,
+      });
     });
 
     const descriptors = await manager.getPromptsForWorkspace(workspaceRequest("workspace"));
@@ -3220,6 +3456,31 @@ describe("MCPServerManager", () => {
     expect(await manager.getPrompt(workspaceId, "stable", "review", {})).toEqual({ text: "hi" });
   });
 
+  test("a serve reports the validated server inventory it derived enablement from", async () => {
+    // Trust (like global config) can change independently of the override
+    // snapshot: a caller comparing only `overridesUsed` with its own snapshot
+    // would keep advertising the withdrawn repo-local server in the prompt.
+    const workspaceId = "ws-servers-used";
+    configService.listServers = mock((_projectPath: string, trusted: boolean) =>
+      Promise.resolve(
+        trusted
+          ? { server: stdioConfig("cmd-1"), stable: stdioConfig("cmd-stable") }
+          : { stable: stdioConfig("cmd-stable") }
+      )
+    );
+    access.startServers = mock(() => {
+      manager.applyProjectTrust([{ projectPath: PROJECT_PATH, trusted: false }]);
+      return Promise.resolve(startResult([["server"], ["stable"]]));
+    });
+
+    const result = await manager.getToolsForWorkspace(
+      workspaceRequest(workspaceId, { trusted: true, overrides: {}, overridesAuthoritative: true })
+    );
+    expect(result.overridesUsed).toEqual({});
+    expect(Object.keys(result.serversUsed ?? {})).toEqual(["stable"]);
+    expect(Object.keys(result.tools).every((name) => name.startsWith("stable_"))).toBe(true);
+  });
+
   test("getToolsForWorkspace restarts when cached instances are marked closed", async () => {
     const workspaceId = "ws-closed";
     configService.listServers = mock(() =>
@@ -3348,6 +3609,78 @@ describe("MCPServerManager", () => {
     expect(Object.keys(toolsResult.tools)).not.toContain("serverb_tool");
   });
 
+  test("a publication landing during the leased tool refresh is honored before the serve returns", async () => {
+    // Leased (deferred-restart) path: an authoritative parent publication
+    // replaces the recorded overrides while `refreshModernInstanceTools` is
+    // awaiting, but its own listServers is still pending — so
+    // `enabledServerNames` is stale unless the repair runs AFTER the refresh.
+    const workspaceId = "ws-publish-during-leased-refresh";
+    const servers = {
+      serverA: stdioConfig("cmd-a"),
+      serverB: stdioConfig("cmd-b"),
+      serverC: stdioConfig("cmd-c"),
+    };
+    let gateListServers = false;
+    const gatedListServers: Array<() => void> = [];
+    configService.listServers = mock(() => {
+      if (!gateListServers) return Promise.resolve(servers);
+      return new Promise<typeof servers>((resolve) => {
+        gatedListServers.push(() => resolve(servers));
+      });
+    });
+    let releaseRefresh: () => void = () => undefined;
+    const refreshB = mock(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseRefresh = resolve;
+        })
+    );
+    access.startServers = mock(() =>
+      Promise.resolve(
+        startResult([
+          ["serverA", { tools: { tool: testTool() }, refreshTools: mock(() => Promise.resolve()) }],
+          ["serverB", { tools: { tool: testTool() }, refreshTools: refreshB }],
+          ["serverC", { tools: { tool: testTool() } }],
+        ])
+      )
+    );
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    manager.acquireLease(workspaceId);
+
+    // Signature change while leased → deferred restart path, which awaits the
+    // modern tool refresh (B blocks).
+    const inFlight = manager.getToolsForWorkspace(
+      workspaceRequest(workspaceId, { overrides: { disabledServers: ["serverC"] } })
+    );
+    while (refreshB.mock.calls.length === 0) {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    // Parent publication revokes B; its listServers stays pending.
+    gateListServers = true;
+    const publication = manager.applyWorkspaceOverrides(workspaceId, {
+      disabledServers: ["serverC", "serverB"],
+    });
+    releaseRefresh();
+    // Keep the publication's listServers pending until the serve's repair
+    // re-derives too (a second gated call) — or the serve returns without one.
+    let settled = false;
+    const servedPromise = inFlight.finally(() => {
+      settled = true;
+    });
+    while (!settled) {
+      if (gatedListServers.length >= 2) {
+        for (const release of gatedListServers.splice(0)) release();
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    for (const release of gatedListServers.splice(0)) release();
+    await publication;
+
+    const served = await servedPromise;
+    expect(Object.keys(served.tools)).toContain("servera_tool");
+    expect(Object.keys(served.tools)).not.toContain("serverb_tool");
+  });
+
   test("getToolsForWorkspace filters disabled-server failures from leased stats", async () => {
     const workspaceId = "ws-disable-failed-while-leased";
     configService.listServers = mock(() =>
@@ -3426,10 +3759,45 @@ describe("MCPServerManager", () => {
     expect(Object.keys(firstStartedServers ?? {})).toEqual(["global"]);
     expect(Object.keys(secondStartedServers ?? {}).sort()).toEqual(["global", "repo"]);
   });
+  test("prompt discovery retries when an ordinary serve replaces the entry during prompts/list", async () => {
+    // A direct edit of the override document is picked up by a concurrent
+    // send's serve, which replaces the published entry without moving either
+    // mutation counter. Descriptors must come from the current entry.
+    const request = workspaceRequest("workspace");
+    access.lastWorkspaceRequestOptions.set("workspace", request);
+    const replaced = { enabledServerNames: new Set<string>(), instances: new Map() };
+    const stale = testInstance("coder", {
+      prompts: [{ name: "stale" }],
+      refreshPrompts: mock(() => {
+        access.workspaceServers.set("workspace", replaced);
+        return Promise.resolve([{ name: "stale" }]);
+      }),
+    });
+    let serves = 0;
+    spyOn(access, "ensureWorkspaceServers").mockImplementation(() => {
+      serves += 1;
+      if (serves === 1) {
+        access.workspaceServers.set("workspace", {
+          enabledServerNames: new Set(["coder"]),
+          instances: new Map([["coder", stale]]),
+        });
+      }
+      return Promise.resolve({ tools: {}, stats: cachedStats(), enablementDerivedFrom: request });
+    });
+
+    const descriptors = await manager.getPromptsForWorkspace(request);
+    expect(descriptors).toEqual([]);
+    expect(serves).toBe(2);
+  });
+
   test("lists namespaced prompt descriptors from connected instances", async () => {
+    // Mirrors a real serve: the options it derived enablement from are recorded.
+    access.lastWorkspaceRequestOptions.set("workspace", workspaceRequest("workspace"));
     const getToolsSpy = spyOn(access, "ensureWorkspaceServers").mockResolvedValue({
       tools: {},
       stats: cachedStats(),
+      // Mirrors serveResult: a serve that vouches for its enablement.
+      enablementDerivedFrom: workspaceRequest("workspace"),
     });
     access.workspaceServers.set("workspace", {
       enabledServerNames: new Set(["Coder Server"]),
@@ -3513,9 +3881,13 @@ describe("MCPServerManager", () => {
   });
 
   test("suffixes every member of a colliding prompt key group, independent of order", async () => {
+    // Mirrors a real serve: the options it derived enablement from are recorded.
+    access.lastWorkspaceRequestOptions.set("workspace", workspaceRequest("workspace"));
     const getToolsSpy = spyOn(access, "ensureWorkspaceServers").mockResolvedValue({
       tools: {},
       stats: cachedStats(),
+      // Mirrors serveResult: a serve that vouches for its enablement.
+      enablementDerivedFrom: workspaceRequest("workspace"),
     });
     const collectKeys = async (promptNames: string[]) => {
       access.workspaceServers.set("workspace", {
@@ -3552,9 +3924,13 @@ describe("MCPServerManager", () => {
   });
 
   test("excludes disabled servers from prompt discovery and getPrompt", async () => {
+    // Mirrors a real serve: the options it derived enablement from are recorded.
+    access.lastWorkspaceRequestOptions.set("workspace", workspaceRequest("workspace"));
     const getToolsSpy = spyOn(access, "ensureWorkspaceServers").mockResolvedValue({
       tools: {},
       stats: cachedStats(),
+      // Mirrors serveResult: a serve that vouches for its enablement.
+      enablementDerivedFrom: workspaceRequest("workspace"),
     });
     access.workspaceServers.set("workspace", {
       enabledServerNames: new Set(["enabled"]),
@@ -3578,16 +3954,22 @@ describe("MCPServerManager", () => {
     const getToolsSpy = spyOn(access, "ensureWorkspaceServers").mockImplementation(() => {
       access.workspaceServers.set("workspace", {
         enabledServerNames: new Set(["coder"]),
+        // Mirrors a real serve: the inventory is as new as the current config.
+        enabledServersGeneration: configService.configGeneration,
         instances: new Map([["coder", testInstance("coder", { getPrompt })]]),
       });
-      return Promise.resolve({ tools: {}, stats: cachedStats() });
+      return Promise.resolve({
+        tools: {},
+        stats: cachedStats(),
+        enablementDerivedFrom: access.lastWorkspaceRequestOptions.get("workspace"),
+      });
     });
     access.lastWorkspaceRequestOptions.set("workspace", request);
 
     expect(await manager.getPrompt("workspace", "coder", "status", {})).toEqual({
       text: "Status",
     });
-    expect(getToolsSpy).toHaveBeenCalledWith(request, false);
+    expect(getToolsSpy).toHaveBeenCalledWith(request, false, undefined);
     getToolsSpy.mockRestore();
   });
 
@@ -3776,11 +4158,19 @@ describe("MCPServerManager", () => {
       Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "Status" } }] })
     );
     const getToolsSpy = spyOn(access, "ensureWorkspaceServers").mockImplementation((options) => {
-      access.workspaceServers.set((options as { workspaceId: string }).workspaceId, {
+      const workspaceId = (options as { workspaceId: string }).workspaceId;
+      access.workspaceServers.set(workspaceId, {
         enabledServerNames: new Set(["coder"]),
+        // Mirrors a real serve: the inventory is as new as the current config.
+        enabledServersGeneration: configService.configGeneration,
         instances: new Map([["coder", testInstance("coder", { getPrompt })]]),
       });
-      return Promise.resolve({ tools: {}, stats: cachedStats() });
+      // Mirrors serveResult: enablement derived from the options recorded now.
+      return Promise.resolve({
+        tools: {},
+        stats: cachedStats(),
+        enablementDerivedFrom: access.lastWorkspaceRequestOptions.get(workspaceId),
+      });
     });
 
     manager.applyProjectTrust([
@@ -3789,7 +4179,7 @@ describe("MCPServerManager", () => {
     ]);
     await manager.getPrompt("workspace", "coder", "status", {});
 
-    expect(getToolsSpy).toHaveBeenCalledWith({ ...request, trusted: false }, false);
+    expect(getToolsSpy).toHaveBeenCalledWith({ ...request, trusted: false }, false, undefined);
     expect(access.lastWorkspaceRequestOptions.get("other-workspace")).toBe(otherRequest);
     getToolsSpy.mockRestore();
   });
@@ -3803,18 +4193,27 @@ describe("MCPServerManager", () => {
       Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "Status" } }] })
     );
     const getToolsSpy = spyOn(access, "ensureWorkspaceServers").mockImplementation((options) => {
-      access.workspaceServers.set((options as { workspaceId: string }).workspaceId, {
+      const workspaceId = (options as { workspaceId: string }).workspaceId;
+      access.workspaceServers.set(workspaceId, {
         enabledServerNames: new Set(["coder"]),
+        // Mirrors a real serve: the inventory is as new as the current config.
+        enabledServersGeneration: configService.configGeneration,
         instances: new Map([["coder", testInstance("coder", { getPrompt })]]),
       });
-      return Promise.resolve({ tools: {}, stats: cachedStats() });
+      // Mirrors serveResult: enablement derived from the options recorded now.
+      return Promise.resolve({
+        tools: {},
+        stats: cachedStats(),
+        enablementDerivedFrom: access.lastWorkspaceRequestOptions.get(workspaceId),
+      });
     });
 
     await manager.getPrompt("workspace", "coder", "status", {});
 
     expect(getToolsSpy).toHaveBeenCalledWith(
       { ...request, projectSecrets: { TOKEN: "new" } },
-      false
+      false,
+      undefined
     );
     getToolsSpy.mockRestore();
   });
@@ -3828,15 +4227,23 @@ describe("MCPServerManager", () => {
       Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "Status" } }] })
     );
     const getToolsSpy = spyOn(access, "ensureWorkspaceServers").mockImplementation((options) => {
-      access.workspaceServers.set((options as { workspaceId: string }).workspaceId, {
+      const workspaceId = (options as { workspaceId: string }).workspaceId;
+      access.workspaceServers.set(workspaceId, {
         enabledServerNames: new Set(["coder"]),
+        // Mirrors a real serve: the inventory is as new as the current config.
+        enabledServersGeneration: configService.configGeneration,
         instances: new Map([["coder", testInstance("coder", { getPrompt })]]),
       });
-      return Promise.resolve({ tools: {}, stats: cachedStats() });
+      // Mirrors serveResult: enablement derived from the options recorded now.
+      return Promise.resolve({
+        tools: {},
+        stats: cachedStats(),
+        enablementDerivedFrom: access.lastWorkspaceRequestOptions.get(workspaceId),
+      });
     });
 
     expect(await manager.getPrompt("workspace", "coder", "status", {})).toEqual({ text: "Status" });
-    expect(getToolsSpy).toHaveBeenCalledWith(request, false);
+    expect(getToolsSpy).toHaveBeenCalledWith(request, false, undefined);
     getToolsSpy.mockRestore();
   });
 
@@ -4115,6 +4522,2408 @@ describe("MCPServerManager", () => {
     expect(withOverride.stats.enabledServerCount).toBe(1);
     const startedServers = startServersMock.mock.calls.at(-1)?.[0] as Record<string, unknown>;
     expect(Object.keys(startedServers)).toEqual([PLUGIN_KEY]);
+  });
+
+  test("forgetWorkspaceOverrides drops the cached snapshot so the caller's fresh read wins again", async () => {
+    configService.listServers = mock(() => Promise.resolve(pluginStdioConfig()));
+    const startServersMock = spyOn(access, "startServers").mockImplementation(
+      (...args: unknown[]) => {
+        const servers = args[0] as Record<string, unknown>;
+        return Promise.resolve(startResult(Object.keys(servers).map((name) => [name, undefined])));
+      }
+    );
+    const workspaceId = "ws-forget";
+    // A published snapshot overlays whatever the caller read from disk.
+    await manager.applyWorkspaceOverrides(workspaceId, { enabledServers: [PLUGIN_KEY] });
+    const overlaid = await manager.getToolsForWorkspace(
+      workspaceRequest(workspaceId, { overrides: {} })
+    );
+    expect(overlaid.stats.enabledServerCount).toBe(1);
+
+    // After eviction the caller's (disk-authoritative) read is used as-is.
+    manager.forgetWorkspaceOverrides(workspaceId);
+    const fresh = await manager.getToolsForWorkspace(
+      workspaceRequest(workspaceId, { overrides: {} })
+    );
+    expect(fresh.stats.enabledServerCount).toBe(0);
+    expect(startServersMock).toHaveBeenCalled();
+  });
+
+  test("forgetWorkspaceOverrides also distrusts recorded options: the next serve re-reads disk", async () => {
+    manager.dispose();
+    let diskOverrides: Record<string, unknown> = { enabledServers: [PLUGIN_KEY] };
+    const readWorkspaceOverrides = mock(() => Promise.resolve(diskOverrides));
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("epoch-1"),
+        readWorkspaceOverrides,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() => Promise.resolve(pluginStdioConfig()));
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(startResult(Object.keys(servers).map((name) => [name, undefined])));
+    });
+    const workspaceId = "ws-forget-recorded";
+
+    // First serve records options (with the disk-read enable) — one disk read.
+    const first = await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    expect(first.stats.enabledServerCount).toBe(1);
+    expect(readWorkspaceOverrides).toHaveBeenCalledTimes(1);
+
+    // A prompt-path style serve (recorded options, no fresh caller read) reuses
+    // the recorded snapshot without touching disk.
+    diskOverrides = {};
+    const recordedOptions = () =>
+      access.lastWorkspaceRequestOptions.get(workspaceId) as MCPWorkspaceRequestOptions;
+    const second = await manager.getToolsForWorkspace(recordedOptions());
+    expect(second.stats.enabledServerCount).toBe(1);
+    expect(readWorkspaceOverrides).toHaveBeenCalledTimes(1);
+
+    // After eviction the same recorded-options serve must re-read disk and
+    // observe the disable — no chat send required.
+    manager.forgetWorkspaceOverrides(workspaceId);
+    const third = await manager.getToolsForWorkspace(recordedOptions());
+    expect(readWorkspaceOverrides).toHaveBeenCalledTimes(2);
+    expect(third.stats.enabledServerCount).toBe(0);
+  });
+
+  test("getPrompt re-reads disk so a direct document edit disabling the server is honored", async () => {
+    // A direct edit of `.xum/mcp.local.jsonc` (own or inherited parent
+    // document) bumps no epoch and publishes nothing; the recorded options
+    // still say "enabled". Prompt dispatch must not trust them blindly.
+    manager.dispose();
+    let diskOverrides: Record<string, unknown> = {};
+    const readWorkspaceOverrides = mock(() => Promise.resolve(diskOverrides));
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("epoch-1"),
+        readWorkspaceOverrides,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() =>
+      Promise.resolve({ server: stdioConfig("cmd-1"), stable: stdioConfig("cmd-stable") })
+    );
+    const getPrompt = mock(() =>
+      Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "hi" } }] })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(
+        startResult(Object.keys(servers).map((name) => [name, { getPrompt }]))
+      );
+    });
+    const workspaceId = "ws-prompt-direct-edit";
+    await manager.getToolsForWorkspace(
+      workspaceRequest(workspaceId, { overrides: {}, overridesAuthoritative: true })
+    );
+    expect(await manager.getPrompt(workspaceId, "server", "review", {})).toEqual({ text: "hi" });
+
+    // Direct edit: disk now disables the server; nothing else moved.
+    diskOverrides = { disabledServers: ["server"] };
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(manager.getPrompt(workspaceId, "server", "review", {})).rejects.toThrow(
+      "is disabled"
+    );
+    expect(await manager.getPrompt(workspaceId, "stable", "review", {})).toEqual({ text: "hi" });
+  });
+
+  test("a direct disk revocation is honored even when an equivalent serve replaces the recorded options mid-gate", async () => {
+    // While the gate awaits its disk read, an overlapping serve whose snapshot
+    // predates the edit records a fresh but EQUIVALENT options object. The
+    // invalidation must still be taken (equivalence, not identity) or the
+    // revoked tool would dispatch.
+    manager.dispose();
+    let diskOverrides: Record<string, unknown> = {};
+    let onDiskRead: (() => void) | undefined;
+    const readWorkspaceOverrides = mock(() => {
+      onDiskRead?.();
+      return Promise.resolve(diskOverrides);
+    });
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("epoch-1"),
+        readWorkspaceOverrides,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    const workspaceId = "ws-equivalent-replacement-revocation";
+    configService.listServers = mock(() => Promise.resolve({ server: stdioConfig("cmd-1") }));
+    const executeTool = mock(() => Promise.resolve({ content: [{ type: "text", text: "ok" }] }));
+    const dummyTool = {
+      description: "test",
+      inputSchema: { type: "object", properties: {} },
+      execute: executeTool,
+    } as unknown as Tool;
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(
+        startResult(Object.keys(servers).map((name) => [name, { tools: { ping: dummyTool } }]))
+      );
+    });
+    const request = workspaceRequest(workspaceId, { overrides: {}, overridesAuthoritative: true });
+    const result = await manager.getToolsForWorkspace(request);
+    const serverTool = result.tools.server_ping;
+    if (!serverTool?.execute) throw new Error("Expected served tool to include execute");
+    manager.acquireLease(workspaceId);
+
+    // Direct edit revokes the server on disk; the gate's read observes it,
+    // but an equivalent pre-edit snapshot is recorded at that very moment.
+    diskOverrides = { disabledServers: ["server"] };
+    onDiskRead = () => {
+      onDiskRead = undefined;
+      access.lastWorkspaceRequestOptions.set(workspaceId, { ...request });
+    };
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(serverTool.execute({}, {} as never)).rejects.toThrow("server 'server'");
+    expect(executeTool).not.toHaveBeenCalled();
+    manager.releaseLease(workspaceId);
+  });
+
+  test("served tool objects fail at call time once their server is disabled", async () => {
+    // Tools leave the manager before the stream starts; a publication landing
+    // in that window (or mid-stream) cannot retract the objects, so every
+    // invocation re-checks the CURRENT enablement — including while the
+    // publication's asynchronous enablement repair is still in flight.
+    const workspaceId = "ws-call-time-gate";
+    configService.listServers = mock(() =>
+      Promise.resolve({ server: stdioConfig("cmd-1"), stable: stdioConfig("cmd-stable") })
+    );
+    const executeTool = mock(() => Promise.resolve({ content: [{ type: "text", text: "ok" }] }));
+    const dummyTool = {
+      description: "test",
+      inputSchema: { type: "object", properties: {} },
+      execute: executeTool,
+    } as unknown as Tool;
+    access.startServers = mock((servers) =>
+      Promise.resolve(
+        startResult(
+          Object.keys(servers as Record<string, unknown>).map((name) => [
+            name,
+            { tools: { ping: dummyTool } },
+          ])
+        )
+      )
+    );
+    const result = await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    const serverTool = result.tools.server_ping;
+    const stableTool = result.tools.stable_ping;
+    if (!serverTool?.execute || !stableTool?.execute) {
+      throw new Error("Expected served tools to include execute");
+    }
+    await serverTool.execute({}, {} as never);
+    expect(executeTool).toHaveBeenCalledTimes(1);
+
+    // Publication whose listServers is slow: an invocation racing it must
+    // not pass on the old set — the latest recorded overrides already revoke
+    // the server, so the call is rejected without waiting for the repair.
+    let releaseListServers!: () => void;
+    configService.listServers = mock(
+      () =>
+        new Promise((resolve) => {
+          releaseListServers = () =>
+            resolve({ server: stdioConfig("cmd-1"), stable: stdioConfig("cmd-stable") });
+        })
+    );
+    const publication = manager.applyWorkspaceOverrides(workspaceId, {
+      disabledServers: ["server"],
+    });
+    const racing: Promise<unknown> = Promise.resolve(serverTool.execute({}, {} as never));
+    racing.catch(() => undefined); // asserted below; keep the rejection handled meanwhile
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(executeTool).toHaveBeenCalledTimes(1);
+    releaseListServers();
+    await publication;
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(racing).rejects.toThrow(
+      "was disabled for this workspace after the request was prepared"
+    );
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(serverTool.execute({}, {} as never)).rejects.toThrow(
+      "was disabled for this workspace after the request was prepared"
+    );
+    expect(executeTool).toHaveBeenCalledTimes(1);
+    // Servers that stay enabled are unaffected.
+    await stableTool.execute({}, {} as never);
+    expect(executeTool).toHaveBeenCalledTimes(2);
+
+    // A narrowed workspace tool allowlist revokes individual tools of a server
+    // that stays enabled.
+    configService.listServers = mock(() =>
+      Promise.resolve({ server: stdioConfig("cmd-1"), stable: stdioConfig("cmd-stable") })
+    );
+    await manager.applyWorkspaceOverrides(workspaceId, { toolAllowlist: { stable: ["other"] } });
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(stableTool.execute({}, {} as never)).rejects.toThrow("tool 'stable/ping'");
+    expect(executeTool).toHaveBeenCalledTimes(2);
+  });
+
+  test("overlapping serves of one workspace with the same authorization both succeed", async () => {
+    // Prompt discovery while a send assembles: each records its own options
+    // object; the first to finish must not be failed closed as if a
+    // publication had revoked it.
+    const workspaceId = "ws-overlapping-serves";
+    configService.listServers = mock(() => Promise.resolve({ server: stdioConfig("cmd-1") }));
+    let releaseStart!: () => void;
+    const started = new Promise<void>((resolve) => {
+      releaseStart = resolve;
+    });
+    access.startServers = mock(async () => {
+      await started;
+      return startResult([["server", { tools: { ping: testTool() } }]]);
+    });
+    const first = manager.getToolsForWorkspace(workspaceRequest(workspaceId, { overrides: {} }));
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const second = manager.getToolsForWorkspace(workspaceRequest(workspaceId, { overrides: {} }));
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    releaseStart();
+    const [a, b] = await Promise.all([first, second]);
+    expect(Object.keys(a.tools)).toEqual(["server_ping"]);
+    expect(Object.keys(b.tools)).toEqual(["server_ping"]);
+
+    // A real authorization change is still detected: different overrides.
+    const third = manager.getToolsForWorkspace(
+      workspaceRequest(workspaceId, { overrides: { disabledServers: ["server"] } })
+    );
+    expect(Object.keys((await third).tools)).toEqual([]);
+  });
+
+  test("tools handed to the model are filtered with the inventory repaired mid-startup", async () => {
+    // A project tool allowlist narrowed while startup awaits must filter the
+    // served tools, not only be enforced by the call-time gate after the
+    // model already selected a removed tool.
+    const workspaceId = "ws-repaired-inventory";
+    let allowlist: string[] | undefined;
+    configService.listServers = mock(() =>
+      Promise.resolve({
+        server: { ...stdioConfig("cmd-1"), ...(allowlist ? { toolAllowlist: allowlist } : {}) },
+      })
+    );
+    access.startServers = mock(() => {
+      // Settings narrows the allowlist while the server starts.
+      allowlist = ["other"];
+      configService.configGeneration += 1;
+      return Promise.resolve(
+        startResult([["server", { tools: { ping: testTool(), other: testTool() } }]])
+      );
+    });
+    const result = await manager.getToolsForWorkspace(
+      workspaceRequest(workspaceId, { overrides: {} })
+    );
+    expect(Object.keys(result.tools)).toEqual(["server_other"]);
+  });
+
+  test("served tool objects honor a global tool allowlist narrowed after the serve", async () => {
+    // Settings narrowing a server's global/project toolAllowlist replaces no
+    // recorded options and changes nothing on the workspace's override disk —
+    // it only bumps the config generation. The gate must not decide on the
+    // allowlist captured with the tool object: it re-derives the inventory
+    // when the generation moved and applies the CURRENT allowlist.
+    const workspaceId = "ws-call-time-global-allowlist";
+    configService.listServers = mock(() => Promise.resolve({ server: stdioConfig("cmd-1") }));
+    const executeTool = mock(() => Promise.resolve({ content: [{ type: "text", text: "ok" }] }));
+    const dummyTool = {
+      description: "test",
+      inputSchema: { type: "object", properties: {} },
+      execute: executeTool,
+    } as unknown as Tool;
+    access.startServers = mock(() =>
+      Promise.resolve(startResult([["server", { tools: { ping: dummyTool, other: dummyTool } }]]))
+    );
+    const result = await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    const pingTool = result.tools.server_ping;
+    const otherTool = result.tools.server_other;
+    if (!pingTool?.execute || !otherTool?.execute) {
+      throw new Error("Expected served tools to include execute");
+    }
+    await pingTool.execute({}, {} as never);
+    expect(executeTool).toHaveBeenCalledTimes(1);
+
+    // Global allowlist narrowed to `other` without any serve in between.
+    configService.listServers = mock(() =>
+      Promise.resolve({ server: { ...stdioConfig("cmd-1"), toolAllowlist: ["other"] } })
+    );
+    configService.configGeneration += 1;
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(pingTool.execute({}, {} as never)).rejects.toThrow("tool 'server/ping'");
+    expect(executeTool).toHaveBeenCalledTimes(1);
+    await otherTool.execute({}, {} as never);
+    expect(executeTool).toHaveBeenCalledTimes(2);
+
+    // Globally disabling the server is caught the same way.
+    configService.listServers = mock(() => Promise.resolve({}));
+    configService.configGeneration += 1;
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(otherTool.execute({}, {} as never)).rejects.toThrow("server 'server'");
+    expect(executeTool).toHaveBeenCalledTimes(2);
+  });
+
+  test("served tool objects re-derive enablement from disk when the workspace was invalidated", async () => {
+    // Descendant/off-host publications and cross-process epoch changes only
+    // set the invalidation marker (no overrides to repair the entry with), so
+    // the gate must not trust the leased entry's enablement: it re-serves from
+    // disk and rejects when disk revokes the server (or cannot answer).
+    manager.dispose();
+    let diskOverrides: Record<string, unknown> | undefined = {};
+    const readWorkspaceOverrides = mock(() => Promise.resolve(diskOverrides));
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("epoch-1"),
+        readWorkspaceOverrides,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    const workspaceId = "ws-call-time-invalidated";
+    configService.listServers = mock(() => Promise.resolve({ server: stdioConfig("cmd-1") }));
+    const executeTool = mock(() => Promise.resolve({ content: [{ type: "text", text: "ok" }] }));
+    const dummyTool = {
+      description: "test",
+      inputSchema: { type: "object", properties: {} },
+      execute: executeTool,
+    } as unknown as Tool;
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(
+        startResult(Object.keys(servers).map((name) => [name, { tools: { ping: dummyTool } }]))
+      );
+    });
+    const result = await manager.getToolsForWorkspace(
+      workspaceRequest(workspaceId, { overrides: {}, overridesAuthoritative: true })
+    );
+    const serverTool = result.tools.server_ping;
+    if (!serverTool?.execute) {
+      throw new Error("Expected served tool to include execute");
+    }
+    // The stream holds its lease while tools are invoked.
+    manager.acquireLease(workspaceId);
+
+    // Invalidation while disk still enables the server: re-derived, allowed.
+    // (The re-serve recorded a fresh options object with the SAME
+    // authorization state; the gate compares by equivalence, so it dispatches
+    // without another round: one read beyond the serve's.)
+    manager.forgetWorkspaceOverrides(workspaceId);
+    await serverTool.execute({}, {} as never);
+    expect(executeTool).toHaveBeenCalledTimes(1);
+    expect(readWorkspaceOverrides).toHaveBeenCalledTimes(2);
+
+    // Invalidation after a parent save that disables the server on disk.
+    diskOverrides = { disabledServers: ["server"] };
+    manager.forgetWorkspaceOverrides(workspaceId);
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(serverTool.execute({}, {} as never)).rejects.toThrow("server 'server'");
+    expect(executeTool).toHaveBeenCalledTimes(1);
+
+    // Invalidation that disk cannot resolve: fail closed at call time too.
+    diskOverrides = undefined;
+    manager.forgetWorkspaceOverrides(workspaceId);
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(serverTool.execute({}, {} as never)).rejects.toThrow("server 'server'");
+    expect(executeTool).toHaveBeenCalledTimes(1);
+    manager.releaseLease(workspaceId);
+  });
+
+  test("served tool objects observe a sibling process's override write before executing", async () => {
+    // Backend B saves overrides that revoke the server: only the on-disk epoch
+    // moves. Without a new serve in this process no marker would ever exist,
+    // so the call-time gate runs the same cross-process preflight as a serve.
+    manager.dispose();
+    let epoch = "epoch-1";
+    let diskOverrides: Record<string, unknown> = {};
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("plugins-1"),
+        readOverridesEpoch: () => Promise.resolve(epoch),
+        readWorkspaceOverrides: () => Promise.resolve(diskOverrides),
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    const workspaceId = "ws-call-time-sibling";
+    configService.listServers = mock(() => Promise.resolve({ server: stdioConfig("cmd-1") }));
+    const executeTool = mock(() => Promise.resolve({ content: [{ type: "text", text: "ok" }] }));
+    const dummyTool = {
+      description: "test",
+      inputSchema: { type: "object", properties: {} },
+      execute: executeTool,
+    } as unknown as Tool;
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(
+        startResult(Object.keys(servers).map((name) => [name, { tools: { ping: dummyTool } }]))
+      );
+    });
+    const result = await manager.getToolsForWorkspace(
+      workspaceRequest(workspaceId, { overrides: {}, overridesAuthoritative: true })
+    );
+    const serverTool = result.tools.server_ping;
+    if (!serverTool?.execute) {
+      throw new Error("Expected served tool to include execute");
+    }
+    manager.acquireLease(workspaceId);
+    await serverTool.execute({}, {} as never);
+    expect(executeTool).toHaveBeenCalledTimes(1);
+
+    // Sibling process: disk now disables the server and the epoch moved.
+    diskOverrides = { disabledServers: ["server"] };
+    epoch = "epoch-2";
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(serverTool.execute({}, {} as never)).rejects.toThrow("server 'server'");
+    expect(executeTool).toHaveBeenCalledTimes(1);
+
+    // …and re-enables it.
+    diskOverrides = {};
+    epoch = "epoch-3";
+    await serverTool.execute({}, {} as never);
+    expect(executeTool).toHaveBeenCalledTimes(2);
+    manager.releaseLease(workspaceId);
+  });
+
+  test("served tool calls hold the override writer's lock from the final epoch read through dispatch", async () => {
+    // A sibling process's revocation that commits between the bracket's
+    // postflight epoch read and the invocation leaves no process-local marker.
+    // Under the writer's lock the write either committed before the fenced
+    // epoch read (observed → re-derived → revoked) or waits until the call has
+    // been dispatched; the tool's own execution never runs under the lock.
+    manager.dispose();
+    let epoch = "epoch-1";
+    let diskOverrides: Record<string, unknown> = {};
+    let lockHeld = false;
+    let acquisitions = 0;
+    let releases = 0;
+    let gateLock: Promise<void> = Promise.resolve();
+    const acquireOverridesLock = mock(async () => {
+      acquisitions += 1;
+      await gateLock;
+      lockHeld = true;
+      return () => {
+        lockHeld = false;
+        releases += 1;
+        return Promise.resolve();
+      };
+    });
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("plugins-1"),
+        readOverridesEpoch: () => Promise.resolve(epoch),
+        readWorkspaceOverrides: () => Promise.resolve(diskOverrides),
+        acquireOverridesLock,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    const workspaceId = "ws-call-time-lock";
+    configService.listServers = mock(() => Promise.resolve({ server: stdioConfig("cmd-1") }));
+    let heldAtDispatch: boolean | undefined;
+    let finishTool!: () => void;
+    const executeTool = mock(() => {
+      heldAtDispatch = lockHeld;
+      return new Promise((resolve) => {
+        finishTool = () => resolve({ content: [{ type: "text", text: "ok" }] });
+      });
+    });
+    const dummyTool = {
+      description: "test",
+      inputSchema: { type: "object", properties: {} },
+      execute: executeTool,
+    } as unknown as Tool;
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(
+        startResult(Object.keys(servers).map((name) => [name, { tools: { ping: dummyTool } }]))
+      );
+    });
+    const result = await manager.getToolsForWorkspace(
+      workspaceRequest(workspaceId, { overrides: {}, overridesAuthoritative: true })
+    );
+    const serverTool = result.tools.server_ping;
+    if (!serverTool?.execute) {
+      throw new Error("Expected served tool to include execute");
+    }
+    manager.acquireLease(workspaceId);
+
+    // Dispatch happens under the lock; the lock is released once the call has
+    // started, not when the tool finishes.
+    const call = serverTool.execute({}, {} as never) as Promise<unknown>;
+    await waitFor(() => executeTool.mock.calls.length === 1);
+    expect(heldAtDispatch).toBe(true);
+    await waitFor(() => releases === 1);
+    expect(acquisitions).toBe(1);
+    finishTool();
+    await call;
+
+    // Sibling revocation racing the handoff: it holds the writer's lock while
+    // the gate (already past its bracket) waits for it, commits disk + epoch,
+    // then releases. The fenced epoch read observes the change and the call
+    // is re-derived from disk instead of dispatched on stale authorization.
+    let releaseSibling!: () => void;
+    gateLock = new Promise<void>((resolve) => {
+      releaseSibling = resolve;
+    });
+    const racing = serverTool.execute({}, {} as never) as Promise<unknown>;
+    await waitFor(() => acquisitions === 2);
+    diskOverrides = { disabledServers: ["server"] };
+    epoch = "epoch-2";
+    releaseSibling();
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(racing).rejects.toThrow("server 'server'");
+    expect(executeTool).toHaveBeenCalledTimes(1);
+    expect(lockHeld).toBe(false);
+
+    // A lock that cannot be acquired before the tool call's deadline/abort
+    // fails the call closed and never leaves a late acquisition held.
+    gateLock = new Promise<void>(() => undefined);
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      serverTool.execute({}, { abortSignal: AbortSignal.abort() } as never)
+    ).rejects.toThrow("aborted");
+    expect(executeTool).toHaveBeenCalledTimes(1);
+    manager.releaseLease(workspaceId);
+  });
+
+  test("an aborted prompt request releases the writer's lock while its fenced epoch read stalls", async () => {
+    // The outer abort race returns to the caller, but the losing callback
+    // still holds the override writer's lock: a stalled home filesystem must
+    // not keep every settings save and prune blocked behind an epoch read
+    // nobody waits for.
+    manager.dispose();
+    let lockHeld = false;
+    let epochReads = 0;
+    const controller = new AbortController();
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("plugins-1"),
+        readOverridesEpoch: () => {
+          epochReads += 1;
+          // Only the fenced read (taken under the lock) stalls.
+          if (lockHeld) {
+            controller.abort();
+            return new Promise<string>(() => undefined);
+          }
+          return Promise.resolve("epoch-1");
+        },
+        readWorkspaceOverrides: () => Promise.resolve({}),
+        acquireOverridesLock: () => {
+          lockHeld = true;
+          return Promise.resolve(() => {
+            lockHeld = false;
+            return Promise.resolve();
+          });
+        },
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    const workspaceId = "ws-prompt-fence-abort";
+    configService.listServers = mock(() => Promise.resolve({ server: stdioConfig("cmd-1") }));
+    const getPrompt = mock(() =>
+      Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "hi" } }] })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(
+        startResult(Object.keys(servers).map((name) => [name, { getPrompt }]))
+      );
+    });
+    await manager.getToolsForWorkspace(
+      workspaceRequest(workspaceId, { overrides: {}, overridesAuthoritative: true })
+    );
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      manager.getPrompt(workspaceId, "server", "review", {}, { signal: controller.signal })
+    ).rejects.toThrow("aborted");
+    await waitFor(() => !lockHeld);
+    expect(getPrompt).not.toHaveBeenCalled();
+    expect(epochReads).toBeGreaterThan(0);
+  });
+
+  test("a sibling override write landing before server startup fails the serve closed instead of launching", async () => {
+    // The writer bumps the epoch right after persisting the document (before
+    // its publication budget). A serve that derived its enabled set before
+    // that write must not launch a server whose revocation is already
+    // durable — the postflight would only close it after its command ran.
+    manager.dispose();
+    let epoch = "epoch-1";
+    const readWorkspaceOverrides = mock(() => {
+      // The sibling's write commits while this serve's disk read is in flight.
+      epoch = "epoch-2";
+      return Promise.resolve({} as Record<string, unknown>);
+    });
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("plugins-1"),
+        readOverridesEpoch: () => Promise.resolve(epoch),
+        readWorkspaceOverrides,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() => Promise.resolve({ server: stdioConfig("cmd-1") }));
+    const startServers = spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(startResult(Object.keys(servers).map((name) => [name, undefined])));
+    });
+    const workspaceId = "ws-startup-fence";
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      manager.getToolsForWorkspace(workspaceRequest(workspaceId, { overrides: {} }))
+    ).rejects.toThrow("changed in another process");
+    expect(startServers).not.toHaveBeenCalled();
+
+    // The next serve's preflight adopts the new epoch and re-derives from disk.
+    readWorkspaceOverrides.mockImplementation(() => Promise.resolve({}));
+    const served = await manager.getToolsForWorkspace(
+      workspaceRequest(workspaceId, { overrides: {} })
+    );
+    expect(served.stats.enabledServerCount).toBe(1);
+    expect(startServers).toHaveBeenCalledTimes(1);
+  });
+
+  test("prompt dispatch holds the override writer's lock from the final epoch read through invocation start", async () => {
+    // Same fence as served tool calls: a sibling process persists a disabling
+    // save, spends its publication budget updating caches, and only then
+    // bumps the epoch — a postflight alone can observe the old token and hand
+    // out content from the now-disabled server.
+    manager.dispose();
+    let epoch = "epoch-1";
+    let diskOverrides: Record<string, unknown> = {};
+    let lockHeld = false;
+    let acquisitions = 0;
+    let gateLock: Promise<void> = Promise.resolve();
+    const acquireOverridesLock = mock(async () => {
+      acquisitions += 1;
+      await gateLock;
+      lockHeld = true;
+      return () => {
+        lockHeld = false;
+        return Promise.resolve();
+      };
+    });
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("plugins-1"),
+        readOverridesEpoch: () => Promise.resolve(epoch),
+        readWorkspaceOverrides: () => Promise.resolve(diskOverrides),
+        acquireOverridesLock,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    const workspaceId = "ws-prompt-lock";
+    configService.listServers = mock(() => Promise.resolve({ server: stdioConfig("cmd-1") }));
+    let heldAtDispatch: boolean | undefined;
+    const getPrompt = mock(() => {
+      heldAtDispatch = lockHeld;
+      return Promise.resolve({
+        messages: [{ role: "user", content: { type: "text", text: "hi" } }],
+      });
+    });
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(
+        startResult(Object.keys(servers).map((name) => [name, { getPrompt }]))
+      );
+    });
+    await manager.getToolsForWorkspace(
+      workspaceRequest(workspaceId, { overrides: {}, overridesAuthoritative: true })
+    );
+
+    expect(await manager.getPrompt(workspaceId, "server", "review", {})).toEqual({ text: "hi" });
+    expect(heldAtDispatch).toBe(true);
+    expect(lockHeld).toBe(false);
+    const acquisitionsAfterFirst = acquisitions;
+
+    // Sibling revocation racing the handoff: it holds the writer's lock while
+    // this request (already past its authoritative re-read) waits for it,
+    // commits disk + epoch, then releases. The fenced epoch read sees the
+    // change and no content is handed out from the disabled server.
+    let releaseSibling!: () => void;
+    gateLock = new Promise<void>((resolve) => {
+      releaseSibling = resolve;
+    });
+    const racing = manager.getPrompt(workspaceId, "server", "review", {});
+    racing.catch(() => undefined);
+    await waitFor(() => acquisitions === acquisitionsAfterFirst + 1);
+    diskOverrides = { disabledServers: ["server"] };
+    epoch = "epoch-2";
+    gateLock = Promise.resolve();
+    releaseSibling();
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(racing).rejects.toThrow("server 'server'");
+    expect(getPrompt).toHaveBeenCalledTimes(1);
+    expect(lockHeld).toBe(false);
+
+    // A same-process global disable landing while the request waits for the
+    // lock advances only the config generation (no provenance change, no
+    // epoch bump): the dispatch must re-derive from the current config
+    // instead of trusting the pre-wait enabled set.
+    diskOverrides = {};
+    epoch = "epoch-3";
+    expect(await manager.getPrompt(workspaceId, "server", "review", {})).toEqual({ text: "hi" });
+    expect(getPrompt).toHaveBeenCalledTimes(2);
+    let releaseSettings!: () => void;
+    gateLock = new Promise<void>((resolve) => {
+      releaseSettings = resolve;
+    });
+    const acquisitionsBefore = acquisitions;
+    const racingGlobal = manager.getPrompt(workspaceId, "server", "review", {});
+    racingGlobal.catch(() => undefined);
+    await waitFor(() => acquisitions === acquisitionsBefore + 1);
+    configService.listServers = mock(() => Promise.resolve({}));
+    configService.configGeneration += 1;
+    gateLock = Promise.resolve();
+    releaseSettings();
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(racingGlobal).rejects.toThrow("server 'server'");
+    expect(getPrompt).toHaveBeenCalledTimes(2);
+    expect(lockHeld).toBe(false);
+  });
+
+  test("served tools of a project-local server are rejected once project trust is revoked", async () => {
+    // applyProjectTrust repairs the live entry's enabled set like an override
+    // publication: the gate must not keep dispatching a server the user just
+    // distrusted from an already-prepared stream.
+    const workspaceId = "ws-call-time-trust";
+    configService.listServers = mock((_projectPath: string, trusted: boolean) =>
+      Promise.resolve(
+        trusted
+          ? { server: stdioConfig("cmd-1"), stable: stdioConfig("cmd-stable") }
+          : { stable: stdioConfig("cmd-stable") }
+      )
+    );
+    const executeTool = mock(() => Promise.resolve({ content: [{ type: "text", text: "ok" }] }));
+    const dummyTool = {
+      description: "test",
+      inputSchema: { type: "object", properties: {} },
+      execute: executeTool,
+    } as unknown as Tool;
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(
+        startResult(Object.keys(servers).map((name) => [name, { tools: { ping: dummyTool } }]))
+      );
+    });
+    const result = await manager.getToolsForWorkspace(
+      workspaceRequest(workspaceId, { trusted: true, overrides: {}, overridesAuthoritative: true })
+    );
+    const projectTool = result.tools.server_ping;
+    const globalTool = result.tools.stable_ping;
+    if (!projectTool?.execute || !globalTool?.execute) {
+      throw new Error("Expected served tools to include execute");
+    }
+    manager.acquireLease(workspaceId);
+    await projectTool.execute({}, {} as never);
+    expect(executeTool).toHaveBeenCalledTimes(1);
+
+    manager.applyProjectTrust([{ projectPath: PROJECT_PATH, trusted: false }]);
+    // The racing call waits for the repair registered by the trust change.
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(projectTool.execute({}, {} as never)).rejects.toThrow("server 'server'");
+    expect(executeTool).toHaveBeenCalledTimes(1);
+    // Servers that do not depend on trust keep working.
+    await globalTool.execute({}, {} as never);
+    expect(executeTool).toHaveBeenCalledTimes(2);
+    manager.releaseLease(workspaceId);
+  });
+
+  test("a serve's disk re-read is cancelled with the caller's signal", async () => {
+    manager.dispose();
+    const readWorkspaceOverrides = mock(
+      (_workspaceId: string, options?: { signal?: AbortSignal }) =>
+        new Promise<Record<string, unknown> | undefined>((resolve) => {
+          options?.signal?.addEventListener("abort", () => resolve(undefined), { once: true });
+        })
+    );
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("plugins-1"),
+        readOverridesEpoch: () => Promise.resolve("epoch-1"),
+        readWorkspaceOverrides,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() => Promise.resolve({ server: stdioConfig("cmd-1") }));
+    spyOn(access, "startServers").mockResolvedValue(startResult([["server"]]));
+    const controller = new AbortController();
+    // A cold serve re-reads disk through the reader; without the signal the
+    // remote read would run to its own (minutes-long) timeout.
+    const pending = manager.getToolsForWorkspace(
+      workspaceRequest("ws-read-signal", { overrides: {}, overridesAuthoritative: true }),
+      { signal: controller.signal }
+    );
+    await waitFor(() => readWorkspaceOverrides.mock.calls.length === 1);
+    expect(readWorkspaceOverrides.mock.calls[0]?.[1]?.signal).toBe(controller.signal);
+    controller.abort();
+    // The aborted read is not a verdict: the serve fails closed.
+    const result = await pending;
+    expect(result.tools).toEqual({});
+    expect(result.overridesUsed).toBeUndefined();
+  });
+
+  test("served tool objects re-read the effective overrides on every call (direct document edit)", async () => {
+    // A direct edit of the workspace's own or an inherited parent document
+    // moves neither the epoch nor any process-local state; the gate compares
+    // disk with the recorded overrides before each call.
+    manager.dispose();
+    let diskOverrides: Record<string, unknown> | undefined = {};
+    const readWorkspaceOverrides = mock(() => Promise.resolve(diskOverrides));
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("plugins-1"),
+        readOverridesEpoch: () => Promise.resolve("epoch-1"),
+        readWorkspaceOverrides,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    const workspaceId = "ws-call-time-direct-edit";
+    configService.listServers = mock(() => Promise.resolve({ server: stdioConfig("cmd-1") }));
+    const executeTool = mock(() => Promise.resolve({ content: [{ type: "text", text: "ok" }] }));
+    const dummyTool = {
+      description: "test",
+      inputSchema: { type: "object", properties: {} },
+      execute: executeTool,
+    } as unknown as Tool;
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(
+        startResult(Object.keys(servers).map((name) => [name, { tools: { ping: dummyTool } }]))
+      );
+    });
+    const result = await manager.getToolsForWorkspace(
+      workspaceRequest(workspaceId, { overrides: {}, overridesAuthoritative: true })
+    );
+    const serverTool = result.tools.server_ping;
+    if (!serverTool?.execute) {
+      throw new Error("Expected served tool to include execute");
+    }
+    manager.acquireLease(workspaceId);
+    await serverTool.execute({}, {} as never);
+    expect(executeTool).toHaveBeenCalledTimes(1);
+
+    // Direct edit: disk disables the server; no epoch bump, no publication.
+    diskOverrides = { disabledServers: ["server"] };
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(serverTool.execute({}, {} as never)).rejects.toThrow("server 'server'");
+    expect(executeTool).toHaveBeenCalledTimes(1);
+    // Unreadable document: fail closed too.
+    diskOverrides = undefined;
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(serverTool.execute({}, {} as never)).rejects.toThrow("server 'server'");
+    // Edited back: allowed again.
+    diskOverrides = {};
+    await serverTool.execute({}, {} as never);
+    expect(executeTool).toHaveBeenCalledTimes(2);
+    // A read that THROWS (unreachable parent checkout, config error) is not a
+    // verdict either: fail closed rather than fall through to the cached set.
+    readWorkspaceOverrides.mockImplementationOnce(() =>
+      Promise.reject(new Error("parent checkout unreachable"))
+    );
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(serverTool.execute({}, {} as never)).rejects.toThrow("could not be re-read");
+    expect(executeTool).toHaveBeenCalledTimes(2);
+    // Disk answers again: re-derived and allowed.
+    await serverTool.execute({}, {} as never);
+    expect(executeTool).toHaveBeenCalledTimes(3);
+    // The re-read honors the tool call's abort signal (Escape) instead of
+    // running to completion first.
+    readWorkspaceOverrides.mockImplementationOnce(() => new Promise(() => undefined));
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      serverTool.execute({}, { abortSignal: AbortSignal.abort() } as never)
+    ).rejects.toThrow("aborted");
+    expect(executeTool).toHaveBeenCalledTimes(3);
+    manager.releaseLease(workspaceId);
+  });
+
+  test("served tool calls do not hang on a publication repair the publisher gave up on", async () => {
+    // The publisher bounds applyWorkspaceOverrides and evicts on timeout; the
+    // stalled repair must neither block nor authorize calls after that.
+    const workspaceId = "ws-stalled-repair-gate";
+    configService.listServers = mock(() => Promise.resolve({ server: stdioConfig("cmd-1") }));
+    const executeTool = mock(() => Promise.resolve({ content: [{ type: "text", text: "ok" }] }));
+    const dummyTool = {
+      description: "test",
+      inputSchema: { type: "object", properties: {} },
+      execute: executeTool,
+    } as unknown as Tool;
+    access.startServers = mock((servers) =>
+      Promise.resolve(
+        startResult(
+          Object.keys(servers as Record<string, unknown>).map((name) => [
+            name,
+            { tools: { ping: dummyTool } },
+          ])
+        )
+      )
+    );
+    const result = await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    const serverTool = result.tools.server_ping;
+    if (!serverTool?.execute) {
+      throw new Error("Expected served tool to include execute");
+    }
+    // Only the publication's config read stalls (later reads answer again).
+    let listServersCalls = 0;
+    configService.listServers = mock(() =>
+      ++listServersCalls === 1
+        ? new Promise(() => undefined)
+        : Promise.resolve({ server: stdioConfig("cmd-1") })
+    );
+    const stalled = manager.applyWorkspaceOverrides(workspaceId, { disabledServers: ["server"] });
+    // The bounded publisher gives up and evicts.
+    manager.forgetWorkspaceOverrides(workspaceId);
+    const startedAt = Date.now();
+    // No disk reader in this fixture: the invalidation cannot be resolved, so
+    // the call fails closed — promptly, without waiting on the stalled repair.
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(serverTool.execute({}, {} as never)).rejects.toThrow("server 'server'");
+    expect(Date.now() - startedAt).toBeLessThan(5_000);
+    expect(executeTool).not.toHaveBeenCalled();
+    void stalled;
+    // A stalled repair still pending (no eviction yet) must not hold a call
+    // past Escape: the wait is abort-aware.
+    const stalled2 = manager.applyWorkspaceOverrides(workspaceId, { disabledServers: [] });
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      serverTool.execute({}, { abortSignal: AbortSignal.abort() } as never)
+    ).rejects.toThrow("aborted");
+    expect(executeTool).not.toHaveBeenCalled();
+    void stalled2;
+  });
+
+  test("a publication whose repair fails invalidates the workspace instead of leaving stale enablement", async () => {
+    // Recorded overrides say "disabled" while the entry keeps the old enabled
+    // set; a per-call disk comparison finds disk equal to the recorded value,
+    // so nothing else would ever repair the entry. Fail closed until re-derived.
+    const workspaceId = "ws-repair-failure";
+    configService.listServers = mock(() => Promise.resolve({ server: stdioConfig("cmd-1") }));
+    const executeTool = mock(() => Promise.resolve({ content: [{ type: "text", text: "ok" }] }));
+    const dummyTool = {
+      description: "test",
+      inputSchema: { type: "object", properties: {} },
+      execute: executeTool,
+    } as unknown as Tool;
+    access.startServers = mock((servers) =>
+      Promise.resolve(
+        startResult(
+          Object.keys(servers as Record<string, unknown>).map((name) => [
+            name,
+            { tools: { ping: dummyTool } },
+          ])
+        )
+      )
+    );
+    const result = await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    const serverTool = result.tools.server_ping;
+    if (!serverTool?.execute) {
+      throw new Error("Expected served tool to include execute");
+    }
+    configService.listServers = mock(() => Promise.reject(new Error("config unreadable")));
+    await manager.applyWorkspaceOverrides(workspaceId, { disabledServers: ["server"] });
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(serverTool.execute({}, {} as never)).rejects.toThrow("server 'server'");
+    expect(executeTool).not.toHaveBeenCalled();
+  });
+
+  test("a publication starting during a call's revalidation is honored before dispatch", async () => {
+    // The disabling save lands after the gate's first pending-repair lookup:
+    // its recorded options are installed but its repair is still pending.
+    // The gate must not dispatch on the pre-publication enabled set.
+    const workspaceId = "ws-gate-late-publication";
+    configService.listServers = mock(() => Promise.resolve({ server: stdioConfig("cmd-1") }));
+    const executeTool = mock(() => Promise.resolve({ content: [{ type: "text", text: "ok" }] }));
+    const dummyTool = {
+      description: "test",
+      inputSchema: { type: "object", properties: {} },
+      execute: executeTool,
+    } as unknown as Tool;
+    access.startServers = mock((servers) =>
+      Promise.resolve(
+        startResult(
+          Object.keys(servers as Record<string, unknown>).map((name) => [
+            name,
+            { tools: { ping: dummyTool } },
+          ])
+        )
+      )
+    );
+    const result = await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    const serverTool = result.tools.server_ping;
+    if (!serverTool?.execute) {
+      throw new Error("Expected served tool to include execute");
+    }
+    // Hook the revalidation bracket: the publication starts inside it, with a
+    // repair that never completes (stalled config read).
+    const realRun = access.runWithStablePluginEpoch.bind(manager);
+    let publication: Promise<void> | undefined;
+    spyOn(access, "runWithStablePluginEpoch").mockImplementation(
+      async (operation: () => Promise<unknown>) => {
+        const value = await realRun(operation);
+        configService.listServers = mock(() => new Promise(() => undefined));
+        publication ??= manager.applyWorkspaceOverrides(workspaceId, {
+          disabledServers: ["server"],
+        });
+        return value;
+      }
+    );
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(serverTool.execute({}, {} as never)).rejects.toThrow("server 'server'");
+    expect(executeTool).not.toHaveBeenCalled();
+  });
+
+  test("a superseded publication repair cannot restore an older enabled set", async () => {
+    // Publication #1 (enables) stalls in listServers past the publisher's
+    // bound; publication #2 (disables) completes. #1's late completion must
+    // not overwrite the live entry's enablement.
+    const workspaceId = "ws-stale-repair";
+    configService.listServers = mock(() =>
+      Promise.resolve({ server: stdioConfig("cmd-1"), stable: stdioConfig("cmd-stable") })
+    );
+    const executeTool = mock(() => Promise.resolve({ content: [{ type: "text", text: "ok" }] }));
+    const dummyTool = {
+      description: "test",
+      inputSchema: { type: "object", properties: {} },
+      execute: executeTool,
+    } as unknown as Tool;
+    access.startServers = mock((servers) =>
+      Promise.resolve(
+        startResult(
+          Object.keys(servers as Record<string, unknown>).map((name) => [
+            name,
+            { tools: { ping: dummyTool } },
+          ])
+        )
+      )
+    );
+    const result = await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    const serverTool = result.tools.server_ping;
+    if (!serverTool?.execute) {
+      throw new Error("Expected served tool to include execute");
+    }
+
+    let releaseFirst!: () => void;
+    configService.listServers = mock(
+      () =>
+        new Promise((resolve) => {
+          releaseFirst = () =>
+            resolve({ server: stdioConfig("cmd-1"), stable: stdioConfig("cmd-stable") });
+        })
+    );
+    const first = manager.applyWorkspaceOverrides(workspaceId, { enabledServers: ["server"] });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    configService.listServers = mock(() => Promise.resolve({ stable: stdioConfig("cmd-stable") }));
+    await manager.applyWorkspaceOverrides(workspaceId, { disabledServers: ["server"] });
+    releaseFirst();
+    await first;
+
+    const entry = access.workspaceServers.get(workspaceId) as
+      | { enabledServerNames: Set<string> }
+      | undefined;
+    expect(entry?.enabledServerNames.has("server")).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(serverTool.execute({}, {} as never)).rejects.toThrow("server 'server'");
+    expect(executeTool).not.toHaveBeenCalled();
+  });
+
+  test("an invalidated workspace whose overrides stay unreadable fails closed until disk answers", async () => {
+    manager.dispose();
+    let diskOverrides: Record<string, unknown> | undefined = { enabledServers: [PLUGIN_KEY] };
+    const readWorkspaceOverrides = mock(() => Promise.resolve(diskOverrides));
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("epoch-1"),
+        readWorkspaceOverrides,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    // A globally ENABLED ordinary server plus a default-disabled plugin server.
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js"), ...pluginStdioConfig() })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(startResult(Object.keys(servers).map((name) => [name, undefined])));
+    });
+    const workspaceId = "ws-fail-closed";
+    // Recorded snapshot: the parent had enabled the plugin server; ordinary runs by default.
+    const recordedOptions = () =>
+      access.lastWorkspaceRequestOptions.get(workspaceId) as MCPWorkspaceRequestOptions;
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    expect((await manager.getToolsForWorkspace(recordedOptions())).stats.enabledServerCount).toBe(
+      2
+    );
+
+    // Parent save (revoking the plugin enable) evicted us; disk is unreadable
+    // during the re-read.
+    manager.forgetWorkspaceOverrides(workspaceId);
+    diskOverrides = undefined;
+    const during = await manager.getToolsForWorkspace(recordedOptions());
+    // Fail closed: neither the recorded plugin enable nor the globally enabled
+    // ordinary server is served from a snapshot disk cannot vouch for.
+    expect(during.stats.enabledServerCount).toBe(0);
+
+    // Disk recovers: the invalidation survived, the revocation is observed,
+    // and ordinary enablement resumes from the authoritative read.
+    diskOverrides = {};
+    const after = await manager.getToolsForWorkspace(recordedOptions());
+    expect(after.stats.enabledServerCount).toBe(1);
+  });
+
+  test("a plugin-epoch refresh that cannot read disk keeps an invalidated workspace failing closed", async () => {
+    manager.dispose();
+    let token = "epoch-1";
+    let diskOverrides: Record<string, unknown> | undefined = { enabledServers: [PLUGIN_KEY] };
+    const readWorkspaceOverrides = mock(() => Promise.resolve(diskOverrides));
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve(token),
+        readWorkspaceOverrides,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js"), ...pluginStdioConfig() })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(startResult(Object.keys(servers).map((name) => [name, undefined])));
+    });
+    const workspaceId = "ws-refresh-invalidated";
+    const recordedOptions = () =>
+      access.lastWorkspaceRequestOptions.get(workspaceId) as MCPWorkspaceRequestOptions;
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    expect((await manager.getToolsForWorkspace(recordedOptions())).stats.enabledServerCount).toBe(
+      2
+    );
+
+    // Parent save evicted us while disk is unreadable; then a sibling
+    // process's plugin mutation bumps the epoch. The refresh sweep's fallback
+    // (scrubbed recorded snapshot) must not repopulate the overlay cache for
+    // the invalidated workspace — that snapshot is what is being distrusted.
+    manager.forgetWorkspaceOverrides(workspaceId);
+    diskOverrides = undefined;
+    token = "epoch-2";
+    const during = await manager.getToolsForWorkspace(recordedOptions());
+    expect(during.stats.enabledServerCount).toBe(0);
+    expect(
+      (
+        access as unknown as { latestWorkspaceOverrides: Map<string, unknown> }
+      ).latestWorkspaceOverrides.has(workspaceId)
+    ).toBe(false);
+
+    // Disk recovers: the invalidation survived the sweep and the revocation
+    // is observed from the authoritative read.
+    diskOverrides = {};
+    const after = await manager.getToolsForWorkspace(recordedOptions());
+    expect(after.stats.enabledServerCount).toBe(1);
+  });
+
+  test("an authoritative publication retires the invalidation and the fail-closed state", async () => {
+    manager.dispose();
+    let diskOverrides: Record<string, unknown> | undefined = {};
+    const readWorkspaceOverrides = mock(() => Promise.resolve(diskOverrides));
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("epoch-1"),
+        readWorkspaceOverrides,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js") })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(startResult(Object.keys(servers).map((name) => [name, undefined])));
+    });
+    const workspaceId = "ws-publication-wins";
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    const recordedOptions = () =>
+      access.lastWorkspaceRequestOptions.get(workspaceId) as MCPWorkspaceRequestOptions;
+
+    // Evicted, then disk unreadable: fails closed.
+    manager.forgetWorkspaceOverrides(workspaceId);
+    diskOverrides = undefined;
+    expect((await manager.getToolsForWorkspace(recordedOptions())).stats.enabledServerCount).toBe(
+      0
+    );
+    // A later parent save resolves the child authoritatively and publishes it:
+    // MCP must come back without waiting for another disk read.
+    await manager.applyWorkspaceOverrides(workspaceId, {});
+    const reads = readWorkspaceOverrides.mock.calls.length;
+    expect((await manager.getToolsForWorkspace(recordedOptions())).stats.enabledServerCount).toBe(
+      1
+    );
+    expect(readWorkspaceOverrides.mock.calls.length).toBe(reads);
+  });
+
+  test("a server revoked mid-startup is not served by the completing serve", async () => {
+    configService.listServers = mock(() =>
+      Promise.resolve({
+        ordinary: stdioConfig("node ordinary.js"),
+        other: stdioConfig("node other.js"),
+      })
+    );
+    const workspaceId = "ws-revoked-mid-startup";
+    spyOn(access, "startServers").mockImplementation(async (...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      // A parent save publishes a disable while these servers are starting.
+      await manager.applyWorkspaceOverrides(workspaceId, { disabledServers: ["ordinary"] });
+      return startResult(
+        Object.keys(servers).map((name) => [name, { tools: { echo: testTool() } }])
+      );
+    });
+    const result = await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    expect(Object.keys(result.tools)).toEqual(["other_echo"]);
+  });
+
+  test("a global eviction landing during a cold serve's first read fails that serve closed", async () => {
+    manager.dispose();
+    let release: (value: Record<string, unknown>) => void = () => undefined;
+    const readWorkspaceOverrides = mock(
+      () => new Promise<Record<string, unknown>>((resolve) => (release = resolve))
+    );
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("epoch-1"),
+        readWorkspaceOverrides,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js") })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(startResult(Object.keys(servers).map((name) => [name, undefined])));
+    });
+    const inFlight = manager.getToolsForWorkspace(workspaceRequest("ws-cold-global"));
+    while (readWorkspaceOverrides.mock.calls.length < 1) {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    // The cold workspace is in neither map, so a global eviction cannot name it…
+    manager.forgetAllWorkspaceOverrides();
+    release({});
+    // …yet its pre-eviction read must not be served…
+    expect((await inFlight).stats.enabledServerCount).toBe(0);
+    // …and the recorded (stale) options must not satisfy the next serve either:
+    // it re-reads disk.
+    const recorded = access.lastWorkspaceRequestOptions.get(
+      "ws-cold-global"
+    ) as MCPWorkspaceRequestOptions;
+    const next = manager.getToolsForWorkspace(recorded);
+    while (readWorkspaceOverrides.mock.calls.length < 2) {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    release({});
+    expect((await next).stats.enabledServerCount).toBe(1);
+  });
+
+  test("a forget landing during an in-flight disk read is not retired by that read", async () => {
+    manager.dispose();
+    let release: (value: Record<string, unknown>) => void = () => undefined;
+    let reads = 0;
+    const readWorkspaceOverrides = mock(() => {
+      reads += 1;
+      if (reads === 1) return Promise.resolve({});
+      if (reads === 2)
+        return new Promise<Record<string, unknown>>((resolve) => (release = resolve));
+      return Promise.resolve({ disabledServers: ["ordinary"] });
+    });
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("epoch-1"),
+        readWorkspaceOverrides,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js") })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(startResult(Object.keys(servers).map((name) => [name, undefined])));
+    });
+    const workspaceId = "ws-forget-race";
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    const recordedOptions = () =>
+      access.lastWorkspaceRequestOptions.get(workspaceId) as MCPWorkspaceRequestOptions;
+
+    manager.forgetWorkspaceOverrides(workspaceId);
+    const inFlight = manager.getToolsForWorkspace(recordedOptions());
+    while (reads < 2) await new Promise((resolve) => setTimeout(resolve, 1));
+    // A newer parent save invalidates again while the (older) read is pending…
+    manager.forgetWorkspaceOverrides(workspaceId);
+    release({}); // …and the older read completes with pre-save state.
+    // The superseded read is not served: this serve fails closed.
+    expect((await inFlight).stats.enabledServerCount).toBe(0);
+
+    // The newer invalidation must still force a disk read, which now sees the disable.
+    const next = await manager.getToolsForWorkspace(recordedOptions());
+    expect(reads).toBe(3);
+    expect(next.stats.enabledServerCount).toBe(0);
+  });
+
+  test("a forget landing after a serve selected its options fails that serve closed", async () => {
+    // The serve already recorded its options and is awaiting server startup
+    // when a parent save evicts the workspace. The recorded options are the
+    // same object, and the config generation is unchanged, so the enablement
+    // repair sees nothing to redo — the invalidation marker alone must gate
+    // the return, or the revoked server's tools reach this stream.
+    manager.dispose();
+    let diskOverrides: Record<string, unknown> = {};
+    const readWorkspaceOverrides = mock(() => Promise.resolve(diskOverrides));
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("epoch-1"),
+        readWorkspaceOverrides,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js") })
+    );
+    let releaseStartup: () => void = () => undefined;
+    let startupGated = false;
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      const result = startResult(
+        Object.keys(servers).map((name) => [name, { tools: { echo: testTool() } }])
+      );
+      if (!startupGated) return Promise.resolve(result);
+      return new Promise((resolve) => {
+        releaseStartup = () => resolve(result);
+      });
+    });
+    const workspaceId = "ws-forget-mid-startup";
+    startupGated = true;
+    const inFlight = manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    while (access.lastWorkspaceRequestOptions.get(workspaceId) === undefined) {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    // Parent save revokes the server on disk and evicts us mid-startup.
+    diskOverrides = { disabledServers: ["ordinary"] };
+    manager.forgetWorkspaceOverrides(workspaceId);
+    releaseStartup();
+    const served = await inFlight;
+    expect(Object.keys(served.tools)).toHaveLength(0);
+    expect(served.promptDescriptors).toHaveLength(0);
+
+    // The marker survived: the next serve re-reads disk and observes the disable.
+    startupGated = false;
+    const recorded = access.lastWorkspaceRequestOptions.get(
+      workspaceId
+    ) as MCPWorkspaceRequestOptions;
+    const next = await manager.getToolsForWorkspace(recorded);
+    expect(readWorkspaceOverrides).toHaveBeenCalledTimes(2);
+    expect(next.stats.enabledServerCount).toBe(0);
+  });
+
+  test("getPrompt does not dispatch through a stale entry when the workspace is invalidated mid-serve", async () => {
+    // getPrompt's dispatch-time ensureWorkspaceServers fails closed via
+    // serveResult, but does not rewrite the cached entry — the prompt path
+    // must consume that verdict rather than consult the stale entry.
+    manager.dispose();
+    let diskOverrides: Record<string, unknown> = {};
+    const readWorkspaceOverrides = mock(() => Promise.resolve(diskOverrides));
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("epoch-1"),
+        readWorkspaceOverrides,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    const servers = { ordinary: stdioConfig("node ordinary.js") };
+    configService.listServers = mock(() => Promise.resolve(servers));
+    const getPrompt = mock(() =>
+      Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "Status" } }] })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const names = Object.keys(args[0] as Record<string, unknown>);
+      return Promise.resolve(
+        startResult(names.map((name) => [name, { prompts: [{ name: "status" }], getPrompt }]))
+      );
+    });
+    const workspaceId = "ws-prompt-forget-mid-serve";
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    // Sanity: the prompt dispatches normally.
+    await manager.getPrompt(workspaceId, "ordinary", "status", {});
+    expect(getPrompt).toHaveBeenCalledTimes(1);
+
+    // getPrompt reads config once in its stabilization loop, then again in the
+    // dispatch-time serve: gate that second read.
+    let listServersCalls = 0;
+    let gatedListServersCalls = 0;
+    let releaseListServers: () => void = () => undefined;
+    configService.listServers = mock(() => {
+      listServersCalls += 1;
+      if (listServersCalls < 2) return Promise.resolve(servers);
+      gatedListServersCalls += 1;
+      return new Promise<typeof servers>((resolve) => {
+        releaseListServers = () => resolve(servers);
+      });
+    });
+    const prompt = manager.getPrompt(workspaceId, "ordinary", "status", {});
+    while (gatedListServersCalls === 0) {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    // Parent save revokes the server on disk and evicts this workspace while
+    // the dispatch-time serve is mid-flight.
+    diskOverrides = { disabledServers: ["ordinary"] };
+    manager.forgetWorkspaceOverrides(workspaceId);
+    releaseListServers();
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(prompt).rejects.toThrow(/unavailable|disabled/);
+    expect(getPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  test("a plugin-epoch refresh never restores a snapshot over a publication that landed mid-read", async () => {
+    manager.dispose();
+    let token = "epoch-1";
+    let release: (value: Record<string, unknown>) => void = () => undefined;
+    let gateRead = false;
+    let diskOverrides: Record<string, unknown> = {};
+    const readWorkspaceOverrides = mock(() => {
+      if (!gateRead) return Promise.resolve(diskOverrides);
+      gateRead = false; // gate exactly one read (the sweep's)
+      return new Promise<Record<string, unknown>>((resolve) => (release = resolve));
+    });
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve(token),
+        readWorkspaceOverrides,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js") })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(startResult(Object.keys(servers).map((name) => [name, undefined])));
+    });
+    const workspaceId = "ws-refresh-vs-publication";
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    const recordedOptions = () =>
+      access.lastWorkspaceRequestOptions.get(workspaceId) as MCPWorkspaceRequestOptions;
+
+    // Sibling plugin mutation: the epoch sweep re-reads this workspace's
+    // overrides; the read is in flight…
+    gateRead = true;
+    token = "epoch-2";
+    const sweep = manager.getToolsForWorkspace(recordedOptions());
+    while (readWorkspaceOverrides.mock.calls.length < 2) {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    // …when a parent save publishes a disable authoritatively (disk first).
+    diskOverrides = { disabledServers: ["ordinary"] };
+    await manager.applyWorkspaceOverrides(workspaceId, { disabledServers: ["ordinary"] });
+    // The read completes with pre-save state; it must not win. (The serve's
+    // stale `{}` snapshot then disagrees with the cache and is revalidated
+    // against disk, which agrees with the publication.)
+    release({});
+    await sweep;
+    expect(recordedOptions().overrides).toEqual({ disabledServers: ["ordinary"] });
+    const next = await manager.getToolsForWorkspace(recordedOptions());
+    expect(next.stats.enabledServerCount).toBe(0);
+  });
+
+  test("a publication landing between the final repair and the return fails that serve closed", async () => {
+    // The repair derives enablement and resolves; the caller resumes one
+    // microtask later. A publication squeezed into that gap replaced the
+    // recorded options (its own listServers still pending) — the entry's
+    // enabled set is stale for this serve and must not be filtered through.
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js") })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(
+        startResult(Object.keys(servers).map((name) => [name, { tools: { echo: testTool() } }]))
+      );
+    });
+    const workspaceId = "ws-publish-after-repair";
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+
+    const repairAccess = access as unknown as {
+      repairEnablementAfterConcurrentMutation: (...args: unknown[]) => Promise<unknown>;
+    };
+    const realRepair = repairAccess.repairEnablementAfterConcurrentMutation.bind(manager);
+    let publication: Promise<void> | undefined;
+    spyOn(repairAccess, "repairEnablementAfterConcurrentMutation").mockImplementation(
+      async (...args: unknown[]) => {
+        const derivedFrom = await realRepair(...args);
+        // Emulate the gap: the publication's synchronous part (recorded
+        // options replaced, marker retired) runs before the caller resumes.
+        publication ??= manager.applyWorkspaceOverrides(workspaceId, {
+          disabledServers: ["ordinary"],
+        });
+        return derivedFrom;
+      }
+    );
+    const served = await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    expect(Object.keys(served.tools)).toHaveLength(0);
+    await publication;
+
+    // The publication's own completion repaired the entry for later serves.
+    spyOn(repairAccess, "repairEnablementAfterConcurrentMutation").mockImplementation(realRepair);
+    const next = await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    expect(Object.keys(next.tools)).toHaveLength(0);
+    expect(next.stats.enabledServerCount).toBe(0);
+  });
+
+  test("getPrompt does not dispatch when a publication lands between the final serve and dispatch", async () => {
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js") })
+    );
+    const getPrompt = mock(() =>
+      Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "Status" } }] })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const names = Object.keys(args[0] as Record<string, unknown>);
+      return Promise.resolve(
+        startResult(names.map((name) => [name, { prompts: [{ name: "status" }], getPrompt }]))
+      );
+    });
+    const workspaceId = "ws-prompt-publish-gap";
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    await manager.getPrompt(workspaceId, "ordinary", "status", {});
+    expect(getPrompt).toHaveBeenCalledTimes(1);
+
+    // Emulate the gap: the dispatch-time serve passed its gate, and a parent
+    // publication's synchronous part (recorded options replaced, marker
+    // retired; its own listServers still pending) runs before getPrompt resumes.
+    const realEnsure = access.ensureWorkspaceServers.bind(manager);
+    let publication: Promise<void> | undefined;
+    let ensureCalls = 0;
+    spyOn(access, "ensureWorkspaceServers").mockImplementation(async (...args: unknown[]) => {
+      const served = await realEnsure(...args);
+      // getPrompt calls ensure twice: stabilization, then dispatch-time.
+      if (++ensureCalls === 2) {
+        publication = manager.applyWorkspaceOverrides(workspaceId, {
+          disabledServers: ["ordinary"],
+        });
+      }
+      return served;
+    });
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(manager.getPrompt(workspaceId, "ordinary", "status", {})).rejects.toThrow(
+      /unavailable|disabled/
+    );
+    expect(getPrompt).toHaveBeenCalledTimes(1);
+    await publication;
+  });
+
+  test("a serve whose enablement repair fails after a publication fails closed", async () => {
+    const servers = { ordinary: stdioConfig("node ordinary.js") };
+    configService.listServers = mock(() => Promise.resolve(servers));
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const names = Object.keys(args[0] as Record<string, unknown>);
+      return Promise.resolve(
+        startResult(names.map((name) => [name, { tools: { echo: testTool() } }]))
+      );
+    });
+    const workspaceId = "ws-repair-fails";
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+
+    const repairAccess = access as unknown as {
+      repairEnablementAfterConcurrentMutation: (...args: unknown[]) => Promise<unknown>;
+    };
+    const realRepair = repairAccess.repairEnablementAfterConcurrentMutation.bind(manager);
+    let publication: Promise<void> | undefined;
+    let releasePublication: () => void = () => undefined;
+    spyOn(repairAccess, "repairEnablementAfterConcurrentMutation").mockImplementation(
+      async (...args: unknown[]) => {
+        if (publication === undefined) {
+          // A publication replaces the recorded options; its own listServers
+          // stays pending until after the serve returns…
+          configService.listServers = mock(
+            () =>
+              new Promise<typeof servers>((resolve) => {
+                releasePublication = () => resolve(servers);
+              })
+          );
+          publication = manager.applyWorkspaceOverrides(workspaceId, {
+            disabledServers: ["ordinary"],
+          });
+        }
+        // …and the repair's own re-derivation fails.
+        configService.listServers = mock(() => Promise.reject(new Error("config unreadable")));
+        try {
+          return await realRepair(...args);
+        } finally {
+          configService.listServers = mock(() => Promise.resolve(servers));
+        }
+      }
+    );
+    const served = await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    // The stale enabled set must not be filtered through as if re-derived.
+    expect(Object.keys(served.tools)).toHaveLength(0);
+    releasePublication();
+    await publication;
+  });
+
+  test("a publication landing during the epoch postflight fails that serve closed", async () => {
+    manager.dispose();
+    let tokenReads = 0;
+    let publication: Promise<void> | undefined;
+    const workspaceId = "ws-publish-during-postflight";
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => {
+          // Per serve: preflight (odd) then postflight (even). The second
+          // serve's postflight is call 4 — publish while it is awaited.
+          if (++tokenReads === 4) {
+            publication = manager.applyWorkspaceOverrides(workspaceId, {
+              disabledServers: ["ordinary"],
+            });
+          }
+          return Promise.resolve("epoch-1");
+        },
+        readWorkspaceOverrides: () => Promise.resolve({}),
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js") })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const names = Object.keys(args[0] as Record<string, unknown>);
+      return Promise.resolve(
+        startResult(names.map((name) => [name, { tools: { echo: testTool() } }]))
+      );
+    });
+    const first = await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    expect(Object.keys(first.tools)).toHaveLength(1);
+
+    const second = await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    expect(publication).toBeDefined();
+    expect(Object.keys(second.tools)).toHaveLength(0);
+    await publication;
+    const third = await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    expect(third.stats.enabledServerCount).toBe(0);
+  });
+
+  test("getToolsForWorkspace fails closed for a non-empty serve without enablement provenance", async () => {
+    // A recursive serve that lost its provenance (or any path that cannot
+    // vouch for what enablement was derived from) must not hand out tools.
+    spyOn(access, "ensureWorkspaceServers").mockImplementation(() =>
+      Promise.resolve({
+        tools: { ordinary_echo: testTool() },
+        toolServerNames: { ordinary_echo: "ordinary" },
+        stats: cachedStats(),
+        promptDescriptors: [],
+      })
+    );
+    const served = await manager.getToolsForWorkspace(workspaceRequest("ws-no-provenance"));
+    expect(Object.keys(served.tools)).toHaveLength(0);
+  });
+
+  test("getPrompt does not dispatch when a forget lands between the final serve and dispatch", async () => {
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js") })
+    );
+    const getPrompt = mock(() =>
+      Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "Status" } }] })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const names = Object.keys(args[0] as Record<string, unknown>);
+      return Promise.resolve(
+        startResult(names.map((name) => [name, { prompts: [{ name: "status" }], getPrompt }]))
+      );
+    });
+    const workspaceId = "ws-prompt-forget-gap";
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    await manager.getPrompt(workspaceId, "ordinary", "status", {});
+    expect(getPrompt).toHaveBeenCalledTimes(1);
+
+    // A forget leaves the recorded options in place and only sets the marker.
+    const realEnsure = access.ensureWorkspaceServers.bind(manager);
+    let ensureCalls = 0;
+    spyOn(access, "ensureWorkspaceServers").mockImplementation(async (...args: unknown[]) => {
+      const served = await realEnsure(...args);
+      if (++ensureCalls === 2) manager.forgetWorkspaceOverrides(workspaceId);
+      return served;
+    });
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(manager.getPrompt(workspaceId, "ordinary", "status", {})).rejects.toThrow(
+      /unavailable|disabled/
+    );
+    expect(getPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  test("an invalidation is retired only once the fresh options are the recorded ones", async () => {
+    // Retiring the marker inside the disk read would leave a window in which
+    // an overlapping serve sees no marker while the stale pre-read options are
+    // still recorded — and installs them as current.
+    manager.dispose();
+    let diskOverrides: Record<string, unknown> = {};
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("epoch-1"),
+        readWorkspaceOverrides: () => Promise.resolve(diskOverrides),
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js") })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(startResult(Object.keys(servers).map((name) => [name, undefined])));
+    });
+    const workspaceId = "ws-retire-after-install";
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    const recordedOptions = () =>
+      access.lastWorkspaceRequestOptions.get(workspaceId) as MCPWorkspaceRequestOptions;
+
+    const generations = (
+      access as unknown as { overridesInvalidationGenerations: Map<string, number> }
+    ).overridesInvalidationGenerations;
+    const recordedAtRetirement: unknown[] = [];
+    const realDelete = generations.delete.bind(generations);
+    generations.delete = (key: string) => {
+      recordedAtRetirement.push(recordedOptions().overrides);
+      return realDelete(key);
+    };
+
+    manager.forgetWorkspaceOverrides(workspaceId);
+    diskOverrides = { disabledServers: ["ordinary"] };
+    const served = await manager.getToolsForWorkspace(recordedOptions());
+    expect(served.stats.enabledServerCount).toBe(0);
+    // Whenever the marker went away, the recorded options already held the
+    // fresh disk state — never the stale pre-read snapshot.
+    expect(recordedAtRetirement.length).toBeGreaterThan(0);
+    for (const overrides of recordedAtRetirement) {
+      expect(overrides).toEqual({ disabledServers: ["ordinary"] });
+    }
+  });
+
+  test("a stale caller snapshot cannot replace overrides recovered after an invalidation", async () => {
+    // After the recovery serve records fresh disk state and retires the
+    // marker, a request still carrying the pre-save caller snapshot takes the
+    // fast path — the recovered overrides must be cached so they overlay it.
+    manager.dispose();
+    let diskOverrides: Record<string, unknown> = {};
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("epoch-1"),
+        readWorkspaceOverrides: () => Promise.resolve(diskOverrides),
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js") })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(startResult(Object.keys(servers).map((name) => [name, undefined])));
+    });
+    const workspaceId = "ws-stale-snapshot-after-recovery";
+    const staleSnapshot = workspaceRequest(workspaceId); // pre-save: nothing disabled
+    expect((await manager.getToolsForWorkspace(staleSnapshot)).stats.enabledServerCount).toBe(1);
+
+    // Parent save disables the server on disk and evicts us; recovery re-reads.
+    manager.forgetWorkspaceOverrides(workspaceId);
+    diskOverrides = { disabledServers: ["ordinary"] };
+    const recorded = access.lastWorkspaceRequestOptions.get(
+      workspaceId
+    ) as MCPWorkspaceRequestOptions;
+    expect((await manager.getToolsForWorkspace(recorded)).stats.enabledServerCount).toBe(0);
+
+    // A request that still holds the pre-save snapshot must not win.
+    const late = await manager.getToolsForWorkspace(staleSnapshot);
+    expect(late.stats.enabledServerCount).toBe(0);
+  });
+
+  test("a non-authoritative caller snapshot fails the serve closed unless disk vouches for it", async () => {
+    // "No overrides" is not "no servers": a globally enabled server disabled
+    // only by a document the caller could not read would otherwise start.
+    manager.dispose();
+    let diskOverrides: Record<string, unknown> | undefined = undefined; // disk not authoritative either
+    const readWorkspaceOverrides = mock(() => Promise.resolve(diskOverrides));
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("epoch-1"),
+        readWorkspaceOverrides,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js") })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(startResult(Object.keys(servers).map((name) => [name, undefined])));
+    });
+    const workspaceId = "ws-untrusted-snapshot";
+    // Establish recorded options first (an authoritative serve).
+    diskOverrides = {};
+    expect(
+      (await manager.getToolsForWorkspace(workspaceRequest(workspaceId))).stats.enabledServerCount
+    ).toBe(1);
+
+    // A request whose snapshot could not be established: even with recorded
+    // options present, disk is re-read; when it cannot vouch either → closed.
+    diskOverrides = undefined;
+    const untrusted = await manager.getToolsForWorkspace(
+      workspaceRequest(workspaceId, { overrides: {}, overridesAuthoritative: false })
+    );
+    expect(untrusted.stats.enabledServerCount).toBe(0);
+    expect(readWorkspaceOverrides).toHaveBeenCalledTimes(2);
+
+    // Disk recovers and disables the server: the authoritative read wins over
+    // the caller's (empty) snapshot.
+    diskOverrides = { disabledServers: ["ordinary"] };
+    const recovered = await manager.getToolsForWorkspace(
+      workspaceRequest(workspaceId, { overrides: {}, overridesAuthoritative: false })
+    );
+    expect(recovered.stats.enabledServerCount).toBe(0);
+    expect(readWorkspaceOverrides).toHaveBeenCalledTimes(3);
+  });
+
+  test("prompt discovery honors a fail-closed serve instead of querying the published entry", async () => {
+    // An invalidation landing while startup is in flight makes the serve fail
+    // closed, yet the started instances are published (the next verifiable
+    // serve reuses them). Discovery must neither run prompts/list against them
+    // nor advertise their prompts on the strength of that entry alone.
+    manager.dispose();
+    const diskOverrides: Record<string, unknown> | undefined = undefined; // disk cannot vouch
+    const readWorkspaceOverrides = mock(() => Promise.resolve(diskOverrides));
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("epoch-1"),
+        readWorkspaceOverrides,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js") })
+    );
+    const workspaceId = "ws-prompts-fail-closed";
+    const refreshPrompts = mock(() => Promise.resolve([{ name: "review" }]));
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      // A parent save's eviction lands mid-startup.
+      manager.forgetWorkspaceOverrides(workspaceId);
+      return Promise.resolve(
+        startResult(
+          Object.keys(servers).map((name) => [
+            name,
+            { prompts: [{ name: "review" }], refreshPrompts },
+          ])
+        )
+      );
+    });
+
+    const descriptors = await manager.getPromptsForWorkspace(workspaceRequest(workspaceId));
+    expect(descriptors).toEqual([]);
+    expect(refreshPrompts).not.toHaveBeenCalled();
+  });
+
+  test("a distrusted re-read draws on the caller's remaining read budget, never a fresh one", async () => {
+    // The caller's own read timed out on an unreachable ancestor: a second
+    // full-length attempt here would double the request's wait and leave
+    // another uncancellable remote probe behind. The re-read gets only what
+    // remains of the caller's deadline (nothing → fail closed without a
+    // read), and the deadline is request-scoped: recorded options must not
+    // carry it into later prompt dispatch re-reads.
+    manager.dispose();
+    const readWorkspaceOverrides = mock(
+      (_workspaceId: string, _options?: { timeoutMs?: number; signal?: AbortSignal }) =>
+        Promise.resolve({} as Record<string, unknown> | undefined)
+    );
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("epoch-1"),
+        readWorkspaceOverrides,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js") })
+    );
+    const getPrompt = mock(() =>
+      Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "hi" } }] })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(
+        startResult(Object.keys(servers).map((name) => [name, { getPrompt }]))
+      );
+    });
+    const workspaceId = "ws-shared-read-budget";
+
+    // Budget exhausted by the caller's read: no second attempt, fail closed.
+    const exhausted = await manager.getToolsForWorkspace(
+      workspaceRequest(workspaceId, {
+        overrides: {},
+        overridesAuthoritative: false,
+        overridesReadDeadlineAt: Date.now() - 1,
+      })
+    );
+    expect(exhausted.stats.enabledServerCount).toBe(0);
+    expect(readWorkspaceOverrides).not.toHaveBeenCalled();
+
+    // Budget partly left: the re-read is bounded by the remainder.
+    const partial = await manager.getToolsForWorkspace(
+      workspaceRequest(workspaceId, {
+        overrides: {},
+        overridesAuthoritative: false,
+        overridesReadDeadlineAt: Date.now() + 5_000,
+      })
+    );
+    expect(partial.stats.enabledServerCount).toBe(1);
+    expect(readWorkspaceOverrides).toHaveBeenCalledTimes(1);
+    const remainder = readWorkspaceOverrides.mock.calls[0][1]?.timeoutMs;
+    expect(remainder).toBeDefined();
+    expect(remainder!).toBeLessThanOrEqual(5_000);
+    expect(remainder!).toBeGreaterThan(0);
+
+    // Prompt dispatch re-reads from the RECORDED options: the send's deadline
+    // (long expired by then) must not be what bounds them.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(await manager.getPrompt(workspaceId, "ordinary", "review", {})).toEqual({ text: "hi" });
+    const promptRead = readWorkspaceOverrides.mock.calls.at(-1);
+    expect(promptRead).toBeDefined();
+    expect(promptRead![1]?.timeoutMs).toBeUndefined();
+  });
+
+  test("a cached publication that disagrees with an authoritative caller read is revalidated against disk", async () => {
+    // A direct edit of the JSONC file bumps no epoch and publishes nothing;
+    // the caller's later authoritative read sees it, the cache does not. Disk
+    // decides — and the cache still repairs a caller snapshot that PREDATES a
+    // save, because disk agrees with the cache in that case.
+    manager.dispose();
+    let diskOverrides: Record<string, unknown> | undefined = {};
+    const readWorkspaceOverrides = mock(() => Promise.resolve(diskOverrides));
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("epoch-1"),
+        readWorkspaceOverrides,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js") })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(startResult(Object.keys(servers).map((name) => [name, undefined])));
+    });
+    const workspaceId = "ws-cache-vs-fresh-caller";
+    await manager.applyWorkspaceOverrides(workspaceId, {}); // in-process publication: enabled
+    // Caller agrees with the cache: served from it, no disk read.
+    expect(
+      (await manager.getToolsForWorkspace(workspaceRequest(workspaceId, { overrides: {} }))).stats
+        .enabledServerCount
+    ).toBe(1);
+    expect(readWorkspaceOverrides).not.toHaveBeenCalled();
+
+    // Direct file edit revokes the server; the caller's fresh read reflects it.
+    diskOverrides = { disabledServers: ["ordinary"] };
+    const afterEdit = await manager.getToolsForWorkspace(
+      workspaceRequest(workspaceId, { overrides: { disabledServers: ["ordinary"] } })
+    );
+    expect(afterEdit.stats.enabledServerCount).toBe(0);
+    expect(readWorkspaceOverrides).toHaveBeenCalledTimes(1);
+    expect(
+      (
+        access as unknown as { latestWorkspaceOverrides: Map<string, unknown> }
+      ).latestWorkspaceOverrides.get(workspaceId)
+    ).toEqual(diskOverrides);
+
+    // A stale caller snapshot from before the edit still loses to disk.
+    const stale = await manager.getToolsForWorkspace(
+      workspaceRequest(workspaceId, { overrides: {} })
+    );
+    expect(stale.stats.enabledServerCount).toBe(0);
+    expect(readWorkspaceOverrides).toHaveBeenCalledTimes(2);
+
+    // Disagreement with an unreadable disk fails closed.
+    diskOverrides = undefined;
+    const unreadable = await manager.getToolsForWorkspace(
+      workspaceRequest(workspaceId, { overrides: {} })
+    );
+    expect(unreadable.stats.enabledServerCount).toBe(0);
+  });
+
+  test("prompt discovery honors a caller's distrust and disagreement over recorded options", async () => {
+    // A warmed workspace has recorded options (server enabled). Its document
+    // then becomes unreadable: the caller forwards overridesAuthoritative
+    // false, and the prompt list must revalidate against disk rather than
+    // keep advertising the stale enabled server's prompts.
+    manager.dispose();
+    let diskOverrides: Record<string, unknown> | undefined = {};
+    const readWorkspaceOverrides = mock(() => Promise.resolve(diskOverrides));
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("epoch-1"),
+        readWorkspaceOverrides,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js") })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const names = Object.keys(args[0] as Record<string, unknown>);
+      return Promise.resolve(
+        startResult(names.map((name) => [name, { prompts: [{ name: "status" }] }]))
+      );
+    });
+    const workspaceId = "ws-prompts-distrusted-caller";
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    expect(await manager.getPromptsForWorkspace(workspaceRequest(workspaceId))).toHaveLength(1);
+
+    // Document unreadable for both the caller and the manager: closed.
+    diskOverrides = undefined;
+    expect(
+      await manager.getPromptsForWorkspace(
+        workspaceRequest(workspaceId, { overrides: {}, overridesAuthoritative: false })
+      )
+    ).toHaveLength(0);
+
+    // Disk readable again and revoking; a fresh authoritative caller read that
+    // disagrees with the recorded (enabled) options is revalidated too.
+    diskOverrides = { disabledServers: ["ordinary"] };
+    expect(
+      await manager.getPromptsForWorkspace(
+        workspaceRequest(workspaceId, { overrides: { disabledServers: ["ordinary"] } })
+      )
+    ).toHaveLength(0);
+  });
+
+  test("a cached publication does not serve a caller whose own read could not establish the document", async () => {
+    // The cache holds an in-process publication (server enabled); the document
+    // has since become unreadable. Neither the caller nor the cache can vouch
+    // for the current authorization: re-read disk, fail closed if it cannot.
+    manager.dispose();
+    let diskOverrides: Record<string, unknown> | undefined = undefined;
+    const readWorkspaceOverrides = mock(() => Promise.resolve(diskOverrides));
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("epoch-1"),
+        readWorkspaceOverrides,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js") })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(startResult(Object.keys(servers).map((name) => [name, undefined])));
+    });
+    const workspaceId = "ws-cached-distrusted-caller";
+    await manager.applyWorkspaceOverrides(workspaceId, {}); // cached: nothing disabled
+    // An authoritative caller is served from the cache without a disk read.
+    expect(
+      (await manager.getToolsForWorkspace(workspaceRequest(workspaceId))).stats.enabledServerCount
+    ).toBe(1);
+    expect(readWorkspaceOverrides).not.toHaveBeenCalled();
+
+    // Distrusted caller, disk unreadable: closed, cache left untouched.
+    const closed = await manager.getToolsForWorkspace(
+      workspaceRequest(workspaceId, { overrides: {}, overridesAuthoritative: false })
+    );
+    expect(closed.stats.enabledServerCount).toBe(0);
+    expect(readWorkspaceOverrides).toHaveBeenCalledTimes(1);
+
+    // Distrusted caller, disk readable and revoking: disk wins over the cache,
+    // and the cache is revalidated with it.
+    diskOverrides = { disabledServers: ["ordinary"] };
+    const revoked = await manager.getToolsForWorkspace(
+      workspaceRequest(workspaceId, { overrides: {}, overridesAuthoritative: false })
+    );
+    expect(revoked.stats.enabledServerCount).toBe(0);
+    expect(
+      (
+        access as unknown as { latestWorkspaceOverrides: Map<string, unknown> }
+      ).latestWorkspaceOverrides.get(workspaceId)
+    ).toEqual(diskOverrides);
+    // The successful reread is recorded as authoritative: prompt paths that
+    // replay the recorded options must not re-enter the disk read forever.
+    const recorded = access.lastWorkspaceRequestOptions.get(
+      workspaceId
+    ) as MCPWorkspaceRequestOptions;
+    expect(recorded.overridesAuthoritative).toBe(true);
+    const readsBefore = readWorkspaceOverrides.mock.calls.length;
+    expect((await manager.getToolsForWorkspace(recorded)).stats.enabledServerCount).toBe(0);
+    expect(readWorkspaceOverrides.mock.calls.length).toBe(readsBefore);
+    expect(
+      (await manager.getToolsForWorkspace(workspaceRequest(workspaceId))).stats.enabledServerCount
+    ).toBe(0);
+  });
+
+  test("a sibling process's override write refreshes cached snapshots before the next serve", async () => {
+    // Two backends share one home: backend A's save publishes only into A's
+    // cache. B learns about it through the override epoch and must not let its
+    // stale overlay supersede the fresh disk state.
+    manager.dispose();
+    let epoch = "epoch-1";
+    let diskOverrides: Record<string, unknown> = {};
+    const readWorkspaceOverrides = mock(() => Promise.resolve(diskOverrides));
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("plugin-epoch"),
+        readOverridesEpoch: () => Promise.resolve(epoch),
+        readWorkspaceOverrides,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js") })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(startResult(Object.keys(servers).map((name) => [name, undefined])));
+    });
+    const served = "ws-sibling-served";
+    const coldCached = "ws-sibling-cold-cached";
+    await manager.getToolsForWorkspace(workspaceRequest(served));
+    // An earlier publication in THIS process cached an inheriting child that
+    // was never served here.
+    await manager.applyWorkspaceOverrides(coldCached, {});
+    // Both caches say "nothing disabled"; recorded options exist for `served`.
+    const recorded = access.lastWorkspaceRequestOptions.get(served) as MCPWorkspaceRequestOptions;
+    expect((await manager.getToolsForWorkspace(recorded)).stats.enabledServerCount).toBe(1);
+    const readsBefore = readWorkspaceOverrides.mock.calls.length;
+
+    // Sibling backend disables the server on disk (for both workspaces) and
+    // bumps the epoch.
+    diskOverrides = { disabledServers: ["ordinary"] };
+    epoch = "epoch-2";
+
+    // Served workspace: the preflight sweep re-read its overrides from disk.
+    const afterServed = await manager.getToolsForWorkspace(recorded);
+    expect(afterServed.stats.enabledServerCount).toBe(0);
+    expect(readWorkspaceOverrides.mock.calls.length).toBeGreaterThan(readsBefore);
+    // Cold cached workspace: its overlay was evicted, so the serve re-reads disk
+    // instead of trusting the stale (empty) overlay or the caller snapshot.
+    const afterCold = await manager.getToolsForWorkspace(workspaceRequest(coldCached));
+    expect(afterCold.stats.enabledServerCount).toBe(0);
+  });
+
+  test("cache state predating the first epoch observation is evicted, not trusted", async () => {
+    // Backend B received an in-process publication for a never-served child;
+    // backend A then revoked the server before B's first serve. The baseline
+    // token cannot vouch for that cache entry.
+    manager.dispose();
+    const readWorkspaceOverrides = mock(() =>
+      Promise.resolve<Record<string, unknown>>({ disabledServers: ["ordinary"] })
+    );
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("plugin-epoch"),
+        readOverridesEpoch: () => Promise.resolve("epoch-already-advanced"),
+        readWorkspaceOverrides,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js") })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(startResult(Object.keys(servers).map((name) => [name, undefined])));
+    });
+    const workspaceId = "ws-cache-before-first-observation";
+    await manager.applyWorkspaceOverrides(workspaceId, {}); // pre-revocation publication
+    const served = await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    expect(readWorkspaceOverrides).toHaveBeenCalled();
+    expect(served.stats.enabledServerCount).toBe(0);
+  });
+
+  test("a sibling override write landing mid-serve is caught by the postflight bracket", async () => {
+    manager.dispose();
+    let epoch = "epoch-1";
+    let diskOverrides: Record<string, unknown> = {};
+    let epochReads = 0;
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("plugin-epoch"),
+        readOverridesEpoch: () => {
+          epochReads += 1;
+          // Second serve: preflight is read 3, postflight is read 4 — the
+          // sibling's write lands between them.
+          if (epochReads === 4) {
+            diskOverrides = { disabledServers: ["ordinary"] };
+            epoch = "epoch-2";
+          }
+          return Promise.resolve(epoch);
+        },
+        readWorkspaceOverrides: () => Promise.resolve(diskOverrides),
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js") })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(startResult(Object.keys(servers).map((name) => [name, undefined])));
+    });
+    const workspaceId = "ws-mid-serve-sibling-write";
+    expect(
+      (await manager.getToolsForWorkspace(workspaceRequest(workspaceId))).stats.enabledServerCount
+    ).toBe(1);
+    // The serve whose postflight observes the new epoch must not return the
+    // pre-revocation result; it retries against disk.
+    const second = await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    expect(second.stats.enabledServerCount).toBe(0);
+  });
+
+  test("the postflight compares against the operation's own baseline, not a baseline advanced by a concurrent serve", async () => {
+    // getPrompt has passed its process-local gates and awaits prompts/get when
+    // a sibling revokes the server; a concurrent serve's preflight observes the
+    // new epoch, evicts, and advances the live baseline. The prompt operation's
+    // postflight then reads an epoch equal to the live baseline — but not to
+    // the one it ran under — and must not accept its pre-revocation result.
+    manager.dispose();
+    let epoch = "epoch-1";
+    let diskOverrides: Record<string, unknown> = {};
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("plugin-epoch"),
+        readOverridesEpoch: () => Promise.resolve(epoch),
+        readWorkspaceOverrides: () => Promise.resolve(diskOverrides),
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js") })
+    );
+    let releasePrompt: () => void = () => undefined;
+    let promptGated = false;
+    const getPrompt = mock(
+      () =>
+        new Promise<{ messages: unknown[] }>((resolve) => {
+          promptGated = true;
+          releasePrompt = () =>
+            resolve({ messages: [{ role: "user", content: { type: "text", text: "Status" } }] });
+        })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const names = Object.keys(args[0] as Record<string, unknown>);
+      return Promise.resolve(
+        startResult(names.map((name) => [name, { prompts: [{ name: "status" }], getPrompt }]))
+      );
+    });
+    const workspaceId = "ws-prompt-baseline";
+    const other = "ws-other-serve";
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    await manager.getToolsForWorkspace(workspaceRequest(other));
+
+    const prompt = manager.getPrompt(workspaceId, "ordinary", "status", {});
+    while (!promptGated) await new Promise((resolve) => setTimeout(resolve, 1));
+    diskOverrides = { disabledServers: ["ordinary"] };
+    epoch = "epoch-2";
+    await manager.getToolsForWorkspace(workspaceRequest(other)); // advances the live baseline
+    releasePrompt();
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(prompt).rejects.toThrow(/disabled|unavailable/);
+  });
+
+  test("an unreadable override epoch fails serves closed instead of acting as a stable version", async () => {
+    manager.dispose();
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("plugin-epoch"),
+        readOverridesEpoch: () => Promise.resolve("mcp-overrides-epoch-unreadable"),
+        readWorkspaceOverrides: () => Promise.resolve({}),
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js") })
+    );
+    const startServers = spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(startResult(Object.keys(servers).map((name) => [name, undefined])));
+    });
+    const workspaceId = "ws-epoch-unreadable";
+    // Every serve — including the first — sees "unreadable" as a change it
+    // cannot bound, and gives up rather than trusting anything (the request
+    // builder then continues without MCP tools) — before any server process
+    // is launched.
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(manager.getToolsForWorkspace(workspaceRequest(workspaceId))).rejects.toThrow(
+      /about to start/
+    );
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(manager.getToolsForWorkspace(workspaceRequest(workspaceId))).rejects.toThrow(
+      /about to start/
+    );
+    expect(startServers).not.toHaveBeenCalled();
+  });
+
+  test("a cold off-host serve re-reads disk instead of trusting a snapshot older than the epoch baseline", async () => {
+    // Backend B read an SSH workspace's overrides (request snapshot), backend A
+    // then revoked the server and bumped the epoch, and only now does B reach
+    // its first manager serve: the baseline it records is already A's token,
+    // so neither eviction nor the postflight can catch the stale snapshot.
+    manager.dispose();
+    let diskOverrides: Record<string, unknown> | undefined = { disabledServers: ["ordinary"] };
+    const readWorkspaceOverrides = mock(() => Promise.resolve(diskOverrides));
+    manager = new MCPServerManager(configService as unknown as MCPConfigService, {
+      pluginInvalidation: {
+        keyPrefix: "plugin:",
+        readToken: () => Promise.resolve("plugin-epoch"),
+        readOverridesEpoch: () => Promise.resolve("epoch-after-sibling-revocation"),
+        readWorkspaceOverrides,
+      },
+    });
+    access = manager as unknown as MCPServerManagerTestAccess;
+    configService.listServers = mock(() =>
+      Promise.resolve({ ordinary: stdioConfig("node ordinary.js") })
+    );
+    spyOn(access, "startServers").mockImplementation((...args: unknown[]) => {
+      const servers = args[0] as Record<string, unknown>;
+      return Promise.resolve(startResult(Object.keys(servers).map((name) => [name, undefined])));
+    });
+    const remote = Object.create(RemoteRuntime.prototype) as Runtime;
+    const served = await manager.getToolsForWorkspace(
+      workspaceRequest("ws-cold-remote", { runtime: remote, overrides: {} })
+    );
+    expect(readWorkspaceOverrides).toHaveBeenCalledTimes(1);
+    expect(served.stats.enabledServerCount).toBe(0);
+
+    // When disk cannot vouch either, the cold serve fails closed rather than
+    // falling back to the unbounded snapshot.
+    diskOverrides = undefined;
+    const unvouched = await manager.getToolsForWorkspace(
+      workspaceRequest("ws-cold-remote-unreadable", { runtime: remote, overrides: {} })
+    );
+    expect(unvouched.stats.enabledServerCount).toBe(0);
   });
 
   test("plugin servers are excluded on off-host runtimes (remote and devcontainer)", async () => {

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -69,6 +69,7 @@ import { AsyncSemaphore } from "@/node/utils/concurrency/asyncSemaphore";
 import { MutexMap } from "@/node/utils/concurrency/mutexMap";
 import { raceWithAbortAndTimeout } from "@/node/utils/concurrency/withTimeout";
 import { stripTrailingSlashes } from "@/node/utils/pathUtils";
+import { isWorkspaceOverridesEpochUnreadable } from "@/node/services/workspaceMcpOverridesService";
 
 const TEST_TIMEOUT_MS = 10_000;
 const IDLE_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
@@ -300,6 +301,60 @@ export function wrapMCPTools(
 type ResolvedHeaders = Record<string, string> | undefined;
 
 type ResolvedTransport = "stdio" | "http" | "sse";
+
+/** How long a served tool call waits for a publication's enablement repair before failing closed. */
+const PENDING_REPAIR_WAIT_MS = 10_000;
+/**
+ * ONE deadline for a served tool call's complete authorization gate: every
+ * wait in it (repair waits, disk re-reads, re-serves, lock acquisition, epoch
+ * reads, across all retry iterations) draws from this single budget, so the
+ * gate as a whole — not each helper — is bounded.
+ */
+const CALL_GATE_TIMEOUT_MS = 30_000;
+/** How long a remote MCP connect keeps the override writer's lock after its initiation (see launchUnderOverrideFence). */
+const LAUNCH_INITIATION_FENCE_MS = 2_000;
+/**
+ * How long a stdio launch may take to hand back its exec stream under the
+ * override writer's lock before it is ABORTED (see launchUnderOverrideFence).
+ * Matches the SSH2 transport's connection-acquisition cap: a cold connection
+ * that takes longer fails as a startup timeout and is retried by the next
+ * request (with a fresh fence) instead of being released to send its command
+ * after a sibling's revocation committed.
+ */
+const STDIO_LAUNCH_FENCE_MS = 15_000;
+/** Iterations a served tool call spends waiting for override state to settle before failing closed. */
+const CALL_GATE_MAX_ATTEMPTS = 5;
+
+/**
+ * Whether two request options derive the same server enablement: same
+ * workspace and project, same trust, same (normalized) overrides, same Agent
+ * Plugin context. Secrets and identity are irrelevant to authorization.
+ */
+function authorizationStateEqual(
+  a: MCPWorkspaceRequestOptions,
+  b: MCPWorkspaceRequestOptions
+): boolean {
+  return (
+    a.workspaceId === b.workspaceId &&
+    a.projectPath === b.projectPath &&
+    (a.trusted ?? false) === (b.trusted ?? false) &&
+    // A non-authoritative record is a different authorization state even
+    // with an identical override value: the latest serve established that
+    // the state could NOT be verified, and an overlapping authoritative
+    // serve must not hand out tools on the strength of the same value.
+    (a.overridesAuthoritative !== false) === (b.overridesAuthoritative !== false) &&
+    workspaceOverridesEqual(a.overrides, b.overrides) &&
+    JSON.stringify(a.agentPlugins ?? null) === JSON.stringify(b.agentPlugins ?? null)
+  );
+}
+
+/** Structural equality of override snapshots (both sides are normalized by the service). */
+export function workspaceOverridesEqual(
+  a: WorkspaceMCPOverrides | undefined,
+  b: WorkspaceMCPOverrides | undefined
+): boolean {
+  return JSON.stringify(a ?? {}) === JSON.stringify(b ?? {});
+}
 
 function secretRecordsEqual(
   a: Record<string, string> | undefined,
@@ -1000,6 +1055,24 @@ export interface MCPWorkspaceRequestOptions {
   workspacePath: string;
   trusted?: boolean;
   overrides?: WorkspaceMCPOverrides;
+  /**
+   * `false` when the caller could not establish `overrides` authoritatively
+   * (indeterminate probe, unreadable document, failed inheritance): the
+   * manager then re-reads disk itself and fails the serve CLOSED if that read
+   * is not authoritative either. "No overrides" is not "no servers" — a
+   * globally enabled server disabled only by an unreadable document would
+   * otherwise start. Omitted means authoritative (internal callers).
+   */
+  overridesAuthoritative?: boolean;
+  /**
+   * Absolute deadline (epoch ms) of the caller's own override read, set when
+   * that read was NOT authoritative. Had it exhausted the budget (an
+   * unreachable SSH/Docker ancestor), the manager's disk re-read gets only
+   * what remains of it — never a fresh full deadline of its own, which would
+   * double the request's wait and leave a second uncancellable remote probe
+   * behind. Nothing remaining → the serve fails closed without a re-read.
+   */
+  overridesReadDeadlineAt?: number;
   projectSecrets?: Record<string, string>;
   agentPlugins?: AgentPluginsMcpContext | null;
 }
@@ -1016,12 +1089,50 @@ interface MCPToolsForWorkspaceResult {
   stats: MCPWorkspaceStats;
   /** Prompt descriptors for model-facing discovery, from the same enabled/stale gates as getPromptsForWorkspace. */
   promptDescriptors: MCPPromptDescriptor[];
+  /**
+   * The validated workspace overrides this serve's enablement was derived
+   * from (disk-authoritative when the caller's snapshot was not); absent when
+   * the serve failed closed. Callers rebuild prompt-facing listings from these
+   * whenever their own snapshot was not authoritative or differs from them (a
+   * publication replaced the caller's snapshot mid-serve).
+   */
+  overridesUsed?: WorkspaceMCPOverrides;
+  /**
+   * The validated server inventory the serve's enablement was derived from —
+   * config, project trust, overrides, and policy as of the last repair. Trust
+   * and global/project config can change independently of the override
+   * snapshot, so callers list the prompt-facing inventory from this rather
+   * than from their own pre-serve `listServers` call.
+   */
+  serversUsed?: MCPServerMap;
+  /**
+   * Internal: the recorded options the served entry's enablement was derived
+   * from; absent when the serve failed closed. getPrompt compares it with the
+   * recorded options at dispatch time (see serveResult).
+   */
+  enablementDerivedFrom?: MCPWorkspaceRequestOptions;
 }
 interface WorkspaceServers {
   configSignature: string;
   instances: Map<string, MCPServerInstance>;
   /** Filters prompts while leased restarts can leave disabled clients cached. */
   enabledServerNames: Set<string>;
+  /**
+   * The validated server inventory `enabledServerNames` was derived from
+   * (config + trust + overrides + policy at derivation time). Returned to
+   * callers as `serversUsed` so the prompt's MCP listing is built from the
+   * same authorization state as the served tools.
+   */
+  enabledServers: MCPServerMap;
+  /**
+   * `configService.configGeneration` read BEFORE the config read
+   * `enabledServers` was derived from. Global mutations (mcp.setEnabled, a
+   * global/project toolAllowlist edit) bump the generation without replacing
+   * recorded options; the call-time gate compares this with the current
+   * generation and re-derives the inventory when it moved, so a tool object
+   * handed out earlier never dispatches on a stale allowlist.
+   */
+  enabledServersGeneration: number;
   stats: MCPWorkspaceStats;
   timedOutServerNames: string[];
   /** Prevent concurrent cached retries from stacking startup attempts for the same server. */
@@ -1065,7 +1176,43 @@ export interface MCPServerManagerOptions {
      * memory. When absent or failing, the affected cached state is dropped
      * instead.
      */
-    readWorkspaceOverrides?: (workspaceId: string) => Promise<WorkspaceMCPOverrides | undefined>;
+    /**
+     * Disk-authoritative override reader. Resolves `undefined` when the state
+     * could NOT be established authoritatively (unreachable/indeterminate
+     * checkout); callers must then treat the read as failed, never as "no
+     * overrides".
+     */
+    readWorkspaceOverrides?: (
+      workspaceId: string,
+      /**
+       * Bound/cancel the read (the service applies its own default deadline
+       * when `timeoutMs` is omitted). A timed-out or aborted read resolves
+       * `undefined`, i.e. fails closed, never "no overrides".
+       */
+      options?: { timeoutMs?: number; signal?: AbortSignal }
+    ) => Promise<WorkspaceMCPOverrides | undefined>;
+    /**
+     * Cross-process override-write epoch (WorkspaceMcpOverridesService bumps
+     * it under its write lock after every save/prune). Two backends sharing
+     * one home publish only into their own caches; when a sibling's token
+     * changes, every cached override snapshot here is refreshed from disk (or
+     * evicted) so a stale in-memory overlay can never supersede a fresh
+     * authoritative request read.
+     */
+    readOverridesEpoch?: () => Promise<string | undefined>;
+    /**
+     * Acquire the override WRITER's lock (the service's in-process queue plus
+     * the cross-process `mcp-overrides.lock`); resolves with the release. A
+     * served tool call holds it from its final epoch read through the
+     * synchronous invocation start, so a sibling process's revocation either
+     * lands before that read (observed) or after the dispatch — never in the
+     * promise continuations between them (see gateServedToolOnEnablement).
+     */
+    acquireOverridesLock?: (options?: {
+      /** Give up (without ever holding the lock) once aborted or past `timeoutMs`. */
+      signal?: AbortSignal;
+      timeoutMs?: number;
+    }) => Promise<() => Promise<void>>;
   };
 }
 
@@ -1099,6 +1246,12 @@ export class MCPServerManager {
    * cached or recorded state to repair, so stale caller snapshots can be overlaid.
    */
   private readonly latestWorkspaceOverrides = new Map<string, WorkspaceMCPOverrides | undefined>();
+  /**
+   * Publication enablement repairs in flight (applyWorkspaceOverrides awaits
+   * listServers before it can rewrite `entry.enabledServerNames`). Served tool
+   * invocations wait for the pending repair before their call-time gate.
+   */
+  private readonly pendingEnablementRepairs = new Map<string, Promise<void>>();
   private readonly latestProjectTrust = new Map<string, boolean>();
   private readonly workspaceRestartLocks = new MutexMap<string>();
   /** Orders racing prompt refresh completions per instance; see refreshInstancePrompts. */
@@ -1135,6 +1288,7 @@ export class MCPServerManager {
   private readonly pluginInvalidation?: MCPServerManagerOptions["pluginInvalidation"];
   private pluginInvalidationTokenSeen = false;
   private lastPluginInvalidationToken: string | undefined;
+  private lastOverridesEpochToken: string | undefined;
   /** Serializes cross-process invalidation checks (see retireCrossProcessPluginInstances). */
   private pluginInvalidationQueue: Promise<unknown> = Promise.resolve();
   private readonly idleCheckInterval: ReturnType<typeof setInterval>;
@@ -1193,11 +1347,42 @@ export class MCPServerManager {
     // published token and proceed; a failed sweep leaves the token
     // unpublished so the next serve retries it.
     const run = async (): Promise<void> => {
-      const token = await invalidation.readToken();
+      const [token, overridesEpoch] = await Promise.all([
+        invalidation.readToken(),
+        invalidation.readOverridesEpoch?.(),
+      ]);
       if (!this.pluginInvalidationTokenSeen) {
         this.pluginInvalidationTokenSeen = true;
         this.lastPluginInvalidationToken = token;
+        this.lastOverridesEpochToken = overridesEpoch;
+        // Cache state can predate the first token observation (in-process
+        // publications for never-served workspaces), and a sibling's write may
+        // already have superseded it: nothing vouches for that state relative
+        // to the accepted baseline, so evict it and let serves re-read disk.
+        if (
+          invalidation.readOverridesEpoch !== undefined &&
+          (this.latestWorkspaceOverrides.size > 0 || this.lastWorkspaceRequestOptions.size > 0)
+        ) {
+          this.forgetAllWorkspaceOverrides();
+        }
         return;
+      }
+      if (
+        overridesEpoch !== this.lastOverridesEpochToken ||
+        isWorkspaceOverridesEpochUnreadable(overridesEpoch)
+      ) {
+        // A sibling process wrote workspace overrides: our caches were never
+        // notified. Evict every snapshot (invalidation markers) and let each
+        // workspace re-read disk lazily on its next serve — an eager re-read
+        // here would cost one full config enumeration per cached workspace
+        // while every other serve waits on this queue. An UNREADABLE epoch
+        // counts as changed on every observation: nothing can prove it did
+        // not change, so nothing cached may be trusted while it persists.
+        log.info(
+          "[MCP] Cross-process workspace override write detected; evicting cached overrides"
+        );
+        this.forgetAllWorkspaceOverrides();
+        this.lastOverridesEpochToken = overridesEpoch;
       }
       if (token === this.lastPluginInvalidationToken) {
         return;
@@ -1219,6 +1404,21 @@ export class MCPServerManager {
     this.pluginInvalidationQueue = next.catch(() => undefined);
     return next;
   }
+
+  /**
+   * Workspaces whose cached AND recorded override snapshots were invalidated by
+   * forgetWorkspaceOverrides, keyed to an invalidation generation. A disk read
+   * retires only the generation it observed before starting, so a newer
+   * invalidation landing mid-read is never acknowledged by the older result.
+   */
+  private readonly overridesInvalidationGenerations = new Map<string, number>();
+  private overridesInvalidationClock = 0;
+  /**
+   * Bumped by forgetAllWorkspaceOverrides: a cold serve (present in neither
+   * map yet) cannot be named by a global eviction, so its first read compares
+   * this clock instead and fails closed when an eviction landed mid-read.
+   */
+  private globalOverridesEvictionGeneration = 0;
 
   /** Remove only Agent Plugin keys when disk-authoritative overrides cannot be read. */
   private scrubPluginOverrideKeys(
@@ -1270,9 +1470,14 @@ export class MCPServerManager {
       }
       let fresh: WorkspaceMCPOverrides | undefined;
       let readFailed = readOverrides === undefined;
+      // A forget landing while the read below is in flight makes its result
+      // pre-change state (same hazard as loadFirstServeWorkspaceOverrides).
+      const generationBefore = this.overridesInvalidationGenerations.get(workspaceId);
       if (readOverrides !== undefined) {
         try {
           fresh = await readOverrides(workspaceId);
+          // Non-authoritative read: keep the scrub fallback, not a guess.
+          if (fresh === undefined) readFailed = true;
         } catch (error) {
           readFailed = true;
           log.warn("[MCP] Failed to reload workspace overrides after sibling plugin mutation", {
@@ -1281,8 +1486,49 @@ export class MCPServerManager {
           });
         }
       }
+      const latest = this.lastWorkspaceRequestOptions.get(workspaceId);
+      if (latest !== recorded) {
+        // An authoritative publication (or a serve) replaced the recorded
+        // options while the read was in flight: it is newer than both the
+        // snapshot and whatever disk state this read observed, so committing
+        // the read would restore pre-publication enablement over it. Keep the
+        // newer state; only scrub plugin keys from it (a publication carries
+        // disk truth, which the sibling's prune already cleaned, so this is a
+        // no-op for it — a serve's stale caller snapshot loses them).
+        if (latest !== undefined) {
+          this.lastWorkspaceRequestOptions.set(workspaceId, {
+            ...latest,
+            overrides: this.scrubPluginOverrideKeys(latest.overrides),
+          });
+          if (this.latestWorkspaceOverrides.has(workspaceId)) {
+            this.latestWorkspaceOverrides.set(
+              workspaceId,
+              this.scrubPluginOverrideKeys(this.latestWorkspaceOverrides.get(workspaceId))
+            );
+          }
+          this.bumpWorkspaceOptionsMutationCount(workspaceId);
+        }
+        continue;
+      }
       const authoritative = readFailed ? this.scrubPluginOverrideKeys(recorded.overrides) : fresh;
-      this.latestWorkspaceOverrides.set(workspaceId, authoritative);
+      const supersededMidRead =
+        this.overridesInvalidationGenerations.get(workspaceId) !== generationBefore;
+      if (
+        this.overridesInvalidationGenerations.has(workspaceId) &&
+        (readFailed || supersededMidRead)
+      ) {
+        // The recorded snapshot of an invalidated workspace is exactly what is
+        // being distrusted (and a value read before a mid-read forget is no
+        // better): scrub it, but do not repopulate the overlay cache from it —
+        // that would bypass the pending disk re-read. The marker stays live.
+        this.latestWorkspaceOverrides.delete(workspaceId);
+      } else {
+        // Either disk was read authoritatively with no forget in between (the
+        // cache now holds disk truth, so retire any marker), or there was no
+        // invalidation to retire in the first place.
+        this.latestWorkspaceOverrides.set(workspaceId, authoritative);
+        this.overridesInvalidationGenerations.delete(workspaceId);
+      }
       this.lastWorkspaceRequestOptions.set(workspaceId, {
         ...recorded,
         overrides: authoritative,
@@ -1310,29 +1556,134 @@ export class MCPServerManager {
    * workspace has none. Disk is authoritative (every override write
    * persists before publishing), so read it now; when it cannot be read,
    * scrub plugin keys from the caller snapshot so a stale enable can never
-   * override a replacement server's default-disabled state. Off-host
-   * workspaces are skipped (plugin servers are never offered there, and the
-   * read would exec remotely).
+   * override a replacement server's default-disabled state — and under
+   * cross-process override-epoch tracking, fail the serve closed, since the
+   * same staleness applies to ordinary servers (offered on every runtime,
+   * so off-host workspaces read too, at the cost of one remote exec per
+   * cold serve).
    */
   private async loadFirstServeWorkspaceOverrides(
-    requestOptions: MCPWorkspaceRequestOptions
-  ): Promise<WorkspaceMCPOverrides | undefined> {
+    requestOptions: MCPWorkspaceRequestOptions,
+    /** Re-read disk even though recorded options exist (see ensureWorkspaceServers). */
+    revalidate = false,
+    readSignal?: AbortSignal
+  ): Promise<{
+    overrides: WorkspaceMCPOverrides | undefined;
+    /**
+     * True when this serve belongs to an invalidated workspace whose overrides
+     * could not be re-read authoritatively: MCP dispatch for THIS serve fails
+     * CLOSED (no servers). The recorded snapshot predates the change that
+     * triggered the invalidation, so serving from it could keep a just-revoked
+     * server running. Per-serve by construction — concurrent serves of one
+     * workspace must not observe each other's availability.
+     */
+    unavailable: boolean;
+    /** Generations observed before the read; callers recheck them after resuming. */
+    observed: { workspace: number | undefined; global: number };
+    /**
+     * Invalidation generation this (authoritative, un-superseded) read
+     * satisfies. NOT retired here: the caller retires it in the same
+     * synchronous block that records the fresh options, so an overlapping
+     * serve can never find the marker gone while stale options are still the
+     * recorded ones.
+     */
+    satisfiesInvalidation?: number;
+    /**
+     * True when `overrides` is a fresh, un-superseded disk read. The caller
+     * records it as authoritative regardless of what the request claimed:
+     * leaving a repaired snapshot marked non-authoritative would make every
+     * later serve re-enter this read (remote probes on SSH/devcontainer).
+     * getPrompt alone distrusts the recorded options on purpose, once per
+     * dispatch (see promptDispatchOptions).
+     */
+    fromDisk: boolean;
+  }> {
+    const { workspaceId } = requestOptions;
+    const invalidationGeneration = this.overridesInvalidationGenerations.get(workspaceId);
+    const observed = {
+      workspace: invalidationGeneration,
+      global: this.globalOverridesEvictionGeneration,
+    };
+    const invalidated = invalidationGeneration !== undefined;
+    // A caller snapshot that is not authoritative (see overridesAuthoritative)
+    // is distrusted exactly like an invalidated recorded one: disk must vouch
+    // for the enablement or the serve fails closed.
+    const distrusted = invalidated || requestOptions.overridesAuthoritative === false || revalidate;
     if (
       this.pluginInvalidation === undefined ||
-      this.lastWorkspaceRequestOptions.has(requestOptions.workspaceId)
+      (this.lastWorkspaceRequestOptions.has(workspaceId) && !distrusted)
     ) {
-      return requestOptions.overrides;
+      return {
+        overrides: requestOptions.overrides,
+        unavailable: this.pluginInvalidation === undefined && distrusted,
+        observed,
+        fromDisk: false,
+      };
     }
-    const execsOffHost =
-      requestOptions.runtime instanceof RemoteRuntime ||
-      requestOptions.runtime instanceof DevcontainerRuntime;
-    if (execsOffHost) {
-      return requestOptions.overrides;
-    }
+    // Every runtime re-reads disk here, off-host (SSH/devcontainer) included:
+    // besides guarding plugin keys (never offered off-host), this read is what
+    // vouches for a COLD serve relative to the override epoch baseline
+    // retireCrossProcessPluginInstances just accepted. The caller's snapshot
+    // may predate a sibling process's write that landed before our first
+    // epoch observation — there was no cache to evict, the snapshot claims
+    // authority, and the postflight sees an unchanged token — so ordinary
+    // remote servers revoked by that sibling would otherwise serve this turn.
+    // Reading after the baseline observation bounds the state to it.
     const readOverrides = this.pluginInvalidation.readWorkspaceOverrides;
     if (readOverrides !== undefined) {
       try {
-        return await readOverrides(requestOptions.workspaceId);
+        // Bounded by what remains of the caller's read budget (its own
+        // read was already bounded; see overridesReadDeadlineAt), else by the
+        // reader's default deadline, and cancelled with the caller's turn: a
+        // mandatory second read must not wait for a remote parent's command
+        // timeout (a timed-out/aborted read is `undefined` → fail closed).
+        const remainingMs =
+          requestOptions.overridesReadDeadlineAt === undefined
+            ? undefined
+            : Math.max(0, requestOptions.overridesReadDeadlineAt - Date.now());
+        const fresh =
+          remainingMs === 0
+            ? undefined
+            : await readOverrides(workspaceId, {
+                ...(remainingMs !== undefined ? { timeoutMs: remainingMs } : {}),
+                ...(readSignal !== undefined ? { signal: readSignal } : {}),
+              });
+        if (fresh !== undefined) {
+          // Compare even when no invalidation existed before the read: a
+          // forget that STARTED during a cold serve's read is just as
+          // superseding as one that advanced an existing generation.
+          const superseded =
+            this.overridesInvalidationGenerations.get(workspaceId) !== invalidationGeneration ||
+            this.globalOverridesEvictionGeneration !== observed.global;
+          if (superseded) {
+            // A forget landed while this read was in flight: the value read is
+            // pre-change state. It must neither retire the newer invalidation
+            // nor be served — fail closed for this serve, and make sure a
+            // marker exists so the NEXT serve re-reads (a global eviction
+            // alone leaves none for a cold workspace, yet this serve is about
+            // to record the stale snapshot as its options).
+            log.warn(
+              "[MCP] Workspace overrides read superseded by a newer invalidation; disabling MCP for this serve",
+              { workspaceId }
+            );
+            if (!this.overridesInvalidationGenerations.has(workspaceId)) {
+              this.markOverridesInvalidated(workspaceId);
+            }
+            return {
+              overrides: this.scrubPluginOverrideKeys(fresh),
+              unavailable: true,
+              observed,
+              fromDisk: false,
+            };
+          }
+          return {
+            overrides: fresh,
+            unavailable: false,
+            observed,
+            fromDisk: true,
+            ...(invalidated ? { satisfiesInvalidation: invalidationGeneration } : {}),
+          };
+        }
       } catch (error) {
         log.warn("[MCP] Failed to load workspace overrides for a first serve", {
           workspaceId: requestOptions.workspaceId,
@@ -1340,7 +1691,24 @@ export class MCPServerManager {
         });
       }
     }
-    return this.scrubPluginOverrideKeys(requestOptions.overrides);
+    // Fail closed when the snapshot is exactly what is being distrusted, and
+    // likewise for a cold serve under cross-process epoch tracking: the
+    // snapshot's authority is only relative to the caller's read, which the
+    // accepted epoch baseline cannot vouch for (see above). Without a reader
+    // (or epoch tracking) there is nothing more to establish; serve it.
+    const unavailable = distrusted || this.pluginInvalidation.readOverridesEpoch !== undefined;
+    if (unavailable) {
+      log.warn(
+        "[MCP] Workspace overrides could not be established authoritatively; disabling MCP for this serve",
+        { workspaceId, invalidated }
+      );
+    }
+    return {
+      overrides: this.scrubPluginOverrideKeys(requestOptions.overrides),
+      unavailable,
+      observed,
+      fromDisk: false,
+    };
   }
 
   /**
@@ -1728,17 +2096,40 @@ export class MCPServerManager {
   private async runWithStablePluginEpoch<T>(operation: () => Promise<T>): Promise<T> {
     for (let attempt = 0; ; attempt++) {
       await this.retireCrossProcessPluginInstances();
+      // Snapshot the baselines THIS operation runs under. The postflight must
+      // compare against them, not against the live fields: a concurrent
+      // serve's preflight can observe a sibling's newer epoch, evict, and
+      // advance the live baseline while this operation is still in flight —
+      // the live field would then match the fresh read and accept a result
+      // derived from pre-eviction state.
+      const pluginTokenUsed = this.lastPluginInvalidationToken;
+      const overridesEpochUsed = this.lastOverridesEpochToken;
       const result = await operation();
       if (this.pluginInvalidation === undefined || !this.pluginInvalidationTokenSeen) {
         return result;
       }
+      // Bracket the operation with BOTH cross-process tokens: a sibling's
+      // override write landing mid-serve changes no process-local
+      // authorization state, so only this recheck can catch it. The retry's
+      // preflight evicts the caches and the operation re-reads disk. An
+      // unreadable epoch never matches: it cannot vouch for anything.
+      // Sequential, override epoch LAST: it is the fence for the served
+      // tool gate, so it must be the final read before the result is
+      // accepted — a parallel read could capture the old epoch while the
+      // slower token read settles, accepting a pair a sibling revocation
+      // completed in between.
       const token = await this.pluginInvalidation.readToken();
-      if (token === this.lastPluginInvalidationToken) {
+      const overridesEpoch = await this.pluginInvalidation.readOverridesEpoch?.();
+      if (
+        token === pluginTokenUsed &&
+        overridesEpoch === overridesEpochUsed &&
+        !isWorkspaceOverridesEpochUnreadable(overridesEpoch)
+      ) {
         return result;
       }
       if (attempt >= 5) {
         throw new Error(
-          "MCP startup kept racing concurrent plugin mutations; retry once plugin installs/updates settle"
+          "MCP startup kept racing concurrent plugin or workspace override mutations; retry once they settle"
         );
       }
       await this.retireCrossProcessPluginInstances();
@@ -1746,9 +2137,86 @@ export class MCPServerManager {
   }
 
   async getToolsForWorkspace(
-    options: MCPWorkspaceRequestOptions
+    options: MCPWorkspaceRequestOptions,
+    /** Cancels the serve's own disk re-read (see loadFirstServeWorkspaceOverrides). */
+    callOptions?: { signal?: AbortSignal }
   ): Promise<MCPToolsForWorkspaceResult> {
-    return this.runWithStablePluginEpoch(() => this.ensureWorkspaceServers(options, true));
+    const result = await this.getToolsForWorkspaceInternal(options, callOptions?.signal);
+    // The epoch postflight awaits readToken() AFTER serveResult's gate: a
+    // publication or eviction landing in that await is not covered by it.
+    // Re-apply the same check at the very last point before the tools leave
+    // the manager. Beyond this point the served instances stay connected for
+    // the stream's duration (see the leased-restart path), but every tool
+    // invocation re-checks enablement (gateServedToolsOnEnablement). A
+    // non-empty result without provenance cannot be vouched for either.
+    const { workspaceId } = options;
+    if (!this.isServeAuthorizationCurrent(workspaceId, result.enablementDerivedFrom)) {
+      // Regardless of result size: even a zero-surface serve (only enabled
+      // server failed to start) carries `overridesUsed`, from which the
+      // caller rebuilds its prompt inventory — stale provenance must not
+      // leave the manager either.
+      if (Object.keys(result.tools).length > 0 || result.promptDescriptors.length > 0) {
+        log.warn(
+          "[MCP] Workspace overrides changed after the serve completed; disabling MCP for this serve",
+          { workspaceId }
+        );
+      }
+      return this.failClosedResult();
+    }
+    // Internal provenance; not part of the caller-facing result.
+    const { enablementDerivedFrom: _derivedFrom, ...served } = result;
+    return served;
+  }
+
+  /**
+   * getToolsForWorkspace that RETAINS the serve's provenance. Recursive
+   * serves inside ensureWorkspaceServers (timed-out retries, lost restart
+   * ownership) must use this one: the public wrapper strips the provenance,
+   * and a result without it can no longer be checked by the outer wrapper.
+   */
+  private getToolsForWorkspaceInternal(
+    options: MCPWorkspaceRequestOptions,
+    readSignal?: AbortSignal
+  ): Promise<MCPToolsForWorkspaceResult> {
+    return this.runWithStablePluginEpoch(() =>
+      this.ensureWorkspaceServers(options, true, readSignal)
+    );
+  }
+
+  /**
+   * Whether enablement derived from `derivedFrom` is still what this
+   * workspace's recorded options and invalidation state describe:
+   * - a publication (or serve/refresh/stop) replaces the recorded options, so
+   *   identity must match;
+   * - a forgetWorkspaceOverrides leaves them in place and only sets the
+   *   invalidation marker, so no marker may be live;
+   * - no provenance means enablement could not be derived at all.
+   * Every point that hands out tools or dispatches a prompt checks this.
+   */
+  private isServeAuthorizationCurrent(
+    workspaceId: string,
+    derivedFrom: MCPWorkspaceRequestOptions | undefined
+  ): boolean {
+    if (derivedFrom === undefined || this.overridesInvalidationGenerations.has(workspaceId)) {
+      return false;
+    }
+    const recorded = this.lastWorkspaceRequestOptions.get(workspaceId);
+    // Equivalence, not identity: two ordinary serves of one workspace that
+    // overlap (prompt discovery while a send assembles) each record their own
+    // options object with the SAME authorization state, and the first to
+    // finish must not be failed closed as if a publication had revoked it. A
+    // publication or trust change records different overrides/trust and is
+    // still detected.
+    return recorded !== undefined && authorizationStateEqual(recorded, derivedFrom);
+  }
+
+  private failClosedResult(): MCPToolsForWorkspaceResult {
+    return {
+      tools: {},
+      toolServerNames: {},
+      stats: this.createWorkspaceStats(0, new Map(), []),
+      promptDescriptors: [],
+    };
   }
 
   /**
@@ -1757,7 +2225,9 @@ export class MCPServerManager {
    */
   private async ensureWorkspaceServers(
     requestOptions: MCPWorkspaceRequestOptions,
-    refreshToolCatalogs: boolean
+    refreshToolCatalogs: boolean,
+    /** Cancels this serve's disk re-read of the overrides (the caller's request/turn signal). */
+    readSignal?: AbortSignal
   ): Promise<MCPToolsForWorkspaceResult> {
     // runWithStablePluginEpoch performs the sibling-mutation preflight BEFORE
     // entering this method, so refreshed disk overrides are visible to the
@@ -1766,24 +2236,89 @@ export class MCPServerManager {
     // Cold workspaces have no recorded state for applyWorkspaceOverrides to repair.
     // Overlay the newest overrides over a caller snapshot that may predate the mutation.
     let options: MCPWorkspaceRequestOptions;
-    if (this.latestWorkspaceOverrides.has(requestOptions.workspaceId)) {
-      options = {
-        ...requestOptions,
-        overrides: this.latestWorkspaceOverrides.get(requestOptions.workspaceId),
-      };
+    // Per-serve fail-closed marker (see loadFirstServeWorkspaceOverrides).
+    let overridesUnavailable = false;
+    let satisfiesInvalidation: number | undefined;
+    // A caller whose own read could not establish the current document
+    // (overridesAuthoritative false: unreadable/invalid file) must not be
+    // served from the cache either: the cached publication predates whatever
+    // made the document unreadable, so nothing vouches for it now. Re-read
+    // disk (fail closed if it cannot vouch) and revalidate the entry.
+    const distrustedCaller = requestOptions.overridesAuthoritative === false;
+    const hadCached = this.latestWorkspaceOverrides.has(requestOptions.workspaceId);
+    const cachedBefore = this.latestWorkspaceOverrides.get(requestOptions.workspaceId);
+    // The cache is a repair hint for caller snapshots that predate a save, not
+    // an authority over a LATER authoritative read: a direct edit of the
+    // JSONC file bumps no epoch and publishes nothing, so a cache entry that
+    // disagrees with an authoritative caller snapshot cannot be told apart
+    // from a stale snapshot without disk. Re-read disk whenever they differ
+    // (steady state agrees, so this costs nothing then); disk decides, a
+    // publication landing mid-read still wins, and an unreadable disk fails
+    // closed. Without a reader the cache stays authoritative as before.
+    const cacheDiffersFromCaller =
+      hadCached &&
+      !distrustedCaller &&
+      this.pluginInvalidation?.readWorkspaceOverrides !== undefined &&
+      requestOptions.overrides !== undefined &&
+      !workspaceOverridesEqual(cachedBefore, requestOptions.overrides);
+    const revalidating = distrustedCaller || cacheDiffersFromCaller;
+    if (hadCached && !revalidating) {
+      options = { ...requestOptions, overrides: cachedBefore };
     } else {
-      const firstServeOverrides = await this.loadFirstServeWorkspaceOverrides(requestOptions);
+      const firstServe = await this.loadFirstServeWorkspaceOverrides(
+        requestOptions,
+        cacheDiffersFromCaller,
+        readSignal
+      );
       // Recheck AFTER the await: an MCP settings save completing while the
       // disk read was in flight published newer state into the cache, and
       // recording the read's older result would expose a just-disabled
       // server for this send (the save's repair path only patches recorded
-      // options, which do not exist yet on a first serve).
-      options = this.latestWorkspaceOverrides.has(requestOptions.workspaceId)
-        ? {
-            ...requestOptions,
-            overrides: this.latestWorkspaceOverrides.get(requestOptions.workspaceId),
-          }
-        : { ...requestOptions, overrides: firstServeOverrides };
+      // options, which do not exist yet on a first serve). An authoritative
+      // publication also supersedes this serve's fail-closed verdict. For a
+      // distrusted caller only a NEW publication counts — the entry that was
+      // already there is exactly what is being revalidated.
+      const cachedAfter = this.latestWorkspaceOverrides.get(requestOptions.workspaceId);
+      if (
+        this.latestWorkspaceOverrides.has(requestOptions.workspaceId) &&
+        (!hadCached || cachedAfter !== cachedBefore)
+      ) {
+        // A publication is disk truth: record it as authoritative even for a
+        // caller whose own read was not (see fromDisk).
+        options = { ...requestOptions, overrides: cachedAfter, overridesAuthoritative: true };
+      } else {
+        options = { ...requestOptions, overrides: firstServe.overrides };
+        satisfiesInvalidation = firstServe.satisfiesInvalidation;
+        // The read's own comparison ran before this continuation resumed; a
+        // forget/eviction squeezed into that gap finds no cache entry to
+        // remove yet, so it is only observable here. Fail closed when seen.
+        // (A publication that retired the generation meanwhile also replaced
+        // the cache, which the branch above already took.)
+        const currentGeneration = this.overridesInvalidationGenerations.get(
+          requestOptions.workspaceId
+        );
+        const supersededAfterRead =
+          currentGeneration !== undefined && currentGeneration !== firstServe.observed.workspace;
+        const globallyEvictedAfterRead =
+          this.globalOverridesEvictionGeneration !== firstServe.observed.global;
+        overridesUnavailable =
+          firstServe.unavailable || supersededAfterRead || globallyEvictedAfterRead;
+        if (globallyEvictedAfterRead && currentGeneration === undefined) {
+          // Same retry guarantee as inside the read: the options recorded
+          // below are pre-eviction state and must be re-read next time.
+          this.markOverridesInvalidated(requestOptions.workspaceId);
+        }
+        if (firstServe.fromDisk && !overridesUnavailable) {
+          options = { ...options, overridesAuthoritative: true };
+        }
+        if (revalidating && hadCached && !overridesUnavailable) {
+          // Disk vouched for the revalidation and nothing superseded the
+          // read (no publication — same object — no forget, no eviction):
+          // the cached entry is revalidated with disk truth. Otherwise it is
+          // left alone (still the newest publication this process knows).
+          this.latestWorkspaceOverrides.set(requestOptions.workspaceId, firstServe.overrides);
+        }
+      }
     }
     // Same cold-workspace gap for project trust: a revocation landing while a
     // stream's pre-await trusted snapshot is still in flight has no recorded
@@ -1793,6 +2328,13 @@ export class MCPServerManager {
     );
     if (latestTrust !== undefined && (options.trusted ?? false) !== latestTrust) {
       options = { ...options, trusted: latestTrust };
+    }
+    // The caller's read deadline is request-scoped (see
+    // overridesReadDeadlineAt): the recorded options are re-used by later
+    // distrusted re-reads (prompt dispatch, invalidation repair), which must
+    // get the reader's default budget, not one that expired with this send.
+    if (options.overridesReadDeadlineAt !== undefined) {
+      options = { ...options, overridesReadDeadlineAt: undefined };
     }
     const {
       workspaceId,
@@ -1806,11 +2348,32 @@ export class MCPServerManager {
     } = options;
 
     this.lastWorkspaceRequestOptions.set(workspaceId, options);
+    // Retire the invalidation the disk read satisfied ONLY now that its fresh
+    // options are the recorded ones (same synchronous block), and only if no
+    // newer forget advanced it meanwhile. Retiring inside the read would open
+    // a window in which an overlapping serve sees no marker while the stale
+    // pre-read options are still recorded — and installs them as current.
+    if (
+      satisfiesInvalidation !== undefined &&
+      !overridesUnavailable &&
+      this.overridesInvalidationGenerations.get(workspaceId) === satisfiesInvalidation
+    ) {
+      // Cache the recovered (authoritative) overrides BEFORE retiring the
+      // marker: a later serve carrying a stale pre-save caller snapshot would
+      // otherwise take the fast path and record that snapshot as current.
+      this.latestWorkspaceOverrides.set(workspaceId, overrides);
+      this.overridesInvalidationGenerations.delete(workspaceId);
+    }
 
     // Global mutations (mcp.setEnabled / mcp.remove) bump the config
     // generation without replacing recorded options; capture it before config
     // reads so enablement repair can detect them.
     const configGenerationUsed = this.configService.configGeneration;
+    // Likewise a forgetWorkspaceOverrides landing during getAllServers() or
+    // server startup only advances this marker (the recorded options above
+    // stay the same object, so the repair below sees nothing to redo). The
+    // serve is checked against it before returning (see serveResult).
+    const overridesGenerationUsed = this.overridesInvalidationGenerations.get(workspaceId);
 
     // Snapshot BEFORE reading config: a plugin swap that lands after this
     // point may invalidate instances this call starts (see
@@ -1842,10 +2405,11 @@ export class MCPServerManager {
       fullServerInfo[name] = info;
     }
 
-    // Apply server-level overrides (enabled/disabled) before caching
-    const enabledServers = this.filterServersByPolicy(
-      this.applyServerOverrides(fullServerInfo, overrides)
-    );
+    // Apply server-level overrides (enabled/disabled) before caching. An
+    // invalidated workspace whose overrides could not be re-read fails closed.
+    const enabledServers = overridesUnavailable
+      ? {}
+      : this.filterServersByPolicy(this.applyServerOverrides(fullServerInfo, overrides));
     const enabledEntries = Object.entries(enabledServers).sort(([a], [b]) => a.localeCompare(b));
 
     const enabledServerNames = new Set(enabledEntries.map(([name]) => name));
@@ -1864,7 +2428,7 @@ export class MCPServerManager {
     ) {
       // Another request published while this config read was pending. Re-read
       // before treating its additions as removals and restarting healthy clients.
-      return this.ensureWorkspaceServers(options, refreshToolCatalogs);
+      return this.ensureWorkspaceServers(options, refreshToolCatalogs, readSignal);
     }
     if (existing && existing.timedOutServerNames === undefined) {
       existing.timedOutServerNames = [];
@@ -1880,6 +2444,14 @@ export class MCPServerManager {
     if (existing?.configSignature === signature && !hasClosedInstance) {
       existing.lastActivity = Date.now();
       delete existing.stalePromptServerNames;
+      // The signature only covers START config, so a leased serve that
+      // deferred a restart may have narrowed `enabledServerNames` under this
+      // same signature (a server disabled mid-stream). This serve's options
+      // re-derive the set; without this the re-enabled server's tools would
+      // stay filtered out until an unrelated publication repaired the entry.
+      existing.enabledServerNames = enabledServerNames;
+      existing.enabledServers = enabledServers;
+      existing.enabledServersGeneration = configGenerationUsed;
 
       const timedOutServerNamesToRetry = this.getTimedOutServerNamesToRetry(
         existing,
@@ -1907,6 +2479,7 @@ export class MCPServerManager {
         }
 
         try {
+          await this.assertOverridesEpochUnmovedBeforeStart();
           const {
             instances: retriedInstances,
             failedServerNames: retryFailedNames,
@@ -1945,7 +2518,7 @@ export class MCPServerManager {
               }
             }
 
-            return this.getToolsForWorkspace(options);
+            return this.getToolsForWorkspaceInternal(options, readSignal);
           }
 
           // Drop retried instances whose plugin tree was swapped mid-startup;
@@ -2008,7 +2581,7 @@ export class MCPServerManager {
                 promptDescriptors: [],
               };
             }
-            return this.getToolsForWorkspace(options);
+            return this.getToolsForWorkspaceInternal(options, readSignal);
           }
 
           const failedServerNames = [
@@ -2042,7 +2615,7 @@ export class MCPServerManager {
       // A trust or settings mutation can land while getAllServers() runs above;
       // re-derive enablement so this cached return cannot leave a revoked
       // repo-local server invocable.
-      await this.repairEnablementAfterConcurrentMutation(
+      const enablementDerivedFrom = await this.repairEnablementAfterConcurrentMutation(
         workspaceId,
         options,
         existing,
@@ -2055,17 +2628,18 @@ export class MCPServerManager {
         this.refreshInstancePromptsInBackground(existing);
       }
 
-      return {
-        // Additions may publish while a cached refresh/retry is awaiting. This
-        // snapshot lacks their allowlists, so leave them for a fresh config read.
-        ...this.collectTools(
-          new Map([...existing.instances].filter(([name]) => enabledServerNames.has(name))),
-          fullServerInfo,
-          overrides
-        ),
-        stats: existing.stats,
-        promptDescriptors: this.promptDescriptorsFor(existing),
-      };
+      // Additions may publish while a cached refresh/retry is awaiting. This
+      // snapshot lacks their allowlists, so leave them for a fresh config read.
+      return this.serveResult(
+        workspaceId,
+        existing,
+        new Map([...existing.instances].filter(([name]) => enabledServerNames.has(name))),
+        overrides,
+        existing.stats,
+        overridesGenerationUsed,
+        enablementDerivedFrom,
+        overridesUnavailable
+      );
     }
 
     const additiveServerNames = existing
@@ -2118,6 +2692,7 @@ export class MCPServerManager {
           }
         }
 
+        await this.assertOverridesEpochUnmovedBeforeStart();
         const {
           instances: restartedInstances,
           failedServerNames: failedNames,
@@ -2188,14 +2763,14 @@ export class MCPServerManager {
               promptDescriptors: [],
             };
           }
-          return this.getToolsForWorkspace(options);
+          return this.getToolsForWorkspaceInternal(options, readSignal);
         }
       }
 
       // An addition may have published while closed-client recovery was pending.
       // Re-read its config rather than overwriting the new entry's catalogs/stats.
       if (existing.configSignature !== retainedSignature) {
-        return this.ensureWorkspaceServers(options, refreshToolCatalogs);
+        return this.ensureWorkspaceServers(options, refreshToolCatalogs, readSignal);
       }
 
       log.info("[MCP] Deferring MCP server restart while stream is active", {
@@ -2210,8 +2785,9 @@ export class MCPServerManager {
       );
 
       // Even while deferring restarts, ensure new tool lists and stats reflect the latest
-      // enabled/disabled server set. We cannot revoke tools already captured by an in-flight
-      // stream, but we can avoid exposing tools from newly-disabled servers to the next stream.
+      // enabled/disabled server set. Tool objects already captured by an in-flight stream
+      // stay connected but fail at call time once their server is disabled (see
+      // gateServedToolsOnEnablement); this keeps them out of the next stream entirely.
       const instancesForTools = new Map(
         [...existing.instances].filter(([serverName]) => enabledServers[serverName] !== undefined)
       );
@@ -2225,6 +2801,8 @@ export class MCPServerManager {
       );
       existing.stats = leasedStats;
       existing.enabledServerNames = enabledServerNames;
+      existing.enabledServers = enabledServers;
+      existing.enabledServersGeneration = configGenerationUsed;
 
       // The deferred restart retains same-named instances with the old config,
       // so record which servers changed to block prompt invocation on them.
@@ -2241,26 +2819,40 @@ export class MCPServerManager {
         );
       }
 
+      if (refreshToolCatalogs) {
+        // Honor SEP-2549 freshness hints instead of caching tool lists for the instance lifetime.
+        await this.refreshModernInstanceTools(instancesForTools);
+      }
+
       // Runs after the staleness recompute so the delete above cannot clobber
-      // staleness detected from a mutation newer than this call's config read.
-      await this.repairEnablementAfterConcurrentMutation(
+      // staleness detected from a mutation newer than this call's config read,
+      // and after the awaited tool refresh: a publication landing during that
+      // await replaces the recorded options while its own listServers is still
+      // pending, so `existing.enabledServerNames` is only trustworthy once the
+      // repair has re-derived it here — the serve's last await before return.
+      const enablementDerivedFrom = await this.repairEnablementAfterConcurrentMutation(
         workspaceId,
         options,
         existing,
         configGenerationUsed
       );
 
+      // Spawned after the repair so the uncancellable detached refresh cannot
+      // target servers a concurrent mutation just revoked.
       if (refreshToolCatalogs) {
-        // Honor SEP-2549 freshness hints instead of caching tool lists for the instance lifetime.
         this.refreshInstancePromptsInBackground(existing);
-        await this.refreshModernInstanceTools(instancesForTools);
       }
 
-      return {
-        ...this.collectTools(instancesForTools, fullServerInfo, overrides),
-        stats: leasedStats,
-        promptDescriptors: this.promptDescriptorsFor(existing),
-      };
+      return this.serveResult(
+        workspaceId,
+        existing,
+        instancesForTools,
+        overrides,
+        leasedStats,
+        overridesGenerationUsed,
+        enablementDerivedFrom,
+        overridesUnavailable
+      );
     }
 
     // Serialize restarts so concurrent callers cannot overwrite cached servers
@@ -2280,7 +2872,7 @@ export class MCPServerManager {
             await this.refreshModernInstanceTools(current.instances);
           }
           // Repair again in case a mutation landed after the concurrent starter's check.
-          await this.repairEnablementAfterConcurrentMutation(
+          const enablementDerivedFrom = await this.repairEnablementAfterConcurrentMutation(
             workspaceId,
             options,
             current,
@@ -2291,11 +2883,16 @@ export class MCPServerManager {
           if (refreshToolCatalogs) {
             this.refreshInstancePromptsInBackground(current);
           }
-          return {
-            ...this.collectTools(current.instances, fullServerInfo, overrides),
-            stats: current.stats,
-            promptDescriptors: this.promptDescriptorsFor(current),
-          };
+          return this.serveResult(
+            workspaceId,
+            current,
+            current.instances,
+            overrides,
+            current.stats,
+            overridesGenerationUsed,
+            enablementDerivedFrom,
+            overridesUnavailable
+          );
         }
       }
 
@@ -2329,6 +2926,7 @@ export class MCPServerManager {
       if (retained) retained.lastActivity = Date.now();
       else await this.stopServers(workspaceId, { retainRestartOptions: true });
 
+      await this.assertOverridesEpochUnmovedBeforeStart();
       const {
         instances,
         failedServerNames: startFailedNames,
@@ -2390,6 +2988,8 @@ export class MCPServerManager {
             for (const [name, instance] of instances) retained.instances.set(name, instance);
             retained.configSignature = signature;
             retained.enabledServerNames = enabledServerNames;
+            retained.enabledServers = enabledServers;
+            retained.enabledServersGeneration = configGenerationUsed;
             retained.timedOutServerNames.push(...startTimedOutNames, ...invalidatedKeys);
             retained.stats = this.createWorkspaceStats(enabledEntries.length, retained.instances, [
               ...retained.stats.failedServerNames,
@@ -2404,6 +3004,8 @@ export class MCPServerManager {
             configSignature: signature,
             instances,
             enabledServerNames,
+            enabledServers,
+            enabledServersGeneration: configGenerationUsed,
             stats: this.createWorkspaceStats(enabledEntries.length, instances, startFailedNames),
             timedOutServerNames: [...startTimedOutNames, ...invalidatedKeys],
             retryingTimedOutServerNames: new Set(),
@@ -2429,7 +3031,7 @@ export class MCPServerManager {
       // Repair first so the awaited refresh never queries a server revoked
       // during startup, then again after it so mutations landing during the
       // slow refresh cannot leak stale descriptors.
-      await this.repairEnablementAfterConcurrentMutation(
+      let enablementDerivedFrom = await this.repairEnablementAfterConcurrentMutation(
         workspaceId,
         options,
         entry,
@@ -2445,7 +3047,7 @@ export class MCPServerManager {
             ? new Map([...promptInstances].filter(([name]) => instances.has(name)))
             : promptInstances
         );
-        await this.repairEnablementAfterConcurrentMutation(
+        enablementDerivedFrom = await this.repairEnablementAfterConcurrentMutation(
           workspaceId,
           options,
           entry,
@@ -2454,13 +3056,20 @@ export class MCPServerManager {
         if (retained) this.refreshInstancePromptsInBackground(entry);
       }
 
-      return {
-        ...this.collectTools(entry.instances, fullServerInfo, overrides),
-        // entry.stats, not the pre-publication `stats`: invalidated instances
-        // were closed before publication and must not count as started.
-        stats: entry.stats,
-        promptDescriptors: this.promptDescriptorsFor(entry),
-      };
+      // entry.stats, not the pre-publication `stats`: invalidated instances
+      // were closed before publication and must not count as started.
+      // entry.instances, not `instances`: an additive publication only started
+      // the new servers; the retained entry still serves the older ones.
+      return this.serveResult(
+        workspaceId,
+        entry,
+        entry.instances,
+        overrides,
+        entry.stats,
+        overridesGenerationUsed,
+        enablementDerivedFrom,
+        overridesUnavailable
+      );
     });
     if (result !== undefined) return result;
     if ((this.workspaceStopEpochs.get(workspaceId) ?? 0) !== stopEpochAtQueue) {
@@ -2471,7 +3080,7 @@ export class MCPServerManager {
         stats: this.createWorkspaceStats(0, new Map(), []),
       };
     }
-    return this.ensureWorkspaceServers(options, refreshToolCatalogs);
+    return this.ensureWorkspaceServers(options, refreshToolCatalogs, readSignal);
   }
 
   async getPromptsForWorkspace(
@@ -2489,19 +3098,46 @@ export class MCPServerManager {
     for (;;) {
       const optionsMutationsBefore = this.workspaceOptionsMutationCounts.get(workspaceId) ?? 0;
       const generationBefore = this.configService.configGeneration;
-      const currentOptions = this.lastWorkspaceRequestOptions.get(workspaceId) ?? options;
+      // Recorded options carry save-time repairs, but the caller's snapshot is
+      // a LATER read: its authority verdict (a document that could not be
+      // read) and any disagreement with the recorded overrides must reach
+      // ensureWorkspaceServers, which revalidates against disk — otherwise a
+      // warmed workspace would keep advertising a server its current document
+      // revokes.
+      const recorded = this.lastWorkspaceRequestOptions.get(workspaceId);
+      const currentOptions =
+        recorded === undefined
+          ? options
+          : options.overridesAuthoritative === false ||
+              (options.overrides !== undefined &&
+                !workspaceOverridesEqual(recorded.overrides, options.overrides))
+            ? {
+                ...recorded,
+                overrides: options.overrides,
+                overridesAuthoritative: options.overridesAuthoritative,
+              }
+            : recorded;
       const secretsUsed = await this.resolveSecretsForRefresh(
         workspaceId,
         currentOptions.projectPath
       );
       const refreshed = await raceWithAbortAndTimeout(
         this.runWithStablePluginEpoch(async () => {
-          await this.ensureWorkspaceServers(
+          const served = await this.ensureWorkspaceServers(
             secretsUsed !== undefined
               ? { ...currentOptions, projectSecrets: secretsUsed }
               : currentOptions,
-            false
+            false,
+            callOptions?.signal
           );
+          // A serve that failed closed (overrides not verifiable — an
+          // inherited parent unreachable, a document unreadable) leaves the
+          // warmed entry cached but vouches for none of its servers: querying
+          // their prompt catalogs would advertise prompts from servers whose
+          // current authorization is unknown. Discover nothing instead.
+          if (served.enablementDerivedFrom === undefined) {
+            return undefined;
+          }
           const entry = this.workspaceServers.get(workspaceId);
           if (entry === undefined) {
             return undefined;
@@ -2513,7 +3149,14 @@ export class MCPServerManager {
             this.promptEligibleInstances(entry),
             callOptions?.signal
           );
-          return entry;
+          // The secret re-resolution belongs inside the bracket too: it is
+          // the last await before the stability check, and a sibling's
+          // override write landing during it changes neither counter below.
+          const secretsNow = await this.resolveSecretsForRefresh(
+            workspaceId,
+            currentOptions.projectPath
+          );
+          return { entry, secretsNow, served };
         }),
         {
           ...(callOptions?.signal !== undefined ? { signal: callOptions.signal } : {}),
@@ -2528,15 +3171,18 @@ export class MCPServerManager {
       if (refreshed.value === undefined) {
         return [];
       }
-      latestEntry = refreshed.value;
-      const secretsNow = await this.resolveSecretsForRefresh(
-        workspaceId,
-        currentOptions.projectPath
-      );
+      latestEntry = refreshed.value.entry;
+      // An ordinary serve landing during prompts/list (a direct edit of the
+      // override document, a disk re-read) can replace the entry or the
+      // recorded options without moving either counter: the captured entry
+      // must still be the published one and the serve's provenance current,
+      // or the descriptors below would come from detached pre-edit state.
       if (
         (this.workspaceOptionsMutationCounts.get(workspaceId) ?? 0) === optionsMutationsBefore &&
         this.configService.configGeneration === generationBefore &&
-        secretRecordsEqual(secretsUsed, secretsNow)
+        secretRecordsEqual(secretsUsed, refreshed.value.secretsNow) &&
+        this.workspaceServers.get(workspaceId) === latestEntry &&
+        this.isServeAuthorizationCurrent(workspaceId, refreshed.value.served.enablementDerivedFrom)
       ) {
         break;
       }
@@ -2714,15 +3360,23 @@ export class MCPServerManager {
   /**
    * Settings changes during startup can miss cache synchronization. Re-derive
    * enablement and mark reconfigured clients stale before prompt dispatch.
+   *
+   * Returns the recorded options `entry.enabledServerNames` was derived from
+   * (captured synchronously with that derivation). serveResult compares it
+   * with the recorded options at return time: a publication landing in the
+   * microtask gap between this method resolving and the caller resuming has
+   * replaced them, and the derived enablement is stale for that serve.
+   * `undefined` means enablement could NOT be (re-)derived — the repair
+   * failed, or there are no recorded options — and the serve fails closed.
    */
   private async repairEnablementAfterConcurrentMutation(
     workspaceId: string,
     optionsUsed: MCPWorkspaceRequestOptions,
     entry: WorkspaceServers,
     configGenerationUsed: number
-  ): Promise<void> {
+  ): Promise<MCPWorkspaceRequestOptions | undefined> {
+    let recorded = this.lastWorkspaceRequestOptions.get(workspaceId);
     try {
-      let recorded = this.lastWorkspaceRequestOptions.get(workspaceId);
       // Workspace mutations replace recorded options; global mutations only bump a
       // generation. Either can invalidate derived enablement.
       let needsRepair =
@@ -2742,6 +3396,8 @@ export class MCPServerManager {
         const latest = this.lastWorkspaceRequestOptions.get(workspaceId);
         if (latest === recorded && this.configService.configGeneration === generationRead) {
           entry.enabledServerNames = new Set(Object.keys(enabled));
+          entry.enabledServers = enabled;
+          entry.enabledServersGeneration = generationRead;
           // configSignature is always in-process JSON.stringify output, so parsing cannot fail.
           const previousEntries = JSON.parse(entry.configSignature) as Record<string, unknown>;
           const reconfigured = Object.keys(signatureEntries).filter(
@@ -2753,16 +3409,63 @@ export class MCPServerManager {
             for (const name of reconfigured) stale.add(name);
             entry.stalePromptServerNames = stale;
           }
-          return;
+          return recorded;
         }
         recorded = latest;
         needsRepair = true;
       }
+      return recorded;
     } catch (error) {
       log.debug("[MCP] Failed to repair enablement after concurrent settings change", {
         workspaceId,
         error: getErrorMessage(error),
       });
+      // Enablement was not re-derived: `entry.enabledServerNames` may still
+      // permit a server the newer options revoked. No verdict → fail closed.
+      return undefined;
+    }
+  }
+
+  /**
+   * Drop a workspace's cached override snapshot so its next request re-reads
+   * disk. Used when a publisher could not establish the workspace's effective
+   * overrides authoritatively (unreachable checkout): caching a guess would
+   * overlay every later request until restart, while a deleted entry simply
+   * defers to the fresh per-request read.
+   */
+  forgetWorkspaceOverrides(workspaceId: string): void {
+    this.latestWorkspaceOverrides.delete(workspaceId);
+    // The marker supersedes any publication repair still in flight (a bounded
+    // publisher evicts exactly because that repair stalled): served tools
+    // must not wait on it before observing the invalidation. Its late result
+    // is discarded by the repair's own fence.
+    this.pendingEnablementRepairs.delete(workspaceId);
+    // Recorded options carry the last served snapshot too, and the prompt
+    // paths (prompt listing, getPrompt) serve from them without a chat send.
+    // Flag them so the next serve of ANY kind re-reads overrides from disk
+    // instead of trusting that snapshot (see loadFirstServeWorkspaceOverrides).
+    this.markOverridesInvalidated(workspaceId);
+    this.bumpWorkspaceOptionsMutationCount(workspaceId);
+  }
+
+  /** Start (or advance) a workspace's invalidation generation. */
+  private markOverridesInvalidated(workspaceId: string): void {
+    this.overridesInvalidationClock += 1;
+    this.overridesInvalidationGenerations.set(workspaceId, this.overridesInvalidationClock);
+  }
+
+  /**
+   * forgetWorkspaceOverrides for every workspace this manager holds any
+   * snapshot for. Used when a publisher could not enumerate the workspace
+   * graph after a write and therefore cannot name the affected descendants.
+   */
+  forgetAllWorkspaceOverrides(): void {
+    this.globalOverridesEvictionGeneration += 1;
+    for (const workspaceId of new Set([
+      ...this.latestWorkspaceOverrides.keys(),
+      ...this.lastWorkspaceRequestOptions.keys(),
+    ])) {
+      this.forgetWorkspaceOverrides(workspaceId);
     }
   }
 
@@ -2772,27 +3475,81 @@ export class MCPServerManager {
     overrides: WorkspaceMCPOverrides | undefined
   ): Promise<void> {
     this.latestWorkspaceOverrides.set(workspaceId, overrides);
+    // An authoritative publication supersedes any pending invalidation: the
+    // cache now holds disk truth, so later serves neither re-read nor fail
+    // closed on its account.
+    this.overridesInvalidationGenerations.delete(workspaceId);
     this.bumpWorkspaceOptionsMutationCount(workspaceId);
     const recorded = this.lastWorkspaceRequestOptions.get(workspaceId);
-    if (recorded) {
-      this.lastWorkspaceRequestOptions.set(workspaceId, { ...recorded, overrides });
-    }
+    if (!recorded) return;
+    const published: MCPWorkspaceRequestOptions = { ...recorded, overrides };
+    this.lastWorkspaceRequestOptions.set(workspaceId, published);
     const entry = this.workspaceServers.get(workspaceId);
-    if (!entry || !recorded) return;
-    try {
-      const enabled = await this.listServers(
-        recorded.projectPath,
-        overrides,
-        recorded.trusted ?? false,
-        recorded.agentPlugins
-      );
-      entry.enabledServerNames = new Set(Object.keys(enabled));
-    } catch (error) {
-      log.debug("[MCP] Failed to sync workspace overrides into cached state", {
-        workspaceId,
-        error: getErrorMessage(error),
-      });
-    }
+    if (!entry) return;
+    await this.repairEnablement(workspaceId, published, entry);
+  }
+
+  /**
+   * Re-derive a live entry's enabled set from freshly recorded options (an
+   * override publication, a project trust change). Registered synchronously
+   * in pendingEnablementRepairs so a tool invocation racing the mutation
+   * waits for the repaired enablement instead of passing the gate on the
+   * pre-mutation set (see gateServedToolOnEnablement); never rejects.
+   */
+  private repairEnablement(
+    workspaceId: string,
+    published: MCPWorkspaceRequestOptions,
+    entry: WorkspaceServers
+  ): Promise<void> {
+    const repair = (async () => {
+      try {
+        const generationRead = this.configService.configGeneration;
+        const enabled = await this.listServers(
+          published.projectPath,
+          published.overrides,
+          published.trusted ?? false,
+          published.agentPlugins
+        );
+        // Fence: the publisher may have given up on this repair (bounded
+        // publication) and a later save, serve, or invalidation may have
+        // replaced the recorded options meanwhile — each derives enablement
+        // from state at least as new as this one, so a late completion must
+        // not restore the older enabled set on the live entry (a served tool
+        // would pass the call-time gate for a server the later save disabled).
+        if (
+          this.lastWorkspaceRequestOptions.get(workspaceId) !== published ||
+          this.workspaceServers.get(workspaceId) !== entry ||
+          this.overridesInvalidationGenerations.has(workspaceId)
+        ) {
+          log.debug("[MCP] Discarding a superseded publication repair", { workspaceId });
+          return;
+        }
+        entry.enabledServerNames = new Set(Object.keys(enabled));
+        entry.enabledServers = enabled;
+        entry.enabledServersGeneration = generationRead;
+      } catch (error) {
+        // The recorded overrides now say one thing and `entry.enabledServerNames`
+        // another (the old set), and the per-call disk comparison would find
+        // disk equal to the recorded value: nothing would ever repair the
+        // entry. Invalidate the workspace so every served tool call and the
+        // next serve re-derive enablement from disk (fail closed until then).
+        log.warn("[MCP] Failed to sync workspace overrides into cached state; invalidating", {
+          workspaceId,
+          error: getErrorMessage(error),
+        });
+        if (this.lastWorkspaceRequestOptions.get(workspaceId) === published) {
+          this.forgetWorkspaceOverrides(workspaceId);
+        }
+      }
+    })();
+    this.pendingEnablementRepairs.set(workspaceId, repair);
+    // Attached before any waiter can observe `repair`, so the registration is
+    // cleared before a gated tool call awaiting it resumes (reaction order).
+    return repair.finally(() => {
+      if (this.pendingEnablementRepairs.get(workspaceId) === repair) {
+        this.pendingEnablementRepairs.delete(workspaceId);
+      }
+    });
   }
 
   /**
@@ -2813,11 +3570,24 @@ export class MCPServerManager {
     for (const [path, trusted] of trustByPath) {
       this.latestProjectTrust.set(path, trusted);
     }
-    for (const [workspaceId, options] of this.lastWorkspaceRequestOptions) {
+    for (const [workspaceId, options] of [...this.lastWorkspaceRequestOptions]) {
       const trusted = trustByPath.get(stripTrailingSlashes(options.projectPath));
       if (trusted === undefined || (options.trusted ?? false) === trusted) continue;
-      this.lastWorkspaceRequestOptions.set(workspaceId, { ...options, trusted });
+      const published: MCPWorkspaceRequestOptions = { ...options, trusted };
+      this.lastWorkspaceRequestOptions.set(workspaceId, published);
       this.bumpWorkspaceOptionsMutationCount(workspaceId);
+      // The live entry's enabled set was derived under the OLD trust, and the
+      // call-time gate evaluates the server info captured at serve time: a
+      // project-local server the user just distrusted would keep dispatching
+      // from an already-prepared stream. Repair the enabled set like an
+      // override publication does (registered synchronously, so a racing
+      // tool call waits for it); the repair's own catch invalidates the
+      // workspace when re-derivation fails.
+      const entry = this.workspaceServers.get(workspaceId);
+      if (entry !== undefined) {
+        // Tracked in pendingEnablementRepairs and self-clearing; it never rejects.
+        this.repairEnablement(workspaceId, published, entry).catch(() => undefined);
+      }
     }
   }
 
@@ -2843,6 +3613,21 @@ export class MCPServerManager {
       });
       return undefined;
     }
+  }
+
+  /**
+   * getPrompt has no caller snapshot: it dispatches from the RECORDED options,
+   * which a direct edit of an override document (the child's, or the parent
+   * document an inheriting child reads through) never touches — no epoch
+   * bump, no publication. Distrust them for the dispatch so
+   * ensureWorkspaceServers re-reads disk (and fails closed when it cannot
+   * vouch); a fresh read is recorded authoritative again. Without a reader the
+   * recorded options stay authoritative, as everywhere else.
+   */
+  private promptDispatchOptions(recorded: MCPWorkspaceRequestOptions): MCPWorkspaceRequestOptions {
+    return this.pluginInvalidation?.readWorkspaceOverrides !== undefined
+      ? { ...recorded, overridesAuthoritative: false }
+      : recorded;
   }
 
   async getPrompt(
@@ -2871,13 +3656,19 @@ export class MCPServerManager {
             // Re-read after the resolver await: a settings mutation recorded
             // while secrets resolved must not be clobbered by a pre-await
             // options snapshot.
-            const currentOptions = this.lastWorkspaceRequestOptions.get(workspaceId) ?? lastOptions;
+            const currentOptions = this.promptDispatchOptions(
+              this.lastWorkspaceRequestOptions.get(workspaceId) ?? lastOptions
+            );
             await this.ensureWorkspaceServers(
               secretsUsed !== undefined
                 ? { ...currentOptions, projectSecrets: secretsUsed }
                 : currentOptions,
-              false
+              false,
+              options?.signal
             );
+            // Inside the bracket like getPromptsForWorkspace: the last await
+            // before the stability check must be covered by the postflight.
+            return this.resolveSecretsForRefresh(workspaceId, lastOptions.projectPath);
           }),
           { ...(options?.signal !== undefined ? { signal: options.signal } : {}) }
         );
@@ -2887,10 +3678,7 @@ export class MCPServerManager {
         if (refreshed.kind === "timeout") {
           throw new Error(`MCP prompt request for '${serverName}/${promptName}' timed out`);
         }
-        const secretsNow = await this.resolveSecretsForRefresh(
-          workspaceId,
-          lastOptions.projectPath
-        );
+        const secretsNow = refreshed.value;
         if (
           (this.workspaceOptionsMutationCounts.get(workspaceId) ?? 0) === optionsMutationsBefore &&
           this.configService.configGeneration === generationBefore &&
@@ -2902,59 +3690,185 @@ export class MCPServerManager {
       }
     }
 
-    const invoked = await raceWithAbortAndTimeout(
-      this.runWithStablePluginEpoch(async () => {
-        // Re-run startup inside the SAME bracket as prompts/get: a sibling
-        // mutation detected by the preflight may have retired the instance
-        // stabilized above, and the operation must rebuild before querying.
-        if (lastOptions !== undefined) {
-          const currentOptions = this.lastWorkspaceRequestOptions.get(workspaceId) ?? lastOptions;
-          await this.ensureWorkspaceServers(
-            stableSecrets !== undefined
-              ? { ...currentOptions, projectSecrets: stableSecrets }
-              : currentOptions,
-            false
-          );
-        }
-        const entry = this.workspaceServers.get(workspaceId);
-        if (entry && !entry.enabledServerNames.has(serverName)) {
-          throw new Error(`MCP server '${serverName}' is disabled`);
-        }
-        if (entry?.stalePromptServerNames?.has(serverName)) {
-          throw new Error(
-            `MCP server '${serverName}' was reconfigured while this request was being prepared; retry`
-          );
-        }
-        const instance = entry?.instances.get(serverName);
-        if (!instance || instance.isClosed) {
-          throw new Error(`MCP server '${serverName}' is not connected`);
-        }
-        this.markActivity(workspaceId);
-        // Include prompts/get itself inside the mutation-epoch bracket. A
-        // sibling update that lands after startup but before materialization
-        // retires the stale instance and retries this read-only operation.
-        const result = await instance.getPrompt(promptName, args, options);
-        const text = flattenMcpPrompt(result);
-        if (text.trim().length === 0) {
-          // Providers can reject empty user content, so fail expansion up
-          // front rather than persisting an empty synthetic user message.
-          throw new Error(`MCP prompt '${serverName}/${promptName}' returned no text content`);
-        }
-        return {
-          // Cap here because both composer expansion and mcp_prompt_get use this path.
-          text: truncateUtf8Bytes(text, MCP_PROMPT_MAX_TEXT_BYTES, MCP_PROMPT_TRUNCATION_MARKER),
-          ...(result.description !== undefined ? { description: result.description } : {}),
-        };
-      }),
-      { ...(options?.signal !== undefined ? { signal: options.signal } : {}) }
+    // Bounded like the served-tool gate: a global settings change landing
+    // during an attempt re-runs the bracket (whose serve re-derives the
+    // inventory), and sustained churn fails closed instead of spinning.
+    for (let attempt = 0; attempt < CALL_GATE_MAX_ATTEMPTS; attempt++) {
+      const invoked = await raceWithAbortAndTimeout(
+        this.runWithStablePluginEpoch(async () => {
+          // Re-run startup inside the SAME bracket as prompts/get: a sibling
+          // mutation detected by the preflight may have retired the instance
+          // stabilized above, and the operation must rebuild before querying.
+          let served: MCPToolsForWorkspaceResult | undefined;
+          if (lastOptions !== undefined) {
+            const currentOptions = this.promptDispatchOptions(
+              this.lastWorkspaceRequestOptions.get(workspaceId) ?? lastOptions
+            );
+            served = await this.ensureWorkspaceServers(
+              stableSecrets !== undefined
+                ? { ...currentOptions, projectSecrets: stableSecrets }
+                : currentOptions,
+              false,
+              options?.signal
+            );
+          }
+          // The serve fails closed (serveResult) when the workspace was
+          // invalidated or re-published mid-serve, but it does not rewrite the
+          // cached entry — consume that verdict here instead of dispatching
+          // through the stale entry. Re-running the SAME check (identity AND
+          // marker) right before dispatch also covers a publication or forget
+          // squeezed between the serve's gate and this continuation.
+          // Synchronous from the last check to the invocation start. A global
+          // settings change (mcp.setEnabled, a config edit) that landed while
+          // this request waited — for the lock below, or an epoch read — only
+          // advances the config generation: it moves neither the provenance
+          // nor the override epoch, so like the served-tool gate the entry's
+          // inventory must be as new as the current generation, or the whole
+          // bracket re-runs (its serve re-derives the inventory).
+          const dispatch = (): ReturnType<MCPServerInstance["getPrompt"]> | "retry" => {
+            if (
+              served !== undefined &&
+              !this.isServeAuthorizationCurrent(workspaceId, served.enablementDerivedFrom)
+            ) {
+              throw new Error(
+                `MCP server '${serverName}' is unavailable while workspace MCP settings are being updated; retry`
+              );
+            }
+            const entry = this.workspaceServers.get(workspaceId);
+            // Only a serve (recorded options) can re-derive the inventory, so
+            // the check is meaningful only when this request ran one.
+            if (
+              served !== undefined &&
+              entry !== undefined &&
+              entry.enabledServersGeneration !== this.configService.configGeneration
+            ) {
+              return "retry";
+            }
+            if (entry && !entry.enabledServerNames.has(serverName)) {
+              throw new Error(`MCP server '${serverName}' is disabled`);
+            }
+            if (entry?.stalePromptServerNames?.has(serverName)) {
+              throw new Error(
+                `MCP server '${serverName}' was reconfigured while this request was being prepared; retry`
+              );
+            }
+            const instance = entry?.instances.get(serverName);
+            if (!instance || instance.isClosed) {
+              throw new Error(`MCP server '${serverName}' is not connected`);
+            }
+            this.markActivity(workspaceId);
+            // Include prompts/get itself inside the mutation-epoch bracket. A
+            // sibling update that lands after startup but before materialization
+            // retires the stale instance and retries this read-only operation.
+            return instance.getPrompt(promptName, args, options);
+          };
+          // Same dispatch fence as served tool calls (see
+          // gateServedToolOnEnablement): a sibling process's disabling save
+          // persists first and bumps the epoch only after its publication
+          // budget, so a postflight alone can still observe the old token and
+          // hand out content from the now-disabled server. Hold the WRITER's
+          // lock from a final epoch read through the synchronous invocation
+          // start; a moved (or unreadable) epoch makes the bracket's postflight
+          // retry this read-only operation instead of dispatching.
+          const acquireOverridesLock = this.pluginInvalidation?.acquireOverridesLock;
+          const readOverridesEpoch = this.pluginInvalidation?.readOverridesEpoch;
+          let pending: ReturnType<MCPServerInstance["getPrompt"]> | "retry";
+          if (acquireOverridesLock === undefined || readOverridesEpoch === undefined) {
+            pending = dispatch();
+          } else {
+            // ONE deadline for acquisition and the fenced epoch read: the outer
+            // abort race cannot stop this callback, so a stalled home filesystem
+            // must not keep the writer's lock held (blocking every settings
+            // save and prune) past the budget — release it and fail closed.
+            const fenceDeadlineAt = Date.now() + CALL_GATE_TIMEOUT_MS;
+            const release = await acquireOverridesLock({
+              timeoutMs: Math.max(0, fenceDeadlineAt - Date.now()),
+              ...(options?.signal !== undefined ? { signal: options.signal } : {}),
+            });
+            try {
+              const epochRead = await raceWithAbortAndTimeout(readOverridesEpoch(), {
+                timeoutMs: Math.max(0, fenceDeadlineAt - Date.now()),
+                ...(options?.signal !== undefined ? { signal: options.signal } : {}),
+              });
+              if (epochRead.kind !== "ok") {
+                throw new Error(
+                  epochRead.kind === "aborted"
+                    ? `MCP prompt request for '${serverName}/${promptName}' was aborted`
+                    : `MCP server '${serverName}' is unavailable: the workspace MCP settings marker could not be read in time; retry`
+                );
+              }
+              const epochNow = epochRead.value;
+              if (
+                epochNow !== this.lastOverridesEpochToken ||
+                isWorkspaceOverridesEpochUnreadable(epochNow)
+              ) {
+                return { epochMoved: true } as const;
+              }
+              pending = dispatch();
+            } finally {
+              await release();
+            }
+          }
+          if (pending === "retry") {
+            return { generationMoved: true } as const;
+          }
+          const result = await pending;
+          const text = flattenMcpPrompt(result);
+          if (text.trim().length === 0) {
+            // Providers can reject empty user content, so fail expansion up
+            // front rather than persisting an empty synthetic user message.
+            throw new Error(`MCP prompt '${serverName}/${promptName}' returned no text content`);
+          }
+          return {
+            prompt: {
+              // Cap here because both composer expansion and mcp_prompt_get use this path.
+              text: truncateUtf8Bytes(
+                text,
+                MCP_PROMPT_MAX_TEXT_BYTES,
+                MCP_PROMPT_TRUNCATION_MARKER
+              ),
+              ...(result.description !== undefined ? { description: result.description } : {}),
+            },
+            derivedFrom: served?.enablementDerivedFrom,
+          };
+        }),
+        { ...(options?.signal !== undefined ? { signal: options.signal } : {}) }
+      );
+      if (invoked.kind === "aborted") {
+        throw new Error(`MCP prompt request for '${serverName}/${promptName}' was aborted`);
+      }
+      if (invoked.kind === "timeout") {
+        throw new Error(`MCP prompt request for '${serverName}/${promptName}' timed out`);
+      }
+      if ("generationMoved" in invoked.value) {
+        continue;
+      }
+      if ("epochMoved" in invoked.value) {
+        // The bracket retries a moved epoch itself; reaching here means the
+        // token settled back on the value the fence compared against (or the
+        // bracket ran without epoch tracking). Nothing vouches for the dispatch.
+        throw new Error(
+          `MCP server '${serverName}' is unavailable while workspace MCP settings are being updated; retry`
+        );
+      }
+      // Same final gate as getToolsForWorkspace: a same-process save that
+      // disables the server after the pre-dispatch check — while the bracket's
+      // postflight token reads were in flight — publishes new recorded options
+      // without moving the token those reads captured. Re-check the serve's
+      // provenance right before handing the content out.
+      if (
+        invoked.value.derivedFrom !== undefined &&
+        !this.isServeAuthorizationCurrent(workspaceId, invoked.value.derivedFrom)
+      ) {
+        throw new Error(
+          `MCP server '${serverName}' is unavailable while workspace MCP settings are being updated; retry`
+        );
+      }
+      return invoked.value.prompt;
+    }
+    throw new Error(
+      `MCP server '${serverName}' is unavailable while MCP settings keep changing; retry`
     );
-    if (invoked.kind === "aborted") {
-      throw new Error(`MCP prompt request for '${serverName}/${promptName}' was aborted`);
-    }
-    if (invoked.kind === "timeout") {
-      throw new Error(`MCP prompt request for '${serverName}/${promptName}' timed out`);
-    }
-    return invoked.value;
   }
 
   /**
@@ -3342,15 +4256,482 @@ export class MCPServerManager {
    * Collect tools from all server instances, applying tool allowlists.
    *
    * @param instances - Map of server instances
-   * @param serverInfo - Project-level server info (for project-level tool allowlists)
    * @param workspaceOverrides - Optional workspace MCP overrides for tool allowlists
    * @returns Aggregated tools record with provider-safe namespaced names, plus
    *   a tool name → server name map so callers can advertise the catalog by server
    */
+  /**
+   * Final gate of a serve, after repairEnablementAfterConcurrentMutation. A
+   * forgetWorkspaceOverrides (parent save that could not resolve this
+   * workspace authoritatively, plugin prune, global eviction) that landed
+   * after this serve selected its options leaves those recorded options in
+   * place and only advances the invalidation marker — so the repair, which
+   * keys on option identity and config generation, re-derives nothing. The
+   * recorded snapshot is exactly what is being distrusted: fail THIS serve
+   * closed (no tools, no prompts); the next one re-reads disk. A publication
+   * that superseded the forget retired the marker and replaced the recorded
+   * options, so it reaches the repaired result below instead.
+   */
+  private serveResult(
+    workspaceId: string,
+    entry: WorkspaceServers,
+    instances: Map<string, MCPServerInstance>,
+    fallbackOverrides: WorkspaceMCPOverrides | undefined,
+    stats: MCPWorkspaceStats,
+    overridesGenerationUsed: number | undefined,
+    /** Recorded options the last repair derived `entry.enabledServerNames` from. */
+    enablementDerivedFrom: MCPWorkspaceRequestOptions | undefined,
+    /** Per-serve fail-closed marker (see ensureWorkspaceServers). */
+    overridesUnavailable: boolean
+  ): MCPToolsForWorkspaceResult {
+    const failClosed = (reason: string): MCPToolsForWorkspaceResult => {
+      log.warn(`[MCP] ${reason}; disabling MCP for this serve`, { workspaceId });
+      return this.failClosedResult();
+    };
+    if (overridesUnavailable) {
+      // The serve enabled nothing because neither the caller nor disk could
+      // vouch for the overrides. The recorded options still hold the caller's
+      // unverified fallback; reporting it as `overridesUsed` would let the
+      // prompt inventory advertise a server the unreadable document hides.
+      return failClosed("Workspace overrides could not be verified");
+    }
+    if (this.overridesInvalidationGenerations.get(workspaceId) !== overridesGenerationUsed) {
+      return failClosed("Workspace overrides invalidated while a serve was in flight");
+    }
+    if (enablementDerivedFrom === undefined) {
+      return failClosed("Workspace enablement could not be re-derived after a concurrent mutation");
+    }
+    // An authoritative publication that landed after the last repair (its own
+    // listServers still pending) replaced the recorded options and retired
+    // any marker, but `entry.enabledServerNames` still reflects the older
+    // options: the publication's own completion repairs the entry for later
+    // serves; this one must not filter through the stale set.
+    if (!this.isServeAuthorizationCurrent(workspaceId, enablementDerivedFrom)) {
+      return failClosed("Workspace overrides changed while a serve was completing");
+    }
+    return {
+      ...this.collectServedTools(workspaceId, entry, instances, fallbackOverrides),
+      stats,
+      promptDescriptors: this.promptDescriptorsFor(entry),
+      ...(enablementDerivedFrom !== undefined
+        ? {
+            enablementDerivedFrom,
+            overridesUsed: enablementDerivedFrom.overrides ?? {},
+            serversUsed: entry.enabledServers,
+          }
+        : {}),
+    };
+  }
+
+  /**
+   * collectTools for a serve's return value AFTER repairEnablementAfterConcurrentMutation:
+   * a settings mutation (or an inherited publication) that landed mid-startup
+   * has already repaired `entry.enabledServerNames` and the recorded options,
+   * but the caller still holds the pre-mutation instance map and overrides.
+   * Serving those would expose a just-revoked server's tools to this stream.
+   */
+  private collectServedTools(
+    workspaceId: string,
+    entry: WorkspaceServers,
+    instances: Map<string, MCPServerInstance>,
+    fallbackOverrides: WorkspaceMCPOverrides | undefined
+  ): { tools: Record<string, Tool>; toolServerNames: Record<string, string> } {
+    const served = new Map(
+      [...instances].filter(([serverName]) => entry.enabledServerNames.has(serverName))
+    );
+    const recorded = this.lastWorkspaceRequestOptions.get(workspaceId);
+    // The REPAIRED inventory (same derivation as `enabledServerNames`), not
+    // the pre-mutation server info the caller started from: a project tool
+    // allowlist narrowed mid-startup must filter the tools handed to the
+    // model, or it receives tools the gate rejects only after selection.
+    const serverInfo = entry.enabledServers;
+    return this.collectTools(
+      served,
+      serverInfo,
+      recorded ? recorded.overrides : fallbackOverrides,
+      (serverName, toolName, tool) =>
+        this.gateServedToolOnEnablement(
+          workspaceId,
+          serverName,
+          toolName,
+          tool,
+          serverInfo[serverName]
+        )
+    );
+  }
+
+  /**
+   * Wait for a publication's enablement repair still in flight, bounded: the
+   * publisher gives up on a stalled repair and evicts (which also drops it
+   * from the map), and a call that grabbed the promise before that must not
+   * hang the stream — fail closed instead, like getPrompt.
+   */
+  private async awaitPendingRepair(
+    workspaceId: string,
+    serverName: string,
+    toolName: string,
+    abortSignal: AbortSignal | undefined,
+    /** Remaining gate budget; the wait never outlives the gate's own deadline. */
+    remainingMs: number
+  ): Promise<void> {
+    const pendingRepair = this.pendingEnablementRepairs.get(workspaceId);
+    if (pendingRepair === undefined) {
+      return;
+    }
+    // Abort-aware like the revalidation itself: Escape must not be ignored
+    // for the whole bound and then misreported as a settings-update error.
+    const raced = await raceWithAbortAndTimeout(pendingRepair, {
+      timeoutMs: Math.max(0, Math.min(PENDING_REPAIR_WAIT_MS, remainingMs)),
+      ...(abortSignal !== undefined ? { signal: abortSignal } : {}),
+    });
+    if (raced.kind === "aborted") {
+      throw new Error(`MCP tool '${serverName}/${toolName}' call was aborted`);
+    }
+    if (raced.kind === "timeout") {
+      throw new Error(
+        `MCP server '${serverName}' is unavailable while workspace MCP settings are being updated; retry`
+      );
+    }
+  }
+
+  /**
+   * Tool objects leave the manager before the stream that uses them starts
+   * (TurnRequestBuilder assembles the request first; StreamManager acquires
+   * its lease later), and a publication landing in between — or mid-stream —
+   * repairs the cached entry but cannot retract objects already handed out.
+   * Rather than shrinking that window, every invocation re-derives the
+   * server's CURRENT authorization for the workspace, so a server (or tool)
+   * revoked after the serve fails at call time regardless of when the change
+   * landed:
+   * - a pending publication repair is awaited first (applyWorkspaceOverrides);
+   * - inside the cross-process epoch bracket, the effective overrides on disk
+   *   are compared with the recorded ones (direct edits) and an invalidation
+   *   marker (forgetWorkspaceOverrides: descendant/off-host publications and
+   *   cross-process epoch changes publish no overrides, only the marker) means
+   *   the recorded enablement can no longer be trusted: re-serve from the
+   *   recorded options so disk re-derives it (a leased entry is repaired in
+   *   place), and reject if the marker survives or the re-read fails;
+   * - a global mutation (mcp.setEnabled, a global/project toolAllowlist edit)
+   *   bumps the config generation without touching recorded options or the
+   *   overrides on disk: the entry's inventory is re-derived when its
+   *   generation is behind (repairEnablementAfterConcurrentMutation);
+   * - the server must be enabled by the LATEST recorded overrides (evaluated
+   *   directly, so a publication that started meanwhile counts even before
+   *   its repair lands), a repair started meanwhile is awaited, the entry's
+   *   CURRENT validated inventory must still hold the server, and the tool
+   *   must pass that inventory's project allowlist intersected with the
+   *   current workspace tool allowlist. The server info captured at serve
+   *   time (`servedInfo`) never authorizes a dispatch — its allowlist is as
+   *   old as the tool object; it only stands in for the early revocation
+   *   check while a publication's repair is pending and the entry's
+   *   inventory is empty (failed closed), so that check still waits for the
+   *   repair instead of rejecting a server the publication re-enables.
+   * Recorded-options identity is deliberately not compared: it changes on
+   * every serve and would fail healthy in-flight tool calls.
+   */
+  private gateServedToolOnEnablement(
+    workspaceId: string,
+    serverName: string,
+    toolName: string,
+    tool: Tool,
+    servedInfo: MCPServerInfo | undefined
+  ): Tool {
+    if (!tool.execute) {
+      return tool;
+    }
+    const originalExecute = tool.execute;
+    const revoked = (what: string) =>
+      new Error(
+        `MCP ${what} was disabled for this workspace after the request was prepared; it is unavailable`
+      );
+    return {
+      ...tool,
+      execute: async (args: Parameters<typeof originalExecute>[0], context) => {
+        const abortSignal =
+          context && typeof context === "object" && "abortSignal" in context
+            ? (context as { abortSignal?: AbortSignal }).abortSignal
+            : undefined;
+        // Bound and abort the authorization work itself: on SSH/Docker the
+        // disk re-read goes through the remote runtime (minutes per op), and
+        // the wrapped tool's own deadline/Escape only start once this returns.
+        // One absolute deadline for the whole gate: every wait below (and
+        // every retry iteration) is given only what remains of it, so
+        // sustained settings contention cannot keep an invocation in this
+        // gate for several helper timeouts in a row.
+        const gateDeadlineAt = Date.now() + CALL_GATE_TIMEOUT_MS;
+        const remainingMs = () => Math.max(0, gateDeadlineAt - Date.now());
+        const bounded = async <T>(work: Promise<T>): Promise<T> => {
+          const raced = await raceWithAbortAndTimeout(work, {
+            timeoutMs: remainingMs(),
+            ...(abortSignal !== undefined ? { signal: abortSignal } : {}),
+          });
+          if (raced.kind === "aborted") {
+            throw new Error(`MCP tool '${serverName}/${toolName}' call was aborted`);
+          }
+          if (raced.kind === "timeout") {
+            throw new Error(
+              `MCP server '${serverName}' is unavailable: its workspace MCP settings could not be re-read in time; retry`
+            );
+          }
+          return raced.value;
+        };
+        // Every await below opens a gap in which a publication can install
+        // new recorded options and start a repair. The decision is therefore
+        // taken in a loop: an iteration whose state moved during an await
+        // starts over; only checks that ran in the same synchronous block as
+        // the dispatch authorize it, so no publication can interleave between
+        // the checks and the call.
+        // The server's CURRENT validated info comes from the live entry's
+        // inventory (refreshed by every serve and repair), never from the
+        // serve that produced this tool object.
+        const currentInfo = (): MCPServerInfo | undefined =>
+          this.workspaceServers.get(workspaceId)?.enabledServers[serverName];
+        const enabledBy = (
+          info: MCPServerInfo | undefined,
+          overrides: WorkspaceMCPOverrides | undefined
+        ): boolean =>
+          info !== undefined &&
+          serverName in
+            this.filterServersByPolicy(
+              this.applyServerOverrides({ [serverName]: info }, overrides)
+            );
+        for (let attempt = 0; attempt < CALL_GATE_MAX_ATTEMPTS; attempt++) {
+          const recorded = this.lastWorkspaceRequestOptions.get(workspaceId);
+          if (recorded === undefined) {
+            throw revoked(`server '${serverName}'`);
+          }
+          if (this.pendingEnablementRepairs.has(workspaceId)) {
+            // A publication is in flight: its recorded overrides are an
+            // in-process save (disk truth) and authoritative for a revocation
+            // even before its enablement repair lands — decide that without
+            // waiting; otherwise wait for the repair and start over.
+            if (!enabledBy(currentInfo() ?? servedInfo, recorded.overrides)) {
+              throw revoked(`server '${serverName}'`);
+            }
+            await this.awaitPendingRepair(
+              workspaceId,
+              serverName,
+              toolName,
+              abortSignal,
+              remainingMs()
+            );
+            continue;
+          }
+          // A global settings mutation since the inventory was derived: no
+          // recorded options changed and disk holds the same overrides, so
+          // neither check below would notice a narrowed global/project
+          // allowlist or a globally disabled server. Re-derive first.
+          const staleEntry = this.workspaceServers.get(workspaceId);
+          if (
+            staleEntry !== undefined &&
+            staleEntry.enabledServersGeneration !== this.configService.configGeneration
+          ) {
+            const repaired = await bounded(
+              this.repairEnablementAfterConcurrentMutation(
+                workspaceId,
+                recorded,
+                staleEntry,
+                staleEntry.enabledServersGeneration
+              )
+            );
+            if (repaired === undefined) {
+              throw new Error(
+                `MCP server '${serverName}' is unavailable because its enablement could not be re-derived after a settings change; retry`
+              );
+            }
+            continue;
+          }
+          // Same cross-process bracket as every serve: a sibling process's
+          // override write bumps only the on-disk epoch, and without a new
+          // serve in THIS process nothing would ever observe it — the preflight
+          // turns it into invalidation markers, the marker path re-derives
+          // from disk, and the postflight retries if the epoch moved meanwhile.
+          // Direct edits of an override document (the workspace's own, or the
+          // parent document an inheriting child reads through) move neither
+          // the epoch nor any process-local state: compare the effective
+          // overrides on disk with the recorded ones and treat a difference
+          // (or an unreadable document) as an invalidation of this workspace.
+          try {
+            await bounded(
+              this.runWithStablePluginEpoch(async () => {
+                const readOverrides = this.pluginInvalidation?.readWorkspaceOverrides;
+                if (
+                  readOverrides !== undefined &&
+                  !this.overridesInvalidationGenerations.has(workspaceId)
+                ) {
+                  const fresh = await readOverrides(
+                    workspaceId,
+                    abortSignal !== undefined ? { signal: abortSignal } : undefined
+                  );
+                  // Equivalence, like decide() below: an overlapping serve
+                  // whose snapshot predates the disk edit records an
+                  // EQUIVALENT object meanwhile; identity would skip the
+                  // invalidation here while dispatch accepts the replacement,
+                  // letting a revoked tool run. A genuinely different record
+                  // (a publication) is left alone: it already re-derived.
+                  const latestRecorded = this.lastWorkspaceRequestOptions.get(workspaceId);
+                  if (
+                    (fresh === undefined || !workspaceOverridesEqual(fresh, recorded.overrides)) &&
+                    latestRecorded !== undefined &&
+                    authorizationStateEqual(latestRecorded, recorded)
+                  ) {
+                    this.forgetWorkspaceOverrides(workspaceId);
+                  }
+                }
+                if (this.overridesInvalidationGenerations.has(workspaceId)) {
+                  const latest = this.lastWorkspaceRequestOptions.get(workspaceId);
+                  if (latest !== undefined) {
+                    await this.ensureWorkspaceServers(latest, false, abortSignal);
+                  }
+                }
+              })
+            );
+          } catch (error) {
+            // The read or re-serve failed (unreachable parent checkout, config
+            // read error, epoch churn, deadline): nothing vouches for the
+            // cached enablement, so the call fails closed and the next serve
+            // re-reads.
+            log.debug("[MCP] Re-derivation before a tool call failed; rejecting the call", {
+              workspaceId,
+              serverName,
+              error: getErrorMessage(error),
+            });
+            this.forgetWorkspaceOverrides(workspaceId);
+            throw error instanceof Error && error.message.includes("aborted")
+              ? error
+              : new Error(
+                  `MCP server '${serverName}' is unavailable because its workspace MCP settings could not be re-read; retry`
+                );
+          }
+          // Decide only on state read NOW (synchronously), and only if nothing
+          // moved since this iteration's snapshot — every await above and
+          // below opens a gap in which a publication can install new recorded
+          // options or start a repair; "retry" restarts the loop on them.
+          const decide = (): "dispatch" | "retry" => {
+            // Equivalence, not identity (see isServeAuthorizationCurrent): an
+            // overlapping ordinary serve (prompt discovery, a concurrent send)
+            // records a fresh options object with the SAME authorization
+            // state; a burst of those must not exhaust the attempts and
+            // reject an authorized call. A publication or trust change
+            // records different overrides/trust and still retries.
+            const latestRecorded = this.lastWorkspaceRequestOptions.get(workspaceId);
+            if (
+              latestRecorded === undefined ||
+              !authorizationStateEqual(latestRecorded, recorded) ||
+              this.pendingEnablementRepairs.has(workspaceId)
+            ) {
+              return "retry";
+            }
+            if (this.overridesInvalidationGenerations.has(workspaceId)) {
+              throw revoked(`server '${serverName}'`);
+            }
+            const entry = this.workspaceServers.get(workspaceId);
+            if (entry === undefined) {
+              throw revoked(`server '${serverName}'`);
+            }
+            if (entry.enabledServersGeneration !== this.configService.configGeneration) {
+              // A global mutation landed during an await above: re-derive.
+              return "retry";
+            }
+            const overrides = recorded.overrides;
+            const info = entry.enabledServers[serverName];
+            if (
+              info === undefined ||
+              !enabledBy(info, overrides) ||
+              !entry.enabledServerNames.has(serverName)
+            ) {
+              throw revoked(`server '${serverName}'`);
+            }
+            if (
+              !(
+                toolName in
+                this.applyToolAllowlist(
+                  serverName,
+                  { [toolName]: tool },
+                  info.toolAllowlist,
+                  overrides
+                )
+              )
+            ) {
+              throw revoked(`tool '${serverName}/${toolName}'`);
+            }
+            return "dispatch";
+          };
+          if (decide() === "retry") {
+            continue;
+          }
+          const acquireOverridesLock = this.pluginInvalidation?.acquireOverridesLock;
+          const readOverridesEpoch = this.pluginInvalidation?.readOverridesEpoch;
+          if (acquireOverridesLock === undefined || readOverridesEpoch === undefined) {
+            // No cross-process writers to fence: the checks above ran in the
+            // same synchronous block as this invocation start.
+            const result: unknown = await Promise.resolve(originalExecute(args, context));
+            return result;
+          }
+          // Cross-process fence. The bracket's postflight epoch read and this
+          // invocation are separated by promise continuations, and a sibling
+          // process's revocation completing in that gap leaves no
+          // process-local marker to observe. Hold the WRITER's lock from a
+          // final epoch read through the synchronous invocation start: a
+          // sibling write either committed (and bumped the epoch) before the
+          // read — observed here, retried by the next preflight — or waits
+          // for the release, by which time the call is already dispatched
+          // under authorization that was current at dispatch. The lock is
+          // released as soon as the invocation has STARTED; the tool's own
+          // execution never runs under it.
+          // The acquisition itself is given the gate's remaining budget and
+          // abort signal: an abandoned call must not stay queued in the
+          // writer's lock queue and briefly hold the lock later, delaying
+          // every settings save queued behind it.
+          const acquisition = acquireOverridesLock({
+            timeoutMs: remainingMs(),
+            ...(abortSignal !== undefined ? { signal: abortSignal } : {}),
+          });
+          let release: () => Promise<void>;
+          try {
+            release = await bounded(acquisition);
+          } catch (error) {
+            // Belt and braces: should the acquisition still succeed after the
+            // race was lost, it must not leave the lock held.
+            acquisition.then((lateRelease) => lateRelease()).catch(() => undefined);
+            throw error;
+          }
+          let pending: Promise<unknown> | undefined;
+          try {
+            const epochNow = await bounded(readOverridesEpoch());
+            if (
+              epochNow !== this.lastOverridesEpochToken ||
+              isWorkspaceOverridesEpochUnreadable(epochNow)
+            ) {
+              // A sibling wrote since the epoch this iteration derived from
+              // (an unreadable epoch vouches for nothing): the next
+              // iteration's preflight evicts and re-derives from disk.
+              continue;
+            }
+            // Process-local state may have moved during the two awaits above.
+            if (decide() === "retry") {
+              continue;
+            }
+            // Synchronous from the last check to the invocation start, under the lock.
+            pending = Promise.resolve(originalExecute(args, context));
+          } finally {
+            await release();
+          }
+          return await pending;
+        }
+        throw new Error(
+          `MCP server '${serverName}' is unavailable while workspace MCP settings keep changing; retry`
+        );
+      },
+    };
+  }
+
   private collectTools(
     instances: Map<string, MCPServerInstance>,
     serverInfo: Record<string, MCPServerInfo>,
-    workspaceOverrides?: WorkspaceMCPOverrides
+    workspaceOverrides?: WorkspaceMCPOverrides,
+    /** Per-tool call-time gate (see gateServedToolOnEnablement); identity when absent. */
+    gate: (serverName: string, toolName: string, tool: Tool) => Tool = (_s, _t, tool) => tool
   ): { tools: Record<string, Tool>; toolServerNames: Record<string, string> } {
     const aggregated: Record<string, Tool> = {};
     const toolServerNames: Record<string, string> = {};
@@ -3415,12 +4796,38 @@ export class MCPServerManager {
           });
         }
 
-        aggregated[result.toolName] = tool;
+        aggregated[result.toolName] = gate(instance.name, toolName, tool);
         toolServerNames[result.toolName] = instance.name;
       }
     }
 
     return { tools: aggregated, toolServerNames };
+  }
+
+  /**
+   * Fence process startup against a sibling process's override write. The
+   * writer persists the document and bumps the epoch BEFORE spending its
+   * publication budget (see writeOverridesLocked), so a serve that derived
+   * its enabled set before that write observes the moved epoch here and
+   * fails closed instead of launching a server whose revocation is already
+   * durable — its repository-configured command must not execute after the
+   * revocation. The bracket's postflight alone would only close the server
+   * after it had started. The next serve's preflight re-derives from disk.
+   */
+  private async assertOverridesEpochUnmovedBeforeStart(): Promise<void> {
+    const readOverridesEpoch = this.pluginInvalidation?.readOverridesEpoch;
+    if (readOverridesEpoch === undefined || !this.pluginInvalidationTokenSeen) {
+      return;
+    }
+    const epochNow = await readOverridesEpoch();
+    if (
+      epochNow !== this.lastOverridesEpochToken ||
+      isWorkspaceOverridesEpochUnreadable(epochNow)
+    ) {
+      throw new Error(
+        "Workspace MCP settings changed in another process (or their change marker is unreadable) while MCP servers were about to start; retry"
+      );
+    }
   }
 
   private async startServers(
@@ -3688,6 +5095,133 @@ export class MCPServerManager {
   }
 
   /**
+   * Fence a stdio process launch against the override WRITER (the read-only
+   * check in assertOverridesEpochUnmovedBeforeStart still leaves the gap
+   * between its read and the spawn): hold the writer's lock from a final
+   * epoch read through the exec that spawns the repository-configured
+   * command. A sibling's revocation therefore either committed (and bumped
+   * the epoch) before the read — observed here, the launch refused — or
+   * waits until the process exists, after which the bracket's postflight
+   * closes it. The lock is released as soon as exec returned; the MCP
+   * handshake never runs under it. Without cross-process tracking there is
+   * nothing to fence: plain launch.
+   */
+  private async launchUnderOverrideFence<T>(
+    /** `launchSignal` aborts with the startup signal AND at an `abortAfterMs` deadline. */
+    launch: (launchSignal: AbortSignal) => Promise<T>,
+    signal: AbortSignal,
+    options?: {
+      /**
+       * Release the lock once `launch` has settled OR this many ms have
+       * passed, whichever comes first. Remote (HTTP/SSE) connections: the
+       * launch IS the handshake (bounded only by the startup deadline) and
+       * cannot hold every settings writer for that long, while its first
+       * request — the traffic the fence exists for — leaves within the first
+       * moments.
+       */
+      releaseAfterMs?: number;
+      /**
+       * stdio: ABORT the launch (via `launchSignal`) when it has not handed
+       * back its exec stream within this many ms, and fail the start as a
+       * timeout (`serverName` names it). Releasing instead would let an SSH
+       * exec still awaiting its connection send the command AFTER a sibling's
+       * revocation committed — the postflight can close a process, not undo
+       * its execution. The SSH2 transport re-checks the signal right before
+       * `client.exec`, so an aborted launch never reaches the remote shell.
+       */
+      abortAfterMs?: { ms: number; serverName: string };
+    }
+  ): Promise<T> {
+    const acquireOverridesLock = this.pluginInvalidation?.acquireOverridesLock;
+    const readOverridesEpoch = this.pluginInvalidation?.readOverridesEpoch;
+    if (
+      acquireOverridesLock === undefined ||
+      readOverridesEpoch === undefined ||
+      !this.pluginInvalidationTokenSeen
+    ) {
+      return launch(signal);
+    }
+    // ONE deadline for acquisition and the fenced read (see getPrompt).
+    const fenceDeadlineAt = Date.now() + CALL_GATE_TIMEOUT_MS;
+    const release = await acquireOverridesLock({
+      timeoutMs: Math.max(0, fenceDeadlineAt - Date.now()),
+      signal,
+    });
+    let released = false;
+    const releaseOnce = async () => {
+      if (!released) {
+        released = true;
+        await release();
+      }
+    };
+    let pending: Promise<T> | undefined;
+    try {
+      const epochRead = await raceWithAbortAndTimeout(readOverridesEpoch(), {
+        timeoutMs: Math.max(0, fenceDeadlineAt - Date.now()),
+        signal,
+      });
+      if (epochRead.kind !== "ok") {
+        throw new Error(
+          epochRead.kind === "aborted"
+            ? "MCP server startup was aborted"
+            : "MCP server startup could not read the workspace MCP settings marker in time; retry"
+        );
+      }
+      if (
+        epochRead.value !== this.lastOverridesEpochToken ||
+        isWorkspaceOverridesEpochUnreadable(epochRead.value)
+      ) {
+        throw new Error(
+          "Workspace MCP settings changed in another process (or their change marker is unreadable) while MCP servers were about to start; retry"
+        );
+      }
+      if (options?.abortAfterMs !== undefined) {
+        const { ms, serverName } = options.abortAfterMs;
+        const launchAbort = new AbortController();
+        const forwardAbort = () => launchAbort.abort();
+        signal.addEventListener("abort", forwardAbort, { once: true });
+        if (signal.aborted) forwardAbort();
+        pending = launch(launchAbort.signal);
+        try {
+          const settled = await raceWithAbortAndTimeout(
+            pending.then(
+              () => undefined,
+              () => undefined
+            ),
+            { timeoutMs: ms }
+          );
+          if (settled.kind === "timeout") {
+            launchAbort.abort();
+            // The aborted launch's own rejection is superseded by the timeout.
+            pending.catch(() => undefined);
+            throw new MCPStartupTimeoutError(serverName, ms);
+          }
+        } finally {
+          signal.removeEventListener("abort", forwardAbort);
+        }
+        return await pending;
+      }
+      pending = launch(signal);
+      if (options?.releaseAfterMs === undefined) {
+        return await pending;
+      }
+      await raceWithAbortAndTimeout(
+        pending.then(
+          () => undefined,
+          () => undefined
+        ),
+        { timeoutMs: options.releaseAfterMs }
+      );
+    } finally {
+      // Released here — BEFORE the remaining wait on a still-pending remote
+      // handshake below: every settings save and prune would otherwise queue
+      // behind an endpoint-controlled request for the whole startup deadline.
+      await releaseOnce();
+    }
+    return await pending;
+  }
+
+  /**
    * Spawn and connect a stdio MCP server (one attempt; negotiation retries
    * live in startSingleServerImpl). Returns null when aborted.
    */
@@ -3704,12 +5238,22 @@ export class MCPServerManager {
     {
       log.debug("[MCP] Spawning stdio server", { name });
       const launch = await prepareStdioLaunch(info);
-      const execStream = await runtime.exec(launch.command, {
-        cwd: launch.cwd ?? workspacePath,
-        ...(launch.env !== undefined ? { env: launch.env } : {}),
-        timeout: 60 * 60 * 24, // 24 hours — process lifetime, not startup
-        abortSignal: signal,
-      });
+      const execStream = await this.launchUnderOverrideFence(
+        (launchSignal) =>
+          runtime.exec(launch.command, {
+            cwd: launch.cwd ?? workspacePath,
+            ...(launch.env !== undefined ? { env: launch.env } : {}),
+            timeout: 60 * 60 * 24, // 24 hours — process lifetime, not startup
+            abortSignal: launchSignal,
+          }),
+        signal,
+        // A host-local exec resolves once the process exists; an SSH exec
+        // can stall on connection acquisition. The writer's lock must not be
+        // held for the whole startup deadline, and the launch must not be
+        // released to send its command after a revocation: abort it instead
+        // (see launchUnderOverrideFence).
+        { abortAfterMs: { ms: STDIO_LAUNCH_FENCE_MS, serverName: name } }
+      );
 
       const cleanupSpawnedExecStream = async () => {
         try {
@@ -3974,25 +5518,39 @@ export class MCPServerManager {
     const verdictKey = JSON.stringify(["remote", name, info.transport, info.url, headers ?? null]);
     let prior = design ? { kind: "legacy" as const } : this.getCachedEraVerdict(verdictKey);
 
-    const tryHttp = async () =>
-      createMCPClient({
-        transport: {
-          type: "http",
-          ...transportBase,
-        },
-        onUncaughtError,
-        ...(prior !== undefined ? { prior } : {}),
-      });
+    // Connection initiation is fenced like a stdio spawn (see
+    // launchUnderOverrideFence): the authenticated handshake must not start
+    // after a sibling's revocation is durable — the postflight can close the
+    // client but cannot undo traffic or credentials already sent.
+    const tryHttp = () =>
+      this.launchUnderOverrideFence(
+        () =>
+          createMCPClient({
+            transport: {
+              type: "http",
+              ...transportBase,
+            },
+            onUncaughtError,
+            ...(prior !== undefined ? { prior } : {}),
+          }),
+        signal,
+        { releaseAfterMs: LAUNCH_INITIATION_FENCE_MS }
+      );
 
-    const trySse = async () =>
-      createMCPClient({
-        transport: {
-          type: "sse",
-          ...transportBase,
-        },
-        onUncaughtError,
-        ...(prior !== undefined ? { prior } : {}),
-      });
+    const trySse = () =>
+      this.launchUnderOverrideFence(
+        () =>
+          createMCPClient({
+            transport: {
+              type: "sse",
+              ...transportBase,
+            },
+            onUncaughtError,
+            ...(prior !== undefined ? { prior } : {}),
+          }),
+        signal,
+        { releaseAfterMs: LAUNCH_INITIATION_FENCE_MS }
+      );
 
     let client: Awaited<ReturnType<typeof createMCPClient>> | null = null;
     let resolvedTransport: ResolvedTransport = "http";

--- a/src/node/services/turnRequestBuilder.ts
+++ b/src/node/services/turnRequestBuilder.ts
@@ -101,7 +101,7 @@ import {
   resolveCoderWireCanonicalModel,
 } from "@/common/constants/coderOAuth";
 import { PROVIDER_DEFINITIONS, type ProviderName } from "@/common/constants/providers";
-import type { WorkspaceMCPOverrides } from "@/common/types/mcp";
+import type { MCPServerMap, WorkspaceMCPOverrides } from "@/common/types/mcp";
 import { isExecLikeEditingCapableInResolvedChain } from "@/common/utils/agentTools";
 import { resolveModelParameterOverrides } from "@/common/utils/ai/modelParameterOverrides";
 import {
@@ -117,12 +117,19 @@ import {
   customProviderWireOrigin,
   isCustomProviderConfig,
 } from "@/common/utils/providers/customProviders";
-import type { MCPServerManager, MCPWorkspaceStats } from "@/node/services/mcpServerManager";
+import {
+  workspaceOverridesEqual,
+  type MCPServerManager,
+  type MCPWorkspaceStats,
+} from "@/node/services/mcpServerManager";
 import { type MemoryService, type MemorySessionContext } from "@/node/services/memoryService";
 import type { TaskService } from "@/node/services/taskService";
 import { resolveMemoryAccessPolicy } from "@/node/services/tools/memory";
 import { isWorkspaceTrustedForSharedExecution } from "@/node/services/utils/workspaceTrust";
-import type { WorkspaceMcpOverridesService } from "./workspaceMcpOverridesService";
+import {
+  MCP_OVERRIDES_READ_TIMEOUT_MS,
+  type WorkspaceMcpOverridesService,
+} from "./workspaceMcpOverridesService";
 
 import { MULTI_PROJECT_CONFIG_KEY } from "@/common/constants/multiProject";
 import {
@@ -204,6 +211,18 @@ import {
 } from "./toolAssembly";
 
 const STREAM_STARTUP_DIAGNOSTIC_THRESHOLD_MS = 1_000;
+
+/** Structural equality of two server inventories (plain JSON-shaped config records). */
+function mcpServerMapsEqual(a: MCPServerMap | undefined, b: MCPServerMap | undefined): boolean {
+  if (a === b) return true;
+  if (a === undefined || b === undefined) return false;
+  const aKeys = Object.keys(a).sort();
+  const bKeys = Object.keys(b).sort();
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every(
+    (key, index) => key === bKeys[index] && JSON.stringify(a[key]) === JSON.stringify(b[key])
+  );
+}
 
 export function resolveMuxProjectRootForHostFs(
   metadata: WorkspaceMetadata,
@@ -1489,17 +1508,41 @@ export class TurnRequestBuilder {
     // Fetch workspace MCP overrides (for filtering servers and tools)
     // NOTE: Stored in <workspace>/.xum/mcp.local.jsonc (not ~/.xum/config.json).
     let mcpOverrides: WorkspaceMCPOverrides | undefined;
+    // Not authoritative (indeterminate probe, unreadable document, failed
+    // inheritance, read error): the manager re-reads disk and fails the MCP
+    // serve closed if it cannot vouch for the enablement either — "no
+    // overrides" would re-enable a globally enabled server that only the
+    // unreadable document disables.
+    let mcpOverridesAuthoritative = false;
     const loadWorkspaceMcpOverridesStartedAt = Date.now();
     try {
-      mcpOverrides = (
-        await this.dependencies.workspaceMcpOverridesService.getOverridesForWorkspace(workspaceId)
-      ).overrides;
+      // Bounded and cancellable: an inheriting child's resolution probes and
+      // reads every ancestor's document on that ancestor's runtime (SSH/Docker
+      // allow minutes per operation); a send must neither hang on it nor
+      // outlive its own interruption. A timeout yields a non-authoritative
+      // read (see above), never authoritative empty overrides.
+      const read = await this.dependencies.workspaceMcpOverridesService.getOverridesForWorkspace(
+        workspaceId,
+        { timeoutMs: MCP_OVERRIDES_READ_TIMEOUT_MS, signal: combinedAbortSignal }
+      );
+      mcpOverrides = read.overrides;
+      mcpOverridesAuthoritative = read.authoritative;
     } catch (error) {
       log.warn("[MCP] Failed to load workspace MCP overrides; continuing without overrides", {
         workspaceId,
         error,
       });
       mcpOverrides = undefined;
+    }
+    if (combinedAbortSignal.aborted) {
+      // Interrupted during the (possibly long) resolution: end the send here
+      // instead of assembling a request nobody waits for.
+      return {
+        type: "finished",
+        result: Ok(
+          this.dependencies.createAbortedTurnHandle(syntheticMessageId, combinedAbortSignal)
+        ),
+      };
     }
     recordStartupPhaseTiming("loadWorkspaceMcpOverridesMs", loadWorkspaceMcpOverridesStartedAt);
 
@@ -1524,14 +1567,21 @@ export class TurnRequestBuilder {
     }
 
     const listMcpServersStartedAt = Date.now();
-    const mcpServers = this.dependencies.bindings.mcpServerManager
-      ? await this.dependencies.bindings.mcpServerManager.listServers(
-          metadata.projectPath,
-          mcpOverrides,
-          projectTrusted,
-          agentPluginsMcpContext
-        )
-      : undefined;
+    // The system prompt's MCP inventory. When the override read was not
+    // authoritative, a listing built from the fallback overrides could
+    // advertise servers the manager's serve excludes (it re-reads disk and
+    // fails closed when it cannot vouch) or omit servers disk enables. In that
+    // case the inventory is rebuilt below from the overrides the validated
+    // serve actually used, or omitted entirely when the serve failed closed.
+    let mcpServers =
+      this.dependencies.bindings.mcpServerManager && mcpOverridesAuthoritative
+        ? await this.dependencies.bindings.mcpServerManager.listServers(
+            metadata.projectPath,
+            mcpOverrides,
+            projectTrusted,
+            agentPluginsMcpContext
+          )
+        : undefined;
     recordStartupPhaseTiming("listMcpServersMs", listMcpServersStartedAt);
 
     const loadAdditionalSystemContextStartedAt = Date.now();
@@ -1683,6 +1733,9 @@ export class TurnRequestBuilder {
       memoryToolAvailable: memoryToolEligible,
       intuitionToolAvailable: intuitionToolEligible,
     });
+    // The MCP inventory the pre-policy context was built with; a later
+    // rebuild from the validated serve makes that context stale.
+    const mcpServersAtPrePolicy = mcpServers;
     recordStartupPhaseTiming("buildStreamSystemContextMs", buildStreamSystemContextStartedAt);
     const { agentSystemPromptSections, agentDefinitions, availableSkills, ancestorPlanFilePaths } =
       prePolicyStreamSystemContext;
@@ -1707,20 +1760,65 @@ export class TurnRequestBuilder {
       const mcpServerManager = this.dependencies.bindings.mcpServerManager;
       const mcpToolSetupStartedAt = Date.now();
       try {
-        const result = await mcpServerManager.getToolsForWorkspace({
-          workspaceId,
-          projectPath: metadata.projectPath,
-          runtime,
-          workspacePath,
-          trusted: projectTrusted,
-          overrides: mcpOverrides,
-          projectSecrets: await secretsToRecord(projectSecrets),
-          agentPlugins: agentPluginsMcpContext,
-        });
+        const result = await mcpServerManager.getToolsForWorkspace(
+          {
+            workspaceId,
+            projectPath: metadata.projectPath,
+            runtime,
+            workspacePath,
+            trusted: projectTrusted,
+            overrides: mcpOverrides,
+            overridesAuthoritative: mcpOverridesAuthoritative,
+            // A non-authoritative read that exhausted its budget (unreachable
+            // remote ancestor) must not be followed by a second full-length
+            // attempt inside the manager: it gets the remainder only.
+            ...(mcpOverridesAuthoritative
+              ? {}
+              : {
+                  overridesReadDeadlineAt:
+                    loadWorkspaceMcpOverridesStartedAt + MCP_OVERRIDES_READ_TIMEOUT_MS,
+                }),
+            projectSecrets: await secretsToRecord(projectSecrets),
+            agentPlugins: agentPluginsMcpContext,
+          },
+          // The manager's own authority re-read (cold/distrusted serve) is
+          // bounded like the read above and ends with this send's interruption.
+          { signal: combinedAbortSignal }
+        );
 
         mcpTools = result.tools;
         mcpToolServerNames = result.toolServerNames;
         mcpStats = result.stats;
+        if (result.overridesUsed === undefined) {
+          // The serve failed closed (overrides invalidated mid-serve, or the
+          // manager could not vouch for them): no tools, no prompts — the
+          // prompt must not advertise servers the serve deliberately withheld.
+          mcpServers = undefined;
+        } else if (result.serversUsed !== undefined) {
+          // The prompt inventory must match the served tools, and every input
+          // to that inventory — not only the override snapshot but project
+          // trust and the global/project MCP config — can change between the
+          // pre-serve listing above and the validated serve. Take the
+          // inventory the serve derived its enablement from; keep the
+          // pre-serve object when it is structurally identical so the
+          // system context is not rebuilt for nothing.
+          if (!mcpServerMapsEqual(mcpServers, result.serversUsed)) {
+            mcpServers = result.serversUsed;
+          }
+        } else if (
+          !mcpOverridesAuthoritative ||
+          !workspaceOverridesEqual(result.overridesUsed, mcpOverrides)
+        ) {
+          // Manager without a validated inventory (test doubles): list from
+          // the overrides the validated serve used, so at least the override
+          // snapshot matches the served tools.
+          mcpServers = await mcpServerManager.listServers(
+            metadata.projectPath,
+            result.overridesUsed,
+            projectTrusted,
+            agentPluginsMcpContext
+          );
+        }
         // Omit the tool when no prompts exist to avoid adding unused schema context.
         if (result.promptDescriptors.length > 0) {
           mcpPromptRuntime = {
@@ -1730,6 +1828,10 @@ export class TurnRequestBuilder {
           };
         }
       } catch (error) {
+        // No tools were served (e.g. runWithStablePluginEpoch gave up on an
+        // unreadable epoch): the prompt must not advertise the pre-serve
+        // inventory either.
+        mcpServers = undefined;
         workspaceLog.error("Failed to start MCP servers", { error });
       } finally {
         mcpSetupDurationMs = Date.now() - mcpToolSetupStartedAt;
@@ -2426,6 +2528,7 @@ export class TurnRequestBuilder {
         );
         const canReuseSystemContext =
           options.reusePrePolicySystemContext &&
+          mcpServers === mcpServersAtPrePolicy &&
           advisorToolAvailable === advisorToolEligible &&
           memoryToolAvailable === memoryToolEligible &&
           intuitionToolAvailable === intuitionToolEligible &&

--- a/src/node/services/workspaceMcpOverridesService.test.ts
+++ b/src/node/services/workspaceMcpOverridesService.test.ts
@@ -1,12 +1,18 @@
 import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import * as fs from "fs/promises";
-import { parse as jsoncParse } from "jsonc-parser";
+import * as fsPromisesModule from "node:fs/promises";
+import { parse as jsoncParse, type ParseError as JsoncParseError } from "jsonc-parser";
 import * as os from "os";
 import * as path from "path";
 import { Config } from "@/node/config";
 import { createRuntime } from "@/node/runtime/runtimeFactory";
 import { execBuffered } from "@/node/utils/runtime/helpers";
 import {
+  isPositivelyAbsent,
+  MCP_OVERRIDES_REVISION_UNAVAILABLE,
+  readHostOverrideDocumentNoFollow,
+  readWorkspaceOverridesEpochToken,
+  runtimeFilesystemIdentity,
   WorkspaceMcpOverridesConflictError,
   WorkspaceMcpOverridesService,
 } from "./workspaceMcpOverridesService";
@@ -69,6 +75,27 @@ describe("WorkspaceMcpOverridesService", () => {
     return { workspaceId, workspacePath };
   }
 
+  /** Project-dir (`local` runtime) workspace: its checkout IS the project path. */
+  async function registerLocalWorkspace(
+    projectPath: string,
+    workspaceId: string,
+    parentWorkspaceId?: string
+  ): Promise<void> {
+    await fs.mkdir(projectPath, { recursive: true });
+    await config.editConfig((cfg) => {
+      const project = cfg.projects.get(projectPath) ?? { workspaces: [] };
+      project.workspaces.push({
+        path: projectPath,
+        id: workspaceId,
+        name: workspaceId,
+        runtimeConfig: { type: "local" },
+        ...(parentWorkspaceId ? { parentWorkspaceId } : {}),
+      });
+      cfg.projects.set(projectPath, project);
+      return cfg;
+    });
+  }
+
   it("returns empty overrides when no file and no legacy config", async () => {
     const projectPath = "/fake/project";
     const workspaceId = "ws-id";
@@ -117,6 +144,2746 @@ describe("WorkspaceMcpOverridesService", () => {
         disabledServers: [`legacy-${index}`],
       });
     }
+  });
+
+  describe("sub-agent inheritance", () => {
+    async function registerChild(
+      parentWorkspaceId: string,
+      workspaceName: string
+    ): Promise<{ workspaceId: string; workspacePath: string }> {
+      const { workspaceId, workspacePath } = await registerWorkspace(workspaceName);
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const workspace = project.workspaces.find((w) => w.id === workspaceId);
+          if (workspace) workspace.parentWorkspaceId = parentWorkspaceId;
+        }
+        return cfg;
+      });
+      return { workspaceId, workspacePath };
+    }
+
+    it("child without its own file inherits the parent chain's overrides", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const parent = await registerWorkspace("inherit-parent");
+      const child = await registerChild(parent.workspaceId, "inherit-child");
+      const grandchild = await registerChild(child.workspaceId, "inherit-grandchild");
+
+      // No overrides anywhere yet: nothing to inherit.
+      expect((await service.getOverridesForWorkspace(child.workspaceId)).overrides).toEqual({});
+
+      await service.setOverridesForWorkspace(parent.workspaceId, {
+        enabledServers: ["globally-disabled"],
+      });
+
+      const inherited = await service.getOverridesForWorkspace(grandchild.workspaceId);
+      expect(inherited.overrides).toEqual({ enabledServers: ["globally-disabled"] });
+      // Read-through, not a copy: the child checkout stays untouched.
+      expect(await pathExists(path.join(child.workspacePath, ".xum", "mcp.local.jsonc"))).toBe(
+        false
+      );
+
+      // Parent edits reach children on the next read.
+      await service.setOverridesForWorkspace(parent.workspaceId, {
+        disabledServers: ["noisy"],
+      });
+      expect((await service.getOverridesForWorkspace(grandchild.workspaceId)).overrides).toEqual({
+        disabledServers: ["noisy"],
+      });
+    });
+
+    it("child's own overrides win over the parent's, and saving them uses the inherited revision", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const parent = await registerWorkspace("own-parent");
+      const child = await registerChild(parent.workspaceId, "own-child");
+      await service.setOverridesForWorkspace(parent.workspaceId, {
+        enabledServers: ["from-parent"],
+      });
+
+      // The dialog snapshot a child user sees is the inherited state; a CAS
+      // save against that revision must succeed.
+      const { revision } = await service.getOverridesForWorkspace(child.workspaceId);
+      await service.setOverridesForWorkspace(
+        child.workspaceId,
+        { disabledServers: ["from-parent"] },
+        { expectedRevision: revision }
+      );
+      expect((await service.getOverridesForWorkspace(child.workspaceId)).overrides).toEqual({
+        disabledServers: ["from-parent"],
+      });
+      expect((await service.getOverridesForWorkspace(parent.workspaceId)).overrides).toEqual({
+        enabledServers: ["from-parent"],
+      });
+
+      // Clearing the child's overrides removes its file and resumes inheriting.
+      await service.setOverridesForWorkspace(child.workspaceId, {});
+      expect((await service.getOverridesForWorkspace(child.workspaceId)).overrides).toEqual({
+        enabledServers: ["from-parent"],
+      });
+    });
+
+    it("legacy config data that normalizes to nothing does not detach a child from its parent", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const parent = await registerWorkspace("legacy-empty-parent");
+      const child = await registerChild(parent.workspaceId, "legacy-empty-child");
+      await service.setOverridesForWorkspace(parent.workspaceId, { enabledServers: ["shots"] });
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === child.workspaceId);
+          if (entry) entry.mcp = { enabledServers: [" "] };
+        }
+        return cfg;
+      });
+
+      expect((await service.getOverridesForWorkspace(child.workspaceId)).overrides).toEqual({
+        enabledServers: ["shots"],
+      });
+      // The noise is cleared instead of shadowing the parent forever.
+      const stored = [...config.loadConfigOrDefault().projects.values()]
+        .flatMap((project) => project.workspaces)
+        .find((w) => w.id === child.workspaceId);
+      expect(stored?.mcp).toBeUndefined();
+    });
+
+    it("inherited resolution never clears an intermediate workspace's empty legacy value", async () => {
+      // Clearing legacy noise is a config MUTATION: only the workspace's own
+      // (depth 0) resolution may perform it. A grandchild reading through the
+      // child must resolve as if the noise were absent yet leave it in place.
+      const service = new WorkspaceMcpOverridesService(config);
+      const parent = await registerWorkspace("legacy-empty-grandparent");
+      const child = await registerChild(parent.workspaceId, "legacy-empty-middle");
+      const grandchild = await registerChild(child.workspaceId, "legacy-empty-grandchild");
+      await service.setOverridesForWorkspace(parent.workspaceId, { enabledServers: ["shots"] });
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === child.workspaceId);
+          if (entry) entry.mcp = { enabledServers: [" "] };
+        }
+        return cfg;
+      });
+
+      expect((await service.getOverridesForWorkspace(grandchild.workspaceId)).overrides).toEqual({
+        enabledServers: ["shots"],
+      });
+      const stored = [...config.loadConfigOrDefault().projects.values()]
+        .flatMap((project) => project.workspaces)
+        .find((w) => w.id === child.workspaceId);
+      expect(stored?.mcp).toEqual({ enabledServers: [" "] });
+    });
+
+    it("read-path legacy clears are compare-and-delete: a value saved meanwhile survives", async () => {
+      // An older/downgraded Xum process can save a new `workspace.mcp` value
+      // between a read observing empty legacy noise and its clear; the clear
+      // must only remove the value it observed.
+      const service = new WorkspaceMcpOverridesService(config);
+      const parent = await registerWorkspace("legacy-cas-parent");
+      const child = await registerChild(parent.workspaceId, "legacy-cas-child");
+      const setLegacy = (value: unknown) =>
+        config.editConfig((cfg) => {
+          for (const project of cfg.projects.values()) {
+            const entry = project.workspaces.find((w) => w.id === child.workspaceId);
+            if (entry) entry.mcp = value as never;
+          }
+          return cfg;
+        });
+      const storedLegacy = () =>
+        [...config.loadConfigOrDefault().projects.values()]
+          .flatMap((project) => project.workspaces)
+          .find((w) => w.id === child.workspaceId)?.mcp;
+      const internals = service as unknown as {
+        clearLegacyOverridesInConfig: (
+          workspaceId: string,
+          options?: { onlyIfEquals?: unknown }
+        ) => Promise<void>;
+      };
+      const newer = { disabledServers: ["shots"] };
+      await setLegacy(newer);
+      // Observed noise, but the stored value changed since: left alone.
+      await internals.clearLegacyOverridesInConfig(child.workspaceId, {
+        onlyIfEquals: { enabledServers: [" "] },
+      });
+      expect(storedLegacy()).toEqual(newer);
+      // Matching observation: cleared.
+      await internals.clearLegacyOverridesInConfig(child.workspaceId, { onlyIfEquals: newer });
+      expect(storedLegacy()).toBeUndefined();
+    });
+
+    it("a read-path legacy migration takes the write locks and never overwrites a save made meanwhile", async () => {
+      // A per-request read (send path, call-time gate) observes an unmigrated
+      // legacy enable and pauses; a settings save persists a disable under
+      // the locks; the read must not then write the stale enable over it —
+      // the epoch retry would trust the restored file and a revoked server
+      // would serve again.
+      const service = new WorkspaceMcpOverridesService(config);
+      const { workspaceId, workspacePath } = await registerWorkspace("legacy-fenced");
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === workspaceId);
+          if (entry) entry.mcp = { enabledServers: ["shots"] };
+        }
+        return cfg;
+      });
+      const filePath = path.join(workspacePath, ".xum", "mcp.local.jsonc");
+
+      // A writer holds the lock while the read runs: the read observes the
+      // legacy value and queues behind the lock for its migration.
+      const release = await service.acquireExclusiveLock();
+      const read = service.getOverridesForWorkspace(workspaceId);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(await pathExists(filePath)).toBe(false);
+      // The writer persists a disable exactly like setOverridesForWorkspace:
+      // document written, legacy value cleared, epoch bumped.
+      const saved = JSON.stringify({ disabledServers: ["shots"] });
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(filePath, saved);
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === workspaceId);
+          if (entry) delete entry.mcp;
+        }
+        return cfg;
+      });
+      await fs.writeFile(path.join(config.rootDir, "mcp-overrides.epoch"), "sibling-save");
+      await release();
+
+      // The paused read honors what it observed read-only, but writes nothing.
+      expect((await read).overrides).toEqual({ enabledServers: ["shots"] });
+      expect(await fs.readFile(filePath, "utf-8")).toBe(saved);
+      expect((await service.getOverridesForWorkspace(workspaceId)).overrides).toEqual({
+        disabledServers: ["shots"],
+      });
+    });
+
+    it("a read-path legacy migration skips a workspace renamed while it waited for the locks", async () => {
+      // The locks are derived from the current registry, the migration target
+      // from the pre-lock resolution: a rename in between must not recreate
+      // the OLD checkout path and clear the only legacy copy.
+      const service = new WorkspaceMcpOverridesService(config);
+      const { workspaceId, workspacePath } = await registerWorkspace("legacy-renamed");
+      const legacyValue = { enabledServers: ["shots"] };
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === workspaceId);
+          if (entry) entry.mcp = legacyValue;
+        }
+        return cfg;
+      });
+      const movedPath = path.join(path.dirname(workspacePath), "renamed");
+
+      const release = await service.acquireExclusiveLock();
+      const read = service.getOverridesForWorkspace(workspaceId);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      // Rename lands while the read waits: checkout moved, registry updated.
+      await fs.rename(workspacePath, movedPath);
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === workspaceId);
+          if (entry) {
+            entry.path = movedPath;
+            entry.name = "renamed";
+          }
+        }
+        return cfg;
+      });
+      await release();
+
+      expect((await read).overrides).toEqual(legacyValue);
+      expect(await pathExists(workspacePath)).toBe(false);
+      const storedLegacy = [...config.loadConfigOrDefault().projects.values()]
+        .flatMap((project) => project.workspaces)
+        .find((w) => w.id === workspaceId)?.mcp;
+      expect(storedLegacy).toEqual(legacyValue);
+      // The next read (from the new path) migrates normally.
+      expect((await service.getOverridesForWorkspace(workspaceId)).overrides).toEqual(legacyValue);
+      expect(await pathExists(path.join(movedPath, ".xum", "mcp.local.jsonc"))).toBe(true);
+    });
+
+    it("an opaque legacy config value keeps the child detached and is preserved", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const parent = await registerWorkspace("legacy-opaque-parent");
+      const child = await registerChild(parent.workspaceId, "legacy-opaque-child");
+      await service.setOverridesForWorkspace(parent.workspaceId, { enabledServers: ["shots"] });
+      const opaque = { disabledServers: "shots" };
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === child.workspaceId);
+          if (entry) entry.mcp = opaque as never;
+        }
+        return cfg;
+      });
+
+      const resolved = await service.getOverridesForWorkspace(child.workspaceId);
+      expect(resolved.overrides).toEqual({});
+      expect(resolved.authoritative).toBe(true);
+      // Neither cleared nor migrated: a newer build may understand it.
+      const stored = [...config.loadConfigOrDefault().projects.values()]
+        .flatMap((project) => project.workspaces)
+        .find((w) => w.id === child.workspaceId);
+      expect(stored?.mcp as unknown).toEqual(opaque);
+      expect(await pathExists(path.join(child.workspacePath, ".xum", "mcp.local.jsonc"))).toBe(
+        false
+      );
+      // Parent saves treat it as an owner.
+      const published: string[] = [];
+      await service.setOverridesForWorkspace(
+        parent.workspaceId,
+        { enabledServers: ["shots", "more"] },
+        {
+          publish: (_persisted, workspaceId) => {
+            published.push(workspaceId);
+            return Promise.resolve();
+          },
+        }
+      );
+      expect(published).toEqual([parent.workspaceId]);
+    });
+
+    it("an unreadable legacy config never lets a child inherit", async () => {
+      // The lenient loader degrades a read failure to an empty config, which
+      // would look like "no legacy value" and inherit the parent's enable over
+      // the child's (unreadable) explicit disable.
+      const service = new WorkspaceMcpOverridesService(config);
+      const parent = await registerWorkspace("legacy-unreadable-parent");
+      const child = await registerChild(parent.workspaceId, "legacy-unreadable-child");
+      await service.setOverridesForWorkspace(parent.workspaceId, { enabledServers: ["shots"] });
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === child.workspaceId);
+          if (entry) entry.mcp = { disabledServers: ["shots"] };
+        }
+        return cfg;
+      });
+      // Fail only the legacy-config read. Each resolution loads config twice
+      // through the snapshot — the workspace enumeration first, then the
+      // legacy lookup that decides between "own" and "inherit" — so failing
+      // every second authoritative load isolates the failure to the latter.
+      const realLoad = config.loadConfigOrDefault.bind(config);
+      let authoritativeLoads = 0;
+      spyOn(config, "loadConfigOrDefault").mockImplementation((options) => {
+        if (options?.throwOnError && ++authoritativeLoads % 2 === 0) {
+          throw new Error("EIO: config.json unreadable");
+        }
+        return realLoad(options);
+      });
+
+      const resolved = await service.getOverridesForWorkspace(child.workspaceId);
+      expect(resolved.overrides).toEqual({});
+      expect(resolved.authoritative).toBe(false);
+      // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+      await expect(
+        service.getOverridesForWorkspace(child.workspaceId, { mode: "strict" })
+      ).rejects.toThrow(/unreadable/);
+    });
+
+    it("the unavailable-revision repair never detaches a child whose PARENT is unreadable", async () => {
+      // The child's own state is intact; the `{}` its dialog showed stands in
+      // for a parent document that may hold enables, disables and allowlists.
+      // A repair save from it would write a child-owned document and drop
+      // them all once the parent recovers.
+      const service = new WorkspaceMcpOverridesService(config);
+      const parent = await registerWorkspace("unavailable-parent");
+      const child = await registerChild(parent.workspaceId, "unavailable-parent-child");
+      await service.setOverridesForWorkspace(parent.workspaceId, {
+        enabledServers: ["shots"],
+        toolAllowlist: { shots: ["capture"] },
+      });
+      const parentDocument = path.join(parent.workspacePath, ".xum", "mcp.local.jsonc");
+      const intact = await fs.readFile(parentDocument, "utf-8");
+      await fs.writeFile(parentDocument, "{ not json");
+      const shown = await service.getOverridesForWorkspace(child.workspaceId);
+      expect(shown.authoritative).toBe(false);
+      expect(shown.overrides).toEqual({});
+
+      // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+      await expect(
+        service.setOverridesForWorkspace(
+          child.workspaceId,
+          { disabledServers: ["other"] },
+          { expectedRevision: MCP_OVERRIDES_REVISION_UNAVAILABLE }
+        )
+      ).rejects.toThrow(/inherited parent/);
+      expect(await pathExists(path.join(child.workspacePath, ".xum", "mcp.local.jsonc"))).toBe(
+        false
+      );
+
+      // Parent recovers: the child still inherits everything.
+      await fs.writeFile(parentDocument, intact);
+      expect((await service.getOverridesForWorkspace(child.workspaceId)).overrides).toEqual({
+        enabledServers: ["shots"],
+        toolAllowlist: { shots: ["capture"] },
+      });
+    });
+
+    it("a child detaching from its parent carries the inherited document's unknown fields", async () => {
+      // The parent's document (written by a newer Xum) applied to the child
+      // through inheritance; the child's own document must keep those fields
+      // or the detach silently drops them for this child on the next upgrade.
+      const service = new WorkspaceMcpOverridesService(config);
+      const parent = await registerWorkspace("detach-opaque-parent");
+      const child = await registerChild(parent.workspaceId, "detach-opaque-child");
+      const parentDocument = path.join(parent.workspacePath, ".xum", "mcp.local.jsonc");
+      await fs.mkdir(path.dirname(parentDocument), { recursive: true });
+      await fs.writeFile(
+        parentDocument,
+        JSON.stringify({ enabledServers: ["shots"], futureField: { granted: true } })
+      );
+      await service.setOverridesForWorkspace(child.workspaceId, { disabledServers: ["shots"] });
+      const childDocument = path.join(child.workspacePath, ".xum", "mcp.local.jsonc");
+      expect(JSON.parse(await fs.readFile(childDocument, "utf-8"))).toEqual({
+        futureField: { granted: true },
+        disabledServers: ["shots"],
+      });
+      // The parent's document is untouched.
+      expect(JSON.parse(await fs.readFile(parentDocument, "utf-8"))).toEqual({
+        enabledServers: ["shots"],
+        futureField: { granted: true },
+      });
+
+      // A parent document this build cannot merge refuses the detach.
+      const other = await registerChild(parent.workspaceId, "detach-unmergeable-child");
+      await fs.writeFile(
+        parentDocument,
+        JSON.stringify({ enabledServers: { shots: "newer-shape" }, futureField: 1 })
+      );
+      // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+      await expect(
+        service.setOverridesForWorkspace(other.workspaceId, { disabledServers: ["shots"] })
+      ).rejects.toThrow(/newer version of Xum/);
+      expect(await pathExists(path.join(other.workspacePath, ".xum", "mcp.local.jsonc"))).toBe(
+        false
+      );
+    });
+
+    it("a save refuses to retire a legacy value mixing known settings with unknown fields", async () => {
+      // Resolution treats the whole value as opaque (the unknown field may
+      // carry authorization semantics), so the UI showed `{}`: retiring the
+      // value on save would drop `enabledServers` the user never saw.
+      const service = new WorkspaceMcpOverridesService(config);
+      const { workspaceId, workspacePath } = await registerWorkspace("legacy-mixed");
+      const mixed: unknown = { enabledServers: ["shots"], futureRule: {} };
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === workspaceId);
+          if (entry) entry.mcp = mixed as never;
+        }
+        return cfg;
+      });
+      expect((await service.getOverridesForWorkspace(workspaceId)).overrides).toEqual({});
+      // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+      await expect(
+        service.setOverridesForWorkspace(workspaceId, { disabledServers: ["other"] })
+      ).rejects.toThrow(/newer version of Xum/);
+      expect(await pathExists(path.join(workspacePath, ".xum", "mcp.local.jsonc"))).toBe(false);
+      const kept = [...config.loadConfigOrDefault().projects.values()]
+        .flatMap((project) => project.workspaces)
+        .find((w) => w.id === workspaceId)?.mcp;
+      expect(kept).toEqual(mixed as never);
+    });
+
+    it("a directory at the child's override path never lets it inherit", async () => {
+      // A corrupt or repository-tracked `mcp.local.jsonc/` directory is not
+      // absence: nothing can be read from it, and falling through to the
+      // parent would expose parent-enabled servers on that evidence.
+      const service = new WorkspaceMcpOverridesService(config);
+      const parent = await registerWorkspace("dir-candidate-parent");
+      const child = await registerChild(parent.workspaceId, "dir-candidate-child");
+      await service.setOverridesForWorkspace(parent.workspaceId, { enabledServers: ["shots"] });
+      await fs.mkdir(path.join(child.workspacePath, ".xum", "mcp.local.jsonc"), {
+        recursive: true,
+      });
+      const resolved = await service.getOverridesForWorkspace(child.workspaceId);
+      expect(resolved.overrides).toEqual({});
+      expect(resolved.authoritative).toBe(false);
+      // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+      await expect(
+        service.getOverridesForWorkspace(child.workspaceId, { mode: "strict" })
+      ).rejects.toThrow(/is a directory/);
+    });
+
+    it("a null legacy value is an opaque value, not absence", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const parent = await registerWorkspace("legacy-null-parent");
+      const child = await registerChild(parent.workspaceId, "legacy-null-child");
+      await service.setOverridesForWorkspace(parent.workspaceId, { enabledServers: ["shots"] });
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === child.workspaceId);
+          if (entry) entry.mcp = null as never;
+        }
+        return cfg;
+      });
+      const resolved = await service.getOverridesForWorkspace(child.workspaceId);
+      expect(resolved.overrides).toEqual({});
+      expect(resolved.authoritative).toBe(true);
+      const stored = [...config.loadConfigOrDefault().projects.values()]
+        .flatMap((project) => project.workspaces)
+        .find((w) => w.id === child.workspaceId);
+      expect(stored?.mcp as unknown).toBeNull();
+    });
+
+    it("evicts the cache when resolution fails after the own file was deleted", async () => {
+      // removeOverridesFile already ran; if the post-delete resolution throws
+      // (e.g. depth assertion), memory must not stay pinned to the deleted
+      // document — publish an eviction, then surface the failure.
+      const service = new WorkspaceMcpOverridesService(config);
+      const parent = await registerWorkspace("evict-on-failure-parent");
+      const child = await registerChild(parent.workspaceId, "evict-on-failure-child");
+      await service.setOverridesForWorkspace(child.workspaceId, { enabledServers: ["shots"] });
+      const internals = service as unknown as {
+        resolveOverridesFor: (...args: unknown[]) => Promise<unknown>;
+      };
+      const realResolve = internals.resolveOverridesFor.bind(service);
+      let deleted = false;
+      spyOn(internals, "resolveOverridesFor").mockImplementation((...args: unknown[]) => {
+        if (deleted) return Promise.reject(new Error("inheritance exceeded 32 levels"));
+        return realResolve(...args);
+      });
+      const published: Array<[unknown, string]> = [];
+      const removal = service as unknown as {
+        removeOverridesFile: (...args: unknown[]) => Promise<void>;
+      };
+      const realRemove = removal.removeOverridesFile.bind(service);
+      spyOn(removal, "removeOverridesFile").mockImplementation((...args: unknown[]) => {
+        deleted = true;
+        return realRemove(...args);
+      });
+      // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+      await expect(
+        service.setOverridesForWorkspace(
+          child.workspaceId,
+          {},
+          {
+            publish: (persisted, workspaceId) => {
+              published.push([persisted, workspaceId]);
+              return Promise.resolve();
+            },
+          }
+        )
+      ).rejects.toThrow(/32 levels/);
+      expect(published).toEqual([[null, child.workspaceId]]);
+      expect(await pathExists(path.join(child.workspacePath, ".xum", "mcp.local.jsonc"))).toBe(
+        false
+      );
+    });
+
+    it("evicts off-host descendants without probing them under the write lock", async () => {
+      // A remote inheriting child would need `stat`s with a 10 s timeout per
+      // level while the lock is held; it is evicted (re-reads on its own
+      // runtime at its next serve) instead — and so is its subtree.
+      const service = new WorkspaceMcpOverridesService(config);
+      const parent = await registerWorkspace("remote-fanout-parent");
+      const remoteChild = "ws-remote-fanout-child";
+      const grandchild = "ws-remote-fanout-grandchild";
+      await config.editConfig((cfg) => {
+        cfg.projects.set("/fake/remote-fanout", {
+          workspaces: [
+            {
+              path: "/remote/child",
+              id: remoteChild,
+              name: "child",
+              parentWorkspaceId: parent.workspaceId,
+              runtimeConfig: { type: "ssh", host: "unreachable.invalid", srcBaseDir: "/remote" },
+            },
+            {
+              path: "/remote/grandchild",
+              id: grandchild,
+              name: "grandchild",
+              parentWorkspaceId: remoteChild,
+              runtimeConfig: { type: "ssh", host: "unreachable.invalid", srcBaseDir: "/remote" },
+            },
+          ],
+        });
+        return cfg;
+      });
+      const published: Array<[unknown, string]> = [];
+      const startedAt = Date.now();
+      await service.setOverridesForWorkspace(
+        parent.workspaceId,
+        { enabledServers: ["shots"] },
+        {
+          publish: (persisted, workspaceId) => {
+            published.push([persisted, workspaceId]);
+            return Promise.resolve();
+          },
+        }
+      );
+      expect(published).toEqual([
+        [{ enabledServers: ["shots"] }, parent.workspaceId],
+        [null, remoteChild],
+        [null, grandchild],
+      ]);
+      // No remote I/O was attempted (an unreachable host would take seconds).
+      expect(Date.now() - startedAt).toBeLessThan(5_000);
+    });
+
+    it("a child file that normalizes to nothing (e.g. after a plugin prune) resumes inheritance", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const parent = await registerWorkspace("pruned-parent");
+      const child = await registerChild(parent.workspaceId, "pruned-child");
+      await service.setOverridesForWorkspace(parent.workspaceId, { disabledServers: ["shots"] });
+      await service.setOverridesForWorkspace(child.workspaceId, {
+        enabledServers: ["plugin:0123456789abcdef:echo"],
+      });
+      expect((await service.getOverridesForWorkspace(child.workspaceId)).overrides).toEqual({
+        enabledServers: ["plugin:0123456789abcdef:echo"],
+      });
+
+      // Uninstall prunes the child's only key; the (now semantically empty) file stays.
+      await service.prunePluginOverrideKeys(child.workspaceId, "plugin:0123456789abcdef:");
+      expect(await pathExists(path.join(child.workspacePath, ".xum", "mcp.local.jsonc"))).toBe(
+        true
+      );
+      expect((await service.getOverridesForWorkspace(child.workspaceId)).overrides).toEqual({
+        disabledServers: ["shots"],
+      });
+
+      // …and parent saves reach it again (not classified as an owner).
+      const published: string[] = [];
+      await service.setOverridesForWorkspace(
+        parent.workspaceId,
+        { disabledServers: ["shots", "more"] },
+        {
+          publish: (_persisted, workspaceId) => {
+            published.push(workspaceId);
+            return Promise.resolve();
+          },
+        }
+      );
+      expect(published).toEqual([parent.workspaceId, child.workspaceId]);
+    });
+
+    it("a child document with a shape this build cannot read stops resolution at the child", async () => {
+      // Valid JSONC that normalizes to nothing here but is NOT known-empty:
+      // a newer release may have written it. The child keeps "no overrides"
+      // (pre-inheritance behaviour) instead of inheriting a parent enable,
+      // and parent saves treat it as an owner.
+      const service = new WorkspaceMcpOverridesService(config);
+      const parent = await registerWorkspace("opaque-parent");
+      await service.setOverridesForWorkspace(parent.workspaceId, { enabledServers: ["shots"] });
+      for (const [index, document] of [
+        '{ "disabledServers": "shots" }',
+        "[]",
+        "null",
+        '{ "toolAllowlist": { "shots": "take" } }',
+      ].entries()) {
+        const child = await registerChild(parent.workspaceId, `opaque-child-${index}`);
+        await fs.mkdir(path.join(child.workspacePath, ".xum"), { recursive: true });
+        await fs.writeFile(path.join(child.workspacePath, ".xum", "mcp.local.jsonc"), document);
+        const resolved = await service.getOverridesForWorkspace(child.workspaceId);
+        expect(resolved.overrides).toEqual({});
+        expect(resolved.authoritative).toBe(true);
+      }
+      const published: string[] = [];
+      await service.setOverridesForWorkspace(
+        parent.workspaceId,
+        { enabledServers: ["shots", "more"] },
+        {
+          publish: (_persisted, workspaceId) => {
+            published.push(workspaceId);
+            return Promise.resolve();
+          },
+        }
+      );
+      expect(published).toEqual([parent.workspaceId]);
+    });
+
+    it("a removed parent leaves nothing to inherit, even for strict prune re-reads", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const child = await registerChild("ws-removed-parent", "orphan-child");
+
+      expect((await service.getOverridesForWorkspace(child.workspaceId)).overrides).toEqual({});
+      // A strict re-read must not throw here: the plugin uninstaller would
+      // otherwise retry the orphan's prune tombstone forever.
+      expect(
+        (await service.getOverridesForWorkspace(child.workspaceId, { mode: "strict" })).overrides
+      ).toEqual({});
+    });
+
+    it("a stalled publisher callback is bounded and the target evicted instead of holding the lock", async () => {
+      // applyWorkspaceOverrides reads the project's MCP config through
+      // listServers; a disconnected project filesystem must not keep
+      // mcp-overrides.lock held indefinitely — the publication is bounded and
+      // the target's cache evicted (its next serve re-reads).
+      const service = new WorkspaceMcpOverridesService(config);
+      const parent = await registerWorkspace("pub-stalled-parent");
+      const child = await registerChild(parent.workspaceId, "pub-stalled-child");
+      const published: Array<[string, unknown]> = [];
+      const publish = (persisted: unknown, workspaceId: string) => {
+        published.push([workspaceId, persisted]);
+        return workspaceId === child.workspaceId && persisted !== null
+          ? new Promise<void>(() => undefined)
+          : Promise.resolve();
+      };
+      const startedAt = Date.now();
+      await service.setOverridesForWorkspace(
+        parent.workspaceId,
+        { enabledServers: ["shared"] },
+        { publish }
+      );
+      expect(Date.now() - startedAt).toBeLessThan(20_000);
+      expect(published).toEqual([
+        [parent.workspaceId, { enabledServers: ["shared"] }],
+        [child.workspaceId, { enabledServers: ["shared"] }],
+        [child.workspaceId, null],
+      ]);
+      // The lock is free again.
+      const release = await service.acquireExclusiveLock();
+      await release();
+    }, 30_000);
+
+    it("saves and prunes re-publish inheriting descendants with their effective state", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const parent = await registerWorkspace("pub-parent");
+      const inheriting = await registerChild(parent.workspaceId, "pub-inheriting");
+      const grandchild = await registerChild(inheriting.workspaceId, "pub-grandchild");
+      const owned = await registerChild(parent.workspaceId, "pub-owned");
+      const ownedChild = await registerChild(owned.workspaceId, "pub-owned-child");
+      await service.setOverridesForWorkspace(owned.workspaceId, { disabledServers: ["mine"] });
+
+      const published: Array<[string, unknown]> = [];
+      const publish = (persisted: unknown, workspaceId: string) => {
+        published.push([workspaceId, persisted]);
+        return Promise.resolve();
+      };
+      await service.setOverridesForWorkspace(
+        parent.workspaceId,
+        { enabledServers: ["plugin:0123456789abcdef:echo", "shared"] },
+        { publish }
+      );
+      // The written workspace first, then inheriting descendants (transitively).
+      // `owned` has its own file, so it and its subtree are left alone.
+      expect(published).toEqual([
+        [parent.workspaceId, { enabledServers: ["plugin:0123456789abcdef:echo", "shared"] }],
+        [inheriting.workspaceId, { enabledServers: ["plugin:0123456789abcdef:echo", "shared"] }],
+        [grandchild.workspaceId, { enabledServers: ["plugin:0123456789abcdef:echo", "shared"] }],
+      ]);
+      expect(published.map(([id]) => id)).not.toContain(owned.workspaceId);
+      expect(published.map(([id]) => id)).not.toContain(ownedChild.workspaceId);
+
+      published.length = 0;
+      await service.prunePluginOverrideKeys(parent.workspaceId, "plugin:0123456789abcdef:", {
+        publish,
+      });
+      expect(published).toEqual([
+        [parent.workspaceId, { enabledServers: ["shared"] }],
+        [inheriting.workspaceId, { enabledServers: ["shared"] }],
+        [grandchild.workspaceId, { enabledServers: ["shared"] }],
+      ]);
+
+      // Clearing a child's own overrides publishes the INHERITED state for it,
+      // not `{}`, so a cache mirroring publications resumes inheritance.
+      published.length = 0;
+      await service.setOverridesForWorkspace(owned.workspaceId, {}, { publish });
+      expect(published).toEqual([
+        [owned.workspaceId, { enabledServers: ["shared"] }],
+        [ownedChild.workspaceId, { enabledServers: ["shared"] }],
+      ]);
+    });
+
+    it("a child saving the shared file re-publishes the parent (isolation: none, upward)", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const projectPath = path.join(tempDir, "shared-upward");
+      await registerLocalWorkspace(projectPath, "up-parent");
+      await registerLocalWorkspace(projectPath, "up-child", "up-parent");
+      await registerLocalWorkspace(path.join(tempDir, "elsewhere"), "unrelated");
+
+      const published: string[] = [];
+      await service.setOverridesForWorkspace(
+        "up-child",
+        { disabledServers: ["shots"] },
+        {
+          publish: (_persisted, workspaceId) => {
+            published.push(workspaceId);
+            return Promise.resolve();
+          },
+        }
+      );
+      // The parent's cache would otherwise keep serving what the child just
+      // disabled; workspaces on other checkouts are untouched.
+      expect(published.sort()).toEqual(["up-child", "up-parent"]);
+    });
+
+    it("recognizes one host checkout registered under a symlinked spelling as a sharer", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const realDir = path.join(tempDir, "real-checkout");
+      const linkDir = path.join(tempDir, "linked-checkout");
+      await fs.mkdir(realDir, { recursive: true });
+      await fs.symlink(realDir, linkDir);
+      await registerLocalWorkspace(realDir, "via-real");
+      await registerLocalWorkspace(linkDir, "via-link");
+
+      const published: string[] = [];
+      await service.setOverridesForWorkspace(
+        "via-link",
+        { disabledServers: ["shots"] },
+        {
+          publish: (_persisted, workspaceId) => {
+            published.push(workspaceId);
+            return Promise.resolve();
+          },
+        }
+      );
+      // Same directory, different project-path spelling: both caches refresh.
+      expect(published.sort()).toEqual(["via-link", "via-real"]);
+    });
+
+    it("a shared save retires every sharer's legacy config value so a cold alias cannot restore a revoked enable", async () => {
+      // Two ids on one checkout (isolation:none task). The alias still carries
+      // a legacy config.json enable; clearing the shared document must not let
+      // the alias's next own resolution migrate that enable back into the
+      // file the user just emptied.
+      const service = new WorkspaceMcpOverridesService(config);
+      const dir = path.join(tempDir, "shared-legacy-checkout");
+      await registerLocalWorkspace(dir, "shared-owner");
+      await registerLocalWorkspace(dir, "shared-alias");
+      await service.setOverridesForWorkspace("shared-owner", { enabledServers: ["shots"] });
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === "shared-alias");
+          if (entry) entry.mcp = { enabledServers: ["shots"] };
+        }
+        return cfg;
+      });
+
+      const published: string[] = [];
+      await service.setOverridesForWorkspace(
+        "shared-owner",
+        {},
+        {
+          publish: (_persisted, workspaceId) => {
+            published.push(workspaceId);
+            return Promise.resolve();
+          },
+        }
+      );
+      expect(published).toContain("shared-alias");
+      const stored = [...config.loadConfigOrDefault().projects.values()]
+        .flatMap((project) => project.workspaces)
+        .find((w) => w.id === "shared-alias");
+      expect(stored?.mcp).toBeUndefined();
+      // The alias's own (cold, depth 0) resolution finds nothing to migrate.
+      expect((await service.getOverridesForWorkspace("shared-alias")).overrides).toEqual({});
+      expect(await pathExists(path.join(dir, ".xum", "mcp.local.jsonc"))).toBe(false);
+    });
+
+    it("a failed shared save leaves every sharer's legacy config value intact", async () => {
+      // The sharer retirement runs only after the replacement state is
+      // persisted: a write that fails must not have discarded an alias's
+      // settings while reporting that nothing was saved.
+      const service = new WorkspaceMcpOverridesService(config);
+      const dir = path.join(tempDir, "shared-legacy-failing-checkout");
+      await registerLocalWorkspace(dir, "failing-owner");
+      await registerLocalWorkspace(dir, "failing-alias");
+      const legacy = { enabledServers: ["shots"] };
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === "failing-alias");
+          if (entry) entry.mcp = legacy;
+        }
+        return cfg;
+      });
+      // `.xum` is a regular file: the overrides directory cannot be created.
+      await fs.writeFile(path.join(dir, ".xum"), "not a directory");
+
+      // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+      await expect(
+        service.setOverridesForWorkspace("failing-owner", { disabledServers: ["shots"] })
+      ).rejects.toThrow("Failed to create");
+      const stored = [...config.loadConfigOrDefault().projects.values()]
+        .flatMap((project) => project.workspaces)
+        .find((w) => w.id === "failing-alias");
+      expect(stored?.mcp).toEqual(legacy);
+    });
+
+    it("evicts a candidate sharer whose checkout cannot be canonicalized instead of assuming it differs", async () => {
+      // realpath failing (stalled mount, timeout) for one registration must
+      // not let its spelled path pass as proof that it is a different checkout:
+      // a tool already served there would otherwise keep running a server the
+      // shared file just disabled. Indeterminate → evict that candidate.
+      const service = new WorkspaceMcpOverridesService(config);
+      const realDir = path.join(tempDir, "real-checkout-indeterminate");
+      const linkDir = path.join(tempDir, "linked-checkout-indeterminate");
+      await fs.mkdir(realDir, { recursive: true });
+      await fs.symlink(realDir, linkDir);
+      await registerLocalWorkspace(realDir, "via-real-indeterminate");
+      await registerLocalWorkspace(linkDir, "via-link-indeterminate");
+      const realRealpath = fsPromisesModule.realpath;
+      const realpathSpy = spyOn(fsPromisesModule, "realpath").mockImplementation(((
+        target: string
+      ) =>
+        target.startsWith(realDir)
+          ? Promise.reject(new Error("EIO: stalled mount"))
+          : realRealpath(target)) as typeof fsPromisesModule.realpath);
+      try {
+        const published: Array<[string, unknown]> = [];
+        await service.setOverridesForWorkspace(
+          "via-link-indeterminate",
+          { disabledServers: ["shots"] },
+          {
+            publish: (persisted, workspaceId) => {
+              published.push([workspaceId, persisted]);
+              return Promise.resolve();
+            },
+          }
+        );
+        expect(published).toEqual([
+          ["via-link-indeterminate", { disabledServers: ["shots"] }],
+          ["via-real-indeterminate", null],
+        ]);
+      } finally {
+        realpathSpy.mockRestore();
+      }
+    });
+
+    it("re-publishes a child that shares the parent's override file (isolation: none)", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const projectPath = path.join(tempDir, "shared-checkout");
+      await registerLocalWorkspace(projectPath, "shared-parent");
+      await registerLocalWorkspace(projectPath, "shared-child", "shared-parent");
+
+      const published: Array<[string, unknown]> = [];
+      await service.setOverridesForWorkspace(
+        "shared-parent",
+        { enabledServers: ["shots"] },
+        {
+          publish: (persisted, workspaceId) => {
+            published.push([workspaceId, persisted]);
+            return Promise.resolve();
+          },
+        }
+      );
+      // The child "owns" that very file, so it must be treated as affected by
+      // the write rather than skipped as an independent owner.
+      expect(published).toEqual([
+        ["shared-parent", { enabledServers: ["shots"] }],
+        ["shared-child", { enabledServers: ["shots"] }],
+      ]);
+    });
+  });
+
+  describe("fork copy", () => {
+    it("copies the raw source document verbatim into the fork checkout", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const source = await registerWorkspace("fork-source");
+      const raw = `{\n  // keep me\n  "enabledServers": ["shots"],\n  "futureField": { "from": "newer build" }\n}\n`;
+      await fs.mkdir(path.join(source.workspacePath, ".xum"), { recursive: true });
+      await fs.writeFile(path.join(source.workspacePath, ".xum", "mcp.local.jsonc"), raw, "utf-8");
+
+      const targetPath = path.join(config.srcDir, "fork-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+      await service.copyOverridesToForkedCheckout(source.workspaceId, {
+        runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+        workspacePath: targetPath,
+        runtimeConfig: undefined,
+      });
+      expect(await fs.readFile(path.join(targetPath, ".xum", "mcp.local.jsonc"), "utf-8")).toBe(
+        raw
+      );
+    });
+
+    it("carries an opaque legacy value into the fork instead of dropping it", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const source = await registerWorkspace("fork-opaque-legacy-source");
+      const opaque = { disabledServers: "shots", futureField: 1 };
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === source.workspaceId);
+          if (entry) entry.mcp = opaque as never;
+        }
+        return cfg;
+      });
+      const targetPath = path.join(config.srcDir, "fork-opaque-legacy-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+      await service.copyOverridesToForkedCheckout(source.workspaceId, {
+        runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+        workspacePath: targetPath,
+        runtimeConfig: undefined,
+      });
+      expect(
+        jsoncParse(await fs.readFile(path.join(targetPath, ".xum", "mcp.local.jsonc"), "utf-8"))
+      ).toEqual(opaque);
+    });
+
+    it("reads a devcontainer source's overrides from the host when forking", async () => {
+      // The source container need not be running (forkWorkspace only creates
+      // the new worktree); an exec-backed probe would be indeterminate and the
+      // copy silently skipped although the file sits on the host worktree.
+      const service = new WorkspaceMcpOverridesService(config);
+      // In-place registration (projectPath === name) keeps the checkout under
+      // the test root regardless of the devcontainer runtime's srcBaseDir.
+      const sourcePath = path.join(config.srcDir, "devcontainer-fork-source");
+      await fs.mkdir(path.join(sourcePath, ".xum"), { recursive: true });
+      const raw = '{ "enabledServers": ["shots"] }\n';
+      await fs.writeFile(path.join(sourcePath, ".xum", "mcp.local.jsonc"), raw);
+      const workspaceId = "ws-devcontainer-fork-source";
+      await config.editConfig((cfg) => {
+        cfg.projects.set(sourcePath, {
+          workspaces: [
+            {
+              path: sourcePath,
+              id: workspaceId,
+              name: sourcePath,
+              runtimeConfig: {
+                type: "devcontainer",
+                configPath: ".devcontainer/devcontainer.json",
+              },
+            },
+          ],
+        });
+        return cfg;
+      });
+      const targetPath = path.join(config.srcDir, "devcontainer-fork-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+      await service.copyOverridesToForkedCheckout(workspaceId, {
+        runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+        workspacePath: targetPath,
+        runtimeConfig: undefined,
+      });
+      expect(await fs.readFile(path.join(targetPath, ".xum", "mcp.local.jsonc"), "utf-8")).toBe(
+        raw
+      );
+    });
+
+    it("uses a devcontainer source's persisted checkout path in the host view", async () => {
+      // Migrated/non-canonical entries persist a path that differs from the
+      // name-derived one; the host view must read where the checkout really is.
+      const service = new WorkspaceMcpOverridesService(config);
+      const persistedPath = path.join(config.srcDir, "elsewhere", "devcontainer-persisted");
+      await fs.mkdir(path.join(persistedPath, ".xum"), { recursive: true });
+      const raw = '{ "enabledServers": ["shots"] }\n';
+      await fs.writeFile(path.join(persistedPath, ".xum", "mcp.local.jsonc"), raw);
+      const workspaceId = "ws-devcontainer-persisted";
+      await config.editConfig((cfg) => {
+        cfg.projects.set("/fake/devcontainer-project", {
+          workspaces: [
+            {
+              path: persistedPath,
+              id: workspaceId,
+              name: "branch",
+              runtimeConfig: {
+                type: "devcontainer",
+                configPath: ".devcontainer/devcontainer.json",
+              },
+            },
+          ],
+        });
+        return cfg;
+      });
+      const targetPath = path.join(config.srcDir, "devcontainer-persisted-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+      await service.copyOverridesToForkedCheckout(workspaceId, {
+        runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+        workspacePath: targetPath,
+        runtimeConfig: undefined,
+      });
+      expect(await fs.readFile(path.join(targetPath, ".xum", "mcp.local.jsonc"), "utf-8")).toBe(
+        raw
+      );
+    });
+
+    it("releases the override lock before writing the fork target", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const source = await registerWorkspace("fork-slow-target-source");
+      await fs.mkdir(path.join(source.workspacePath, ".xum"), { recursive: true });
+      await fs.writeFile(
+        path.join(source.workspacePath, ".xum", "mcp.local.jsonc"),
+        JSON.stringify({ enabledServers: ["shots"] })
+      );
+      const targetPath = path.join(config.srcDir, "fork-slow-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+      // A target runtime whose writes stall (remote transfer) must not hold
+      // the global override lock for unrelated settings writers.
+      const realRuntime = createRuntime({ type: "local" }, { projectPath: targetPath });
+      let releaseWrite: () => void = () => undefined;
+      const writeStarted = new Promise<void>((resolve) => {
+        const slowRuntime = Object.create(realRuntime) as typeof realRuntime;
+        slowRuntime.writeFile = (...args: Parameters<typeof realRuntime.writeFile>) => {
+          resolve();
+          const stream = realRuntime.writeFile(...args);
+          const realWrite = stream.getWriter.bind(stream);
+          stream.getWriter = () => {
+            const writer = realWrite();
+            const realClose = writer.close.bind(writer);
+            writer.close = () => new Promise<void>((r) => (releaseWrite = r)).then(realClose);
+            return writer;
+          };
+          return stream;
+        };
+        void service
+          .copyOverridesToForkedCheckout(source.workspaceId, {
+            runtime: slowRuntime,
+            workspacePath: targetPath,
+            runtimeConfig: undefined,
+          })
+          .then(() => (copyDone = true));
+      });
+      let copyDone = false;
+      await writeStarted;
+      // The lock is free while the target write is still pending.
+      const release = await Promise.race([
+        service.acquireExclusiveLock(),
+        new Promise<never>((_r, reject) =>
+          setTimeout(() => reject(new Error("lock still held during target write")), 2_000)
+        ),
+      ]);
+      expect(copyDone).toBe(false);
+      await release();
+      releaseWrite();
+      while (!copyDone) await new Promise((r) => setTimeout(r, 1));
+    });
+
+    it("skips the fork copy rather than normalizing when the source document cannot be reread", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const source = await registerWorkspace("fork-reread-fails");
+      const sourceFile = path.join(source.workspacePath, ".xum", "mcp.local.jsonc");
+      await fs.mkdir(path.dirname(sourceFile), { recursive: true });
+      await fs.writeFile(
+        sourceFile,
+        '{\n  // keep\n  "enabledServers": ["shots"], "futureField": 1\n}\n'
+      );
+      const targetPath = path.join(config.srcDir, "fork-reread-fails-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+      // Resolution reads the document (statIsFile + parse) through the
+      // runtime; the raw no-follow reread for the copy (an `open` on the host
+      // file) then fails — the fork must not receive a lossy rewrite. A failed
+      // raw read is first treated as a possibly-vacated path (retry with a
+      // fresh resolution), so every raw read fails here; only the terminal
+      // locked attempt gives up.
+      const realOpen = fsPromisesModule.open;
+      let rawReads = 0;
+      const openSpy = spyOn(fsPromisesModule, "open").mockImplementation((...args) => {
+        if (args[0] === sourceFile) {
+          rawReads += 1;
+          return Promise.reject(new Error("EIO: persistent"));
+        }
+        return realOpen(...args);
+      });
+      try {
+        await service.copyOverridesToForkedCheckout(source.workspaceId, {
+          runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+          workspacePath: targetPath,
+          runtimeConfig: undefined,
+        });
+      } finally {
+        openSpy.mockRestore();
+      }
+      // 3 unlocked attempts + the locked fallback, one raw read each.
+      expect(rawReads).toBe(4);
+      expect(await pathExists(path.join(targetPath, ".xum", "mcp.local.jsonc"))).toBe(false);
+    });
+
+    it("the fork copy waits for the exclusive override lock", async () => {
+      // The raw source document read must serialize with concurrent settings
+      // saves (a torn read must not become the fork's configuration).
+      const service = new WorkspaceMcpOverridesService(config);
+      const source = await registerWorkspace("fork-locked-source");
+      await fs.mkdir(path.join(source.workspacePath, ".xum"), { recursive: true });
+      await fs.writeFile(
+        path.join(source.workspacePath, ".xum", "mcp.local.jsonc"),
+        JSON.stringify({ enabledServers: ["shots"] })
+      );
+      const targetPath = path.join(config.srcDir, "fork-locked-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+
+      const release = await service.acquireExclusiveLock();
+      let copyDone = false;
+      const copy = service
+        .copyOverridesToForkedCheckout(source.workspaceId, {
+          runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+          workspacePath: targetPath,
+          runtimeConfig: undefined,
+        })
+        .then(() => {
+          copyDone = true;
+        });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(copyDone).toBe(false);
+      expect(await pathExists(path.join(targetPath, ".xum", "mcp.local.jsonc"))).toBe(false);
+
+      await release();
+      await copy;
+      expect(await pathExists(path.join(targetPath, ".xum", "mcp.local.jsonc"))).toBe(true);
+    });
+
+    it("resolves an inheriting source's ancestors outside the lock and only reads the document under it", async () => {
+      // An inheriting SSH source probes remote paths per ancestor level; that
+      // traversal must not hold the global override lock (unrelated saves would
+      // time out). Only the raw document read serializes with writers.
+      const service = new WorkspaceMcpOverridesService(config);
+      const parent = await registerWorkspace("fork-unlocked-ancestor");
+      const raw = `{\n  "enabledServers": ["shots"]\n}\n`;
+      await fs.mkdir(path.join(parent.workspacePath, ".xum"), { recursive: true });
+      await fs.writeFile(path.join(parent.workspacePath, ".xum", "mcp.local.jsonc"), raw, "utf-8");
+      const child = await registerWorkspace("fork-unlocked-source");
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === child.workspaceId);
+          if (entry) entry.parentWorkspaceId = parent.workspaceId;
+        }
+        return cfg;
+      });
+      const targetPath = path.join(config.srcDir, "fork-unlocked-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+
+      const internals = service as unknown as {
+        resolveOverridesFor: (...args: unknown[]) => Promise<unknown>;
+      };
+      const realResolve = internals.resolveOverridesFor.bind(service);
+      let resolutions = 0;
+      spyOn(internals, "resolveOverridesFor").mockImplementation(async (...args: unknown[]) => {
+        const result = await realResolve(...args);
+        resolutions += 1;
+        return result;
+      });
+
+      const release = await service.acquireExclusiveLock();
+      let copyDone = false;
+      const copy = service
+        .copyOverridesToForkedCheckout(child.workspaceId, {
+          runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+          workspacePath: targetPath,
+          runtimeConfig: undefined,
+        })
+        .then(() => {
+          copyDone = true;
+        });
+      // Resolution (including the ancestor walk) completes while the lock is
+      // held by someone else; the copy then blocks on the raw read.
+      while (resolutions === 0) await new Promise((resolve) => setTimeout(resolve, 1));
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(copyDone).toBe(false);
+      await release();
+      await copy;
+      expect(await fs.readFile(path.join(targetPath, ".xum", "mcp.local.jsonc"), "utf-8")).toBe(
+        raw
+      );
+    });
+
+    it("re-resolves the fork source when a write completed between resolution and the locked read", async () => {
+      // The unlocked resolution picked the ancestor's document; a save (here a
+      // sibling process: child file + epoch bump) then made the child's own
+      // file authoritative. The stale preparation must not be copied.
+      const service = new WorkspaceMcpOverridesService(config);
+      const parent = await registerWorkspace("fork-stale-ancestor");
+      await fs.mkdir(path.join(parent.workspacePath, ".xum"), { recursive: true });
+      await fs.writeFile(
+        path.join(parent.workspacePath, ".xum", "mcp.local.jsonc"),
+        JSON.stringify({ enabledServers: ["parent-only"] })
+      );
+      const child = await registerWorkspace("fork-stale-source");
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === child.workspaceId);
+          if (entry) entry.parentWorkspaceId = parent.workspaceId;
+        }
+        return cfg;
+      });
+      const targetPath = path.join(config.srcDir, "fork-stale-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+
+      const internals = service as unknown as {
+        resolveOverridesFor: (...args: unknown[]) => Promise<unknown>;
+      };
+      const realResolve = internals.resolveOverridesFor.bind(service);
+      let resolutions = 0;
+      spyOn(internals, "resolveOverridesFor").mockImplementation(async (...args: unknown[]) => {
+        const result = await realResolve(...args);
+        resolutions += 1;
+        return result;
+      });
+
+      const release = await service.acquireExclusiveLock();
+      const copy = service.copyOverridesToForkedCheckout(child.workspaceId, {
+        runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+        workspacePath: targetPath,
+        runtimeConfig: undefined,
+      });
+      while (resolutions === 0) await new Promise((resolve) => setTimeout(resolve, 1));
+      // Sibling save lands while our lock is held: child-owned file + epoch.
+      const childRaw = JSON.stringify({ disabledServers: ["parent-only"] });
+      await fs.mkdir(path.join(child.workspacePath, ".xum"), { recursive: true });
+      await fs.writeFile(path.join(child.workspacePath, ".xum", "mcp.local.jsonc"), childRaw);
+      await fs.writeFile(path.join(config.rootDir, "mcp-overrides.epoch"), "sibling-write");
+      await release();
+      await copy;
+      expect(resolutions).toBeGreaterThan(1);
+      expect(await fs.readFile(path.join(targetPath, ".xum", "mcp.local.jsonc"), "utf-8")).toBe(
+        childRaw
+      );
+    });
+
+    it("re-resolves the fork source when a direct edit gives the child its own document", async () => {
+      // A direct edit of `.xum/mcp.local.jsonc` bumps no epoch and rewrites no
+      // config; the commit point must still notice that the child now owns a
+      // document that takes precedence over the ancestor's the resolution chose.
+      const service = new WorkspaceMcpOverridesService(config);
+      const parent = await registerWorkspace("fork-direct-ancestor");
+      await fs.mkdir(path.join(parent.workspacePath, ".xum"), { recursive: true });
+      await fs.writeFile(
+        path.join(parent.workspacePath, ".xum", "mcp.local.jsonc"),
+        JSON.stringify({ enabledServers: ["parent-only"] })
+      );
+      const child = await registerWorkspace("fork-direct-source");
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === child.workspaceId);
+          if (entry) entry.parentWorkspaceId = parent.workspaceId;
+        }
+        return cfg;
+      });
+      const targetPath = path.join(config.srcDir, "fork-direct-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+      const internals = service as unknown as {
+        resolveOverridesFor: (...args: unknown[]) => Promise<unknown>;
+      };
+      const realResolve = internals.resolveOverridesFor.bind(service);
+      let resolutions = 0;
+      spyOn(internals, "resolveOverridesFor").mockImplementation(async (...args: unknown[]) => {
+        const result = await realResolve(...args);
+        resolutions += 1;
+        return result;
+      });
+
+      const release = await service.acquireExclusiveLock();
+      const copy = service.copyOverridesToForkedCheckout(child.workspaceId, {
+        runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+        workspacePath: targetPath,
+        runtimeConfig: undefined,
+      });
+      while (resolutions === 0) await new Promise((resolve) => setTimeout(resolve, 1));
+      const childRaw = JSON.stringify({ disabledServers: ["parent-only"] });
+      await fs.mkdir(path.join(child.workspacePath, ".xum"), { recursive: true });
+      await fs.writeFile(path.join(child.workspacePath, ".xum", "mcp.local.jsonc"), childRaw);
+      await release();
+      await copy;
+      expect(resolutions).toBeGreaterThan(1);
+      expect(await fs.readFile(path.join(targetPath, ".xum", "mcp.local.jsonc"), "utf-8")).toBe(
+        childRaw
+      );
+    });
+
+    it("re-resolves the fork source when the child's document appears after the precedence probe", async () => {
+      // The commit point probes precedence, then re-reads the selected
+      // ancestor document. A child-owned document created between those two
+      // steps leaves the ancestor document unchanged, so only a second probe
+      // AFTER the content check can see it.
+      const service = new WorkspaceMcpOverridesService(config);
+      const parent = await registerWorkspace("fork-late-ancestor");
+      await fs.mkdir(path.join(parent.workspacePath, ".xum"), { recursive: true });
+      await fs.writeFile(
+        path.join(parent.workspacePath, ".xum", "mcp.local.jsonc"),
+        JSON.stringify({ enabledServers: ["parent-only"] })
+      );
+      const child = await registerWorkspace("fork-late-source");
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === child.workspaceId);
+          if (entry) entry.parentWorkspaceId = parent.workspaceId;
+        }
+        return cfg;
+      });
+      const targetPath = path.join(config.srcDir, "fork-late-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+      const internals = service as unknown as {
+        forkSourcePrecedenceUnchanged: (...args: unknown[]) => Promise<boolean>;
+      };
+      const realProbe = internals.forkSourcePrecedenceUnchanged.bind(service);
+      const childRaw = JSON.stringify({ disabledServers: ["parent-only"] });
+      let probes = 0;
+      spyOn(internals, "forkSourcePrecedenceUnchanged").mockImplementation(
+        async (...args: unknown[]) => {
+          const unchanged = await realProbe(...args);
+          probes += 1;
+          if (probes === 1) {
+            // Direct edit landing right after the first (absent) probe round.
+            await fs.mkdir(path.join(child.workspacePath, ".xum"), { recursive: true });
+            await fs.writeFile(path.join(child.workspacePath, ".xum", "mcp.local.jsonc"), childRaw);
+          }
+          return unchanged;
+        }
+      );
+
+      await service.copyOverridesToForkedCheckout(child.workspaceId, {
+        runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+        workspacePath: targetPath,
+        runtimeConfig: undefined,
+      });
+      expect(probes).toBeGreaterThan(1);
+      expect(await fs.readFile(path.join(targetPath, ".xum", "mcp.local.jsonc"), "utf-8")).toBe(
+        childRaw
+      );
+    });
+
+    it("re-resolves the fork source when an ancestor document appears over a child's empty fallback document", async () => {
+      // The child's own document normalizes to nothing (recognized-empty) and
+      // no ancestor supplies overrides, so the resolution keeps the child file
+      // only as the copy source. A parent document created directly before the
+      // commit point (no epoch, no config change) now supplies the effective
+      // overrides; the transparent child file must not stop the precedence
+      // probes from seeing it.
+      const service = new WorkspaceMcpOverridesService(config);
+      const parent = await registerWorkspace("fork-transparent-ancestor");
+      const child = await registerWorkspace("fork-transparent-source");
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === child.workspaceId);
+          if (entry) entry.parentWorkspaceId = parent.workspaceId;
+        }
+        return cfg;
+      });
+      await fs.mkdir(path.join(child.workspacePath, ".xum"), { recursive: true });
+      await fs.writeFile(
+        path.join(child.workspacePath, ".xum", "mcp.local.jsonc"),
+        JSON.stringify({ enabledServers: [] })
+      );
+      const targetPath = path.join(config.srcDir, "fork-transparent-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+      const internals = service as unknown as {
+        resolveOverridesFor: (...args: unknown[]) => Promise<unknown>;
+      };
+      const realResolve = internals.resolveOverridesFor.bind(service);
+      let resolutions = 0;
+      spyOn(internals, "resolveOverridesFor").mockImplementation(async (...args: unknown[]) => {
+        const result = await realResolve(...args);
+        if ((args[3] ?? 0) === 0) resolutions += 1;
+        return result;
+      });
+
+      const release = await service.acquireExclusiveLock();
+      const copy = service.copyOverridesToForkedCheckout(child.workspaceId, {
+        runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+        workspacePath: targetPath,
+        runtimeConfig: undefined,
+      });
+      while (resolutions === 0) await new Promise((resolve) => setTimeout(resolve, 1));
+      const parentRaw = JSON.stringify({ enabledServers: ["parent-only"] });
+      await fs.mkdir(path.join(parent.workspacePath, ".xum"), { recursive: true });
+      await fs.writeFile(path.join(parent.workspacePath, ".xum", "mcp.local.jsonc"), parentRaw);
+      await release();
+      await copy;
+      expect(resolutions).toBeGreaterThan(1);
+      expect(await fs.readFile(path.join(targetPath, ".xum", "mcp.local.jsonc"), "utf-8")).toBe(
+        parentRaw
+      );
+    });
+
+    it("re-resolves the fork source when a higher-priority candidate appears at the owner", async () => {
+      // The resolution selected the legacy-named `.mux/mcp.local.jsonc`; a
+      // direct edit then creates the canonical `.xum/` document, which takes
+      // precedence at the same level.
+      const service = new WorkspaceMcpOverridesService(config);
+      const source = await registerWorkspace("fork-owner-precedence");
+      await fs.mkdir(path.join(source.workspacePath, ".mux"), { recursive: true });
+      await fs.writeFile(
+        path.join(source.workspacePath, ".mux", "mcp.local.jsonc"),
+        JSON.stringify({ enabledServers: ["legacy-enable"] })
+      );
+      const targetPath = path.join(config.srcDir, "fork-owner-precedence-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+      const internals = service as unknown as {
+        resolveOverridesFor: (...args: unknown[]) => Promise<unknown>;
+      };
+      const realResolve = internals.resolveOverridesFor.bind(service);
+      let resolutions = 0;
+      spyOn(internals, "resolveOverridesFor").mockImplementation(async (...args: unknown[]) => {
+        const result = await realResolve(...args);
+        resolutions += 1;
+        return result;
+      });
+
+      const release = await service.acquireExclusiveLock();
+      const copy = service.copyOverridesToForkedCheckout(source.workspaceId, {
+        runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+        workspacePath: targetPath,
+        runtimeConfig: undefined,
+      });
+      while (resolutions === 0) await new Promise((resolve) => setTimeout(resolve, 1));
+      const canonicalRaw = JSON.stringify({ disabledServers: ["legacy-enable"] });
+      await fs.mkdir(path.join(source.workspacePath, ".xum"), { recursive: true });
+      await fs.writeFile(path.join(source.workspacePath, ".xum", "mcp.local.jsonc"), canonicalRaw);
+      await release();
+      await copy;
+      expect(resolutions).toBeGreaterThan(1);
+      expect(await fs.readFile(path.join(targetPath, ".xum", "mcp.local.jsonc"), "utf-8")).toBe(
+        canonicalRaw
+      );
+    });
+
+    it("re-resolves the fork source when it was renamed between resolution and the locked read", async () => {
+      // A rename rewrites config under the override lock without bumping the
+      // epoch; the unlocked resolution read the document at the old path.
+      const service = new WorkspaceMcpOverridesService(config);
+      const source = await registerWorkspace("fork-renamed-source");
+      const raw = JSON.stringify({ enabledServers: ["shots"] });
+      await fs.mkdir(path.join(source.workspacePath, ".xum"), { recursive: true });
+      await fs.writeFile(path.join(source.workspacePath, ".xum", "mcp.local.jsonc"), raw);
+      const targetPath = path.join(config.srcDir, "fork-renamed-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+      const internals = service as unknown as {
+        resolveOverridesFor: (...args: unknown[]) => Promise<unknown>;
+      };
+      const realResolve = internals.resolveOverridesFor.bind(service);
+      let resolutions = 0;
+      spyOn(internals, "resolveOverridesFor").mockImplementation(async (...args: unknown[]) => {
+        const result = await realResolve(...args);
+        resolutions += 1;
+        return result;
+      });
+
+      const release = await service.acquireExclusiveLock();
+      const copy = service.copyOverridesToForkedCheckout(source.workspaceId, {
+        runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+        workspacePath: targetPath,
+        runtimeConfig: undefined,
+      });
+      while (resolutions === 0) await new Promise((resolve) => setTimeout(resolve, 1));
+      // Rename lands under the lock: checkout moves, config rewritten, no epoch.
+      const renamedPath = getWorkspacePath({
+        srcDir: config.srcDir,
+        projectName: "fork-renamed-source",
+        workspaceName: "renamed",
+      });
+      await fs.rename(source.workspacePath, renamedPath);
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === source.workspaceId);
+          if (entry) {
+            entry.name = "renamed";
+            entry.path = renamedPath;
+          }
+        }
+        return cfg;
+      });
+      await release();
+      await copy;
+      expect(resolutions).toBeGreaterThan(1);
+      expect(await fs.readFile(path.join(targetPath, ".xum", "mcp.local.jsonc"), "utf-8")).toBe(
+        raw
+      );
+    });
+
+    it("does not migrate a legacy value that a save cleared before the fork acquired the lock", async () => {
+      // The pre-lock config snapshot saw a legacy `workspace.mcp` enable; a
+      // clearing save then removed it (and the file). Resolving under the lock
+      // from the stale snapshot would migrate the revoked enable back into the
+      // source and copy it into the fork.
+      const service = new WorkspaceMcpOverridesService(config);
+      const source = await registerWorkspace("fork-legacy-cleared");
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === source.workspaceId);
+          if (entry) entry.mcp = { enabledServers: ["revoked"] };
+        }
+        return cfg;
+      });
+      const targetPath = path.join(config.srcDir, "fork-legacy-cleared-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+
+      const release = await service.acquireExclusiveLock();
+      const copy = service.copyOverridesToForkedCheckout(source.workspaceId, {
+        runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+        workspacePath: targetPath,
+        runtimeConfig: undefined,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      // The clearing save completes while the fork waits for the lock (a
+      // sibling process here: config edit + epoch bump).
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === source.workspaceId);
+          if (entry) delete entry.mcp;
+        }
+        return cfg;
+      });
+      await fs.writeFile(path.join(config.rootDir, "mcp-overrides.epoch"), "cleared");
+      await release();
+      await copy;
+      expect(await pathExists(path.join(source.workspacePath, ".xum", "mcp.local.jsonc"))).toBe(
+        false
+      );
+      expect(await pathExists(path.join(targetPath, ".xum", "mcp.local.jsonc"))).toBe(false);
+    });
+
+    it("re-resolves the fork source when an ancestor's legacy value was revoked between resolution and the locked commit", async () => {
+      // The source inherits from a parent whose only configuration is an
+      // unmigrated legacy `workspace.mcp` enable (inheritance reads it
+      // read-only, so no document exists to re-read at the commit point). A
+      // direct config edit / older Xum process then revokes it without an
+      // epoch bump; the fork must not persist the revoked enable.
+      const service = new WorkspaceMcpOverridesService(config);
+      const parent = await registerWorkspace("fork-legacy-ancestor");
+      const child = await registerWorkspace("fork-legacy-ancestor-source");
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          for (const entry of project.workspaces) {
+            if (entry.id === parent.workspaceId) entry.mcp = { enabledServers: ["revoked"] };
+            if (entry.id === child.workspaceId) entry.parentWorkspaceId = parent.workspaceId;
+          }
+        }
+        return cfg;
+      });
+      const targetPath = path.join(config.srcDir, "fork-legacy-ancestor-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+      const internals = service as unknown as {
+        resolveOverridesFor: (...args: unknown[]) => Promise<unknown>;
+      };
+      const realResolve = internals.resolveOverridesFor.bind(service);
+      // Top-level (depth 0) resolutions only; the inherited parent step recurses.
+      let resolutions = 0;
+      spyOn(internals, "resolveOverridesFor").mockImplementation(async (...args: unknown[]) => {
+        const result = await realResolve(...args);
+        if ((args[3] ?? 0) === 0) resolutions += 1;
+        return result;
+      });
+
+      const release = await service.acquireExclusiveLock();
+      const copy = service.copyOverridesToForkedCheckout(child.workspaceId, {
+        runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+        workspacePath: targetPath,
+        runtimeConfig: undefined,
+      });
+      while (resolutions === 0) await new Promise((resolve) => setTimeout(resolve, 1));
+      // Legacy revoked with no epoch bump and no config identity change.
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === parent.workspaceId);
+          if (entry) delete entry.mcp;
+        }
+        return cfg;
+      });
+      await release();
+      await copy;
+      expect(resolutions).toBeGreaterThan(1);
+      expect(await pathExists(path.join(targetPath, ".xum", "mcp.local.jsonc"))).toBe(false);
+    });
+
+    it("keeps a source with a legacy config.json value fully under the lock (it may migrate)", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const source = await registerWorkspace("fork-legacy-locked");
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === source.workspaceId);
+          if (entry) entry.mcp = { enabledServers: ["legacy-only"] };
+        }
+        return cfg;
+      });
+      const targetPath = path.join(config.srcDir, "fork-legacy-locked-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+      const internals = service as unknown as {
+        resolveOverridesFor: (...args: unknown[]) => Promise<unknown>;
+      };
+      const resolveSpy = spyOn(internals, "resolveOverridesFor");
+
+      const release = await service.acquireExclusiveLock();
+      const copy = service.copyOverridesToForkedCheckout(source.workspaceId, {
+        runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+        workspacePath: targetPath,
+        runtimeConfig: undefined,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      // No resolution (hence no migration write) until the lock is ours.
+      expect(resolveSpy).not.toHaveBeenCalled();
+      await release();
+      await copy;
+      expect(
+        jsoncParse(
+          await fs.readFile(path.join(source.workspacePath, ".xum", "mcp.local.jsonc"), "utf-8")
+        )
+      ).toEqual({ enabledServers: ["legacy-only"] });
+      expect(
+        jsoncParse(await fs.readFile(path.join(targetPath, ".xum", "mcp.local.jsonc"), "utf-8"))
+      ).toEqual({ enabledServers: ["legacy-only"] });
+    });
+
+    it("writes a devcontainer fork's copy on the host even when the runtime is a multi-project wrapper", async () => {
+      // A multi-project devcontainer fork's runtime is a MultiProjectRuntime
+      // wrapping the (not yet started) devcontainers: any exec/stat through it
+      // fails, so the host filesystem view must be chosen from the runtime
+      // CONFIG, not the runtime class.
+      const service = new WorkspaceMcpOverridesService(config);
+      const source = await registerWorkspace("fork-wrapped-devcontainer");
+      await fs.mkdir(path.join(source.workspacePath, ".xum"), { recursive: true });
+      await fs.writeFile(
+        path.join(source.workspacePath, ".xum", "mcp.local.jsonc"),
+        JSON.stringify({ enabledServers: ["shots"] })
+      );
+      const targetPath = path.join(config.srcDir, "fork-wrapped-target");
+      await fs.mkdir(targetPath, { recursive: true });
+      const unstartedContainer = createRuntime({ type: "local" }, { projectPath: targetPath });
+      const wrapper = Object.create(unstartedContainer) as typeof unstartedContainer;
+      const refuse = (): never => {
+        throw new Error("container not started");
+      };
+      wrapper.exec = refuse;
+      wrapper.stat = refuse;
+      wrapper.writeFile = refuse;
+      wrapper.readFile = refuse;
+      await service.copyOverridesToForkedCheckout(source.workspaceId, {
+        runtime: wrapper,
+        workspacePath: targetPath,
+        runtimeConfig: { type: "devcontainer", configPath: ".devcontainer/devcontainer.json" },
+      });
+      expect(
+        jsoncParse(await fs.readFile(path.join(targetPath, ".xum", "mcp.local.jsonc"), "utf-8"))
+      ).toEqual({ enabledServers: ["shots"] });
+    });
+
+    it("forking an inheriting sub-agent copies the ancestor's raw document", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const parent = await registerWorkspace("fork-ancestor");
+      const raw = `{\n  // ancestor comment\n  "enabledServers": ["shots"],\n  "futureField": 1\n}\n`;
+      await fs.mkdir(path.join(parent.workspacePath, ".xum"), { recursive: true });
+      await fs.writeFile(path.join(parent.workspacePath, ".xum", "mcp.local.jsonc"), raw, "utf-8");
+      const child = await registerWorkspace("fork-inheriting-source");
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === child.workspaceId);
+          if (entry) entry.parentWorkspaceId = parent.workspaceId;
+        }
+        return cfg;
+      });
+
+      const targetPath = path.join(config.srcDir, "fork-ancestor-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+      await service.copyOverridesToForkedCheckout(child.workspaceId, {
+        runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+        workspacePath: targetPath,
+        runtimeConfig: undefined,
+      });
+      expect(await fs.readFile(path.join(targetPath, ".xum", "mcp.local.jsonc"), "utf-8")).toBe(
+        raw
+      );
+    });
+
+    it("strips Agent Plugin keys from the copy while keeping comments and unknown fields", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const source = await registerWorkspace("fork-plugins");
+      const raw = `{\n  // keep me\n  "enabledServers": ["plugin:0123456789abcdef:echo", "shots"],\n  "toolAllowlist": { "plugin:0123456789abcdef:echo": ["x"], "shots": ["take_screenshot"] },\n  "futureField": true\n}\n`;
+      await fs.mkdir(path.join(source.workspacePath, ".xum"), { recursive: true });
+      await fs.writeFile(path.join(source.workspacePath, ".xum", "mcp.local.jsonc"), raw, "utf-8");
+
+      const targetPath = path.join(config.srcDir, "fork-plugins-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+      await service.copyOverridesToForkedCheckout(source.workspaceId, {
+        runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+        workspacePath: targetPath,
+        runtimeConfig: undefined,
+      });
+      const copied = await fs.readFile(path.join(targetPath, ".xum", "mcp.local.jsonc"), "utf-8");
+      // A fresh checkout has no consent context for plugin servers: the copy
+      // must not carry an enable the fork's first request would act on.
+      expect(copied).toContain("// keep me");
+      expect(jsoncParse(copied)).toEqual({
+        enabledServers: ["shots"],
+        toolAllowlist: { shots: ["take_screenshot"] },
+        futureField: true,
+      });
+    });
+
+    it("refuses the copy when a field this build does not own still carries a plugin key", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const source = await registerWorkspace("fork-future-plugin");
+      // Pruning succeeds (owned fields are clean) but a future field smuggles a key.
+      const raw = `{ "enabledServers": ["shots"], "futureEnables": ["plugin:0123456789abcdef:echo"] }\n`;
+      await fs.mkdir(path.join(source.workspacePath, ".xum"), { recursive: true });
+      await fs.writeFile(path.join(source.workspacePath, ".xum", "mcp.local.jsonc"), raw, "utf-8");
+
+      const targetPath = path.join(config.srcDir, "fork-future-plugin-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+      await service.copyOverridesToForkedCheckout(source.workspaceId, {
+        runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+        workspacePath: targetPath,
+        runtimeConfig: undefined,
+      });
+      expect(await pathExists(path.join(targetPath, ".xum", "mcp.local.jsonc"))).toBe(false);
+    });
+
+    it("refuses to write through a symlinked or tracked target path", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const source = await registerWorkspace("fork-symlink-source");
+      await service.setOverridesForWorkspace(source.workspaceId, { enabledServers: ["shots"] });
+      const outside = path.join(tempDir, "outside-the-checkout");
+      await fs.mkdir(outside, { recursive: true });
+
+      // Repo-controlled `.xum -> ../outside` link: the write must not escape.
+      const linkedDir = path.join(config.srcDir, "fork-linked-dir", "branch");
+      await fs.mkdir(linkedDir, { recursive: true });
+      await fs.symlink(outside, path.join(linkedDir, ".xum"));
+      await service.copyOverridesToForkedCheckout(source.workspaceId, {
+        runtime: createRuntime({ type: "local" }, { projectPath: linkedDir }),
+        workspacePath: linkedDir,
+        runtimeConfig: undefined,
+      });
+      expect(await fs.readdir(outside)).toEqual([]);
+
+      // Tracked regular file at the path: repo content is left untouched.
+      const tracked = path.join(config.srcDir, "fork-tracked", "branch");
+      await fs.mkdir(path.join(tracked, ".xum"), { recursive: true });
+      await fs.writeFile(path.join(tracked, ".xum", "mcp.local.jsonc"), "{}\n", "utf-8");
+      await service.copyOverridesToForkedCheckout(source.workspaceId, {
+        runtime: createRuntime({ type: "local" }, { projectPath: tracked }),
+        workspacePath: tracked,
+        runtimeConfig: undefined,
+      });
+      expect(await fs.readFile(path.join(tracked, ".xum", "mcp.local.jsonc"), "utf-8")).toBe(
+        "{}\n"
+      );
+    });
+
+    it("keeps an uninspectable document unless it could hide a plugin key", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const write = async (name: string, raw: string) => {
+        const source = await registerWorkspace(name);
+        await fs.mkdir(path.join(source.workspacePath, ".xum"), { recursive: true });
+        await fs.writeFile(
+          path.join(source.workspacePath, ".xum", "mcp.local.jsonc"),
+          raw,
+          "utf-8"
+        );
+        const targetPath = path.join(config.srcDir, `${name}-target`, "branch");
+        await fs.mkdir(targetPath, { recursive: true });
+        await service.copyOverridesToForkedCheckout(source.workspaceId, {
+          runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+          workspacePath: targetPath,
+          runtimeConfig: undefined,
+        });
+        return path.join(targetPath, ".xum", "mcp.local.jsonc");
+      };
+      // Newer-build shape for an owned field: pruning cannot inspect it, but
+      // the text provably contains no canonical plugin key => copied verbatim.
+      const opaqueSafe = `{ "enabledServers": { "v2": ["shots"] } }\n`;
+      expect(await fs.readFile(await write("fork-opaque-safe", opaqueSafe), "utf-8")).toBe(
+        opaqueSafe
+      );
+      // Same opaque shape carrying a plugin key => consent wins, nothing copied.
+      const opaquePlugin = `{ "enabledServers": { "v2": ["plugin:0123456789abcdef:echo"] } }\n`;
+      expect(await pathExists(await write("fork-opaque-plugin", opaquePlugin))).toBe(false);
+      // JSON escapes must not smuggle a key past the screen (decoded strings are inspected).
+      const escaped = `{ "enabledServers": { "v2": ["plugin\\u003a0123456789abcdef\\u003aecho"] } }\n`;
+      expect(await pathExists(await write("fork-opaque-escaped", escaped))).toBe(false);
+    });
+
+    it("copies a document this build cannot interpret rather than dropping it", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const source = await registerWorkspace("fork-future");
+      const raw = `{ "futureField": ["from a newer build"] }\n`;
+      await fs.mkdir(path.join(source.workspacePath, ".xum"), { recursive: true });
+      await fs.writeFile(path.join(source.workspacePath, ".xum", "mcp.local.jsonc"), raw, "utf-8");
+      // Normalizes to {} here, yet the fork must keep the file for a later upgrade.
+      expect((await service.getOverridesForWorkspace(source.workspaceId)).overrides).toEqual({});
+
+      const targetPath = path.join(config.srcDir, "fork-future-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+      await service.copyOverridesToForkedCheckout(source.workspaceId, {
+        runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+        workspacePath: targetPath,
+        runtimeConfig: undefined,
+      });
+      expect(await fs.readFile(path.join(targetPath, ".xum", "mcp.local.jsonc"), "utf-8")).toBe(
+        raw
+      );
+    });
+
+    it("migrates legacy config.json overrides before deciding a shared-checkout fork needs no copy", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const projectPath = path.join(tempDir, "fork-legacy-project");
+      await registerLocalWorkspace(projectPath, "fork-legacy");
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === "fork-legacy");
+          if (entry) entry.mcp = { enabledServers: ["legacy-only"] };
+        }
+        return cfg;
+      });
+
+      // Same path as the source (project-dir fork): nothing to copy, but the
+      // legacy entry must land in the shared file or the fork sees nothing.
+      await service.copyOverridesToForkedCheckout("fork-legacy", {
+        runtime: createRuntime({ type: "local" }, { projectPath }),
+        workspacePath: projectPath,
+        runtimeConfig: { type: "local" },
+      });
+      expect(
+        jsoncParse(await fs.readFile(path.join(projectPath, ".xum", "mcp.local.jsonc"), "utf-8"))
+      ).toEqual({ enabledServers: ["legacy-only"] });
+    });
+
+    it("materializes an opaque legacy value into the shared file for a same-checkout fork", async () => {
+      // The opaque value lives only in the source's ID-scoped config entry;
+      // a project-dir fork shares the checkout but gets a new id, so without
+      // the file it would lose the forward-compatible configuration for good.
+      const service = new WorkspaceMcpOverridesService(config);
+      const projectPath = path.join(tempDir, "fork-opaque-shared-project");
+      await registerLocalWorkspace(projectPath, "fork-opaque-shared");
+      const opaque = { disabledServers: "shots", futureField: 1 };
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === "fork-opaque-shared");
+          if (entry) entry.mcp = opaque as never;
+        }
+        return cfg;
+      });
+      await service.copyOverridesToForkedCheckout("fork-opaque-shared", {
+        runtime: createRuntime({ type: "local" }, { projectPath }),
+        workspacePath: projectPath,
+        runtimeConfig: { type: "local" },
+      });
+      expect(
+        jsoncParse(await fs.readFile(path.join(projectPath, ".xum", "mcp.local.jsonc"), "utf-8"))
+      ).toEqual(opaque);
+      // The source resolves exactly as before: child-owned, nothing this
+      // build can read.
+      expect(await service.getOverridesForWorkspace("fork-opaque-shared")).toMatchObject({
+        overrides: {},
+        authoritative: true,
+      });
+    });
+
+    it("skips the fork copy when git exclude coverage cannot be established", async () => {
+      // A fresh checkout has no override document; creating one Git can see
+      // would let workspace-local authorization settings be committed by
+      // accident. Coverage is installed strictly BEFORE the write.
+      const service = new WorkspaceMcpOverridesService(config);
+      const source = await registerWorkspace("fork-exclude-source");
+      await fs.mkdir(path.join(source.workspacePath, ".xum"), { recursive: true });
+      await fs.writeFile(
+        path.join(source.workspacePath, ".xum", "mcp.local.jsonc"),
+        JSON.stringify({ enabledServers: ["shots"] })
+      );
+      const targetPath = path.join(config.srcDir, "fork-exclude-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+      await execBuffered(
+        createRuntime({ type: "local" }, { projectPath: targetPath }),
+        "git init -q",
+        {
+          cwd: targetPath,
+          timeout: 10,
+        }
+      );
+      // The exclude file's directory is unwritable: installing the pattern fails.
+      const infoDir = path.join(targetPath, ".git", "info");
+      await fs.mkdir(infoDir, { recursive: true });
+      await fs.writeFile(path.join(infoDir, "exclude"), "");
+      await fs.chmod(infoDir, 0o500);
+      await fs.chmod(path.join(infoDir, "exclude"), 0o400);
+      try {
+        // chmod cannot block root; the classification is exercised on ordinary CI users.
+        if (process.getuid?.() === 0) return;
+        await service.copyOverridesToForkedCheckout(source.workspaceId, {
+          runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+          workspacePath: targetPath,
+          runtimeConfig: undefined,
+        });
+        expect(await pathExists(path.join(targetPath, ".xum", "mcp.local.jsonc"))).toBe(false);
+      } finally {
+        await fs.chmod(infoDir, 0o700);
+        await fs.chmod(path.join(infoDir, "exclude"), 0o600);
+      }
+    });
+
+    it("skips the fork copy when the strict git probe fails without a definitive answer", async () => {
+      // A nonzero `git rev-parse --git-path` (transient Git failure) is not
+      // "nothing to ignore": strict mode must treat it as unverified coverage
+      // and write nothing, instead of returning normally like the lenient path.
+      const service = new WorkspaceMcpOverridesService(config);
+      const source = await registerWorkspace("fork-probe-source");
+      await fs.mkdir(path.join(source.workspacePath, ".xum"), { recursive: true });
+      await fs.writeFile(
+        path.join(source.workspacePath, ".xum", "mcp.local.jsonc"),
+        JSON.stringify({ enabledServers: ["shots"] })
+      );
+      const targetPath = path.join(config.srcDir, "fork-probe-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+      const real = createRuntime({ type: "local" }, { projectPath: targetPath });
+      await execBuffered(real, "git init -q", { cwd: targetPath, timeout: 10 });
+      const flaky = Object.create(real) as typeof real;
+      flaky.exec = (command, options) =>
+        real.exec(
+          command.includes("--git-path") ? "echo 'fatal: transient' >&2; exit 1" : command,
+          options
+        );
+      await service.copyOverridesToForkedCheckout(source.workspaceId, {
+        runtime: flaky,
+        workspacePath: targetPath,
+        runtimeConfig: undefined,
+      });
+      expect(await pathExists(path.join(targetPath, ".xum", "mcp.local.jsonc"))).toBe(false);
+      // Git's definitive "not a git repository" remains a non-failure: a
+      // checkout Git cannot see has nothing to commit.
+      const plainPath = path.join(config.srcDir, "fork-probe-plain");
+      await fs.mkdir(plainPath, { recursive: true });
+      await service.copyOverridesToForkedCheckout(source.workspaceId, {
+        runtime: createRuntime({ type: "local" }, { projectPath: plainPath }),
+        workspacePath: plainPath,
+        runtimeConfig: undefined,
+      });
+      expect(await pathExists(path.join(plainPath, ".xum", "mcp.local.jsonc"))).toBe(true);
+    });
+
+    it("never replaces an unreadable git exclude file with only the Xum patterns", async () => {
+      // The exclude update rewrites the whole file: an unreadable existing
+      // file (EACCES, transient I/O) must abort the update — and, strictly,
+      // the fork copy — instead of being treated as empty and erased.
+      const service = new WorkspaceMcpOverridesService(config);
+      const source = await registerWorkspace("fork-exclude-unreadable-source");
+      await fs.mkdir(path.join(source.workspacePath, ".xum"), { recursive: true });
+      await fs.writeFile(
+        path.join(source.workspacePath, ".xum", "mcp.local.jsonc"),
+        JSON.stringify({ enabledServers: ["shots"] })
+      );
+      const targetPath = path.join(config.srcDir, "fork-exclude-unreadable-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+      await execBuffered(
+        createRuntime({ type: "local" }, { projectPath: targetPath }),
+        "git init -q",
+        {
+          cwd: targetPath,
+          timeout: 10,
+        }
+      );
+      const excludePath = path.join(targetPath, ".git", "info", "exclude");
+      await fs.mkdir(path.dirname(excludePath), { recursive: true });
+      const personal = "# personal\nscratch/\n";
+      await fs.writeFile(excludePath, personal);
+      await fs.chmod(excludePath, 0o000);
+      try {
+        // chmod cannot block root; the classification is exercised on ordinary CI users.
+        if (process.getuid?.() === 0) return;
+        await service.copyOverridesToForkedCheckout(source.workspaceId, {
+          runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+          workspacePath: targetPath,
+          runtimeConfig: undefined,
+        });
+        expect(await pathExists(path.join(targetPath, ".xum", "mcp.local.jsonc"))).toBe(false);
+      } finally {
+        await fs.chmod(excludePath, 0o600);
+      }
+      expect(await fs.readFile(excludePath, "utf-8")).toBe(personal);
+    });
+
+    it("the send-path read is bounded and yields a non-authoritative result on timeout", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const source = await registerWorkspace("bounded-read");
+      const internals = service as unknown as {
+        resolveOverridesFor: (...args: unknown[]) => Promise<unknown>;
+      };
+      spyOn(internals, "resolveOverridesFor").mockImplementation(
+        () => new Promise(() => undefined)
+      );
+      const read = await service.getOverridesForWorkspace(source.workspaceId, { timeoutMs: 20 });
+      expect(read).toMatchObject({ overrides: {}, authoritative: false });
+      // Strict callers get the failure instead of a guess.
+      // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+      await expect(
+        service.getOverridesForWorkspace(source.workspaceId, { mode: "strict", timeoutMs: 20 })
+      ).rejects.toThrow("timed out");
+      // …and an already-aborted signal short-circuits the same way.
+      const aborted = await service.getOverridesForWorkspace(source.workspaceId, {
+        signal: AbortSignal.abort(),
+      });
+      expect(aborted.authoritative).toBe(false);
+    });
+
+    it("gives up at one absolute deadline instead of a fresh budget per retry", async () => {
+      // Sustained settings activity keeps invalidating unlocked preparations;
+      // WorkspaceService.fork awaits this best-effort copy before init, so
+      // retries, the locked fallback and the target write must all draw on
+      // the same budget rather than each resetting it.
+      const service = new WorkspaceMcpOverridesService(config);
+      const source = await registerWorkspace("fork-deadline");
+      await service.setOverridesForWorkspace(source.workspaceId, { enabledServers: ["shots"] });
+      const targetPath = path.join(config.srcDir, "fork-deadline-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+      const internals = service as unknown as {
+        prepareForkCopySource: (...args: unknown[]) => Promise<unknown>;
+      };
+      const realNow = Date.now;
+      let skewMs = 0;
+      const nowSpy = spyOn(Date, "now").mockImplementation(() => realNow() + skewMs);
+      const prepare = spyOn(internals, "prepareForkCopySource").mockImplementation(() => {
+        // The attempt consumed the whole operation budget before going stale.
+        skewMs += 61_000;
+        return Promise.resolve("stale");
+      });
+      let attempts: number;
+      try {
+        await service.copyOverridesToForkedCheckout(source.workspaceId, {
+          runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+          workspacePath: targetPath,
+          runtimeConfig: undefined,
+        });
+        attempts = prepare.mock.calls.length;
+      } finally {
+        nowSpy.mockRestore();
+        prepare.mockRestore();
+      }
+      // No second attempt and no locked fallback once the budget is spent.
+      expect(attempts).toBe(1);
+      expect(await pathExists(path.join(targetPath, ".xum"))).toBe(false);
+    });
+
+    it("refuses to copy a source document reached through a symlink", async () => {
+      // SECURITY: the source document is copied RAW into the fork's checkout;
+      // a repo-tracked symlink at the source path would exfiltrate a host
+      // file (here a stand-in for providers.jsonc) into the target, where the
+      // repo's init hook can read it.
+      const service = new WorkspaceMcpOverridesService(config);
+      const source = await registerWorkspace("fork-symlink-source");
+      const secret = path.join(config.rootDir, "providers.jsonc");
+      await fs.writeFile(secret, JSON.stringify({ apiKey: "sk-secret" }));
+      await fs.mkdir(path.join(source.workspacePath, ".mux"), { recursive: true });
+      await fs.symlink(secret, path.join(source.workspacePath, ".mux", "mcp.local.jsonc"));
+      const targetPath = path.join(config.srcDir, "fork-symlink-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+      await service.copyOverridesToForkedCheckout(source.workspaceId, {
+        runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+        workspacePath: targetPath,
+        runtimeConfig: undefined,
+      });
+      expect(await pathExists(path.join(targetPath, ".xum", "mcp.local.jsonc"))).toBe(false);
+
+      // A symlinked DIRECTORY segment is refused the same way.
+      await fs.rm(path.join(source.workspacePath, ".mux"), { recursive: true, force: true });
+      const elsewhere = path.join(config.rootDir, "elsewhere");
+      await fs.mkdir(elsewhere, { recursive: true });
+      await fs.writeFile(
+        path.join(elsewhere, "mcp.local.jsonc"),
+        JSON.stringify({ enabledServers: ["shots"] })
+      );
+      await fs.symlink(elsewhere, path.join(source.workspacePath, ".xum"));
+      await service.copyOverridesToForkedCheckout(source.workspaceId, {
+        runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+        workspacePath: targetPath,
+        runtimeConfig: undefined,
+      });
+      expect(await pathExists(path.join(targetPath, ".xum", "mcp.local.jsonc"))).toBe(false);
+    });
+
+    it("does nothing when the source has no effective overrides", async () => {
+      const service = new WorkspaceMcpOverridesService(config);
+      const source = await registerWorkspace("fork-empty");
+      const targetPath = path.join(config.srcDir, "fork-empty-target", "branch");
+      await fs.mkdir(targetPath, { recursive: true });
+      await service.copyOverridesToForkedCheckout(source.workspaceId, {
+        runtime: createRuntime({ type: "local" }, { projectPath: targetPath }),
+        workspacePath: targetPath,
+        runtimeConfig: undefined,
+      });
+      expect(await pathExists(path.join(targetPath, ".xum"))).toBe(false);
+    });
+  });
+
+  it("serves no overrides when a higher-priority candidate cannot be probed", async () => {
+    // `.xum/` unreadable (EACCES → indeterminate) while the legacy-named
+    // `.mux/mcp.local.jsonc` is readable and enables a server: the hidden
+    // canonical document takes precedence and may disable it, so with
+    // precedence unestablished nothing is served, and nothing is trusted.
+    // chmod cannot block root; the classification is exercised on ordinary CI users.
+    if (process.getuid?.() === 0) return;
+    const service = new WorkspaceMcpOverridesService(config);
+    const { workspaceId, workspacePath } = await registerWorkspace("hidden-canonical");
+    await fs.mkdir(path.join(workspacePath, ".mux"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspacePath, ".mux", "mcp.local.jsonc"),
+      JSON.stringify({ enabledServers: ["shots"] })
+    );
+    const blockedDir = path.join(workspacePath, ".xum");
+    await fs.mkdir(blockedDir, { recursive: true });
+    await fs.chmod(blockedDir, 0o000);
+    try {
+      const resolved = await service.getOverridesForWorkspace(workspaceId);
+      expect(resolved.overrides).toEqual({});
+      expect(resolved.authoritative).toBe(false);
+    } finally {
+      await fs.chmod(blockedDir, 0o755);
+    }
+  });
+
+  it("refuses a non-empty save while the canonical document cannot be probed", async () => {
+    // The write replaces exactly the file that could not be read: once I/O
+    // recovers it would have truncated a newer version's fields it never saw.
+    if (process.getuid?.() === 0) return;
+    const service = new WorkspaceMcpOverridesService(config);
+    const { workspaceId, workspacePath } = await registerWorkspace("unprobed-canonical");
+    const blockedDir = path.join(workspacePath, ".xum");
+    await fs.mkdir(blockedDir, { recursive: true });
+    await fs.writeFile(
+      path.join(blockedDir, "mcp.local.jsonc"),
+      JSON.stringify({ enabledServers: ["shots"], futureField: true })
+    );
+    await fs.chmod(blockedDir, 0o000);
+    try {
+      for (const options of [undefined, { expectedRevision: MCP_OVERRIDES_REVISION_UNAVAILABLE }]) {
+        // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+        await expect(
+          service.setOverridesForWorkspace(workspaceId, { disabledServers: ["other"] }, options)
+        ).rejects.toThrow(/Could not read the workspace's current MCP settings document/);
+      }
+    } finally {
+      await fs.chmod(blockedDir, 0o755);
+    }
+    expect(
+      JSON.parse(await fs.readFile(path.join(blockedDir, "mcp.local.jsonc"), "utf-8"))
+    ).toEqual({
+      enabledServers: ["shots"],
+      futureField: true,
+    });
+  });
+
+  it("serves the canonical document strictly when only a lower-priority path cannot be probed", async () => {
+    // The canonical `.xum/mcp.local.jsonc` is valid while the legacy-named
+    // `.mux/` directory is unreadable (EACCES): whatever `.mux/` holds is
+    // shadowed by the canonical document, so precedence IS established and
+    // the strict settings read must not report the state as unavailable —
+    // saving that sentinel would then conflict forever against the valid
+    // document, leaving MCP settings impossible to view or edit.
+    if (process.getuid?.() === 0) return;
+    const service = new WorkspaceMcpOverridesService(config);
+    const { workspaceId, workspacePath } = await registerWorkspace("shadowed-blocked");
+    await fs.mkdir(path.join(workspacePath, ".xum"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspacePath, ".xum", "mcp.local.jsonc"),
+      JSON.stringify({ enabledServers: ["shots"] })
+    );
+    const blockedDir = path.join(workspacePath, ".mux");
+    await fs.mkdir(blockedDir, { recursive: true });
+    await fs.chmod(blockedDir, 0o000);
+    try {
+      const resolved = await service.getOverridesForWorkspace(workspaceId, { mode: "strict" });
+      expect(resolved.overrides).toEqual({ enabledServers: ["shots"] });
+      expect(resolved.authoritative).toBe(true);
+      // And the save path (CAS against that revision) accepts the revision.
+      await service.setOverridesForWorkspace(
+        workspaceId,
+        { enabledServers: ["shots", "other"] },
+        { expectedRevision: resolved.revision }
+      );
+      expect((await service.getOverridesForWorkspace(workspaceId)).overrides).toEqual({
+        enabledServers: ["shots", "other"],
+      });
+    } finally {
+      await fs.chmod(blockedDir, 0o755);
+    }
+  });
+
+  it("keeps fields it does not own when saving over a newer version's document", async () => {
+    // A newer Xum wrote a document with a field this build does not know
+    // (upgrade↔downgrade must be friction-free): saving from this build
+    // patches the known fields into that document instead of round-tripping
+    // the normalized object, and clearing the known fields keeps the document.
+    const service = new WorkspaceMcpOverridesService(config);
+    const { workspaceId, workspacePath } = await registerWorkspace("opaque-fields");
+    const filePath = path.join(workspacePath, ".xum", "mcp.local.jsonc");
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(
+      filePath,
+      JSON.stringify({ futureField: { deny: ["shots"] }, enabledServers: ["shots"] })
+    );
+
+    const first = await service.getOverridesForWorkspace(workspaceId);
+    expect(first.overrides).toEqual({ enabledServers: ["shots"] });
+    await service.setOverridesForWorkspace(
+      workspaceId,
+      { enabledServers: ["shots", "other"] },
+      { expectedRevision: first.revision }
+    );
+    expect(JSON.parse(await fs.readFile(filePath, "utf8"))).toEqual({
+      futureField: { deny: ["shots"] },
+      enabledServers: ["shots", "other"],
+    });
+
+    const second = await service.getOverridesForWorkspace(workspaceId);
+    await service.setOverridesForWorkspace(workspaceId, {}, { expectedRevision: second.revision });
+    expect(JSON.parse(await fs.readFile(filePath, "utf8"))).toEqual({
+      futureField: { deny: ["shots"] },
+    });
+    // The remaining document is the workspace's own configuration: it does
+    // not resume inheritance, and a retry of the clear is idempotent.
+    const cleared = await service.getOverridesForWorkspace(workspaceId);
+    expect(cleared.overrides).toEqual({});
+    await service.setOverridesForWorkspace(workspaceId, {}, { expectedRevision: second.revision });
+    expect(JSON.parse(await fs.readFile(filePath, "utf8"))).toEqual({
+      futureField: { deny: ["shots"] },
+    });
+  });
+
+  it("carries an opaque legacy value's unknown fields into the saved document instead of clearing them", async () => {
+    // A newer Xum wrote a `workspace.mcp` value this build does not recognize;
+    // the dialog shows `{}` and its save retires the legacy value — the
+    // newer version's fields must move into the document, not vanish.
+    const service = new WorkspaceMcpOverridesService(config);
+    const { workspaceId, workspacePath } = await registerWorkspace("opaque-legacy-save");
+    const setLegacy = (value: unknown) =>
+      config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === workspaceId);
+          if (entry) entry.mcp = value as never;
+        }
+        return cfg;
+      });
+    // Unknown fields only: a value that also carries known settings the
+    // dialog could not show refuses the save instead (see the mixed-value test).
+    await setLegacy({ futureField: { deny: ["shots"] } });
+    const read = await service.getOverridesForWorkspace(workspaceId);
+    expect(read.overrides).toEqual({});
+    await service.setOverridesForWorkspace(
+      workspaceId,
+      { enabledServers: ["other"] },
+      { expectedRevision: read.revision }
+    );
+    const filePath = path.join(workspacePath, ".xum", "mcp.local.jsonc");
+    expect(JSON.parse(await fs.readFile(filePath, "utf8"))).toEqual({
+      futureField: { deny: ["shots"] },
+      enabledServers: ["other"],
+    });
+    const storedLegacy = () =>
+      [...config.loadConfigOrDefault().projects.values()]
+        .flatMap((project) => project.workspaces)
+        .find((w) => w.id === workspaceId)?.mcp;
+    expect(storedLegacy()).toBeUndefined();
+
+    // A legacy shape that cannot live in a document at all refuses the save
+    // and stays in place: only a build that understands it may replace it.
+    await fs.rm(filePath);
+    await setLegacy(null);
+    const opaque = await service.getOverridesForWorkspace(workspaceId);
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      service.setOverridesForWorkspace(
+        workspaceId,
+        { enabledServers: ["other"] },
+        { expectedRevision: opaque.revision }
+      )
+    ).rejects.toThrow("newer version");
+    expect(storedLegacy()).toBeNull();
+    expect(await pathExists(filePath)).toBe(false);
+  });
+
+  it("a clearing save is failure-atomic: legacy values retire before the document goes", async () => {
+    // Removing the document first would expose a shadowed legacy enable as
+    // authoritative if a later step failed — re-enabling a globally disabled
+    // server after the save reported failure.
+    const service = new WorkspaceMcpOverridesService(config);
+    const { workspaceId, workspacePath } = await registerWorkspace("atomic-clear");
+    const filePath = path.join(workspacePath, ".xum", "mcp.local.jsonc");
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, JSON.stringify({ disabledServers: ["shots"] }));
+    await config.editConfig((cfg) => {
+      for (const project of cfg.projects.values()) {
+        const entry = project.workspaces.find((w) => w.id === workspaceId);
+        if (entry) entry.mcp = { enabledServers: ["shots"] };
+      }
+      return cfg;
+    });
+    const internals = service as unknown as {
+      clearLegacyOverridesInConfig: (...args: unknown[]) => Promise<void>;
+    };
+    spyOn(internals, "clearLegacyOverridesInConfig").mockImplementationOnce(() =>
+      Promise.reject(new Error("config.json unwritable"))
+    );
+    const before = await readWorkspaceOverridesEpochToken(config.rootDir);
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(service.setOverridesForWorkspace(workspaceId, {})).rejects.toThrow(
+      "config.json unwritable"
+    );
+    // The document still shadows the legacy enable; nothing changed.
+    expect(await pathExists(filePath)).toBe(true);
+    expect((await service.getOverridesForWorkspace(workspaceId)).overrides).toEqual({
+      disabledServers: ["shots"],
+    });
+    expect(await readWorkspaceOverridesEpochToken(config.rootDir)).toBe(before);
+
+    await service.setOverridesForWorkspace(workspaceId, {});
+    expect(await pathExists(filePath)).toBe(false);
+    expect((await service.getOverridesForWorkspace(workspaceId)).overrides).toEqual({});
+    expect(await readWorkspaceOverridesEpochToken(config.rootDir)).not.toBe(before);
+  });
+
+  it("SSH registrations under different projects share a checkout by identity and path", async () => {
+    // Two SSH registrations of one host + remote path under different project
+    // entries mutate the same remote file: a save through one must retire the
+    // other's legacy value, or it migrates back on the alias's next read.
+    const service = new WorkspaceMcpOverridesService(config);
+    await config.editConfig((cfg) => {
+      cfg.projects.set("/fake/ssh-proj-a", {
+        workspaces: [
+          {
+            path: "/remote/shared",
+            id: "ws-ssh-proj-a",
+            name: "shared",
+            runtimeConfig: { type: "ssh", host: "remote.invalid", srcBaseDir: "/remote" },
+          },
+        ],
+      });
+      cfg.projects.set("/fake/ssh-proj-b", {
+        workspaces: [
+          {
+            path: "/remote/shared",
+            id: "ws-ssh-proj-b",
+            name: "shared",
+            mcp: { enabledServers: ["shots"] },
+            runtimeConfig: { type: "ssh", host: "remote.invalid", srcBaseDir: "/remote" },
+          },
+        ],
+      });
+      return cfg;
+    });
+    const internals = service as unknown as {
+      getRuntimeAndWorkspacePath: (
+        id: string
+      ) => Promise<{ metadata: unknown; workspacePath: string }>;
+      planSharersLegacyRetirement: (
+        workspaceId: string,
+        written: unknown,
+        writtenPath: string,
+        snapshot: unknown
+      ) => Promise<{ sharerIds: string[] }>;
+    };
+    // The snapshot surface the planner and sharer scan read (no remote I/O:
+    // off-host paths canonicalize to themselves).
+    const snapshot = {
+      loadLegacyConfig: () => config.loadConfigOrDefault({ throwOnError: true }),
+      loadAllMetadata: () =>
+        config.getAllWorkspaceMetadata({ throwOnError: true, probeCheckouts: false }),
+      canonicalize: (_identity: string, filePath: string) => Promise.resolve(filePath),
+    };
+    const written = await internals.getRuntimeAndWorkspacePath("ws-ssh-proj-a");
+    const plan = await internals.planSharersLegacyRetirement(
+      "ws-ssh-proj-a",
+      written.metadata,
+      path.posix.join(written.workspacePath, ".xum", "mcp.local.jsonc"),
+      snapshot
+    );
+    expect(plan.sharerIds).toEqual(["ws-ssh-proj-b"]);
+
+    // A registration on ANOTHER SSH identity with the same remote path may be
+    // an ssh_config alias of the same machine: unverifiable, so a save while
+    // it carries a legacy value is refused rather than leaving that value to
+    // migrate back over the write.
+    await config.editConfig((cfg) => {
+      cfg.projects.set("/fake/ssh-proj-c", {
+        workspaces: [
+          {
+            path: "/remote/shared",
+            id: "ws-ssh-alias-c",
+            name: "shared",
+            mcp: { enabledServers: ["shots"] },
+            runtimeConfig: { type: "ssh", host: "alias-of-remote", srcBaseDir: "/remote" },
+          },
+        ],
+      });
+      return cfg;
+    });
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      internals.planSharersLegacyRetirement(
+        "ws-ssh-proj-a",
+        written.metadata,
+        path.posix.join(written.workspacePath, ".xum", "mcp.local.jsonc"),
+        snapshot
+      )
+    ).rejects.toThrow("may share this checkout");
+  });
+
+  it("refuses a save when checkout sharers carry conflicting opaque legacy fields", async () => {
+    // Two registrations of one checkout each hold a newer version's data with
+    // the same unknown field but different values: a last-write-wins merge
+    // would keep one and the save would clear the other for good.
+    const service = new WorkspaceMcpOverridesService(config);
+    const shared = path.join(config.srcDir, "conflict-shared");
+    await registerLocalWorkspace(shared, "ws-conflict-a");
+    await registerLocalWorkspace(shared, "ws-conflict-b");
+    // A newer version's shape this build does not recognize.
+    const opaque = (value: number): unknown => ({ futureField: value });
+    await config.editConfig((cfg) => {
+      for (const project of cfg.projects.values()) {
+        for (const entry of project.workspaces) {
+          if (entry.id === "ws-conflict-a") entry.mcp = opaque(1) as never;
+          if (entry.id === "ws-conflict-b") entry.mcp = opaque(2) as never;
+        }
+      }
+      return cfg;
+    });
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      service.setOverridesForWorkspace("ws-conflict-a", { enabledServers: ["shots"] })
+    ).rejects.toThrow("conflicting");
+    expect(await pathExists(path.join(shared, ".xum", "mcp.local.jsonc"))).toBe(false);
+    // Agreeing values merge fine and both legacy values are retired.
+    await config.editConfig((cfg) => {
+      for (const project of cfg.projects.values()) {
+        for (const entry of project.workspaces) {
+          if (entry.id === "ws-conflict-b") entry.mcp = opaque(1) as never;
+        }
+      }
+      return cfg;
+    });
+    await service.setOverridesForWorkspace("ws-conflict-a", { enabledServers: ["shots"] });
+    expect(
+      JSON.parse(await fs.readFile(path.join(shared, ".xum", "mcp.local.jsonc"), "utf8"))
+    ).toEqual({ futureField: 1, enabledServers: ["shots"] });
+  });
+
+  it("rolls back a legacy migration whose epoch signal failed so a later read retries it", async () => {
+    // A document left behind without the durable signal would stop every later
+    // read (never retrying the bump), leaving another backend's pre-migration
+    // cache trusted for good.
+    const service = new WorkspaceMcpOverridesService(config);
+    const { workspaceId, workspacePath } = await registerWorkspace("migration-rollback");
+    const legacyValue = { enabledServers: ["shots"] };
+    await config.editConfig((cfg) => {
+      for (const project of cfg.projects.values()) {
+        const entry = project.workspaces.find((w) => w.id === workspaceId);
+        if (entry) entry.mcp = legacyValue;
+      }
+      return cfg;
+    });
+    const internals = service as unknown as { bumpOverridesEpoch: () => Promise<void> };
+    const realBump = internals.bumpOverridesEpoch.bind(service);
+    // An older process persists a compatibility-path document while the
+    // signal fails: the rollback must delete exactly the migrated document.
+    const olderProcessDoc = path.join(workspacePath, ".mux", "mcp.local.jsonc");
+    const filePath = path.join(workspacePath, ".xum", "mcp.local.jsonc");
+    const replacement = JSON.stringify({ disabledServers: ["replaced"] });
+    let failures = 0;
+    const bump = spyOn(internals, "bumpOverridesEpoch").mockImplementation(async () => {
+      failures += 1;
+      if (failures === 1) {
+        await fs.mkdir(path.dirname(olderProcessDoc), { recursive: true });
+        await fs.writeFile(olderProcessDoc, JSON.stringify({ disabledServers: ["other"] }));
+      } else {
+        // Second attempt: a direct edit REPLACED the canonical document
+        // between the migration write and the failed signal; the rollback
+        // must leave the replacement alone.
+        await fs.writeFile(filePath, replacement);
+      }
+      throw new Error("epoch file unwritable");
+    });
+    expect((await service.getOverridesForWorkspace(workspaceId)).overrides).toEqual(legacyValue);
+    expect(await pathExists(filePath)).toBe(false);
+    expect(await pathExists(olderProcessDoc)).toBe(true);
+    await fs.rm(olderProcessDoc);
+    expect((await service.getOverridesForWorkspace(workspaceId)).overrides).toEqual(legacyValue);
+    expect(await fs.readFile(filePath, "utf8")).toBe(replacement);
+    expect(await fs.readdir(path.dirname(filePath))).toEqual(["mcp.local.jsonc"]);
+    await fs.rm(filePath);
+    const storedLegacy = () =>
+      [...config.loadConfigOrDefault().projects.values()]
+        .flatMap((project) => project.workspaces)
+        .find((w) => w.id === workspaceId)?.mcp;
+    expect(storedLegacy()).toEqual(legacyValue);
+
+    bump.mockImplementation(realBump);
+    expect((await service.getOverridesForWorkspace(workspaceId)).overrides).toEqual(legacyValue);
+    expect(await pathExists(filePath)).toBe(true);
+    expect(storedLegacy()).toBeUndefined();
+  });
+
+  it("a non-empty save moves the epoch before retiring legacy values", async () => {
+    // The document is the durable state (it shadows every legacy value), so
+    // a sibling about to launch a server this save revokes must observe the
+    // epoch without waiting for the per-sharer config edits.
+    const service = new WorkspaceMcpOverridesService(config);
+    const { workspaceId } = await registerWorkspace("epoch-before-legacy");
+    await config.editConfig((cfg) => {
+      for (const project of cfg.projects.values()) {
+        const entry = project.workspaces.find((w) => w.id === workspaceId);
+        if (entry) entry.mcp = { enabledServers: ["shots"] };
+      }
+      return cfg;
+    });
+    const before = await readWorkspaceOverridesEpochToken(config.rootDir);
+    const internals = service as unknown as {
+      clearLegacyOverridesInConfig: (...args: unknown[]) => Promise<void>;
+    };
+    const realClear = internals.clearLegacyOverridesInConfig.bind(service);
+    let epochAtClear: string | undefined;
+    spyOn(internals, "clearLegacyOverridesInConfig").mockImplementation(
+      async (...args: unknown[]) => {
+        epochAtClear = await readWorkspaceOverridesEpochToken(config.rootDir);
+        return realClear(...args);
+      }
+    );
+    await service.setOverridesForWorkspace(workspaceId, { disabledServers: ["shots"] });
+    expect(epochAtClear).toBeDefined();
+    expect(epochAtClear).not.toBe(before);
+  });
+
+  it("clearing settings refuses to remove through a symlinked override directory", async () => {
+    // SECURITY: `rm -f .xum/mcp.local.jsonc` follows a repo-tracked `.xum`
+    // symlink and would delete a sibling checkout's document.
+    const service = new WorkspaceMcpOverridesService(config);
+    const victim = await registerWorkspace("rm-symlink-victim");
+    const source = await registerWorkspace("rm-symlink-source");
+    await service.setOverridesForWorkspace(victim.workspaceId, { enabledServers: ["shots"] });
+    await fs.symlink(
+      path.join(victim.workspacePath, ".xum"),
+      path.join(source.workspacePath, ".xum")
+    );
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(service.setOverridesForWorkspace(source.workspaceId, {})).rejects.toThrow(
+      "symbolic link"
+    );
+    expect((await service.getOverridesForWorkspace(victim.workspaceId)).overrides).toEqual({
+      enabledServers: ["shots"],
+    });
+  });
+
+  it("refuses to save over a valid document whose root is not an object", async () => {
+    // A newer Xum wrote `null`/an array as the document: nothing of it can
+    // live next to this build's fields, so the save must not replace it.
+    const service = new WorkspaceMcpOverridesService(config);
+    const { workspaceId, workspacePath } = await registerWorkspace("non-object-doc");
+    const filePath = path.join(workspacePath, ".xum", "mcp.local.jsonc");
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    for (const content of ["null", '["shots"]']) {
+      await fs.writeFile(filePath, content);
+      const read = await service.getOverridesForWorkspace(workspaceId);
+      expect(read.overrides).toEqual({});
+      // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+      await expect(
+        service.setOverridesForWorkspace(
+          workspaceId,
+          { enabledServers: ["other"] },
+          { expectedRevision: read.revision }
+        )
+      ).rejects.toThrow("newer version");
+      // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+      await expect(
+        service.setOverridesForWorkspace(workspaceId, {}, { expectedRevision: read.revision })
+      ).rejects.toThrow("newer version");
+      expect(await fs.readFile(filePath, "utf8")).toBe(content);
+    }
+  });
+
+  it("refuses to save over known fields stored in a shape this build cannot read", async () => {
+    // A newer version stores `toolAllowlist.server` as an object: a save
+    // rebuilt from normalized data would silently delete it — in the
+    // document and in a legacy value alike.
+    const service = new WorkspaceMcpOverridesService(config);
+    const { workspaceId, workspacePath } = await registerWorkspace("newer-known-shape");
+    const filePath = path.join(workspacePath, ".xum", "mcp.local.jsonc");
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    const newer = JSON.stringify({ toolAllowlist: { server: { allow: ["ping"] } } });
+    await fs.writeFile(filePath, newer);
+    const read = await service.getOverridesForWorkspace(workspaceId);
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      service.setOverridesForWorkspace(
+        workspaceId,
+        { enabledServers: ["other"] },
+        { expectedRevision: read.revision }
+      )
+    ).rejects.toThrow("newer version");
+    expect(await fs.readFile(filePath, "utf8")).toBe(newer);
+
+    await fs.rm(filePath);
+    const legacy: unknown = { toolAllowlist: { server: { allow: ["ping"] } } };
+    await config.editConfig((cfg) => {
+      for (const project of cfg.projects.values()) {
+        const entry = project.workspaces.find((w) => w.id === workspaceId);
+        if (entry) entry.mcp = legacy as never;
+      }
+      return cfg;
+    });
+    const legacyRead = await service.getOverridesForWorkspace(workspaceId);
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      service.setOverridesForWorkspace(
+        workspaceId,
+        { enabledServers: ["other"] },
+        { expectedRevision: legacyRead.revision }
+      )
+    ).rejects.toThrow("newer version");
+    expect(await pathExists(filePath)).toBe(false);
+  });
+
+  it("a bounded read returns at its deadline even while its migration write is still in flight", async () => {
+    // The started write settles under its own locks; the request-path read
+    // must not wait for a remote runtime's command timeout on top of the
+    // advertised deadline.
+    const service = new WorkspaceMcpOverridesService(config);
+    const { workspaceId } = await registerWorkspace("bounded-read-migration");
+    await config.editConfig((cfg) => {
+      for (const project of cfg.projects.values()) {
+        const entry = project.workspaces.find((w) => w.id === workspaceId);
+        if (entry) entry.mcp = { enabledServers: ["shots"] };
+      }
+      return cfg;
+    });
+    const internals = service as unknown as {
+      migrateLegacyOverridesFenced: (
+        target: unknown,
+        snapshot: { trackSideEffect: (effect: Promise<unknown>) => Promise<unknown> }
+      ) => Promise<boolean>;
+    };
+    spyOn(internals, "migrateLegacyOverridesFenced").mockImplementation((_target, snapshot) => {
+      // A write that never settles (stalled remote checkout).
+      snapshot.trackSideEffect(new Promise(() => undefined)).catch(() => undefined);
+      return new Promise(() => undefined);
+    });
+    const startedAt = Date.now();
+    const read = await service.getOverridesForWorkspace(workspaceId, { timeoutMs: 50 });
+    expect(read.authoritative).toBe(false);
+    expect(Date.now() - startedAt).toBeLessThan(5_000);
+  });
+
+  it("a legacy migration refuses to write through a symlinked override directory", async () => {
+    // SECURITY: a repo-tracked `.xum` symlink pointing at another checkout's
+    // `.xum` would make the (link-following) migration write plant the
+    // source's enabled-server override in that sibling workspace.
+    const service = new WorkspaceMcpOverridesService(config);
+    const victim = await registerWorkspace("symlink-victim");
+    const source = await registerWorkspace("symlink-source");
+    await fs.mkdir(path.join(victim.workspacePath, ".xum"), { recursive: true });
+    await fs.symlink(
+      path.join(victim.workspacePath, ".xum"),
+      path.join(source.workspacePath, ".xum")
+    );
+    const legacyValue = { enabledServers: ["shots"] };
+    await config.editConfig((cfg) => {
+      for (const project of cfg.projects.values()) {
+        const entry = project.workspaces.find((w) => w.id === source.workspaceId);
+        if (entry) entry.mcp = legacyValue;
+      }
+      return cfg;
+    });
+
+    // Honored read-only; nothing is written anywhere.
+    expect((await service.getOverridesForWorkspace(source.workspaceId)).overrides).toEqual(
+      legacyValue
+    );
+    expect(await pathExists(path.join(victim.workspacePath, ".xum", "mcp.local.jsonc"))).toBe(
+      false
+    );
+    expect((await service.getOverridesForWorkspace(victim.workspaceId)).overrides).toEqual({});
+    const storedLegacy = [...config.loadConfigOrDefault().projects.values()]
+      .flatMap((project) => project.workspaces)
+      .find((w) => w.id === source.workspaceId)?.mcp;
+    expect(storedLegacy).toEqual(legacyValue);
+  });
+
+  it("every override write bumps the cross-process epoch token", async () => {
+    const service = new WorkspaceMcpOverridesService(config);
+    const { workspaceId } = await registerWorkspace("epoch");
+    expect(await readWorkspaceOverridesEpochToken(config.rootDir)).toBeUndefined();
+
+    await service.setOverridesForWorkspace(workspaceId, {
+      enabledServers: ["plugin:0123456789abcdef:echo", "other"],
+    });
+    const afterSave = await readWorkspaceOverridesEpochToken(config.rootDir);
+    expect(afterSave).toBeDefined();
+
+    await service.prunePluginOverrideKeys(workspaceId, "plugin:0123456789abcdef:");
+    const afterPrune = await readWorkspaceOverridesEpochToken(config.rootDir);
+    expect(afterPrune).not.toBe(afterSave);
+
+    await service.setOverridesForWorkspace(workspaceId, {});
+    const afterClear = await readWorkspaceOverridesEpochToken(config.rootDir);
+    expect(afterClear).not.toBe(afterPrune);
+
+    // Reads never bump it.
+    await service.getOverridesForWorkspace(workspaceId);
+    expect(await readWorkspaceOverridesEpochToken(config.rootDir)).toBe(afterClear);
   });
 
   it("prefers canonical override files when both metadata trees exist", async () => {
@@ -304,6 +3071,91 @@ describe("WorkspaceMcpOverridesService", () => {
     expect(after.overrides).toEqual({ disabledServers: ["other"] });
   });
 
+  it("a save whose epoch bump failed can be retried from the same dialog snapshot", async () => {
+    // The file write lands (changing the stored revision) but the cross-process
+    // change signal does not. The dialog still holds the pre-save revision, so
+    // its retry must be admitted as idempotent — otherwise the missing
+    // invalidation could never be published from that dialog.
+    const projectPath = "/fake/project";
+    const workspaceId = "ws-id";
+    const workspaceName = "branch";
+    const workspacePath = getWorkspacePath({
+      srcDir: config.srcDir,
+      projectName: "project",
+      workspaceName,
+    });
+    await fs.mkdir(workspacePath, { recursive: true });
+    await config.editConfig((cfg) => {
+      cfg.projects.set(projectPath, {
+        workspaces: [
+          {
+            path: workspacePath,
+            id: workspaceId,
+            name: workspaceName,
+            runtimeConfig: { type: "worktree", srcBaseDir: config.srcDir },
+          },
+        ],
+      });
+      return cfg;
+    });
+    const service = new WorkspaceMcpOverridesService(config);
+    await service.setOverridesForWorkspace(workspaceId, { disabledServers: ["a"] });
+    const epochPath = path.join(config.rootDir, "mcp-overrides.epoch");
+    const epochBefore = await fs.readFile(epochPath, "utf-8");
+    const snapshot = await service.getOverridesForWorkspace(workspaceId);
+
+    const internals = service as unknown as { bumpOverridesEpoch: () => Promise<void> };
+    // mockImplementationOnce, not mockRejectedValueOnce: Bun creates the
+    // rejected promise eagerly, which the runner reports as an unhandled
+    // rejection before the save ever consumes it.
+    const bump = spyOn(internals, "bumpOverridesEpoch");
+    const failBumpOnce = () =>
+      bump.mockImplementationOnce(() => Promise.reject(new Error("epoch rename failed")));
+    failBumpOnce();
+    const incoming = { disabledServers: ["a", "b"] };
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      service.setOverridesForWorkspace(workspaceId, incoming, {
+        expectedRevision: snapshot.revision,
+      })
+    ).rejects.toThrow(/epoch rename failed/);
+    // Disk moved on without a signal.
+    expect((await service.getOverridesForWorkspace(workspaceId)).overrides).toEqual(incoming);
+    expect(await fs.readFile(epochPath, "utf-8")).toBe(epochBefore);
+
+    // Retrying the SAME content with the stale revision publishes the epoch.
+    await service.setOverridesForWorkspace(workspaceId, incoming, {
+      expectedRevision: snapshot.revision,
+    });
+    expect(bump).toHaveBeenCalledTimes(2);
+    expect(await fs.readFile(epochPath, "utf-8")).not.toBe(epochBefore);
+
+    // Different content behind the same stale revision is still a conflict.
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      service.setOverridesForWorkspace(
+        workspaceId,
+        { disabledServers: ["c"] },
+        { expectedRevision: snapshot.revision }
+      )
+    ).rejects.toThrow(WorkspaceMcpOverridesConflictError);
+
+    // Clearing: the removal landed, the bump did not, and the retry of `{}`
+    // with the stale revision goes through as well.
+    const beforeClear = await service.getOverridesForWorkspace(workspaceId);
+    failBumpOnce();
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      service.setOverridesForWorkspace(workspaceId, {}, { expectedRevision: beforeClear.revision })
+    ).rejects.toThrow(/epoch rename failed/);
+    await service.setOverridesForWorkspace(
+      workspaceId,
+      {},
+      { expectedRevision: beforeClear.revision }
+    );
+    expect((await service.getOverridesForWorkspace(workspaceId)).overrides).toEqual({});
+  });
+
   it("strict reads throw on unreadable content instead of reporting empty overrides", async () => {
     const projectPath = "/fake/project";
     const workspaceId = "ws-id";
@@ -350,6 +3202,212 @@ describe("WorkspaceMcpOverridesService", () => {
     await fs.rm(path.join(workspacePath, ".mux", "mcp.local.jsonc"));
     const absent = await service.getOverridesForWorkspace(workspaceId, { mode: "strict" });
     expect(absent.overrides).toEqual({});
+  });
+
+  it("coordinates the override epoch and writer locks under the configured coordination root", async () => {
+    // `xum run` registers under a disposable root while its MCP configuration
+    // is the persistent home: its fences must observe and contend with a
+    // desktop/server backend's saves there, not under the disposable root.
+    const coordinationRootDir = path.join(tempDir, "persistent-home");
+    await fs.mkdir(coordinationRootDir, { recursive: true });
+    const service = new WorkspaceMcpOverridesService(config, { coordinationRootDir });
+    const { workspaceId } = await registerWorkspace("coordination-root");
+    const before = await readWorkspaceOverridesEpochToken(coordinationRootDir);
+    await service.setOverridesForWorkspace(workspaceId, { enabledServers: ["shots"] });
+    expect(await readWorkspaceOverridesEpochToken(coordinationRootDir)).not.toBe(before);
+    expect(await pathExists(path.join(config.rootDir, "mcp-overrides.epoch"))).toBe(false);
+    // The writer lock lives there too: a sibling on the same root contends.
+    const sibling = new WorkspaceMcpOverridesService(config, { coordinationRootDir });
+    const release = await service.acquireExclusiveLock();
+    try {
+      // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+      await expect(sibling.acquireExclusiveLock({ timeoutMs: 300 })).rejects.toThrow();
+    } finally {
+      await release();
+    }
+  });
+
+  it("prunePluginOverrideKeys validates every override document before rewriting any", async () => {
+    // Canonical file prunable, compatibility file uneditable: a first-file
+    // rewrite followed by a throw would leave a durable revocation that the
+    // caller never learns about (no epoch bump). Nothing may be written.
+    const service = new WorkspaceMcpOverridesService(config);
+    const { workspaceId, workspacePath } = await registerWorkspace("prune-validate-first");
+    const canonical = path.join(workspacePath, ".xum", "mcp.local.jsonc");
+    const compat = path.join(workspacePath, ".mux", "mcp.local.jsonc");
+    await fs.mkdir(path.dirname(canonical), { recursive: true });
+    await fs.mkdir(path.dirname(compat), { recursive: true });
+    const canonicalRaw = JSON.stringify({ enabledServers: ["plugin:0123456789abcdef:echo"] });
+    await fs.writeFile(canonical, canonicalRaw);
+    // Unreadable shape that MAY carry a plugin key: throws in phase one.
+    await fs.writeFile(compat, '{ "enabledServers": ["plugin:0123456789abcdef:echo"], ');
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      service.prunePluginOverrideKeys(workspaceId, "plugin:0123456789abcdef:")
+    ).rejects.toThrow();
+    expect(await fs.readFile(canonical, "utf-8")).toBe(canonicalRaw);
+  });
+
+  it("prunePluginOverrideKeys owes the cross-process epoch only when an override document exists", async () => {
+    // Registration sanitizes every fresh checkout through this path; a clean
+    // checkout (no override file) must not fail — and roll the creation back —
+    // because the epoch file is transiently unwritable. Any existing document
+    // owes the signal even when this pass rewrites nothing: an earlier pass
+    // may have pruned it and failed its bump, and the tombstone retry must
+    // still publish the invalidation.
+    const service = new WorkspaceMcpOverridesService(config);
+    const projectPath = "/fake/project";
+    const workspaceId = "ws-id";
+    const workspacePath = getWorkspacePath({
+      srcDir: config.srcDir,
+      projectName: "project",
+      workspaceName: "branch",
+    });
+    await fs.mkdir(workspacePath, { recursive: true });
+    await config.editConfig((cfg) => {
+      cfg.projects.set(projectPath, {
+        workspaces: [
+          {
+            path: workspacePath,
+            id: workspaceId,
+            name: "branch",
+            runtimeConfig: { type: "worktree", srcBaseDir: config.srcDir },
+          },
+        ],
+      });
+      return cfg;
+    });
+    const internals = service as unknown as { bumpOverridesEpoch: () => Promise<void> };
+    const bump = spyOn(internals, "bumpOverridesEpoch").mockImplementation(() =>
+      Promise.reject(new Error("epoch unwritable"))
+    );
+    // No file, nothing pruned: no epoch owed.
+    await service.prunePluginOverrideKeys(workspaceId, "plugin:0123456789abcdef:");
+    expect(bump).not.toHaveBeenCalled();
+    // A real prune publishes the signal — and surfaces its failure (the
+    // uninstaller keeps its tombstone).
+    const filePath = path.join(workspacePath, ".xum", "mcp.local.jsonc");
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(
+      filePath,
+      JSON.stringify({ enabledServers: ["shots", "plugin:0123456789abcdef:echo"] })
+    );
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      service.prunePluginOverrideKeys(workspaceId, "plugin:0123456789abcdef:")
+    ).rejects.toThrow(/epoch unwritable/);
+    expect(bump).toHaveBeenCalledTimes(1);
+    expect(jsoncParse(await fs.readFile(filePath, "utf-8"))).toEqual({ enabledServers: ["shots"] });
+    // The tombstone retry finds nothing left to prune but still owes (and
+    // retries) the bump; once it succeeds the retry completes.
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      service.prunePluginOverrideKeys(workspaceId, "plugin:0123456789abcdef:")
+    ).rejects.toThrow(/epoch unwritable/);
+    expect(bump).toHaveBeenCalledTimes(2);
+    bump.mockRestore();
+    await service.prunePluginOverrideKeys(workspaceId, "plugin:0123456789abcdef:");
+    expect(await pathExists(path.join(config.rootDir, "mcp-overrides.epoch"))).toBe(true);
+
+    // Registration-time sanitization of a NEW identity (epochOnlyWhenRewritten):
+    // a key-free document — e.g. one a fork copy just created — owes nothing,
+    // so an unwritable epoch file must not roll the creation back; a document
+    // this pass actually rewrites still publishes (and surfaces) the bump.
+    const failing = spyOn(internals, "bumpOverridesEpoch").mockImplementation(() =>
+      Promise.reject(new Error("epoch unwritable"))
+    );
+    await service.prunePluginOverrideKeys(workspaceId, "plugin:", { epochOnlyWhenRewritten: true });
+    expect(failing).not.toHaveBeenCalled();
+    await fs.writeFile(
+      filePath,
+      JSON.stringify({ enabledServers: ["shots", "plugin:0123456789abcdef:echo"] })
+    );
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      service.prunePluginOverrideKeys(workspaceId, "plugin:", { epochOnlyWhenRewritten: true })
+    ).rejects.toThrow(/epoch unwritable/);
+    expect(failing).toHaveBeenCalledTimes(1);
+    failing.mockRestore();
+  });
+
+  it("prunePluginOverrideKeys keeps compact single-line arrays parseable", async () => {
+    // jsonc.modify corrupts a compact array when its last element is removed
+    // (`["a","b"]` → `["a""]`); the prune must never leave an unparseable file.
+    const service = new WorkspaceMcpOverridesService(config);
+    const projectPath = "/fake/project";
+    const workspaceId = "ws-id";
+    const workspacePath = getWorkspacePath({
+      srcDir: config.srcDir,
+      projectName: "project",
+      workspaceName: "branch",
+    });
+    const filePath = path.join(workspacePath, ".xum", "mcp.local.jsonc");
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await config.editConfig((cfg) => {
+      cfg.projects.set(projectPath, {
+        workspaces: [
+          {
+            path: workspacePath,
+            id: workspaceId,
+            name: "branch",
+            runtimeConfig: { type: "worktree", srcBaseDir: config.srcDir },
+          },
+        ],
+      });
+      return cfg;
+    });
+    const key = "plugin:0123456789abcdef:echo";
+    const cases: Array<[string, unknown]> = [
+      [JSON.stringify({ enabledServers: ["shots", key] }), { enabledServers: ["shots"] }],
+      [JSON.stringify({ enabledServers: [key, "shots"] }), { enabledServers: ["shots"] }],
+      [JSON.stringify({ enabledServers: ["a", key, "b"] }), { enabledServers: ["a", "b"] }],
+      [JSON.stringify({ enabledServers: [key] }), { enabledServers: [] }],
+      [
+        `{"disabledServers":["shots",${JSON.stringify(key)}],"x":1}`,
+        { disabledServers: ["shots"], x: 1 },
+      ],
+      [
+        `{ /* c */ "enabledServers": [ "shots" , ${JSON.stringify(key)} ] }`,
+        { enabledServers: ["shots"] },
+      ],
+      // Comments attached to a RETAINED neighbor survive on either side.
+      [
+        `{"enabledServers":[${JSON.stringify(key)}, /* why shots */ "shots"], "keep": /* k */ 1}`,
+        { enabledServers: ["shots"], keep: 1 },
+      ],
+      [
+        `{"enabledServers":["shots", // trailing on shots\n ${JSON.stringify(key)}]}`,
+        { enabledServers: ["shots"] },
+      ],
+      [
+        `{"enabledServers":["a", /* mid */ ${JSON.stringify(key)}, /* b's */ "b"]}`,
+        { enabledServers: ["a", "b"] },
+      ],
+    ];
+    for (const [original, expected] of cases) {
+      await fs.writeFile(filePath, original);
+      await service.prunePluginOverrideKeys(workspaceId, "plugin:0123456789abcdef:");
+      const text = await fs.readFile(filePath, "utf-8");
+      const errors: JsoncParseError[] = [];
+      expect(jsoncParse(text, errors)).toEqual(expected);
+      expect(errors).toEqual([]);
+    }
+    // Every comment that was not inside the removed element survives.
+    expect(await fs.readFile(filePath, "utf-8")).toContain("/* b's */");
+    await fs.writeFile(
+      filePath,
+      `{"enabledServers":[${JSON.stringify(key)}, /* why shots */ "shots"], "keep": /* k */ 1}`
+    );
+    await service.prunePluginOverrideKeys(workspaceId, "plugin:0123456789abcdef:");
+    const text = await fs.readFile(filePath, "utf-8");
+    expect(text).toContain("/* why shots */");
+    expect(text).toContain("/* k */");
+    await fs.writeFile(
+      filePath,
+      `{"enabledServers":["shots", // trailing on shots\n ${JSON.stringify(key)}]}`
+    );
+    await service.prunePluginOverrideKeys(workspaceId, "plugin:0123456789abcdef:");
+    expect(await fs.readFile(filePath, "utf-8")).toContain("// trailing on shots");
   });
 
   it("prunePluginOverrideKeys removes only prefix keys and preserves unknown fields", async () => {
@@ -441,7 +3499,7 @@ describe("WorkspaceMcpOverridesService", () => {
       [pruned.workspaceId, untouched.workspaceId, broken.workspaceId, "ws-missing"],
       "plugin:0123456789abcdef:",
       {
-        publish: (workspaceId, persisted) => {
+        publish: (persisted, workspaceId) => {
           published.push([workspaceId, persisted]);
           return Promise.resolve();
         },
@@ -461,10 +3519,12 @@ describe("WorkspaceMcpOverridesService", () => {
       [untouched.workspaceId, {}],
     ]);
     // The sweep cost must not scale with a full config parse per workspace:
-    // one metadata load up front and one post-sweep re-resolution (each
-    // loading config once), plus the batch's single legacy-config snapshot.
-    expect(metadataSpy).toHaveBeenCalledTimes(2);
-    expect(configSpy).toHaveBeenCalledTimes(3);
+    // two registry loads to derive and verify the checkout lock keys, one
+    // fresh load under the global lock for the sweep itself and one
+    // post-sweep re-resolution (each loading config once), plus the batch's
+    // single legacy-config snapshot.
+    expect(metadataSpy).toHaveBeenCalledTimes(4);
+    expect(configSpy).toHaveBeenCalledTimes(5);
   });
 
   it("prunePluginOverrideKeysForWorkspaces prunes every checkout sharing a duplicated ID", async () => {
@@ -541,6 +3601,332 @@ describe("WorkspaceMcpOverridesService", () => {
     expect(after.enabledServers).toEqual([]);
   });
 
+  it("a workspace lock (held by a rename) blocks only that workspace's override writers", async () => {
+    const service = new WorkspaceMcpOverridesService(config);
+    const renaming = await registerWorkspace("ws-lock-renaming");
+    const unrelated = await registerWorkspace("ws-lock-unrelated");
+    const release = await service.acquireWorkspaceLock(renaming.workspaceId);
+    try {
+      // An unrelated workspace's save is not serialized behind the rename.
+      await service.setOverridesForWorkspace(unrelated.workspaceId, {
+        enabledServers: ["shots"],
+      });
+      // The renamed workspace's save (and its plugin-key prune) wait for the
+      // move to finish instead of writing into the vacated path.
+      let saveSettled = false;
+      const save = service
+        .setOverridesForWorkspace(renaming.workspaceId, { enabledServers: ["shots"] })
+        .then(() => {
+          saveSettled = true;
+        });
+      let pruneSettled = false;
+      const prune = service
+        .prunePluginOverrideKeysForWorkspaces([renaming.workspaceId], "plugin:")
+        .then(() => {
+          pruneSettled = true;
+        });
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect(saveSettled).toBe(false);
+      expect(pruneSettled).toBe(false);
+      await release();
+      await Promise.all([save, prune]);
+    } finally {
+      await release().catch(() => undefined);
+    }
+    expect((await service.getOverridesForWorkspace(renaming.workspaceId)).overrides).toEqual({
+      enabledServers: ["shots"],
+    });
+  });
+
+  it("a batch of workspace locks never retains an unrelated lock while waiting for a busy one", async () => {
+    const service = new WorkspaceMcpOverridesService(config);
+    const free = await registerWorkspace("ws-batch-free");
+    const busy = await registerWorkspace("ws-batch-busy");
+    const releaseBusy = await service.acquireWorkspaceLock(busy.workspaceId);
+    try {
+      let pruneSettled = false;
+      const prune = service
+        .prunePluginOverrideKeysForWorkspaces([free.workspaceId, busy.workspaceId], "plugin:")
+        .then(() => {
+          pruneSettled = true;
+        });
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect(pruneSettled).toBe(false);
+      // The free workspace's own writer is not blocked by the waiting batch.
+      const startedAt = Date.now();
+      await service.setOverridesForWorkspace(free.workspaceId, { enabledServers: ["shots"] });
+      expect(Date.now() - startedAt).toBeLessThan(5_000);
+      await releaseBusy();
+      await prune;
+    } finally {
+      await releaseBusy().catch(() => undefined);
+    }
+  });
+
+  it("the workspace lock is still derived when an unrelated legacy entry's metadata is malformed", async () => {
+    // Rename and removal take this lock: an unreadable metadata.json of some
+    // OTHER id-less legacy entry must not brick every healthy workspace.
+    const service = new WorkspaceMcpOverridesService(config);
+    const healthy = await registerWorkspace("lock-despite-corrupt-sibling");
+    const legacyPath = path.join(config.srcDir, "legacy-project", "old-branch");
+    await fs.mkdir(legacyPath, { recursive: true });
+    // Id-less legacy entry: its stable id comes from metadata.json.
+    const legacyEntry: unknown = { path: legacyPath };
+    await config.editConfig((cfg) => {
+      cfg.projects.set("/fake/legacy-project", { workspaces: [legacyEntry as never] });
+      return cfg;
+    });
+    const sessionDir = path.join(config.sessionsDir, "old-branch");
+    await fs.mkdir(sessionDir, { recursive: true });
+    await fs.writeFile(path.join(sessionDir, "metadata.json"), "{ not json");
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      config.getAllWorkspaceMetadata({ probeCheckouts: false, throwOnError: true })
+    ).rejects.toThrow();
+
+    // The lock still fences by checkout identity (a second acquirer waits).
+    const release = await service.acquireWorkspaceLock(healthy.workspaceId);
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      service.acquireWorkspaceLock(healthy.workspaceId, { acquireTimeoutMs: 300 })
+    ).rejects.toThrow("in progress for this workspace");
+    await release();
+
+    // A workspace the lenient walk cannot see keeps failing closed.
+    await fs.writeFile(path.join(tempDir, "config.json"), "{ not json");
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(service.acquireWorkspaceLock(healthy.workspaceId)).rejects.toThrow();
+  });
+
+  it("aliases sharing one checkout contend for one lock", async () => {
+    // An isolation:none child and its parent hold distinct ids for one
+    // override document: a rename through one id must fence a save through
+    // the other, so the lock is keyed by checkout identity, not by id.
+    const service = new WorkspaceMcpOverridesService(config);
+    const dir = path.join(tempDir, "alias-lock-checkout");
+    await registerLocalWorkspace(dir, "alias-lock-parent");
+    await registerLocalWorkspace(dir, "alias-lock-child");
+    const release = await service.acquireWorkspaceLock("alias-lock-parent");
+    try {
+      let saveSettled = false;
+      const save = service
+        .setOverridesForWorkspace("alias-lock-child", { enabledServers: ["shots"] })
+        .then(() => {
+          saveSettled = true;
+        });
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect(saveSettled).toBe(false);
+      await release();
+      await save;
+    } finally {
+      await release().catch(() => undefined);
+    }
+    expect((await service.getOverridesForWorkspace("alias-lock-child")).overrides).toEqual({
+      enabledServers: ["shots"],
+    });
+  });
+
+  it("a save through a symlinked spelling of a checkout contends with the real spelling's lock", async () => {
+    const service = new WorkspaceMcpOverridesService(config);
+    const realDir = path.join(tempDir, "lock-real-checkout");
+    const linkDir = path.join(tempDir, "lock-linked-checkout");
+    await fs.mkdir(realDir, { recursive: true });
+    await fs.symlink(realDir, linkDir);
+    await registerLocalWorkspace(realDir, "lock-via-real");
+    await registerLocalWorkspace(linkDir, "lock-via-link");
+    const release = await service.acquireWorkspaceLock("lock-via-real");
+    try {
+      let saveSettled = false;
+      const save = service
+        .setOverridesForWorkspace("lock-via-link", { enabledServers: ["shots"] })
+        .then(() => {
+          saveSettled = true;
+        });
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect(saveSettled).toBe(false);
+      await release();
+      await save;
+    } finally {
+      await release().catch(() => undefined);
+    }
+  });
+
+  it("a save never recreates a checkout that disappeared after the registry read", async () => {
+    // Workspace removal takes no override lock: the checkout can be gone by
+    // the time the save writes. Refuse instead of materializing a stray `.xum`.
+    const service = new WorkspaceMcpOverridesService(config);
+    const { workspaceId, workspacePath } = await registerWorkspace("removed-checkout");
+    await fs.rm(workspacePath, { recursive: true, force: true });
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      service.setOverridesForWorkspace(workspaceId, { enabledServers: ["shots"] })
+    ).rejects.toThrow("checkout is not available");
+    expect(await pathExists(workspacePath)).toBe(false);
+  });
+
+  it("a dialog opened on an unreadable document can repair it with the unavailable revision", async () => {
+    const service = new WorkspaceMcpOverridesService(config);
+    const { workspaceId, workspacePath } = await registerWorkspace("repair-unavailable");
+    await fs.mkdir(path.join(workspacePath, ".xum"), { recursive: true });
+    await fs.writeFile(path.join(workspacePath, ".xum", "mcp.local.jsonc"), "{ not json");
+    // The state is not authoritative: the sentinel repairs it.
+    await service.setOverridesForWorkspace(
+      workspaceId,
+      { disabledServers: ["shots"] },
+      { expectedRevision: MCP_OVERRIDES_REVISION_UNAVAILABLE }
+    );
+    expect((await service.getOverridesForWorkspace(workspaceId)).overrides).toEqual({
+      disabledServers: ["shots"],
+    });
+    // Readable again: the sentinel is a stale snapshot like any other.
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      service.setOverridesForWorkspace(
+        workspaceId,
+        { enabledServers: ["other"] },
+        { expectedRevision: MCP_OVERRIDES_REVISION_UNAVAILABLE }
+      )
+    ).rejects.toThrow("changed while this dialog was open");
+  });
+
+  it("workspace locks are keyed by the normalized id", async () => {
+    const service = new WorkspaceMcpOverridesService(config);
+    const release = await service.acquireWorkspaceLock("ws-trim");
+    try {
+      // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+      await expect(
+        service.acquireWorkspaceLock(" ws-trim ", { acquireTimeoutMs: 500 })
+      ).rejects.toThrow("in progress for this workspace");
+    } finally {
+      await release();
+    }
+  });
+
+  it("an exclusive-lock acquisition past its deadline gives up without ever holding the lock", async () => {
+    const service = new WorkspaceMcpOverridesService(config);
+    const release = await service.acquireExclusiveLock();
+    // Queued behind the holder with a budget that expires while waiting.
+    const expired = service.acquireExclusiveLock({ timeoutMs: 50 });
+    const aborted = service.acquireExclusiveLock({ signal: AbortSignal.abort() });
+    // Both settle while other assertions run; mark them handled up front.
+    expired.catch(() => undefined);
+    aborted.catch(() => undefined);
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    let laterAcquired = false;
+    const later = service.acquireExclusiveLock().then((releaseLater) => {
+      laterAcquired = true;
+      return releaseLater;
+    });
+    await release();
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(expired).rejects.toThrow("updating workspace MCP settings");
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(aborted).rejects.toThrow("aborted");
+    // The abandoned entries did not hold the lock: the next writer proceeds.
+    const releaseLater = await later;
+    expect(laterAcquired).toBe(true);
+    await releaseLater();
+  });
+
+  it("an aborted exclusive-lock acquisition stops polling a sibling process's hold immediately", async () => {
+    // Two service instances = two processes sharing one home: the second's
+    // queue is empty, so it polls the cross-process lock file directly.
+    const holder = new WorkspaceMcpOverridesService(config);
+    const waiter = new WorkspaceMcpOverridesService(config);
+    const release = await holder.acquireExclusiveLock();
+    try {
+      const controller = new AbortController();
+      const startedAt = Date.now();
+      const acquisition = waiter.acquireExclusiveLock({ signal: controller.signal });
+      setTimeout(() => controller.abort(), 100);
+      // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+      await expect(acquisition).rejects.toThrow("aborted");
+      expect(Date.now() - startedAt).toBeLessThan(5_000);
+    } finally {
+      await release();
+    }
+  });
+
+  it("SSH registrations of one remote path share a lock key across host aliases", async () => {
+    // Two ssh_config aliases can name the same machine; nothing can resolve
+    // them to a stable identity here, so a rename through one alias and a
+    // save through the other must still contend on the checkout.
+    const service = new WorkspaceMcpOverridesService(config);
+    await config.editConfig((cfg) => {
+      cfg.projects.set("/fake/ssh-aliases", {
+        workspaces: [
+          {
+            path: "/remote/shared",
+            id: "ws-ssh-alias-a",
+            name: "alias-a",
+            runtimeConfig: { type: "ssh", host: "alias-a", srcBaseDir: "/remote" },
+          },
+          {
+            path: "/remote/shared",
+            id: "ws-ssh-alias-b",
+            name: "alias-b",
+            runtimeConfig: { type: "ssh", host: "alias-b", srcBaseDir: "/remote" },
+          },
+          {
+            path: "/remote/other",
+            id: "ws-ssh-alias-c",
+            name: "alias-c",
+            runtimeConfig: { type: "ssh", host: "alias-a", srcBaseDir: "/remote" },
+          },
+        ],
+      });
+      return cfg;
+    });
+    const internals = service as unknown as {
+      checkoutLockKeys: (ids: string[]) => Promise<{ keys: Map<string, string[]> }>;
+    };
+    const { keys } = await internals.checkoutLockKeys([
+      "ws-ssh-alias-a",
+      "ws-ssh-alias-b",
+      "ws-ssh-alias-c",
+    ]);
+    const shared = (a: string, b: string) =>
+      (keys.get(a) ?? []).filter((key) => (keys.get(b) ?? []).includes(key));
+    expect(shared("ws-ssh-alias-a", "ws-ssh-alias-b")).toHaveLength(1);
+    // Different remote paths never contend, alias or not.
+    expect(shared("ws-ssh-alias-a", "ws-ssh-alias-c")).toHaveLength(0);
+  });
+
+  it("an id registered on several checkouts locks every one of them", async () => {
+    // Corrupted config can list one stable id under several entries; the
+    // plugin sweep prunes every host-local checkout carrying it, so the
+    // batch must hold each checkout's key, not the one a last-write-wins
+    // map happened to keep.
+    const service = new WorkspaceMcpOverridesService(config);
+    const pathA = path.join(config.srcDir, "dup-a");
+    const pathB = path.join(config.srcDir, "dup-b");
+    await registerLocalWorkspace(pathA, "ws-dup-a");
+    await registerLocalWorkspace(pathB, "ws-dup-b");
+    const internals = service as unknown as {
+      checkoutLockKeys: (ids: string[]) => Promise<{ keys: Map<string, string[]> }>;
+    };
+    const separate = await internals.checkoutLockKeys(["ws-dup-a", "ws-dup-b"]);
+    const expected = [
+      ...(separate.keys.get("ws-dup-a") ?? []),
+      ...(separate.keys.get("ws-dup-b") ?? []),
+    ];
+    expect(expected.length).toBeGreaterThanOrEqual(2);
+
+    await config.editConfig((cfg) => {
+      for (const project of cfg.projects.values()) {
+        for (const entry of project.workspaces) {
+          if (entry.id === "ws-dup-a" || entry.id === "ws-dup-b") entry.id = "ws-duplicated";
+        }
+      }
+      return cfg;
+    });
+    const { keys } = await internals.checkoutLockKeys(["ws-duplicated"]);
+    const duplicated = keys.get("ws-duplicated") ?? [];
+    for (const key of expected) {
+      expect(duplicated).toContain(key);
+    }
+  });
+
   it("acquireExclusiveLock holds the prune sweep until released", async () => {
     const service = new WorkspaceMcpOverridesService(config);
     const { workspaceId } = await registerWorkspace("locked");
@@ -562,15 +3948,58 @@ describe("WorkspaceMcpOverridesService", () => {
     expect(sweepDone).toBe(true);
   });
 
+  it("prunePluginOverrideKeysForWorkspaces walks each inheriting subtree once", async () => {
+    // A swept chain must not be re-traversed from every ancestor (O(N²)
+    // probes under the exclusive lock): the grandchild is published by the
+    // root's fan-out and once more by its own strict verification — never a
+    // third time via the child's fan-out.
+    const service = new WorkspaceMcpOverridesService(config);
+    const root = await registerWorkspace("chain-root");
+    const child = await registerWorkspace("chain-child");
+    const grandchild = await registerWorkspace("chain-grandchild");
+    await config.editConfig((cfg) => {
+      for (const project of cfg.projects.values()) {
+        for (const entry of project.workspaces) {
+          if (entry.id === child.workspaceId) entry.parentWorkspaceId = root.workspaceId;
+          if (entry.id === grandchild.workspaceId) entry.parentWorkspaceId = child.workspaceId;
+        }
+      }
+      return cfg;
+    });
+    await service.setOverridesForWorkspace(root.workspaceId, {
+      enabledServers: ["plugin:0123456789abcdef:echo", "other"],
+    });
+
+    const published = new Map<string, number>();
+    const failures = await service.prunePluginOverrideKeysForWorkspaces(
+      [root.workspaceId, child.workspaceId, grandchild.workspaceId],
+      "plugin:0123456789abcdef:",
+      {
+        publish: (_persisted, workspaceId) => {
+          published.set(workspaceId, (published.get(workspaceId) ?? 0) + 1);
+          return Promise.resolve();
+        },
+      }
+    );
+    expect(failures).toEqual([]);
+    expect(published.get(root.workspaceId)).toBe(1);
+    expect(published.get(child.workspaceId)).toBe(2);
+    expect(published.get(grandchild.workspaceId)).toBe(2);
+  });
+
   it("prunePluginOverrideKeysForWorkspaces fails a workspace renamed during the sweep", async () => {
     const service = new WorkspaceMcpOverridesService(config);
     const stable = await registerWorkspace("stable");
     const moved = await registerWorkspace("moved");
     await config.getAllWorkspaceMetadata();
     const realGetAll = config.getAllWorkspaceMetadata.bind(config);
-    // Second load (the post-sweep re-resolution) sees the workspace under a
-    // new name — exactly what a concurrent rename leaves behind.
+    // Fourth load (the post-sweep re-resolution; the first two derive and
+    // verify the checkout lock keys, the third is the sweep's own view) sees
+    // the workspace under a new name — exactly what a concurrent rename
+    // leaves behind.
     spyOn(config, "getAllWorkspaceMetadata")
+      .mockImplementationOnce(realGetAll)
+      .mockImplementationOnce(realGetAll)
       .mockImplementationOnce(realGetAll)
       .mockImplementationOnce(async () =>
         (await realGetAll()).map((metadata) =>
@@ -654,6 +4083,91 @@ describe("WorkspaceMcpOverridesService", () => {
     await expect(
       service.prunePluginOverrideKeys(workspaceId, "plugin:0123456789abcdef:")
     ).rejects.toThrow(/resolves outside the workspace/);
+  });
+
+  it("the verified document read never follows a symlink swapped in after the path guards", async () => {
+    // The segment guards are point-in-time; the read that copies bytes out of
+    // the checkout (fork copy, carried unknown fields) must fail on a symlink
+    // — at the final component OR a parent segment — rather than read the
+    // file it points at.
+    const checkout = path.join(config.srcDir, "nofollow-read");
+    await fs.mkdir(path.join(checkout, ".xum"), { recursive: true });
+    const own = path.join(checkout, ".xum", "mcp.local.jsonc");
+    await fs.writeFile(own, '{ "enabledServers": ["shots"] }');
+    expect(await readHostOverrideDocumentNoFollow(own, checkout)).toBe(
+      '{ "enabledServers": ["shots"] }'
+    );
+
+    // Final component swapped for a symlink to a host file.
+    const secret = path.join(config.srcDir, "secret.json");
+    await fs.writeFile(secret, '{ "token": "hunter2" }');
+    await fs.rm(own);
+    await fs.symlink(secret, own);
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(readHostOverrideDocumentNoFollow(own, checkout)).rejects.toThrow();
+    await fs.rm(own);
+
+    // Parent segment swapped for a symlink to a SIBLING checkout's `.xum`:
+    // O_NOFOLLOW alone follows it (regular file at the end), the post-open
+    // verification does not.
+    const sibling = path.join(config.srcDir, "sibling-checkout");
+    await fs.mkdir(path.join(sibling, ".xum"), { recursive: true });
+    await fs.writeFile(
+      path.join(sibling, ".xum", "mcp.local.jsonc"),
+      '{ "enabledServers": ["sibling-secret-server"] }'
+    );
+    await fs.rm(path.join(checkout, ".xum"), { recursive: true, force: true });
+    await fs.symlink(path.join(sibling, ".xum"), path.join(checkout, ".xum"));
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(readHostOverrideDocumentNoFollow(own, checkout)).rejects.toThrow(/symbolic link/);
+    // A directory and a path outside the checkout are refused too.
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(readHostOverrideDocumentNoFollow(sibling, checkout)).rejects.toThrow();
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(readHostOverrideDocumentNoFollow(secret, checkout)).rejects.toThrow(
+      /outside the checkout/
+    );
+  });
+
+  it("saves a devcontainer workspace's settings on the host without a running container", async () => {
+    // The override files live in the host worktree and DevcontainerRuntime
+    // reads/writes them there; only `exec` needs `devcontainer exec` (a
+    // running container). The symlink guard must therefore probe the host —
+    // and still refuse a symlinked segment.
+    const service = new WorkspaceMcpOverridesService(config);
+    // In-place registration (projectPath === name) keeps the checkout under
+    // the test root regardless of the devcontainer runtime's srcBaseDir.
+    const checkout = path.join(config.srcDir, "devcontainer-save");
+    await fs.mkdir(checkout, { recursive: true });
+    const workspaceId = "ws-devcontainer-save";
+    await config.editConfig((cfg) => {
+      cfg.projects.set(checkout, {
+        workspaces: [
+          {
+            path: checkout,
+            id: workspaceId,
+            name: checkout,
+            runtimeConfig: { type: "devcontainer", configPath: ".devcontainer/devcontainer.json" },
+          },
+        ],
+      });
+      return cfg;
+    });
+
+    await service.setOverridesForWorkspace(workspaceId, { disabledServers: ["shots"] });
+    expect(
+      jsoncParse(await fs.readFile(path.join(checkout, ".xum", "mcp.local.jsonc"), "utf-8"))
+    ).toEqual({ disabledServers: ["shots"] });
+
+    await fs.rm(path.join(checkout, ".xum"), { recursive: true, force: true });
+    const outsideDir = path.join(config.srcDir, "outside-devcontainer");
+    await fs.mkdir(outsideDir, { recursive: true });
+    await fs.symlink(outsideDir, path.join(checkout, ".xum"));
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      service.setOverridesForWorkspace(workspaceId, { disabledServers: ["other"] })
+    ).rejects.toThrow(/symbolic link/);
+    expect(await pathExists(path.join(outsideDir, "mcp.local.jsonc"))).toBe(false);
   });
 
   it("CAS saves from two service instances are serialized by the cross-process lock", async () => {
@@ -808,7 +4322,7 @@ describe("WorkspaceMcpOverridesService", () => {
     await Promise.all([
       service.prunePluginOverrideKeys(workspaceId, "plugin:0123456789abcdef:", {
         publish: (persisted) => {
-          published.push({ via: "prune", enabled: persisted.enabledServers });
+          published.push({ via: "prune", enabled: persisted?.enabledServers });
           return Promise.resolve();
         },
       }),
@@ -817,7 +4331,7 @@ describe("WorkspaceMcpOverridesService", () => {
         { enabledServers: ["other-server", "third-server"] },
         {
           publish: (persisted) => {
-            published.push({ via: "set", enabled: persisted.enabledServers });
+            published.push({ via: "set", enabled: persisted?.enabledServers });
             return Promise.resolve();
           },
         }
@@ -961,6 +4475,55 @@ describe("WorkspaceMcpOverridesService", () => {
     await expect(
       service.prunePluginOverrideKeys(workspaceId, "plugin:0123456789abcdef:")
     ).rejects.toThrow(/unrecognized root shape/);
+
+    // An opaque shape that PROVABLY carries no canonical plugin key anywhere
+    // has nothing to prune: it is left verbatim (a fork copy preserves the
+    // same document on the same evidence; registration must not reject it).
+    const opaqueClean = '{\n  // newer build\n  "enabledServers": { "v2": ["shots"] }\n}\n';
+    await fs.writeFile(filePath, opaqueClean);
+    await service.prunePluginOverrideKeys(workspaceId, "plugin:0123456789abcdef:");
+    expect(await fs.readFile(filePath, "utf-8")).toBe(opaqueClean);
+    // …but a key hidden in a SHADOWED duplicate property is still seen.
+    await fs.writeFile(
+      filePath,
+      '{ "enabledServers": ["plugin:0123456789abcdef:echo"], "enabledServers": { "v2": [] } }'
+    );
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      service.prunePluginOverrideKeys(workspaceId, "plugin:0123456789abcdef:")
+    ).rejects.toThrow(/duplicate|unrecognized/);
+
+    // The owned fields prune cleanly, but a newer build's UNKNOWN top-level
+    // field still carries the same instance key: success would retire the
+    // tombstone while the key survives, so the prune is rejected (and the
+    // owned-field edit is not written either — the document stays verbatim).
+    const retained = JSON.stringify({
+      enabledServers: ["plugin:0123456789abcdef:echo"],
+      authorizations: { "plugin:0123456789abcdef:echo": "granted" },
+    });
+    await fs.writeFile(filePath, retained);
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      service.prunePluginOverrideKeys(workspaceId, "plugin:0123456789abcdef:")
+    ).rejects.toThrow(/fields this version does not edit/);
+    expect(await fs.readFile(filePath, "utf-8")).toBe(retained);
+    // A DIFFERENT instance's key in that unknown field is not this prune's
+    // concern; an ordinary server name that is not in canonical key shape is
+    // not a hit either (a "plugin:" registration-wide prune passes too).
+    await fs.writeFile(
+      filePath,
+      JSON.stringify({
+        enabledServers: ["plugin:0123456789abcdef:echo", "myplugin:x"],
+        authorizations: { "plugin:fedcba9876543210:echo": "granted" },
+      })
+    );
+    await service.prunePluginOverrideKeys(workspaceId, "plugin:0123456789abcdef:");
+    expect(jsoncParse(await fs.readFile(filePath, "utf-8"))).toEqual({
+      enabledServers: ["myplugin:x"],
+      authorizations: { "plugin:fedcba9876543210:echo": "granted" },
+    });
+    await fs.writeFile(filePath, JSON.stringify({ enabledServers: ["myplugin:x"] }));
+    await service.prunePluginOverrideKeys(workspaceId, "plugin:");
   });
 
   it("prunePluginOverrideKeys rejects duplicate properties instead of mis-editing", async () => {
@@ -1076,6 +4639,105 @@ describe("WorkspaceMcpOverridesService", () => {
     expect(await pathExists(filePath)).toBe(false);
   });
 
+  it("runtime filesystem identity ignores non-identity fields and never matches Docker", () => {
+    // Coder metadata: the workspace name selects the machine (see below), the
+    // remaining flags do not.
+    expect(
+      runtimeFilesystemIdentity({
+        type: "ssh",
+        host: "box",
+        srcBaseDir: "/srv",
+        coder: { workspaceName: "w", existingWorkspace: true },
+      } as never)
+    ).toBe(
+      runtimeFilesystemIdentity({
+        type: "ssh",
+        host: "box",
+        srcBaseDir: "/other",
+        coder: { workspaceName: "w" },
+      } as never)
+    );
+    expect(
+      runtimeFilesystemIdentity({ type: "ssh", host: "box", srcBaseDir: "/srv" } as never)
+    ).not.toBe(
+      runtimeFilesystemIdentity({ type: "ssh", host: "elsewhere", srcBaseDir: "/srv" } as never)
+    );
+    // Same alias, different port: a different machine. Default port is 22.
+    expect(
+      runtimeFilesystemIdentity({
+        type: "ssh",
+        host: "box",
+        port: 2222,
+        srcBaseDir: "/srv",
+      } as never)
+    ).not.toBe(
+      runtimeFilesystemIdentity({ type: "ssh", host: "box", srcBaseDir: "/srv" } as never)
+    );
+    expect(
+      runtimeFilesystemIdentity({ type: "ssh", host: "box", port: 22, srcBaseDir: "/srv" } as never)
+    ).toBe(runtimeFilesystemIdentity({ type: "ssh", host: "box", srcBaseDir: "/srv" } as never));
+    // Coder configs keep the raw placeholder host; the real endpoint comes from the workspace name.
+    expect(
+      runtimeFilesystemIdentity({
+        type: "ssh",
+        host: "coder://",
+        srcBaseDir: "/srv",
+        coder: { workspaceName: "alpha" },
+      } as never)
+    ).not.toBe(
+      runtimeFilesystemIdentity({
+        type: "ssh",
+        host: "coder://",
+        srcBaseDir: "/srv",
+        coder: { workspaceName: "beta" },
+      } as never)
+    );
+    // Project-dir and worktree workspaces live on the same host filesystem.
+    expect(runtimeFilesystemIdentity({ type: "local" } as never)).toBe(
+      runtimeFilesystemIdentity({ type: "worktree", srcBaseDir: "/x" } as never)
+    );
+    expect(
+      runtimeFilesystemIdentity({ type: "docker", image: "node:20" } as never)
+    ).toBeUndefined();
+  });
+
+  it("treats only stat's own no-such-file diagnostic as positive absence", () => {
+    // Local runtimes: errno codes, possibly wrapped as `cause`.
+    expect(isPositivelyAbsent(Object.assign(new Error("x"), { code: "ENOENT" }))).toBe(true);
+    expect(
+      isPositivelyAbsent(
+        new Error("wrapped", { cause: Object.assign(new Error(), { code: "ENOTDIR" }) })
+      )
+    ).toBe(true);
+    expect(isPositivelyAbsent(Object.assign(new Error("x"), { code: "EACCES" }))).toBe(false);
+    // Exec-backed runtimes relay stat(1)'s stderr (GNU, busybox, BSD spellings).
+    for (const stderr of [
+      "stat: cannot statx '/w/.xum/mcp.local.jsonc': No such file or directory",
+      "stat: can't stat '/w/.xum/mcp.local.jsonc': No such file or directory",
+      "stat: /w/.xum/mcp.local.jsonc: stat: No such file or directory",
+      "stat: cannot statx '/w/.xum/mcp.local.jsonc': Not a directory",
+    ]) {
+      expect(
+        isPositivelyAbsent(new Error(`Failed to stat /w/.xum/mcp.local.jsonc: ${stderr}`))
+      ).toBe(true);
+    }
+    // Transport/setup noise mentioning a missing file must stay indeterminate.
+    expect(
+      isPositivelyAbsent(
+        new Error(
+          "Failed to stat /w/.xum/mcp.local.jsonc: Warning: Identity file /home/u/.ssh/id not accessible: No such file or directory.\nssh: connect to host box port 22: Connection refused"
+        )
+      )
+    ).toBe(false);
+    expect(
+      isPositivelyAbsent(
+        new Error(
+          "Failed to stat /w/.xum/mcp.local.jsonc: stat: cannot statx '/w/.xum/mcp.local.jsonc': Permission denied"
+        )
+      )
+    ).toBe(false);
+  });
+
   it("migrates legacy config.json overrides into workspace-local file", async () => {
     const projectPath = "/fake/project";
     const workspaceId = "ws-id";
@@ -1123,5 +4785,159 @@ describe("WorkspaceMcpOverridesService", () => {
     const projectConfig = loaded.projects.get(projectPath);
     expect(projectConfig).toBeDefined();
     expect(projectConfig!.workspaces[0].mcp).toBeUndefined();
+  });
+
+  it("a document with unknown top-level fields is child-owned and does not inherit", async () => {
+    // A newer release may give a new field authorization semantics while every
+    // known field is empty; a downgraded build must not inherit the parent's
+    // enables over it (fail closed), only a document made of known empty
+    // fields resolves as absent.
+    const parentPath = getWorkspacePath({
+      srcDir: config.srcDir,
+      projectName: "project",
+      workspaceName: "parent",
+    });
+    const childPath = getWorkspacePath({
+      srcDir: config.srcDir,
+      projectName: "project",
+      workspaceName: "child",
+    });
+    await fs.mkdir(path.join(parentPath, ".xum"), { recursive: true });
+    await fs.mkdir(path.join(childPath, ".xum"), { recursive: true });
+    await fs.writeFile(
+      path.join(parentPath, ".xum", "mcp.local.jsonc"),
+      JSON.stringify({ enabledServers: ["shots"] })
+    );
+    await config.editConfig((cfg) => {
+      cfg.projects.set("/fake/project", {
+        workspaces: [
+          {
+            path: parentPath,
+            id: "ws-parent",
+            name: "parent",
+            runtimeConfig: { type: "worktree", srcBaseDir: config.srcDir },
+          },
+          {
+            path: childPath,
+            id: "ws-child",
+            name: "child",
+            runtimeConfig: { type: "worktree", srcBaseDir: config.srcDir },
+            parentWorkspaceId: "ws-parent",
+          },
+        ],
+      });
+      return cfg;
+    });
+    const service = new WorkspaceMcpOverridesService(config);
+    const childFile = path.join(childPath, ".xum", "mcp.local.jsonc");
+    // Known, empty fields: not a decision → inherits.
+    await fs.writeFile(childFile, JSON.stringify({ enabledServers: [] }));
+    expect((await service.getOverridesForWorkspace("ws-child")).overrides).toEqual({
+      enabledServers: ["shots"],
+    });
+    // An unknown field with every known field empty: the child's own document.
+    await fs.writeFile(childFile, JSON.stringify({ enabledServers: [], denyAll: true }));
+    expect((await service.getOverridesForWorkspace("ws-child")).overrides).toEqual({});
+  });
+
+  it("keeps the legacy value when the replacement document cannot be written", async () => {
+    // A repo can track `.xum` as a regular file, so the override directory
+    // cannot be created. The save must fail without having cleared the legacy
+    // value first — otherwise the child would inherit the parent's enables
+    // instead of the settings the legacy value carried.
+    const parentPath = getWorkspacePath({
+      srcDir: config.srcDir,
+      projectName: "project",
+      workspaceName: "parent",
+    });
+    const childPath = getWorkspacePath({
+      srcDir: config.srcDir,
+      projectName: "project",
+      workspaceName: "child",
+    });
+    await fs.mkdir(path.join(parentPath, ".xum"), { recursive: true });
+    await fs.mkdir(childPath, { recursive: true });
+    await fs.writeFile(
+      path.join(parentPath, ".xum", "mcp.local.jsonc"),
+      JSON.stringify({ enabledServers: ["parent-enable"] })
+    );
+    await fs.writeFile(path.join(childPath, ".xum"), "tracked regular file\n");
+    await config.editConfig((cfg) => {
+      cfg.projects.set("/fake/project", {
+        workspaces: [
+          {
+            path: parentPath,
+            id: "ws-parent",
+            name: "parent",
+            runtimeConfig: { type: "worktree", srcBaseDir: config.srcDir },
+          },
+          {
+            path: childPath,
+            id: "ws-child",
+            name: "child",
+            runtimeConfig: { type: "worktree", srcBaseDir: config.srcDir },
+            parentWorkspaceId: "ws-parent",
+            mcp: { disabledServers: ["parent-enable"] },
+          },
+        ],
+      });
+      return cfg;
+    });
+    const service = new WorkspaceMcpOverridesService(config);
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      service.setOverridesForWorkspace("ws-child", { disabledServers: ["parent-enable", "x"] })
+    ).rejects.toThrow();
+    expect(config.loadConfigOrDefault().projects.get("/fake/project")!.workspaces[1].mcp).toEqual({
+      disabledServers: ["parent-enable"],
+    });
+    expect((await service.getOverridesForWorkspace("ws-child")).overrides).toEqual({
+      disabledServers: ["parent-enable"],
+    });
+  });
+
+  it("never migrates legacy overrides over an existing document that normalizes to empty", async () => {
+    // Downgrade↔upgrade: an older build wrote legacy config.json overrides
+    // while a newer build's file holds only fields this build does not
+    // understand. Migration must not clobber those fields.
+    const projectPath = "/fake/project";
+    const workspaceId = "ws-id";
+    const workspaceName = "branch";
+    const workspacePath = getWorkspacePath({
+      srcDir: config.srcDir,
+      projectName: "project",
+      workspaceName,
+    });
+    const filePath = path.join(workspacePath, ".xum", "mcp.local.jsonc");
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    const newerBuildDocument = '{ "futureField": { "keep": true } }\n';
+    await fs.writeFile(filePath, newerBuildDocument);
+
+    await config.editConfig((cfg) => {
+      cfg.projects.set(projectPath, {
+        workspaces: [
+          {
+            path: workspacePath,
+            id: workspaceId,
+            name: workspaceName,
+            runtimeConfig: { type: "worktree", srcBaseDir: config.srcDir },
+            mcp: { disabledServers: ["server-a"] },
+          },
+        ],
+      });
+      return cfg;
+    });
+
+    const service = new WorkspaceMcpOverridesService(config);
+    const { overrides } = await service.getOverridesForWorkspace(workspaceId);
+    // The newer build's document is the workspace's own configuration: it
+    // decides (nothing this build can read → no overrides), the legacy value
+    // does not shadow it…
+    expect(overrides).toEqual({});
+    // …and neither the file nor the legacy entry is rewritten.
+    expect(await fs.readFile(filePath, "utf8")).toBe(newerBuildDocument);
+    expect(config.loadConfigOrDefault().projects.get(projectPath)!.workspaces[0].mcp).toEqual({
+      disabledServers: ["server-a"],
+    });
   });
 });

--- a/src/node/services/workspaceMcpOverridesService.ts
+++ b/src/node/services/workspaceMcpOverridesService.ts
@@ -1,5 +1,6 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import * as fsPromises from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
 import * as path from "path";
 import * as jsonc from "jsonc-parser";
 import {
@@ -8,22 +9,622 @@ import {
 } from "@/common/compat/legacyMux";
 import assert from "@/common/utils/assert";
 import type { WorkspaceMCPOverrides } from "@/common/types/mcp";
-import type { RuntimeConfig } from "@/common/types/runtime";
+import { isDevcontainerRuntime, type RuntimeConfig } from "@/common/types/runtime";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import type { Config, ProjectsConfig } from "@/node/config";
-import { type createRuntime } from "@/node/runtime/runtimeFactory";
+import { createRuntime } from "@/node/runtime/runtimeFactory";
 import { createRuntimeForWorkspace } from "@/node/runtime/runtimeHelpers";
 import { execBuffered, readFileString, writeFileString } from "@/node/utils/runtime/helpers";
 import { hasErrorCode } from "@/node/services/tools/skillFileUtils";
 import { acquireCrossProcessLock } from "@/node/utils/main/crossProcessLock";
-import { isCanonicalPluginServerKey } from "@/node/services/agentPlugins/mcpConfig";
+import { raceWithAbortAndTimeout } from "@/node/utils/concurrency/withTimeout";
+import {
+  isCanonicalPluginServerKey,
+  PLUGIN_SERVER_KEY_PREFIX,
+} from "@/node/services/agentPlugins/mcpConfig";
 import { log } from "@/node/services/log";
 import { getErrorMessage } from "@/common/utils/errors";
+import { resolveCoderSSHHost } from "@/constants/coder";
 
 const MCP_OVERRIDE_FILENAMES = ["mcp.local.jsonc", "mcp.local.json"] as const;
+/**
+ * Cross-process override-write epoch. Two Xum backends sharing one home each
+ * publish only into their own MCPServerManager cache; a sibling's save or
+ * prune is otherwise invisible until that cache happens to be evicted, and
+ * the stale in-memory overlay would supersede a fresh authoritative request
+ * read. Every write here bumps the token (under the write lock); managers
+ * compare it on each serve preflight and refresh/evict their caches.
+ */
+const MCP_OVERRIDES_EPOCH_FILE = "mcp-overrides.epoch";
+
+const MCP_OVERRIDES_EPOCH_UNREADABLE_TOKEN = "mcp-overrides-epoch-unreadable";
+
+export async function readWorkspaceOverridesEpochToken(
+  rootDir: string
+): Promise<string | undefined> {
+  try {
+    return await fsPromises.readFile(path.join(rootDir, MCP_OVERRIDES_EPOCH_FILE), "utf-8");
+  } catch (error) {
+    // Unreadable is indistinguishable from "changed" for a reader; managers
+    // treat EVERY observation of this sentinel as a change (see
+    // isWorkspaceOverridesEpochUnreadable), never as a stable version.
+    return hasFsCode(error, "ENOENT") ? undefined : MCP_OVERRIDES_EPOCH_UNREADABLE_TOKEN;
+  }
+}
+
+export function isWorkspaceOverridesEpochUnreadable(token: string | undefined): boolean {
+  return token === MCP_OVERRIDES_EPOCH_UNREADABLE_TOKEN;
+}
 const MCP_OVERRIDES_GITIGNORE_PATTERNS = PROJECT_METADATA_DIR_NAMES.flatMap((dirName) =>
   MCP_OVERRIDE_FILENAMES.map((filename) => `${dirName}/${filename}`)
 );
+/**
+ * Receives the effective overrides of a workspace after a write. Called for the
+ * written workspace AND for every other workspace the write affected (hence
+ * the explicit workspaceId), inside the exclusive write queue. `null` means
+ * the effective state could not be established authoritatively (unreachable
+ * checkout): the receiver must DROP any cached snapshot for that workspace so
+ * its next request reads disk, rather than cache a guess.
+ */
+export type OverridesPublisher = (
+  persisted: WorkspaceMCPOverrides | null,
+  /** Target workspace, or ALL_WORKSPACES_TARGET (only ever with `null`: evict every cache). */
+  workspaceId: string
+) => Promise<void>;
+
+/**
+ * Publisher target meaning "every workspace this receiver knows about". Sent
+ * with `null` when the workspace graph could not be enumerated after a write:
+ * the receiver cannot be told WHICH inheriting descendants are stale, so it
+ * must drop all cached snapshots rather than keep serving revoked enablement.
+ */
+export const ALL_WORKSPACES_TARGET = "*";
+/**
+ * Revision reported to the settings UI when the current state could not be
+ * established (see getWorkspaceMcpOverrides). A save carrying it back is the
+ * explicit repair path for an unreadable document (see writeOverridesLocked).
+ */
+export const MCP_OVERRIDES_REVISION_UNAVAILABLE = "unavailable";
+
+interface ResolvedOverrides {
+  overrides: WorkspaceMCPOverrides;
+  /**
+   * False when any probe along the resolution (own paths or an inherited
+   * ancestor's) was indeterminate, or an ancestor read failed: `overrides` is
+   * then the safe fallback, not disk truth, and must not be cached as such.
+   */
+  authoritative: boolean;
+  /**
+   * Authority was lost in an ANCESTOR (unreachable parent checkout, an
+   * indeterminate parent probe), not in this workspace's own document. The
+   * own state is intact but the effective one is unknown: a save that
+   * "repairs" the empty fallback would detach the child from inheritance and
+   * silently drop everything the parent's document holds.
+   */
+  authorityLostInherited?: true;
+  /**
+   * The document that supplied the overrides. `ownerWorkspaceId` identifies
+   * WHICH chain member's checkout it lives in: paths alone are ambiguous
+   * across runtimes (every Docker workspace reports `/src`), so an inheriting
+   * child and its parent can share the same file path in different
+   * filesystems.
+   */
+  sourceFile?: {
+    runtime: ReturnType<typeof createRuntime>;
+    filePath: string;
+    ownerWorkspaceId: string;
+    /** The owner's checkout root on `runtime` (containment checks before the raw document is copied). */
+    workspacePath: string;
+    /** `runtime` reads the host filesystem (see ResolvedWorkspace.hostFilesystem). */
+    hostFilesystem: boolean;
+    /**
+     * The document normalizes to nothing for this build and did not decide
+     * the effective overrides (see withOwnDocumentFallback): it is copied so
+     * its forward-compatible fields survive a fork, but ancestors still
+     * take part in precedence (a parent document appearing later wins).
+     */
+    transparent?: true;
+  };
+  /**
+   * A legacy config.json `workspace.mcp` value whose shape this build cannot
+   * read (see isRecognizedOverridesDocument). It stays where it is, but a fork
+   * must still carry it: the fork is independent and would otherwise lose that
+   * forward-compatible configuration for good.
+   */
+  opaqueLegacyValue?: unknown;
+}
+
+/** local/worktree checkouts live on this host's filesystem; everything else execs remotely. */
+function isHostLocalRuntimeConfig(config: RuntimeConfig): boolean {
+  return config.type === "local" || config.type === "worktree";
+}
+
+/**
+ * The override files of this checkout are host files: local/worktree
+ * checkouts, and devcontainer checkouts — host worktrees whose runtime maps
+ * `stat`/`readFile`/`writeFile` to the host path while `exec` needs a RUNNING
+ * container (`devcontainer exec`). Path guards for these must not exec.
+ */
+function overridesOnHostFilesystem(config: RuntimeConfig | undefined): boolean {
+  return (
+    config !== undefined && (isHostLocalRuntimeConfig(config) || isDevcontainerRuntime(config))
+  );
+}
+
+/**
+ * Filesystem identity of a runtime config: two workspaces can share a checkout
+ * only when this matches AND their paths match. Ignores non-identity fields
+ * (e.g. Coder's `existingWorkspace` flag, which forkWorkspace flips on the
+ * parent alone). Docker never shares: every container reports `/src`.
+ */
+export function runtimeFilesystemIdentity(config: RuntimeConfig): string | undefined {
+  switch (config.type) {
+    case "local":
+    case "worktree":
+      return "host";
+    case "ssh":
+      // Host + effective port address one machine (mirrors SSHRuntime's
+      // project sync key); the identity file only affects authentication.
+      // Coder configs may persist the raw `coder://` placeholder host while
+      // runtimeFactory derives the real endpoint from the workspace name —
+      // resolve the same way so distinct Coder machines never coincide.
+      return `ssh:${resolveCoderSSHHost(config.host, config.coder?.workspaceName).trim()}:${config.port ?? 22}`;
+    case "devcontainer":
+      // The override files live in the host worktree (DevcontainerRuntime
+      // maps them to host paths; see overridesOnHostFilesystem): a
+      // devcontainer registration shares its checkout with a local/worktree
+      // alias — and with another devcontainer spelling of the same
+      // `configPath` — so all of them must contend for one lock.
+      return "host";
+    case "docker":
+      return undefined;
+  }
+}
+/**
+ * SECURITY: read a host override document whose bytes leave the checkout (the
+ * fork copy; unknown fields carried into another document) without following
+ * a symlink swapped in after the point-in-time segment guards. Code running
+ * in the checkout (a devcontainer's, whose files are read on the host by
+ * design) can replace the document — or a PARENT segment such as `.xum` —
+ * with a symlink between a check and a path-based read. Node cannot open
+ * relative to a pinned directory descriptor, so the read is verified instead:
+ * 1. open once with O_NOFOLLOW (the final component is never followed) and
+ *    fstat the handle (a regular file);
+ * 2. AFTER the open, re-guard every repo-controlled segment under the
+ *    checkout's realpath (`lstat`, not a symlink) and require the file at
+ *    that canonical path to be the very inode the handle holds.
+ * A parent swapped to a symlink at open time either still is one at step 2
+ * (guard fails) or was swapped back (the handle's inode then differs from
+ * the checkout's own file); the bytes are read from the verified handle. A
+ * hardlink planted inside the checkout is indistinguishable from the
+ * checkout's own file — by any check — and is out of scope.
+ */
+export async function readHostOverrideDocumentNoFollow(
+  filePath: string,
+  workspacePath: string
+): Promise<string> {
+  const refuse = (reason: string): never => {
+    throw new Error(
+      `Workspace MCP overrides path could not be verified (${reason}); refusing to read it: ${filePath}`
+    );
+  };
+  const handle = await fsPromises.open(
+    filePath,
+    fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0)
+  );
+  try {
+    const opened = await handle.stat();
+    if (!opened.isFile()) refuse("not a regular file");
+    const relative = path.relative(workspacePath, filePath).replaceAll("\\", "/");
+    if (relative.startsWith("..") || path.isAbsolute(relative)) refuse("outside the checkout");
+    const root = await fsPromises.realpath(workspacePath);
+    let current = root;
+    for (const segment of relative.split("/")) {
+      current = path.join(current, segment);
+      if ((await fsPromises.lstat(current)).isSymbolicLink())
+        refuse(`${segment} is a symbolic link`);
+    }
+    const canonical = await fsPromises.stat(current);
+    if (canonical.dev !== opened.dev || canonical.ino !== opened.ino) {
+      refuse("the opened file is not the checkout's own document");
+    }
+    return await handle.readFile("utf-8");
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
+ * SECURITY: refuse to write to or remove through a symlinked override path
+ * segment. The checkout root is trusted; the two repo-controlled segments of
+ * every candidate (`.xum`, `.xum/mcp.local.jsonc`, and the compatibility
+ * spellings) are probed. Host files (`hostFilesystem`: local/worktree
+ * checkouts, devcontainer host worktrees — see overridesOnHostFilesystem) are
+ * probed with `lstat`, so a stopped devcontainer or an unmapped container cwd
+ * cannot fail a write that the runtime performs on the host anyway;
+ * exec-backed runtimes (SSH/Docker) with shell `test ! -L` — mirrors
+ * isForkCopyTargetWritable. A failed shell probe is refused too: nothing
+ * vouches for the path then.
+ */
+async function assertOverrideSegmentsNotSymlinked(
+  runtime: ReturnType<typeof createRuntime>,
+  workspacePath: string,
+  hostFilesystem: boolean
+): Promise<void> {
+  const segments = new Set<string>();
+  for (const relativeFile of MCP_OVERRIDES_GITIGNORE_PATTERNS) {
+    segments.add(relativeFile.split("/")[0]);
+    segments.add(relativeFile);
+  }
+  const refuse = (): never => {
+    throw new Error(
+      `Workspace MCP overrides path is a symbolic link or could not be verified; refusing to write or remove through it: ${workspacePath}`
+    );
+  };
+  if (hostFilesystem) {
+    for (const segment of segments) {
+      let isSymbolicLink: boolean;
+      try {
+        isSymbolicLink = (
+          await fsPromises.lstat(path.join(workspacePath, segment))
+        ).isSymbolicLink();
+      } catch {
+        // Same verdict as `test -L`: a segment that cannot be lstat'ed (absent
+        // — the write creates it — or inside a directory without search
+        // permission) is not a link that a write or `rm` could follow either;
+        // the operation itself fails on such a path.
+        continue;
+      }
+      if (isSymbolicLink) return refuse();
+    }
+    return;
+  }
+  const probe = await execBuffered(
+    runtime,
+    [...segments].map((segment) => `test ! -L "${segment}"`).join(" && "),
+    { cwd: workspacePath, timeout: 10 }
+  );
+  if (probe.exitCode !== 0) refuse();
+}
+
+/**
+ * Canonical form of an override file path for sharer comparison. On the host
+ * filesystem, resolve the (existing) parent directory through symlinks so two
+ * registrations of one checkout compare equal; the file itself may not exist
+ * yet, so canonicalize its directory and re-append the name. Falls back to the
+ * spelled path when nothing resolves.
+ */
+/**
+ * Canonical (realpath) spelling of a host override path, or `undefined` when
+ * it could not be established (missing checkout, stalled filesystem, realpath
+ * timeout). Callers must treat `undefined` as indeterminate — comparing the
+ * spelled path instead would prove nothing about two registrations naming the
+ * same checkout through different symlinks.
+ */
+async function canonicalizeHostPath(
+  identity: string,
+  filePath: string
+): Promise<string | undefined> {
+  if (identity !== "host") {
+    return filePath;
+  }
+  const dir = path.dirname(filePath);
+  const resolvedDir = await boundedRealpath(dir);
+  if (resolvedDir !== undefined) {
+    return path.join(resolvedDir, path.basename(filePath));
+  }
+  // The `.xum` dir may not exist yet; canonicalize the checkout root instead.
+  const resolvedRoot = await boundedRealpath(path.dirname(dir));
+  return resolvedRoot !== undefined
+    ? path.join(resolvedRoot, path.basename(dir), path.basename(filePath))
+    : undefined;
+}
+
+/**
+ * realpath against a stalled filesystem (disconnected NFS) can block
+ * indefinitely, and the publication scan runs inside the exclusive write
+ * queue — one wedged candidate would serialize every later override write
+ * behind it. Cap each canonicalization like the registration scan in
+ * WorkspaceService does; a timeout behaves like any other realpath failure.
+ */
+const REALPATH_TIMEOUT_MS = 2_000;
+/**
+ * Per-descendant budget for the host-side ownership probe + resolution in
+ * publishEffectiveOverrides. LocalBaseRuntime.stat/readFile have no timeout
+ * and ignore abort signals, so a worktree on a disconnected NFS/FUSE mount
+ * would otherwise wedge the publication — and every later writer — under
+ * the exclusive lock. On timeout the descendant (and its subtree) is
+ * evicted instead: its next serve re-reads on its own.
+ */
+const HOST_DESCENDANT_TIMEOUT_MS = 5_000;
+
+/**
+ * Reject with `message` when `promise` has not settled within `timeoutMs`.
+ * The losing promise keeps running: callers whose work has side effects must
+ * pass `onTimeout` to flip a cooperative cancellation flag the work checks
+ * before every side effect (see ConfigSnapshot.cancel).
+ */
+async function withDeadline<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+  onTimeout?: () => void
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          onTimeout?.();
+          reject(new Error(message));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+async function boundedRealpath(target: string): Promise<string | undefined> {
+  try {
+    return await withDeadline(
+      fsPromises.realpath(target),
+      REALPATH_TIMEOUT_MS,
+      "realpath timed out"
+    );
+  } catch {
+    return undefined;
+  }
+}
+/**
+ * Memoized config reads shared across one resolution/publication — or one
+ * batch sweep. Loading config.json is a synchronous full parse (~100 ms on a
+ * multi-thousand-workspace config), so re-reading it per inheritance level,
+ * per re-published descendant, or per swept workspace made plugin installs
+ * appear hung for tens of minutes. Host realpaths are memoized too: sharer
+ * detection canonicalizes every host-local workspace's override path.
+ */
+class ConfigSnapshot {
+  private readonly store: {
+    legacy?: ProjectsConfig;
+    all?: Promise<FrontendWorkspaceMetadata[]>;
+    canonical: Map<string, Promise<string | undefined>>;
+    /** In-flight writes started by this operation (see trackSideEffect). */
+    sideEffects: Set<Promise<unknown>>;
+  };
+  private _cancelled = false;
+
+  constructor(
+    private readonly config: Config,
+    /**
+     * Read devcontainer workspaces' override files through the host
+     * filesystem instead of `devcontainer exec`. Their checkouts are host
+     * worktrees; the fork path uses this because the source container need
+     * not be running (forkWorkspace only creates the new worktree), and an
+     * exec-backed probe against a stopped container would be indeterminate —
+     * silently skipping the copy for a file that is readable on the host.
+     */
+    readonly hostFilesystemView = false,
+    store?: ConfigSnapshot["store"],
+    /**
+     * The operation holds the workspace and global override write locks
+     * (setOverridesForWorkspace, the prune sweep, the locked fork path).
+     * Depth-0 resolution may then mutate directly (legacy migration, empty
+     * legacy clear); every other resolution — the send path's and the
+     * call-time gate's per-request reads, the settings read — is an unlocked
+     * READER whose mutation must first take those locks and re-verify (see
+     * migrateLegacyOverridesFenced), or a read that paused after observing
+     * the legacy value could overwrite a disable a save persisted meanwhile.
+     */
+    readonly writerLocksHeld = false
+  ) {
+    this.store = store ?? { canonical: new Map(), sideEffects: new Set() };
+  }
+
+  /**
+   * Register a write this operation started. Cancellation cannot stop a
+   * write that is already in flight (LocalBaseRuntime.writeFile ignores its
+   * abort signal), so a lock holder that timed out must keep the lock until
+   * every tracked write has settled — otherwise the abandoned write could
+   * land on top of a newer save made under the released lock.
+   */
+  trackSideEffect<T>(effect: Promise<T>): Promise<T> {
+    this.store.sideEffects.add(effect);
+    void effect.finally(() => this.store.sideEffects.delete(effect)).catch(() => undefined);
+    return effect;
+  }
+
+  /** Resolves once every tracked in-flight write has settled (errors ignored). */
+  async settleSideEffects(): Promise<void> {
+    while (this.store.sideEffects.size > 0) {
+      await Promise.allSettled([...this.store.sideEffects]);
+    }
+  }
+
+  /**
+   * Cooperative cancellation for work that runs under a deadline. A
+   * `Promise.race` deadline cannot stop the losing promise, so once the
+   * deadline fires the abandoned work must not perform side effects that the
+   * caller assumed happened under its lock or before its own eviction: the
+   * legacy migration write checks this flag before writing, and publication
+   * steps check it before publishing.
+   */
+  cancel(): void {
+    this._cancelled = true;
+  }
+
+  get cancelled(): boolean {
+    return this._cancelled;
+  }
+
+  /** Same memoized config reads, independent cancellation (one per bounded step). */
+  scoped(): ConfigSnapshot {
+    return new ConfigSnapshot(
+      this.config,
+      this.hostFilesystemView,
+      this.store,
+      this.writerLocksHeld
+    );
+  }
+
+  /**
+   * Authoritative too (throwOnError): the lenient loader degrades a transient
+   * read failure to an EMPTY config, which would classify a child whose only
+   * own setting is a legacy `workspace.mcp` value as inheriting — and serve a
+   * parent-enabled server the child explicitly disabled. Callers turn the
+   * throw into a non-authoritative, non-inheriting result.
+   */
+  loadLegacyConfig(): ProjectsConfig {
+    return (this.store.legacy ??= this.config.loadConfigOrDefault({ throwOnError: true }));
+  }
+
+  /**
+   * Authoritative enumeration (throwOnError): a partial/empty snapshot from
+   * a transient config read failure would silently skip inheriting
+   * descendants and leave their caches stale. Loaded once; a failure is
+   * memoized too so one operation sees one consistent answer.
+   */
+  loadAllMetadata(): Promise<FrontendWorkspaceMetadata[]> {
+    // Registry data only: override resolution needs ids, paths, runtimes and
+    // parent links, never the per-checkout existence probe — which is one
+    // fs.access per registered workspace, paid on every request and blocked
+    // indefinitely by any stalled mount (see Config.getAllWorkspaceMetadata).
+    return (this.store.all ??= this.config.getAllWorkspaceMetadata({
+      throwOnError: true,
+      probeCheckouts: false,
+    }));
+  }
+
+  canonicalize(identity: string, filePath: string): Promise<string | undefined> {
+    if (identity !== "host") {
+      return Promise.resolve(filePath);
+    }
+    let pending = this.store.canonical.get(filePath);
+    if (pending === undefined) {
+      pending = canonicalizeHostPath(identity, filePath);
+      this.store.canonical.set(filePath, pending);
+    }
+    return pending;
+  }
+}
+
+/** Unlocked fork-copy preparations attempted before the terminal fallback (see copyOverridesToForkedCheckout). */
+const FORK_COPY_ATTEMPTS = 3;
+/**
+ * Budget for a fork-copy preparation that runs UNDER the override lock
+ * (legacy migration, or the terminal host-local fallback); bounds the lock
+ * hold time well below its 60 s acquisition timeout so unrelated writers are
+ * never starved by a stalled checkout.
+ */
+const FORK_COPY_LOCKED_TIMEOUT_MS = 15_000;
+/**
+ * ONE absolute deadline for the whole fork-time override copy: every
+ * preparation attempt, lock acquisition, the terminal locked fallback and the
+ * target-side write (writability probe, mkdir, write, git exclude) draw on
+ * what remains of it. The fork awaits this best-effort copy before
+ * init/registration, remote runtimes allow minutes per operation, and
+ * sustained settings activity would otherwise reset a per-step budget on
+ * every retry: an unreachable source or target, or a busy writer, must make
+ * the copy give up — not stall the fork for several budgets in a row.
+ */
+const FORK_COPY_TIMEOUT_MS = 60_000;
+/** Cooperative cancellation state shared between copyOverridesToForkedCheckout's deadline and writeForkCopy. */
+interface ForkCopyProgress {
+  cancelled: boolean;
+  /**
+   * The in-flight target mutation once started — the git exclude update, then
+   * the document write; joined by a timed-out copy (see
+   * copyOverridesToForkedCheckout) so neither can land after the caller moved on.
+   */
+  mutation?: Promise<void>;
+}
+/** Parallel realpath budget for the sharer scan (see publishEffectiveOverrides). */
+const CANONICALIZE_CONCURRENCY = 16;
+/** Budget for acquiring a workspace lock — or a whole batch of them (see withWorkspaceLocks). */
+const WORKSPACE_LOCK_ACQUIRE_TIMEOUT_MS = 60_000;
+const WORKSPACE_LOCK_RETRY_BACKOFF_MS = 150;
+/** Budget for an unlocked reader's legacy migration to take the write locks (see migrateLegacyOverridesFenced). */
+const MIGRATION_LOCK_TIMEOUT_MS = 5_000;
+/** What a depth-0 resolution migrates (see migrateLegacyOverrides). */
+interface LegacyMigrationTarget {
+  workspaceId: string;
+  /** The config.json value observed by the resolution (compared verbatim under the locks). */
+  legacy: WorkspaceMCPOverrides;
+  normalizedLegacy: WorkspaceMCPOverrides;
+  runtime: ReturnType<typeof createRuntime>;
+  workspacePath: string;
+  canonicalPath: string;
+  filePaths: readonly string[];
+  runtimeConfig: RuntimeConfig | undefined;
+}
+/** Bound for each override resolution a settings save performs while holding the write locks. */
+const SAVE_RESOLUTION_TIMEOUT_MS = 30_000;
+/** A checkout moved between key derivation and lock acquisition (see withWorkspaceLocks). */
+class CheckoutKeysChangedError extends Error {
+  constructor() {
+    super("workspace checkout keys changed while acquiring their locks");
+  }
+}
+/** Result of one checkout-lock key derivation (see checkoutLockKeys). */
+interface CheckoutLockKeys {
+  /** Every lock key of each resolvable workspace's checkout. */
+  keys: Map<string, string[]>;
+  /** Workspaces whose checkout identity could not be established (not locked). */
+  unresolvable: Array<{ workspaceId: string; error: Error }>;
+  /** The registry view the derivation read (registry-only enumeration). */
+  registry: FrontendWorkspaceMetadata[];
+}
+const WORKSPACE_LOCK_TIMEOUT_MESSAGE =
+  "Another Mux operation (a rename or an MCP settings update) is in progress for this workspace. Wait for it to finish and try again.";
+/** Parallel descendant probes/resolutions per breadth level (see publishEffectiveOverrides). */
+const PUBLICATION_CONCURRENCY = 8;
+/**
+ * Overall budget for one publication fan-out under the exclusive lock (sharer
+ * scan + descendant levels). Well below the lock's 60 s acquisition timeout;
+ * exhaustion evicts every cache rather than holding the lock longer.
+ */
+const PUBLICATION_TIMEOUT_MS = 30_000;
+/**
+ * Bound for one request-path override read (getOverridesForWorkspace with
+ * `timeoutMs`): a send, prompt discovery, or the manager's authority re-read
+ * must not wait for a remote parent's 300 s command timeout. Shared by every
+ * request-path reader so the manager's re-read is bounded like the caller's.
+ */
+export const MCP_OVERRIDES_READ_TIMEOUT_MS = 30_000;
+/**
+ * Wall-clock budget shared by one publication (or one whole batch sweep, so
+ * `n` stalled workspaces cannot hold the lock for `n × PUBLICATION_TIMEOUT_MS`).
+ */
+interface PublicationBudget {
+  remaining(): number;
+  exhausted(): boolean;
+}
+function createPublicationBudget(timeoutMs = PUBLICATION_TIMEOUT_MS): PublicationBudget {
+  const deadlineAt = Date.now() + timeoutMs;
+  return {
+    remaining: () => Math.max(1, deadlineAt - Date.now()),
+    exhausted: () => Date.now() >= deadlineAt,
+  };
+}
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T) => Promise<R>
+): Promise<R[]> {
+  assert(limit > 0, "mapWithConcurrency: limit must be positive");
+  const results: R[] = new Array<R>(items.length);
+  let next = 0;
+  const worker = async (): Promise<void> => {
+    for (let index = next++; index < items.length; index = next++) {
+      results[index] = await fn(items[index]);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}
+/** Bound for parent-chain override inheritance; task trees are far shallower than this. */
+const MAX_OVERRIDES_INHERITANCE_DEPTH = 32;
 
 function joinForRuntime(runtimeConfig: RuntimeConfig | undefined, ...parts: string[]): string {
   assert(parts.length > 0, "joinForRuntime requires at least one path segment");
@@ -41,6 +642,110 @@ function isAbsoluteForRuntime(runtimeConfig: RuntimeConfig | undefined, filePath
 
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((v) => typeof v === "string");
+}
+
+/**
+ * Whether a parsed override document has a shape this build fully understands:
+ * an object root whose owned fields, when present, carry their known types.
+ * Anything else (`null`, an array, `"disabledServers": "shots"`, a string
+ * allowlist entry) may have been written by a newer release. Such a document
+ * normalizes to nothing here, but it is NOT a decision to inherit from the
+ * parent: the child has configuration of its own that this build cannot read,
+ * and resolving through the parent could start a server the opaque document
+ * disables. Resolution stops at the child (no overrides), exactly as before
+ * inheritance existed; the prune path rejects the same shapes. The same
+ * applies to any top-level field this build does not know: a newer release
+ * may give it authorization semantics (e.g. a deny rule) with every known
+ * field empty, and a downgraded build inheriting the parent's enables over
+ * it could start a server the document disables. Only a document made
+ * exclusively of known, empty-normalizing fields is "empty".
+ */
+/** The override fields this build owns: what prunePluginOverrideKeys edits by JSON path and what isRecognizedOverridesDocument accepts. */
+const PRUNED_OVERRIDE_FIELDS = new Set(["enabledServers", "disabledServers", "toolAllowlist"]);
+
+function isRecognizedOverridesDocument(raw: unknown): boolean {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return false;
+  }
+  const obj = raw as Record<string, unknown>;
+  if (Object.keys(obj).some((key) => !PRUNED_OVERRIDE_FIELDS.has(key))) {
+    return false;
+  }
+  return knownFieldShapesSupported(obj);
+}
+
+/**
+ * Whether every field this build owns that is present in `obj` has the shape
+ * this build can read and rewrite. A newer version may store a known field
+ * in a newer shape (e.g. `toolAllowlist.server` as an object); such a field
+ * cannot be preserved through a save built from normalized data, so callers
+ * refuse to edit the document rather than silently drop it.
+ */
+function knownFieldShapesSupported(obj: Record<string, unknown>): boolean {
+  for (const field of ["disabledServers", "enabledServers"] as const) {
+    if (obj[field] !== undefined && !isStringArray(obj[field])) return false;
+  }
+  const allowlist = obj.toolAllowlist;
+  if (allowlist === undefined) return true;
+  if (allowlist === null || typeof allowlist !== "object" || Array.isArray(allowlist)) {
+    return false;
+  }
+  return Object.values(allowlist as Record<string, unknown>).every(isStringArray);
+}
+
+/**
+ * The fields of a legacy config.json value that this build does not own, for
+ * carrying into the workspace document when a save retires the value: `{}`
+ * when the value is absent or recognized (nothing to preserve), `undefined`
+ * when it is opaque but not an object — nothing of it can live in a document.
+ */
+function opaqueLegacyFieldsOf(legacy: unknown): Record<string, unknown> | undefined {
+  if (legacy === undefined || isRecognizedOverridesDocument(legacy)) {
+    return {};
+  }
+  if (legacy === null || typeof legacy !== "object" || Array.isArray(legacy)) {
+    return undefined;
+  }
+  const obj = legacy as Record<string, unknown>;
+  // A known field in a shape this build cannot read is newer-version data
+  // just as much as an unknown field — and it cannot be carried as-is.
+  if (!knownFieldShapesSupported(obj)) {
+    return undefined;
+  }
+  // Mixed value: known fields with data next to an unknown field. Resolution
+  // treats the whole value as opaque (the unknown field may carry
+  // authorization semantics), so the settings UI showed `{}` — a save built
+  // from it would retire the legacy value and drop known settings the user
+  // never saw. Only a build that reads the whole value may edit it.
+  if (!isEmptyOverrides(normalizeWorkspaceMcpOverrides(obj))) {
+    return undefined;
+  }
+  return Object.fromEntries(
+    Object.entries(obj).filter(([key]) => !PRUNED_OVERRIDE_FIELDS.has(key))
+  );
+}
+
+/**
+ * Merge unknown fields carried by legacy values that one save retires. Two
+ * registrations sharing a checkout may each hold a newer version's data; a
+ * last-write-wins merge would silently keep one and the save would clear the
+ * other for good, so a field present in both with different values refuses
+ * the save instead of choosing arbitrarily.
+ */
+function mergeOpaqueFields(
+  into: Record<string, unknown>,
+  fields: Record<string, unknown>,
+  ownerWorkspaceId: string
+): Record<string, unknown> {
+  for (const [key, value] of Object.entries(fields)) {
+    if (key in into && JSON.stringify(into[key]) !== JSON.stringify(value)) {
+      throw new Error(
+        `Workspaces sharing this checkout carry conflicting MCP settings written by a newer version of Xum (field "${key}", workspace ${ownerWorkspaceId}); the settings were not saved. Upgrade Xum to edit them.`
+      );
+    }
+    into[key] = value;
+  }
+  return into;
 }
 
 function normalizeWorkspaceMcpOverrides(raw: unknown): WorkspaceMCPOverrides {
@@ -163,46 +868,206 @@ async function assertPruneTargetNotSymlinked(
   }
 }
 
+/**
+ * SECURITY: host-local override writes that may CREATE the document (a save,
+ * the fork's shared-checkout materialization) must land inside the checkout
+ * they intend to edit. Like assertPruneTargetNotSymlinked, but the file may
+ * not exist yet: the (existing) `.xum` directory must not be a symlink and
+ * must resolve inside the canonicalized workspace root — a tracked
+ * `.xum -> /elsewhere` link would otherwise redirect the write — and an
+ * existing file must not be a symlink either.
+ */
+async function assertHostOverrideWriteContained(
+  filePath: string,
+  workspacePath: string
+): Promise<void> {
+  const dir = path.dirname(filePath);
+  if ((await fsPromises.lstat(dir)).isSymbolicLink()) {
+    throw new Error(
+      `Workspace MCP overrides directory is a symbolic link, refusing to write into it: ${dir}`
+    );
+  }
+  const resolvedDir = await fsPromises.realpath(dir);
+  const resolvedRoot = await fsPromises.realpath(workspacePath);
+  if (resolvedDir !== resolvedRoot && !resolvedDir.startsWith(resolvedRoot + path.sep)) {
+    throw new Error(
+      `Workspace MCP overrides directory resolves outside the workspace, refusing to write into it: ${dir}`
+    );
+  }
+  try {
+    if ((await fsPromises.lstat(filePath)).isSymbolicLink()) {
+      throw new Error(
+        `Workspace MCP overrides file is a symbolic link, refusing to modify it: ${filePath}`
+      );
+    }
+  } catch (error) {
+    if (!hasFsCode(error, "ENOENT")) {
+      throw error;
+    }
+  }
+}
+
+/**
+ * Whether a stat failure positively proves the path is absent. Local runtimes
+ * surface node errno codes (RuntimeError wraps them as `cause`); exec-backed
+ * remote runtimes (SSH/Docker) only relay stat(1)'s stderr inside
+ * `Failed to stat <path>: <stderr>`, so match stat's OWN diagnostic line
+ * (`stat: cannot statx '…': No such file or directory`, busybox `can't stat`,
+ * BSD `stat: …: stat: No such file…`). Requiring the `stat:` program prefix
+ * keeps transport/setup noise from counting — OpenSSH prints
+ * `Warning: Identity file … not accessible: No such file or directory` and
+ * exits 255 when the connection itself fails, which must stay indeterminate.
+ */
+export function isPositivelyAbsent(error: unknown): boolean {
+  if (hasFsCode(error, "ENOENT") || hasFsCode(error, "ENOTDIR")) {
+    return true;
+  }
+  return /(?:^|: )stat: [^\n]*(?:No such file or directory|Not a directory)/im.test(
+    getErrorMessage(error)
+  );
+}
+
+type OverridesFileProbe =
+  | { kind: "file" }
+  | { kind: "absent" }
+  /** EACCES, I/O error, transport hiccup: the file may or may not exist. */
+  | { kind: "indeterminate"; error: unknown };
+
+/**
+ * Never throws: strict callers decide per PRECEDENCE whether an indeterminate
+ * probe matters (see selectProbedCandidate) — a failing lower-priority
+ * compatibility path must not make a valid canonical document unreadable.
+ */
+async function probeOverridesFile(
+  runtime: ReturnType<typeof createRuntime>,
+  filePath: string
+): Promise<OverridesFileProbe> {
+  try {
+    const stat = await runtime.stat(filePath);
+    // A DIRECTORY at a candidate path is not absence: treating it as such
+    // would let an inheriting child fall through to its parent's enables on
+    // the strength of a corrupt (or repository-tracked) `mcp.local.jsonc/`.
+    // Nothing can be read from it either, so precedence stays unestablished.
+    return stat.isDirectory
+      ? {
+          kind: "indeterminate",
+          error: new Error(`Workspace MCP overrides path is a directory: ${filePath}`),
+        }
+      : { kind: "file" };
+  } catch (error) {
+    return isPositivelyAbsent(error) ? { kind: "absent" } : { kind: "indeterminate", error };
+  }
+}
+
+/**
+ * Honors path-order precedence over probes taken in parallel: the first
+ * candidate that is a file wins and every lower-priority probe is irrelevant
+ * (whatever it holds is shadowed). An indeterminate probe at or above the
+ * first file leaves precedence unestablished — the hidden higher-priority
+ * document may disable what the visible one enables — so the result is
+ * indeterminate (strict callers throw that probe's error: "cannot tell" must
+ * stay distinct from "positively absent", or the plugin uninstaller could
+ * retire a prune tombstone against a file it never actually read).
+ */
+function selectProbedCandidate(
+  probes: readonly OverridesFileProbe[]
+):
+  | { kind: "file"; index: number }
+  | { kind: "absent" }
+  | { kind: "indeterminate"; error: unknown } {
+  for (const [index, probe] of probes.entries()) {
+    if (probe.kind === "file") return { kind: "file", index };
+    if (probe.kind === "indeterminate") return probe;
+  }
+  return { kind: "absent" };
+}
+
 async function statIsFile(
   runtime: ReturnType<typeof createRuntime>,
   filePath: string,
   mode: "lenient" | "strict"
 ): Promise<boolean> {
-  try {
-    const stat = await runtime.stat(filePath);
-    return !stat.isDirectory;
-  } catch (error) {
-    // Strict callers must distinguish "file genuinely absent" (fine: no
-    // overrides) from "cannot tell" (EACCES, I/O error): treating the latter
-    // as absent would let the plugin uninstaller retire a prune tombstone
-    // against a file it never actually read. Strict reads only run against
-    // local/worktree runtimes, so node fs error codes are reliable here
-    // (RuntimeError wraps them as `cause`).
-    if (mode === "strict" && !hasFsCode(error, "ENOENT") && !hasFsCode(error, "ENOTDIR")) {
-      throw error;
-    }
-    return false;
+  const probe = await probeOverridesFile(runtime, filePath);
+  if (probe.kind === "indeterminate" && mode === "strict") {
+    throw probe.error;
   }
+  return probe.kind === "file";
 }
 
 /** A workspace's metadata with its runtime and checkout path resolved. */
+/** A fork copy ready to write: the source document text and where it goes. */
+interface ForkCopySource {
+  content: string;
+  targetPath: string;
+}
+
 interface ResolvedWorkspace {
   metadata: FrontendWorkspaceMetadata;
   runtime: ReturnType<typeof createRuntime>;
   workspacePath: string;
+  /** `runtime` reads the host filesystem (local/worktree, or a devcontainer through the host view). */
+  hostFilesystem: boolean;
+}
+
+/**
+ * Registry entries grouped by stable id (corrupted config may register one id
+ * several times). `hostLocalOnly` keeps just local/worktree entries — the
+ * plugin sweep's view (plugin servers never run off-host, and its symlink
+ * guard uses host fs semantics); lock derivation needs every entry.
+ */
+function groupMetadataById(
+  all: FrontendWorkspaceMetadata[],
+  hostLocalOnly: boolean
+): Map<string, FrontendWorkspaceMetadata[]> {
+  const grouped = new Map<string, FrontendWorkspaceMetadata[]>();
+  for (const metadata of all) {
+    if (hostLocalOnly && !isHostLocalRuntimeConfig(metadata.runtimeConfig)) {
+      continue;
+    }
+    const entries = grouped.get(metadata.id);
+    if (entries) {
+      entries.push(metadata);
+    } else {
+      grouped.set(metadata.id, [metadata]);
+    }
+  }
+  return grouped;
 }
 
 export class WorkspaceMcpOverridesService {
-  constructor(private readonly config: Config) {
+  /**
+   * Root holding the cross-process coordination state (override epoch file,
+   * writer locks). Defaults to the config root; a process whose registry
+   * root is disposable (`xum run`) but whose MCP configuration lives in the
+   * persistent Xum home passes that home, so its fences observe and contend
+   * with a desktop/server backend's saves on the same checkouts.
+   */
+  private readonly coordinationRootDir: string;
+
+  constructor(
+    private readonly config: Config,
+    options?: { coordinationRootDir?: string }
+  ) {
     assert(config, "WorkspaceMcpOverridesService requires a Config instance");
+    this.coordinationRootDir = options?.coordinationRootDir ?? config.rootDir;
   }
 
-  private async getWorkspaceMetadata(workspaceId: string): Promise<FrontendWorkspaceMetadata> {
+  /**
+   * With a snapshot, the (authoritative) enumeration is shared with the
+   * resolution that follows — a child's parent lookup otherwise re-parses and
+   * re-enriches the whole registry on every sub-agent turn.
+   */
+  private async getWorkspaceMetadata(
+    workspaceId: string,
+    snapshot?: ConfigSnapshot
+  ): Promise<FrontendWorkspaceMetadata> {
     assert(typeof workspaceId === "string", "workspaceId must be a string");
     const trimmed = workspaceId.trim();
     assert(trimmed.length > 0, "workspaceId must not be empty");
 
-    const all = await this.config.getAllWorkspaceMetadata();
+    const all = snapshot
+      ? await snapshot.loadAllMetadata()
+      : await this.config.getAllWorkspaceMetadata({ probeCheckouts: false });
     const metadata = all.find((m) => m.id === trimmed);
     if (!metadata) {
       throw new Error(`Workspace metadata not found for ${trimmed}`);
@@ -227,11 +1092,36 @@ export class WorkspaceMcpOverridesService {
     return undefined;
   }
 
-  private async clearLegacyOverridesInConfig(workspaceId: string): Promise<void> {
+  private async clearLegacyOverridesInConfig(
+    workspaceId: string,
+    options?: {
+      /**
+       * Compare-and-delete: clear only while the stored value still equals
+       * the one this operation observed. Read-path clears (empty-legacy
+       * noise, migration) run without the write locks, so an older or
+       * downgraded Xum process may have saved a NEW `workspace.mcp` value in
+       * between; deleting it blindly would lose that decision and re-attach
+       * the child to its parent's configuration. Lock-holding writers (a
+       * save) omit this: the user's write wins.
+       */
+      onlyIfEquals?: WorkspaceMCPOverrides;
+    }
+  ): Promise<void> {
+    const expected =
+      options?.onlyIfEquals === undefined ? undefined : JSON.stringify(options.onlyIfEquals);
     await this.config.editConfig((config) => {
       for (const [_projectPath, projectConfig] of config.projects) {
         const workspace = projectConfig.workspaces.find((w) => w.id === workspaceId);
         if (workspace) {
+          if (expected !== undefined && JSON.stringify(workspace.mcp) !== expected) {
+            log.debug(
+              "[MCP] Legacy workspace MCP overrides changed since they were read; not clearing",
+              {
+                workspaceId,
+              }
+            );
+            return config;
+          }
           delete workspace.mcp;
           return config;
         }
@@ -240,26 +1130,58 @@ export class WorkspaceMcpOverridesService {
     });
   }
 
-  private async getRuntimeAndWorkspacePath(workspaceId: string): Promise<ResolvedWorkspace> {
-    return this.resolveWorkspace(await this.getWorkspaceMetadata(workspaceId));
+  private async getRuntimeAndWorkspacePath(
+    workspaceId: string,
+    snapshot?: ConfigSnapshot
+  ): Promise<ResolvedWorkspace> {
+    return this.resolveWorkspace(await this.getWorkspaceMetadata(workspaceId, snapshot));
   }
 
-  private resolveWorkspace(metadata: FrontendWorkspaceMetadata): ResolvedWorkspace {
-    const runtime = createRuntimeForWorkspace(metadata);
+  /** Same as getRuntimeAndWorkspacePath for callers that already hold the metadata (no config re-scan). */
+  private resolveWorkspace(
+    metadata: FrontendWorkspaceMetadata,
+    snapshot?: ConfigSnapshot
+  ): ResolvedWorkspace {
+    const workspaceRuntime = createRuntimeForWorkspace(metadata);
 
     // In-place workspaces (CLI/benchmarks) store the workspace path directly by setting
     // metadata.projectPath === metadata.name.
     const isInPlace = metadata.projectPath === metadata.name;
     const workspacePath = isInPlace
       ? metadata.projectPath
-      : runtime.getWorkspacePath(metadata.projectPath, metadata.name);
+      : workspaceRuntime.getWorkspacePath(metadata.projectPath, metadata.name);
 
     assert(
       typeof workspacePath === "string" && workspacePath.length > 0,
       "workspacePath is required"
     );
 
-    return { metadata, runtime, workspacePath };
+    // See ConfigSnapshot.hostFilesystemView. Same treatment the fork target
+    // receives: devcontainer checkouts are host worktrees, so the host path is
+    // the file's real location — at the PERSISTED checkout path (Docker labels
+    // devcontainers by the exact host path from startup, so a migrated/
+    // non-canonical entry can differ from the name-derived path). Decided from
+    // the runtime CONFIG, not the runtime class: a multi-project workspace
+    // wraps its devcontainers in a MultiProjectRuntime.
+    if (snapshot?.hostFilesystemView && isDevcontainerRuntime(metadata.runtimeConfig)) {
+      const hostPath = isInPlace ? workspacePath : (metadata.namedWorkspacePath ?? workspacePath);
+      return {
+        metadata,
+        runtime: createRuntime({ type: "local" }, { projectPath: hostPath }),
+        workspacePath: hostPath,
+        hostFilesystem: true,
+      };
+    }
+    return {
+      metadata,
+      runtime: workspaceRuntime,
+      workspacePath,
+      // Devcontainer override files are host files too (the runtime maps
+      // stat/read/write to the host worktree): path guards on such a source
+      // — e.g. an inherited document read while the parent's container is
+      // stopped — must probe the host, not `devcontainer exec`.
+      hostFilesystem: overridesOnHostFilesystem(metadata.runtimeConfig),
+    };
   }
 
   private getOverridesFilePaths(
@@ -272,38 +1194,133 @@ export class WorkspaceMcpOverridesService {
     );
   }
 
+  /**
+   * Lenient reads report whether the parsed value is the file's real content:
+   * a transient read failure OR a parse error yields `{}` with
+   * `authoritative: false`, so callers publishing caches never pin an empty
+   * snapshot over a file that later becomes readable/repaired — the request
+   * itself still proceeds with "no overrides".
+   */
   private async readOverridesFile(
     runtime: ReturnType<typeof createRuntime>,
     filePath: string,
     mode: "lenient" | "strict"
-  ): Promise<unknown> {
+  ): Promise<{ parsed: unknown; authoritative: boolean }> {
+    let raw: string;
     try {
-      const raw = await readFileString(runtime, filePath);
-      const errors: jsonc.ParseError[] = [];
-      const parsed: unknown = jsonc.parse(raw, errors) as unknown;
-      if (errors.length > 0) {
-        // Strict callers (the plugin uninstaller's override prune) must not
-        // see "{}" for a file whose real content is unreadable: retiring a
-        // prune tombstone against that empty view would let the stale
-        // enabledServers key silently re-enable a reinstalled plugin's
-        // server once the file becomes readable again.
-        if (mode === "strict") {
-          throw new Error(`Workspace MCP overrides file has JSONC parse errors: ${filePath}`);
-        }
-        log.warn("[MCP] Failed to parse workspace MCP overrides (JSONC parse errors)", {
-          filePath,
-          errorCount: errors.length,
-        });
-        return {};
-      }
-      return parsed;
+      raw = await readFileString(runtime, filePath);
     } catch (error) {
       if (mode === "strict") {
         throw error;
       }
-      // Treat any read failure as "no overrides".
+      // Treat a read failure as "no overrides" for this request only.
       log.debug("[MCP] Failed to read workspace MCP overrides file", { filePath, error });
-      return {};
+      return { parsed: {}, authoritative: false };
+    }
+    const errors: jsonc.ParseError[] = [];
+    const parsed: unknown = jsonc.parse(raw, errors) as unknown;
+    if (errors.length > 0) {
+      // Strict callers (the plugin uninstaller's override prune) must not
+      // see "{}" for a file whose real content is unreadable: retiring a
+      // prune tombstone against that empty view would let the stale
+      // enabledServers key silently re-enable a reinstalled plugin's
+      // server once the file becomes readable again.
+      if (mode === "strict") {
+        throw new Error(`Workspace MCP overrides file has JSONC parse errors: ${filePath}`);
+      }
+      log.warn("[MCP] Failed to parse workspace MCP overrides (JSONC parse errors)", {
+        filePath,
+        errorCount: errors.length,
+      });
+      return { parsed: {}, authoritative: false };
+    }
+    return { parsed, authoritative: true };
+  }
+
+  /**
+   * Forward compatibility (see isRecognizedOverridesDocument): the fields of
+   * the workspace's own document that this build does not own. A newer Xum
+   * may have written them; a save from this (downgraded) build patches its
+   * known fields into that document and keeps the rest, instead of
+   * round-tripping the normalized object — which would silently discard the
+   * newer version's data (upgrade↔downgrade must stay friction-free).
+   * - `indeterminate` when it cannot be told whether such fields exist
+   *   (EACCES, I/O error). The caller refuses a clearing save (removal would
+   *   destroy them). A write is refused too when the CANONICAL path itself
+   *   could not be probed (`canonicalUnprobed`): the write replaces exactly
+   *   that file and would truncate fields it never read once I/O recovers. A
+   *   write may proceed when only a lower-priority compatibility path is
+   *   unprobed: the canonical document it creates shadows that file without
+   *   touching it, and the UNAVAILABLE repair path stays usable.
+   * - `unmergeable` for a VALID document whose root is not an object (`null`,
+   *   an array, a scalar): nothing of it can live next to this build's
+   *   fields, so only a build that understands it may replace it.
+   * - A document with parse errors has no recoverable fields — that is
+   *   exactly what the repair path replaces wholesale.
+   */
+  private async readOpaqueOverrideFields(
+    runtime: ReturnType<typeof createRuntime>,
+    filePaths: readonly string[],
+    /** The paths are host files under `workspacePath`: read verified (see readHostOverrideDocumentNoFollow). */
+    hostFilesystem: boolean,
+    workspacePath: string
+  ): Promise<
+    | { kind: "fields"; fields: Record<string, unknown> }
+    | { kind: "indeterminate"; canonicalUnprobed: boolean }
+    | { kind: "unmergeable" }
+  > {
+    // The effective own document by precedence (a compatibility-path
+    // document is what a clearing save removes and what a write shadows).
+    const probes = await Promise.all(
+      filePaths.map((filePath) => probeOverridesFile(runtime, filePath))
+    );
+    const selected = selectProbedCandidate(probes);
+    if (selected.kind === "indeterminate") {
+      return { kind: "indeterminate", canonicalUnprobed: probes[0].kind === "indeterminate" };
+    }
+    if (selected.kind === "absent") {
+      return { kind: "fields", fields: {} };
+    }
+    const raw = hostFilesystem
+      ? await readHostOverrideDocumentNoFollow(filePaths[selected.index], workspacePath)
+      : await readFileString(runtime, filePaths[selected.index]);
+    const errors: jsonc.ParseError[] = [];
+    const parsed: unknown = jsonc.parse(raw, errors) as unknown;
+    if (errors.length > 0) {
+      return { kind: "fields", fields: {} };
+    }
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { kind: "unmergeable" };
+    }
+    const obj = parsed as Record<string, unknown>;
+    // A known field stored in a newer shape would be dropped by a save built
+    // from normalized data: refuse to edit rather than silently delete it.
+    if (!knownFieldShapesSupported(obj)) {
+      return { kind: "unmergeable" };
+    }
+    return {
+      kind: "fields",
+      fields: Object.fromEntries(
+        Object.entries(obj).filter(([key]) => !PRUNED_OVERRIDE_FIELDS.has(key))
+      ),
+    };
+  }
+
+  /** Throws unless `workspacePath` is an existing directory on `runtime` (see writeOverridesLocked). */
+  private async assertCheckoutExists(
+    runtime: ReturnType<typeof createRuntime>,
+    workspacePath: string
+  ): Promise<void> {
+    let isDirectory: boolean;
+    try {
+      isDirectory = (await runtime.stat(workspacePath)).isDirectory;
+    } catch (error) {
+      throw new Error(
+        `Workspace checkout is not available (${getErrorMessage(error)}); the MCP settings were not saved.`
+      );
+    }
+    if (!isDirectory) {
+      throw new Error(`Workspace checkout is not a directory: ${workspacePath}`);
     }
   }
 
@@ -325,14 +1342,46 @@ export class WorkspaceMcpOverridesService {
   private async ensureOverridesGitignored(
     runtime: ReturnType<typeof createRuntime>,
     workspacePath: string,
-    runtimeConfig: RuntimeConfig | undefined
+    runtimeConfig: RuntimeConfig | undefined,
+    /**
+     * "lenient" (default): best effort, never fails a workspace operation.
+     * "strict": throws when ignore coverage could not be established — used
+     * before creating a document in a checkout that has none yet (fork copy),
+     * where a visible file could be committed by accident.
+     */
+    failure: "lenient" | "strict" = "lenient"
   ): Promise<void> {
+    // Every "nothing to do" exit below is indistinguishable from a transient
+    // Git failure (a nonzero probe, an empty path). Lenient callers accept
+    // that; a strict caller is about to create the document and must not:
+    // returning normally would count unverified coverage as established.
+    const unverified = (reason: string): void => {
+      if (failure === "strict") {
+        throw new Error(`git exclude coverage could not be verified: ${reason}`);
+      }
+      log.debug("[MCP] Skipping git exclude update for workspace MCP overrides", {
+        workspacePath,
+        reason,
+      });
+    };
     try {
       const isInsideGitResult = await execBuffered(runtime, "git rev-parse --is-inside-work-tree", {
         cwd: workspacePath,
         timeout: 10,
       });
-      if (isInsideGitResult.exitCode !== 0 || isInsideGitResult.stdout.trim() !== "true") {
+      if (isInsideGitResult.exitCode !== 0) {
+        // Git's own definitive answer ("fatal: not a git repository ...")
+        // means nothing can be committed from here; any other nonzero
+        // result (missing git, I/O error, timeout) proves nothing.
+        if (/not a git repository/i.test(isInsideGitResult.stderr)) {
+          return;
+        }
+        return unverified(
+          `git rev-parse --is-inside-work-tree exited ${isInsideGitResult.exitCode}: ${isInsideGitResult.stderr.trim()}`
+        );
+      }
+      if (isInsideGitResult.stdout.trim() !== "true") {
+        // Inside a bare repository or .git directory: not a work tree.
         return;
       }
 
@@ -345,23 +1394,41 @@ export class WorkspaceMcpOverridesService {
         }
       );
       if (excludePathResult.exitCode !== 0) {
-        return;
+        return unverified(
+          `git rev-parse --git-path exited ${excludePathResult.exitCode}: ${excludePathResult.stderr.trim()}`
+        );
       }
 
       const excludeFilePathRaw = excludePathResult.stdout.trim();
       if (excludeFilePathRaw.length === 0) {
-        return;
+        return unverified("git rev-parse --git-path returned no path");
       }
 
       const excludeFilePath = isAbsoluteForRuntime(runtimeConfig, excludeFilePathRaw)
         ? excludeFilePathRaw
         : joinForRuntime(runtimeConfig, workspacePath, excludeFilePathRaw);
 
+      // Only a POSITIVELY absent exclude file is an empty one. Any other stat
+      // or read failure (EACCES, transient remote I/O) must abort: the update
+      // below replaces the whole file, and treating an unreadable file as
+      // empty would erase the user's own exclusions. Lenient callers skip the
+      // update; strict callers (about to create the document) fail.
       let existing = "";
+      let excludeFileExists: boolean;
       try {
-        existing = await readFileString(runtime, excludeFilePath);
-      } catch {
-        // Missing exclude file is OK.
+        excludeFileExists = !(await runtime.stat(excludeFilePath)).isDirectory;
+      } catch (error) {
+        if (!isPositivelyAbsent(error)) {
+          return unverified(`could not stat ${excludeFilePath}: ${getErrorMessage(error)}`);
+        }
+        excludeFileExists = false;
+      }
+      if (excludeFileExists) {
+        try {
+          existing = await readFileString(runtime, excludeFilePath);
+        } catch (error) {
+          return unverified(`could not read ${excludeFilePath}: ${getErrorMessage(error)}`);
+        }
       }
 
       const existingPatterns = new Set(
@@ -382,6 +1449,9 @@ export class WorkspaceMcpOverridesService {
 
       await writeFileString(runtime, excludeFilePath, updated);
     } catch (error) {
+      if (failure === "strict") {
+        throw error;
+      }
       // Best-effort only; never fail a workspace operation because git ignore couldn't be updated.
       log.debug("[MCP] Failed to add workspace MCP overrides file to git exclude", {
         workspacePath,
@@ -392,7 +1462,8 @@ export class WorkspaceMcpOverridesService {
 
   private async removeOverridesFile(
     runtime: ReturnType<typeof createRuntime>,
-    workspacePath: string
+    workspacePath: string,
+    runtimeConfig: RuntimeConfig | undefined
   ): Promise<void> {
     // Remove canonical and legacy file names so no conflicting source remains.
     // The exit code MUST be checked: callers (e.g. the Agent Plugin
@@ -400,6 +1471,14 @@ export class WorkspaceMcpOverridesService {
     // setOverridesForWorkspace rejecting when clearing overrides failed —
     // a swallowed `rm` failure would leave a stale enabledServers key that
     // a plugin reinstall could silently reactivate.
+    // SECURITY: `rm -f` follows a symlinked parent directory; a repo-tracked
+    // `.xum`/`.mux` symlink would make clearing this workspace delete a
+    // sibling checkout's document.
+    await assertOverrideSegmentsNotSymlinked(
+      runtime,
+      workspacePath,
+      overridesOnHostFilesystem(runtimeConfig)
+    );
     const paths = MCP_OVERRIDES_GITIGNORE_PATTERNS.map((filePath) => `"${filePath}"`).join(" ");
     const result = await execBuffered(runtime, `rm -f ${paths}`, {
       cwd: workspacePath,
@@ -413,76 +1492,535 @@ export class WorkspaceMcpOverridesService {
   }
 
   /**
+   * Remove `filePath` only if it still holds exactly `expectedContent`
+   * (rollback of a write this operation made). Ownership-safe: the document
+   * is first RENAMED aside (atomic on one filesystem — a concurrent
+   * replacement lands as a new file that is never touched), then inspected;
+   * ours is deleted, anyone else's is moved back without clobbering a newer
+   * one. The symlink guard ran before the write; paths are relative to the
+   * checkout for the shell like removeOverridesFile.
+   */
+  private async removeExactDocument(
+    runtime: ReturnType<typeof createRuntime>,
+    workspacePath: string,
+    filePath: string,
+    expectedContent: string
+  ): Promise<void> {
+    // Host paths are joined with the platform separator (backslashes on
+    // Windows) while the candidates are spelled with `/`.
+    const normalizedFilePath = filePath.replaceAll("\\", "/");
+    const relative = MCP_OVERRIDES_GITIGNORE_PATTERNS.find((candidate) =>
+      normalizedFilePath.endsWith(candidate)
+    );
+    assert(relative !== undefined, "migrated document must be a known override path");
+    const suffix = `${process.pid}-${Date.now()}`;
+    const aside = `${relative}.rollback-${suffix}`;
+    const run = async (command: string): Promise<void> => {
+      const result = await execBuffered(runtime, command, { cwd: workspacePath, timeout: 10 });
+      if (result.exitCode !== 0) {
+        throw new Error(
+          `Failed to roll back the migrated override document: ${result.stderr.trim() || `${command.split(" ")[0]} exited with code ${result.exitCode}`}`
+        );
+      }
+    };
+    await run(`mv "${relative}" "${aside}"`);
+    const current = await readFileString(runtime, `${filePath}.rollback-${suffix}`);
+    if (current === expectedContent) {
+      await run(`rm -f "${aside}"`);
+      return;
+    }
+    // Not ours: put it back unless a newer document appeared meanwhile
+    // (then the older one we hold is obsolete and dropped).
+    log.warn("[MCP] Not rolling back a migrated override document that changed meanwhile", {
+      filePath,
+    });
+    await run(`mv -n "${aside}" "${relative}" && rm -f "${aside}"`);
+  }
+
+  /**
    * Read workspace MCP overrides from <workspace>/.xum/mcp.local.jsonc.
    *
    * If the file doesn't exist, we fall back to legacy overrides stored in ~/.mux/config.json
-   * and migrate them into the workspace-local file.
+   * and migrate them into the workspace-local file. Sub-agent (task child)
+   * workspaces without overrides of their own inherit their parent's.
    *
    * The returned revision is an opaque token for setOverridesForWorkspace's
    * expectedRevision check.
    */
   async getOverridesForWorkspace(
     workspaceId: string,
-    options?: { mode?: "lenient" | "strict" }
-  ): Promise<{ overrides: WorkspaceMCPOverrides; revision: string }> {
-    const overrides = await this.loadOverrides(workspaceId, options?.mode ?? "lenient");
-    return { overrides, revision: computeOverridesRevision(overrides) };
-  }
-
-  private async loadOverrides(
-    workspaceId: string,
-    mode: "lenient" | "strict" = "lenient"
-  ): Promise<WorkspaceMCPOverrides> {
-    return this.loadOverridesForResolved(await this.getRuntimeAndWorkspacePath(workspaceId), mode);
+    options?: {
+      mode?: "lenient" | "strict";
+      /**
+       * Bound the complete resolution (own probes, legacy migration, every
+       * inherited ancestor level — remote probes and document reads on an
+       * SSH/Docker parent chain allow minutes per operation). On timeout or
+       * abort the result is NOT authoritative (the manager then re-reads and
+       * fails closed if it cannot vouch either); strict mode throws instead.
+       * The snapshot is cancelled so abandoned resolution starts no write.
+       */
+      timeoutMs?: number;
+      signal?: AbortSignal;
+    }
+  ): Promise<{ overrides: WorkspaceMCPOverrides; revision: string; authoritative: boolean }> {
+    const snapshot = new ConfigSnapshot(this.config);
+    const mode = options?.mode ?? "lenient";
+    const resolution = (async () =>
+      this.resolveOverridesFor(
+        await this.getWorkspaceMetadata(workspaceId, snapshot),
+        mode,
+        snapshot
+      ))();
+    let resolved: ResolvedOverrides;
+    if (options?.timeoutMs === undefined && options?.signal === undefined) {
+      resolved = await resolution;
+    } else {
+      const raced = await raceWithAbortAndTimeout(resolution, {
+        ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
+        ...(options.signal !== undefined ? { signal: options.signal } : {}),
+      });
+      if (raced.kind !== "ok") {
+        snapshot.cancel();
+        // Not awaited: the losing resolution may be stuck on a remote probe,
+        // and cancellation blocks any migration write it has not started. A
+        // write it HAS started runs under its own write locks (see
+        // migrateLegacyOverridesFenced) and settles there — waiting for it
+        // here would hold this bounded read for the remote runtime's command
+        // timeout instead of the advertised deadline.
+        resolution.catch(() => undefined);
+        snapshot.settleSideEffects().catch(() => undefined);
+        const reason =
+          raced.kind === "aborted"
+            ? "workspace MCP override resolution was aborted"
+            : "workspace MCP override resolution timed out";
+        if (mode === "strict") {
+          throw new Error(reason);
+        }
+        log.warn(`[MCP] ${reason}; serving no overrides (non-authoritative)`, { workspaceId });
+        return { overrides: {}, revision: computeOverridesRevision({}), authoritative: false };
+      }
+      resolved = raced.value;
+    }
+    return {
+      overrides: resolved.overrides,
+      revision: computeOverridesRevision(resolved.overrides),
+      authoritative: resolved.authoritative,
+    };
   }
 
   /**
-   * `loadLegacyConfig` lets batch callers share one config snapshot: loading
-   * config.json is a synchronous full parse, so re-reading it per workspace
-   * made a 2000-workspace sweep take tens of minutes.
+   * True when the workspace's OWN persisted state already is exactly what
+   * saving `normalized` would leave behind: the workspace-local file holds
+   * that content (or, for empty overrides, no own document exists) and no
+   * legacy config.json value remains. Lets setOverridesForWorkspace accept a
+   * stale expectedRevision for an idempotent retry — a save whose file write
+   * landed but whose epoch bump failed changed the stored revision, so the
+   * dialog's retry would otherwise be rejected as a conflict and the missing
+   * cross-process invalidation could never be published from that dialog.
+   * Anything indeterminate (non-authoritative resolution, unreadable legacy
+   * config where it matters) is not a match: the CAS then fails closed.
    */
-  private async loadOverridesForResolved(
-    resolved: ResolvedWorkspace,
+  private isPersistedAsOwn(
+    workspaceId: string,
+    current: ResolvedOverrides,
+    normalized: WorkspaceMCPOverrides,
+    ownFilePaths: readonly string[],
+    snapshot: ConfigSnapshot
+  ): boolean {
+    if (!current.authoritative || current.opaqueLegacyValue !== undefined) {
+      return false;
+    }
+    const ownSource =
+      current.sourceFile?.ownerWorkspaceId === workspaceId &&
+      ownFilePaths.includes(current.sourceFile.filePath);
+    if (isEmptyOverrides(normalized)) {
+      // "Cleared" means no own document AND no legacy value (a leftover legacy
+      // value would be honored on the next read).
+      try {
+        if (
+          this.getLegacyOverridesFromConfig(workspaceId, snapshot.loadLegacyConfig()) !== undefined
+        ) {
+          return false;
+        }
+      } catch {
+        return false;
+      }
+      // An own document holding only fields this build does not own is kept
+      // by a clearing save (see readOpaqueOverrideFields), so it IS what that
+      // save leaves behind; a recognized-empty (transparent) document is not
+      // — the save removes it.
+      return (
+        !ownSource ||
+        (current.sourceFile?.transparent !== true && isEmptyOverrides(current.overrides))
+      );
+    }
+    // An own document shadows any legacy value on every read, so a legacy
+    // value the previous attempt failed to clear does not make the state
+    // different from what this save would leave behind (the retry clears it).
+    return (
+      ownSource &&
+      computeOverridesRevision(current.overrides) === computeOverridesRevision(normalized)
+    );
+  }
+
+  private async resolveOverridesFor(
+    metadata: FrontendWorkspaceMetadata,
     mode: "lenient" | "strict",
-    loadLegacyConfig: () => ProjectsConfig = () => this.config.loadConfigOrDefault()
-  ): Promise<WorkspaceMCPOverrides> {
-    const { metadata, runtime, workspacePath } = resolved;
+    snapshot: ConfigSnapshot = new ConfigSnapshot(this.config),
+    inheritanceDepth = 0
+  ): Promise<ResolvedOverrides> {
     const workspaceId = metadata.id;
+    const { runtime, workspacePath, hostFilesystem } = this.resolveWorkspace(metadata, snapshot);
     const filePaths = this.getOverridesFilePaths(workspacePath, metadata.runtimeConfig);
     const canonicalPath = filePaths[0];
 
-    for (const filePath of filePaths) {
-      if (await statIsFile(runtime, filePath, mode)) {
-        return normalizeWorkspaceMcpOverrides(
-          await this.readOverridesFile(runtime, filePath, mode)
-        );
-      }
+    // Probe every candidate in parallel (one round trip on exec-backed remote
+    // runtimes instead of four), then honor precedence in path order: probes
+    // below the first confirmed file are irrelevant (a failing compatibility
+    // path must not make a valid canonical document unreadable).
+    // Inheritance requires every candidate path to be POSITIVELY absent: an
+    // indeterminate probe (EACCES, transport hiccup) may hide a child file that
+    // explicitly disables a server the parent enables, so it must keep the
+    // pre-inheritance behavior (no overrides) rather than apply the parent's.
+    const selected = selectProbedCandidate(
+      await Promise.all(filePaths.map((filePath) => probeOverridesFile(runtime, filePath)))
+    );
+    if (selected.kind === "indeterminate" && mode === "strict") {
+      throw selected.error;
     }
+    // A blocked HIGHER-priority candidate may hide the real document, which
+    // takes precedence over any visible one and may disable what it enables:
+    // with precedence unestablished, serve NO overrides (fail closed) rather
+    // than a lower-priority file's (selectProbedCandidate stops at the blocked
+    // probe, so no file is read here).
+    const allAbsent = selected.kind !== "indeterminate";
+    // Own document that normalizes to nothing for this build (see below): it
+    // still deserves to be the fork-copy source when no ancestor supplies one,
+    // so its forward-compatible fields survive a fork made while downgraded.
+    let emptyOwnDocument: ResolvedOverrides["sourceFile"];
+    if (selected.kind === "file") {
+      const filePath = filePaths[selected.index];
+      // A document this build could not read authoritatively (lenient parse
+      // errors) yields no overrides.
+      const read = await this.readOverridesFile(runtime, filePath, mode);
+      if (!read.authoritative) {
+        return { overrides: {}, authoritative: false };
+      }
+      const overrides = normalizeWorkspaceMcpOverrides(read.parsed);
+      // Non-empty, or a shape this build cannot vouch for as empty (see
+      // isRecognizedOverridesDocument): the child's own document decides.
+      if (!isEmptyOverrides(overrides) || !isRecognizedOverridesDocument(read.parsed)) {
+        return {
+          overrides,
+          authoritative: true,
+          sourceFile: {
+            runtime,
+            filePath,
+            ownerWorkspaceId: workspaceId,
+            workspacePath,
+            hostFilesystem,
+          },
+        };
+      }
+      // A document that normalizes to NOTHING for this build (e.g. the plugin
+      // uninstaller pruned its last key, leaving `{ "enabledServers": [] }`,
+      // or only forward-compatible fields remain) is not a decision to detach
+      // from the parent: resolve as if it were absent. The file itself stays,
+      // so unknown fields survive for a later upgrade.
+      emptyOwnDocument = {
+        runtime,
+        filePath,
+        ownerWorkspaceId: workspaceId,
+        workspacePath,
+        hostFilesystem,
+      };
+    }
+    // Only when the inherited result is empty too: pairing non-empty inherited
+    // overrides (e.g. a parent's legacy value whose migration failed) with the
+    // child's unrelated empty document would make a fork copy that document
+    // and lose every inherited setting.
+    const withOwnDocumentFallback = (resolved: ResolvedOverrides): ResolvedOverrides =>
+      resolved.sourceFile === undefined &&
+      emptyOwnDocument !== undefined &&
+      isEmptyOverrides(resolved.overrides)
+        ? { ...resolved, sourceFile: { ...emptyOwnDocument, transparent: true } }
+        : resolved;
 
     // No workspace-local file => try migrating legacy config.json storage.
-    const legacy = this.getLegacyOverridesFromConfig(workspaceId, loadLegacyConfig());
-    if (!legacy || isEmptyOverrides(legacy)) {
-      return {};
+    let legacy: WorkspaceMCPOverrides | undefined;
+    try {
+      legacy = this.getLegacyOverridesFromConfig(workspaceId, snapshot.loadLegacyConfig());
+    } catch (error) {
+      if (mode === "strict") throw error;
+      // Unknown whether this workspace owns a legacy value: neither inherit
+      // nor let caches trust the (empty) result.
+      log.warn("[MCP] Could not read legacy workspace MCP overrides; not inheriting", {
+        workspaceId,
+        error: getErrorMessage(error),
+      });
+      return { overrides: {}, authoritative: false };
+    }
+    // Explicit presence check: `null` is an opaque VALUE (the config loader
+    // preserves raw workspace fields), not absence.
+    if (legacy !== undefined && !isRecognizedOverridesDocument(legacy)) {
+      // A legacy value whose shape this build cannot read is the child's own
+      // configuration, not noise — keep it in place and stop here; a hidden
+      // file behind an indeterminate probe still makes the result a guess.
+      return { overrides: {}, authoritative: allAbsent, opaqueLegacyValue: legacy };
+    }
+    if (legacy === undefined || isEmptyOverrides(legacy)) {
+      if (!allAbsent) {
+        log.debug("[MCP] Workspace override probe was indeterminate; not inheriting", {
+          workspaceId,
+        });
+        return { overrides: {}, authoritative: false };
+      }
+      return withOwnDocumentFallback(
+        await this.loadInheritedOverrides(metadata, mode, snapshot, inheritanceDepth)
+      );
     }
 
     const normalizedLegacy = normalizeWorkspaceMcpOverrides(legacy);
+    if (!allAbsent) {
+      // A candidate file may exist behind the indeterminate probe: never
+      // migrate over it, and never let caches trust the legacy value.
+      return { overrides: normalizedLegacy, authoritative: false };
+    }
     if (isEmptyOverrides(normalizedLegacy)) {
-      return {};
+      // Structurally present but effectively empty legacy data (e.g. blank
+      // names) is noise, not a decision: clear it so it stops shadowing the
+      // parent chain, and resolve exactly as if it were absent. The clear is
+      // a config MUTATION and follows the same rules as the migration write
+      // below: only the workspace's own (depth 0) resolution may perform it,
+      // never one whose owning operation already timed out (a late edit could
+      // delete a `workspace.mcp` value another or older Xum process wrote
+      // meanwhile), and it is tracked so settleSideEffects waits for it.
+      if (inheritanceDepth === 0 && !snapshot.cancelled) {
+        await snapshot
+          .trackSideEffect(this.clearLegacyOverridesInConfig(workspaceId, { onlyIfEquals: legacy }))
+          .catch((error: unknown) =>
+            log.debug("[MCP] Failed to clear empty legacy workspace MCP overrides", {
+              workspaceId,
+              error: getErrorMessage(error),
+            })
+          );
+      }
+      return withOwnDocumentFallback(
+        await this.loadInheritedOverrides(metadata, mode, snapshot, inheritanceDepth)
+      );
     }
 
-    try {
-      await this.ensureOverridesDir(runtime, workspacePath, metadata.runtimeConfig);
-      await writeFileString(
-        runtime,
-        canonicalPath,
-        JSON.stringify(normalizedLegacy, null, 2) + "\n"
-      );
-      await this.ensureOverridesGitignored(runtime, workspacePath, metadata.runtimeConfig);
-      await this.clearLegacyOverridesInConfig(workspaceId);
-      log.info("[MCP] Migrated workspace MCP overrides from config.json", {
+    // Inherited resolution (depth > 0) is READ-ONLY: a child's request must not
+    // rewrite its parent's file outside the parent's own save path, where a
+    // concurrent parent save could be clobbered by the stale legacy value.
+    // Likewise never migrate OVER an existing document: one that normalizes to
+    // nothing here may hold a newer build's fields (downgrade↔upgrade), and
+    // the migration write would destroy them.
+    if (inheritanceDepth > 0 || emptyOwnDocument !== undefined) {
+      return { overrides: normalizedLegacy, authoritative: true };
+    }
+    if (snapshot.cancelled) {
+      // The operation that owned this resolution timed out and released its
+      // lock (or evicted): writing now could overwrite a newer settings save.
+      // Honor the legacy value read-only; a later read migrates.
+      log.debug("[MCP] Skipping legacy override migration: owning operation timed out", {
         workspaceId,
-        filePath: canonicalPath,
       });
+      return { overrides: normalizedLegacy, authoritative: true };
+    }
+    const target = {
+      workspaceId,
+      legacy,
+      normalizedLegacy,
+      runtime,
+      workspacePath,
+      canonicalPath,
+      filePaths,
+      runtimeConfig: metadata.runtimeConfig,
+    };
+    const migrated = snapshot.writerLocksHeld
+      ? await this.migrateLegacyOverrides(target, snapshot)
+      : await this.migrateLegacyOverridesFenced(target, snapshot);
+
+    return {
+      overrides: normalizedLegacy,
+      authoritative: true,
+      // Only a file that was actually written can be copied raw.
+      ...(migrated
+        ? {
+            sourceFile: {
+              runtime,
+              filePath: canonicalPath,
+              ownerWorkspaceId: workspaceId,
+              workspacePath,
+              hostFilesystem,
+            },
+          }
+        : {}),
+    };
+  }
+
+  /**
+   * An unlocked reader's migration (see ConfigSnapshot.writerLocksHeld):
+   * takes the workspace and global write locks like every other writer of
+   * the document — bounded, so a request never waits long behind a busy
+   * writer (the value stays honored read-only; a later read migrates) — and
+   * re-verifies under them that the legacy value is still the one observed
+   * (a save meanwhile cleared or replaced it) and that no document exists at
+   * any candidate path (a save meanwhile wrote one). Without this a read that
+   * paused after observing the legacy enable could overwrite a disable a
+   * save persisted meanwhile, and the epoch retry would then trust the
+   * restored file.
+   */
+  private async migrateLegacyOverridesFenced(
+    target: LegacyMigrationTarget,
+    snapshot: ConfigSnapshot
+  ): Promise<boolean> {
+    try {
+      return await this.withWorkspaceLocks(
+        [target.workspaceId],
+        (locked) =>
+          this.runExclusive(
+            async () => {
+              if (locked.unresolvable.length > 0 || snapshot.cancelled) {
+                return false;
+              }
+              // The target was captured before the locks. A rename that moved
+              // the checkout meanwhile would otherwise be migrated into the OLD
+              // path (recreating it) while the only legacy copy is cleared —
+              // the renamed workspace silently loses its overrides. Migrate
+              // only when a registry read taken under BOTH locks still names
+              // the captured checkout (the lock derivation's view predates the
+              // global lock wait).
+              const registry = await this.config.getAllWorkspaceMetadata({
+                throwOnError: true,
+                probeCheckouts: false,
+              });
+              const current = registry.find((m) => m.id === target.workspaceId);
+              if (
+                current === undefined ||
+                JSON.stringify(current.runtimeConfig) !== JSON.stringify(target.runtimeConfig) ||
+                this.resolveWorkspace(current, snapshot).workspacePath !== target.workspacePath
+              ) {
+                return false;
+              }
+              const fresh = this.getLegacyOverridesFromConfig(
+                target.workspaceId,
+                this.config.loadConfigOrDefault({ throwOnError: true })
+              );
+              if (JSON.stringify(fresh) !== JSON.stringify(target.legacy)) {
+                return false;
+              }
+              const selected = selectProbedCandidate(
+                await Promise.all(
+                  target.filePaths.map((filePath) => probeOverridesFile(target.runtime, filePath))
+                )
+              );
+              if (selected.kind !== "absent") {
+                return false;
+              }
+              return this.migrateLegacyOverrides(target, snapshot);
+            },
+            { timeoutMs: MIGRATION_LOCK_TIMEOUT_MS }
+          ),
+        MIGRATION_LOCK_TIMEOUT_MS
+      );
+    } catch (error) {
+      log.debug("[MCP] Skipping legacy override migration: write locks not acquired", {
+        workspaceId: target.workspaceId,
+        error: getErrorMessage(error),
+      });
+      return false;
+    }
+  }
+
+  /** Migrate a legacy config.json value into the workspace file; the caller holds the write locks. Returns whether the document was written. */
+  private async migrateLegacyOverrides(
+    target: LegacyMigrationTarget,
+    snapshot: ConfigSnapshot
+  ): Promise<boolean> {
+    const { workspaceId, legacy, normalizedLegacy, runtime, workspacePath, canonicalPath } = target;
+    let migrated = false;
+    try {
+      // SECURITY: same containment as a dialog save (writeOverridesLocked). A
+      // repo-tracked `.xum` symlink pointing at another checkout's `.xum`
+      // would otherwise make this write — which follows links on EVERY
+      // runtime, SSH included — plant the source's enabled-server override in
+      // a sibling workspace. The shell probe covers exec-backed runtimes; the
+      // host check adds realpath containment.
+      const hostFilesystem = overridesOnHostFilesystem(target.runtimeConfig);
+      await assertOverrideSegmentsNotSymlinked(runtime, workspacePath, hostFilesystem);
+      // Tracked like the write below: a `mkdir -p` that outlives a bounded
+      // owner's deadline is joined before its locks are released, or a
+      // removal landing in between deletes the checkout and the late mkdir
+      // recreates the `.xum` path as an orphan (same hazard as the fork copy's
+      // directory step, see writeForkCopy).
+      await snapshot.trackSideEffect(
+        this.ensureOverridesDir(runtime, workspacePath, target.runtimeConfig)
+      );
+      if (hostFilesystem) {
+        await assertHostOverrideWriteContained(canonicalPath, workspacePath);
+      }
+      if (snapshot.cancelled) {
+        // Timed out during the directory step: the lock may be released
+        // already, so the write below must not start (see trackSideEffect
+        // for a write that had already started).
+        log.debug("[MCP] Skipping legacy override migration: owning operation timed out", {
+          workspaceId,
+        });
+        return false;
+      }
+      // The WHOLE mutation tail is one tracked side effect: a bounded owner
+      // that times out joins it (settleSideEffects) before releasing its
+      // locks, and a cancellation observed after the write still stops the
+      // config clear — the one step that deletes state — so a late tail can
+      // never remove a legacy value written under a later operation's lock.
+      await snapshot.trackSideEffect(
+        (async () => {
+          const content = JSON.stringify(normalizedLegacy, null, 2) + "\n";
+          await writeFileString(runtime, canonicalPath, content);
+          // The document exists now: siblings must learn about it even if the
+          // owner gave up meanwhile. Should the durable signal fail, the
+          // document is rolled back — every later read would otherwise stop
+          // at it and never retry the migration, leaving another backend's
+          // pre-migration cache trusted for good. The legacy value is still
+          // in place (cleared only below), so the next read migrates again.
+          try {
+            await this.bumpOverridesEpoch();
+          } catch (error) {
+            // Compare-and-delete of exactly the document this migration wrote:
+            // never the compatibility paths, and never a canonical document an
+            // older process or a direct edit replaced meanwhile.
+            await this.removeExactDocument(runtime, workspacePath, canonicalPath, content).catch(
+              (rollbackError: unknown) =>
+                log.warn("[MCP] Could not roll back a legacy migration whose epoch signal failed", {
+                  workspaceId,
+                  error: getErrorMessage(rollbackError),
+                })
+            );
+            throw error;
+          }
+          migrated = true;
+          if (snapshot.cancelled) {
+            log.debug(
+              "[MCP] Legacy override migration wrote its document but skips the config clear: owning operation timed out",
+              { workspaceId }
+            );
+            return;
+          }
+          await this.ensureOverridesGitignored(runtime, workspacePath, target.runtimeConfig);
+          if (snapshot.cancelled) {
+            return;
+          }
+          // Only the value that was migrated: a newer legacy value saved
+          // meanwhile by an older process is left for a later read to migrate.
+          await this.clearLegacyOverridesInConfig(workspaceId, { onlyIfEquals: legacy });
+          log.info("[MCP] Migrated workspace MCP overrides from config.json", {
+            workspaceId,
+            filePath: canonicalPath,
+          });
+        })()
+      );
     } catch (error) {
       // Migration is best-effort; if it fails, still honor legacy overrides.
       log.warn("[MCP] Failed to migrate workspace MCP overrides; using legacy config.json values", {
@@ -490,8 +2028,1328 @@ export class WorkspaceMcpOverridesService {
         error,
       });
     }
+    return migrated;
+  }
 
-    return normalizedLegacy;
+  /**
+   * Sub-agent (task child) workspaces are fresh checkouts created from
+   * committed state, so the parent's gitignored `.xum/mcp.local.jsonc` never
+   * reaches them. Without inheritance, a server that is disabled in global
+   * config and enabled only for the parent workspace is silently absent for
+   * every sub-agent — and with it `tool_catalog_search`, which only exists
+   * when MCP tools are present. Resolve through the parent chain (read-through,
+   * no copy) so parent edits and plugin-uninstall prunes apply to children on
+   * their next request. A child that saves its own overrides opts out; saving
+   * empty overrides removes the file and resumes inheriting. Parent saves and
+   * prunes re-publish inheriting descendants (see publishEffectiveOverrides).
+   */
+  private async loadInheritedOverrides(
+    metadata: FrontendWorkspaceMetadata,
+    mode: "lenient" | "strict",
+    snapshot: ConfigSnapshot,
+    inheritanceDepth: number
+  ): Promise<ResolvedOverrides> {
+    const parentWorkspaceId = metadata.parentWorkspaceId;
+    if (parentWorkspaceId == null) {
+      return { overrides: {}, authoritative: true };
+    }
+    // Parent links form a tree; a cycle would mean corrupted config.
+    assert(
+      inheritanceDepth < MAX_OVERRIDES_INHERITANCE_DEPTH,
+      `Workspace MCP override inheritance exceeded ${MAX_OVERRIDES_INHERITANCE_DEPTH} levels for ${metadata.id}`
+    );
+    try {
+      // A removed parent leaves nothing to inherit. Checked explicitly (in both
+      // modes) so a strict prune re-read of an orphaned child does not fail —
+      // and retry — forever on a parent that will never come back. The config
+      // read must be authoritative (see ConfigSnapshot.loadAllMetadata): its
+      // default empty fallback on a transient read failure is
+      // indistinguishable from removal and would publish `{}` over the
+      // parent's real settings.
+      const all = await snapshot.loadAllMetadata();
+      const parent = all.find((m) => m.id === parentWorkspaceId);
+      if (parent === undefined) {
+        return { overrides: {}, authoritative: true };
+      }
+      const inherited = await this.resolveOverridesFor(
+        parent,
+        mode,
+        snapshot,
+        inheritanceDepth + 1
+      );
+      return inherited.authoritative ? inherited : { ...inherited, authorityLostInherited: true };
+    } catch (error) {
+      if (mode === "strict") {
+        throw error;
+      }
+      // An unreachable parent runtime must not fail the child's send.
+      log.warn("[MCP] Failed to inherit parent workspace MCP overrides", {
+        workspaceId: metadata.id,
+        parentWorkspaceId,
+        error: getErrorMessage(error),
+      });
+      return { overrides: {}, authoritative: false, authorityLostInherited: true };
+    }
+  }
+
+  /**
+   * Publish the written workspace's effective overrides, then re-publish every
+   * other workspace the write affected so cached enablement in
+   * MCPServerManager tracks it instead of going stale until a cold request:
+   * - workspaces on the SAME runtime identity whose canonical override path IS
+   *   the written file (an `isolation: "none"` task shares its parent's
+   *   physical checkout, in either direction: a child save changes the
+   *   parent's file too), and
+   * - descendants that inherit (no file of their own) from any affected
+   *   workspace, transitively. A descendant owning its own file cuts off its
+   *   subtree: those grandchildren inherit from it, not from us.
+   * A workspace whose state cannot be established authoritatively (checkout
+   * unreachable) gets `null`: its cached snapshot is dropped, never replaced
+   * with a guess, so recovery reads disk. Failures on other workspaces are
+   * logged, never propagated — they must not fail the writer's save or keep a
+   * prune tombstone alive.
+   */
+  private async publishEffectiveOverrides(
+    workspaceId: string,
+    own: WorkspaceMCPOverrides | null,
+    publish: OverridesPublisher,
+    /** Canonical override path the write landed on. */
+    writtenPath: string,
+    snapshot: ConfigSnapshot = new ConfigSnapshot(this.config),
+    /**
+     * Workspaces already published by this operation. A batch sweep shares
+     * one set across every swept workspace so a subtree is traversed once
+     * (from its topmost swept ancestor) rather than once per ancestor.
+     */
+    published = new Set<string>(),
+    /** Shared by a batch sweep; a single save gets its own (see PublicationBudget). */
+    budget: PublicationBudget = createPublicationBudget()
+  ): Promise<void> {
+    try {
+      await this.publishEffectiveOverridesInner(
+        workspaceId,
+        own,
+        publish,
+        writtenPath,
+        snapshot,
+        published,
+        budget
+      );
+    } finally {
+      // Steps that timed out may still have a migration write in flight; the
+      // caller releases the lock right after this returns, so wait for them
+      // (they are the only writes this operation started). The lock's lease
+      // renewal keeps the holder non-reclaimable meanwhile.
+      await snapshot.settleSideEffects();
+    }
+  }
+
+  /**
+   * Workspaces registered on the SAME checkout as `written` (aliases: e.g. an
+   * isolation:none task sharing its parent's directory). Sharing means the
+   * same runtime identity (host/container: Docker reports `/src` for every
+   * container and two SSH hosts can hold the same path) AND the same override
+   * path on it — never the same project registration: two SSH registrations
+   * under different projects but one host and checkout path mutate one remote
+   * file, and omitting one would let its legacy `workspace.mcp` value migrate
+   * back over the other's save. Host-local checkouts may be registered under
+   * different spellings of one directory (symlinked project paths), so
+   * realpaths are compared there. Candidates whose canonical path cannot be established are
+   * reported separately (`indeterminate`): they may or may not share.
+   * "unverifiable": the written checkout itself cannot be canonicalized.
+   * "timeout": the bounded parallel scan exceeded `timeoutMs` (this runs
+   * under the exclusive lock; stalled mounts must not hold every writer).
+   */
+  private async findCheckoutSharers(
+    written: FrontendWorkspaceMetadata,
+    writtenPath: string,
+    all: readonly FrontendWorkspaceMetadata[],
+    snapshot: ConfigSnapshot,
+    timeoutMs: number,
+    exclude: ReadonlySet<string>
+  ): Promise<
+    | { sharers: FrontendWorkspaceMetadata[]; indeterminate: FrontendWorkspaceMetadata[] }
+    | "unverifiable"
+    | "timeout"
+  > {
+    const writtenIdentity = runtimeFilesystemIdentity(written.runtimeConfig);
+    if (writtenIdentity === undefined) {
+      return { sharers: [], indeterminate: [] };
+    }
+    const canonicalWritten = await snapshot.canonicalize(writtenIdentity, writtenPath);
+    if (canonicalWritten === undefined) {
+      return "unverifiable";
+    }
+    const candidates: Array<{ metadata: FrontendWorkspaceMetadata; path: string }> = [];
+    // SSH `host` may be an ssh_config alias: two aliases can name one machine,
+    // and nothing here resolves them. A registration on another SSH identity
+    // with the SAME remote path may therefore share the checkout — it is
+    // reported indeterminate (never a sharer, never excluded), so a save
+    // while it carries a legacy value is refused rather than leaving a stale
+    // value to migrate back over the user's write. Self-healing: reading
+    // that workspace once migrates its value away.
+    const possibleAliases: FrontendWorkspaceMetadata[] = [];
+    for (const m of all) {
+      if (m.id === written.id || exclude.has(m.id)) continue;
+      const identity = runtimeFilesystemIdentity(m.runtimeConfig);
+      if (identity !== writtenIdentity) {
+        if (
+          written.runtimeConfig.type === "ssh" &&
+          m.runtimeConfig.type === "ssh" &&
+          this.canonicalOverridesPathFor(m) === writtenPath
+        ) {
+          possibleAliases.push(m);
+        }
+        continue;
+      }
+      const candidate = this.canonicalOverridesPathFor(m);
+      if (candidate !== undefined) candidates.push({ metadata: m, path: candidate });
+    }
+    // Canonicalize in bounded parallel, not serially: every stalled-filesystem
+    // candidate can burn two realpath timeouts, so hundreds of dead NFS
+    // checkouts would otherwise hold every later writer for minutes.
+    let canonical: Array<string | undefined>;
+    try {
+      canonical = await withDeadline(
+        mapWithConcurrency(candidates, CANONICALIZE_CONCURRENCY, (candidate) =>
+          snapshot.canonicalize(writtenIdentity, candidate.path)
+        ),
+        timeoutMs,
+        "sharer scan exceeded its budget"
+      );
+    } catch {
+      return "timeout";
+    }
+    const sharers: FrontendWorkspaceMetadata[] = [];
+    const indeterminate: FrontendWorkspaceMetadata[] = [...possibleAliases];
+    for (const [index, candidate] of candidates.entries()) {
+      const canonicalCandidate = canonical[index];
+      if (canonicalCandidate === undefined) indeterminate.push(candidate.metadata);
+      else if (canonicalCandidate === canonicalWritten) sharers.push(candidate.metadata);
+    }
+    return { sharers, indeterminate };
+  }
+
+  private async publishEffectiveOverridesInner(
+    workspaceId: string,
+    own: WorkspaceMCPOverrides | null,
+    publish: OverridesPublisher,
+    writtenPath: string,
+    snapshot: ConfigSnapshot,
+    published: Set<string>,
+    // One budget for the WHOLE fan-out (own publication, sharer scan, every
+    // level): each probe is bounded, but thousands of candidates on stalled
+    // mounts would still add up under the exclusive lock past its acquisition
+    // timeout (and the stale lease). When the budget runs out nothing below
+    // can be published authoritatively: evict every cache instead, and let
+    // the abandoned work's cancellation flags keep it from publishing later.
+    budget: PublicationBudget
+  ): Promise<void> {
+    // The publisher callback itself (MCPServerManager.applyWorkspaceOverrides)
+    // repairs cached enablement through listServers, which reads the
+    // project's MCP config — a disconnected project filesystem would hold the
+    // override lock indefinitely. Bound every publication too; on timeout (or
+    // failure) evict the target instead: eviction is a synchronous marker,
+    // the target's next serve re-reads, and the abandoned repair completes
+    // harmlessly with the same overrides later.
+    const publishBounded = async (
+      persisted: WorkspaceMCPOverrides,
+      target: string,
+      timeoutMs: number
+    ): Promise<void> => {
+      try {
+        await withDeadline(
+          publish(persisted, target),
+          timeoutMs,
+          `override publication to workspace ${target} timed out`
+        );
+      } catch (error) {
+        log.warn("[MCP] Override publication did not complete; evicting the target's cache", {
+          workspaceId,
+          target,
+          error: getErrorMessage(error),
+        });
+        await publish(null, target);
+      }
+    };
+    if (own === null) {
+      await publish(null, workspaceId);
+    } else {
+      await publishBounded(own, workspaceId, budget.remaining());
+    }
+    // When the authoritative enumeration fails there is no descendant to
+    // evict individually: drop every cache instead.
+    let all: FrontendWorkspaceMetadata[];
+    try {
+      // Under the budget like every other step held under the lock: the
+      // enumeration is registry-only (no per-checkout probes), but its
+      // read-time migration replay goes through the config queue.
+      all = await withDeadline(
+        snapshot.loadAllMetadata(),
+        budget.remaining(),
+        "workspace enumeration exceeded the publication budget"
+      );
+    } catch (error) {
+      // The lenient fallback can be EMPTY after the same failure, leaving no
+      // descendant to evict individually: drop every cache instead.
+      log.warn("[MCP] Workspace enumeration failed during override publication; evicting all", {
+        workspaceId,
+        error: getErrorMessage(error),
+      });
+      snapshot.cancel();
+      await publish(null, ALL_WORKSPACES_TARGET);
+      return;
+    }
+    const written = all.find((m) => m.id === workspaceId);
+    published.add(workspaceId);
+    const evictAll = async (reason: string): Promise<void> => {
+      log.warn(`[MCP] Override publication ${reason}; evicting all cached overrides`, {
+        workspaceId,
+      });
+      snapshot.cancel();
+      await publish(null, ALL_WORKSPACES_TARGET);
+    };
+    // Index once: scanning `all` per visited node made publication
+    // O(total × affected) under the exclusive lock.
+    const childrenByParent = new Map<string, FrontendWorkspaceMetadata[]>();
+    for (const m of all) {
+      if (m.parentWorkspaceId == null) continue;
+      const siblings = childrenByParent.get(m.parentWorkspaceId);
+      if (siblings) siblings.push(m);
+      else childrenByParent.set(m.parentWorkspaceId, [m]);
+    }
+    const childrenOf = (id: string) =>
+      (childrenByParent.get(id) ?? []).filter((m) => !published.has(m.id));
+    let sharers: FrontendWorkspaceMetadata[] = [];
+    // Candidates whose canonical path could not be established: they may or
+    // may not share the written checkout, so their caches (and subtrees) are
+    // evicted rather than left possibly stale.
+    let indeterminateSharers: FrontendWorkspaceMetadata[] = [];
+    if (written) {
+      const scan = await this.findCheckoutSharers(
+        written,
+        writtenPath,
+        all,
+        snapshot,
+        budget.remaining(),
+        published
+      );
+      if (scan === "unverifiable") {
+        // Nothing can be compared against: no sharer can be told apart from a
+        // non-sharer, so no cache below can be trusted.
+        await evictAll("could not canonicalize the written checkout");
+        return;
+      }
+      if (scan === "timeout") {
+        await evictAll("could not finish its sharer scan in time");
+        return;
+      }
+      sharers = scan.sharers;
+      indeterminateSharers = scan.indeterminate;
+    }
+    // "refresh": re-resolve and publish (or evict when not authoritative).
+    // "evict": an ancestor between this node and the write was indeterminate,
+    // so nothing below it can be resolved authoritatively — drop caches all the
+    // way down instead of leaving a stale inherited snapshot on a reachable
+    // grandchild.
+    interface Step {
+      metadata: FrontendWorkspaceMetadata;
+      shares: boolean;
+      action: "refresh" | "evict";
+    }
+    let level: Step[] = [
+      ...sharers.map((metadata): Step => ({ metadata, shares: true, action: "refresh" })),
+      ...indeterminateSharers.map(
+        (metadata): Step => ({ metadata, shares: true, action: "evict" })
+      ),
+      ...childrenOf(workspaceId).map(
+        (metadata): Step => ({ metadata, shares: false, action: "refresh" })
+      ),
+    ];
+    // Each descendant's ownership probe and resolution can exec remote `stat`s
+    // with a 10 s timeout, and this runs under the exclusive override lock: a
+    // large or slow task tree processed serially would hold every later writer
+    // past its lock-acquisition timeout. Publish one breadth level at a time
+    // (parents before children, so a child's inherited state is final) with
+    // bounded parallelism inside the level.
+    while (level.length > 0) {
+      if (budget.exhausted()) {
+        await evictAll("exceeded its budget before finishing the descendant fan-out");
+        return;
+      }
+      // Dedupe within a level: the same child can be reached as a sharer's
+      // child and as ours. `published` is only extended after the level runs,
+      // so the check below cannot race a sibling worker.
+      const seen = new Set<string>();
+      const steps = level.filter((step) => {
+        if (published.has(step.metadata.id) || seen.has(step.metadata.id)) return false;
+        seen.add(step.metadata.id);
+        return true;
+      });
+      const nextLevel = await mapWithConcurrency(
+        steps,
+        PUBLICATION_CONCURRENCY,
+        async (next): Promise<Step[]> => {
+          const child = next.metadata;
+          try {
+            let action = next.action;
+            // Off-host workspaces would need remote `stat`s (10 s timeout each
+            // level) while the write lock is held; a slow chain could exceed
+            // the lock's acquisition and stale bounds. Evict them (and their
+            // subtree) without I/O — their next serve re-reads on their own
+            // runtime.
+            if (!isHostLocalRuntimeConfig(child.runtimeConfig)) {
+              action = "evict";
+            } else {
+              // Host filesystem I/O can stall too (see HOST_DESCENDANT_TIMEOUT_MS);
+              // a timeout is handled like an indeterminate probe: evict. The
+              // step's own snapshot scope is cancelled on timeout so the
+              // abandoned work performs no migration write or publication.
+              const step = snapshot.scoped();
+              const deadline = <T>(work: Promise<T>) =>
+                withDeadline(
+                  work,
+                  Math.min(HOST_DESCENDANT_TIMEOUT_MS, budget.remaining()),
+                  `workspace ${child.id} checkout did not respond`,
+                  () => step.cancel()
+                );
+              try {
+                if (!next.shares) {
+                  const ownership = await deadline(this.probeOwnOverrides(child, step));
+                  // Owns a file: unaffected, and so is its subtree (it inherits from the owner).
+                  if (ownership === "own") return [];
+                  if (ownership === "indeterminate") action = "evict";
+                }
+                if (action === "refresh") {
+                  const resolved = await deadline(this.resolveOverridesFor(child, "lenient", step));
+                  if (!resolved.authoritative || step.cancelled) action = "evict";
+                  else {
+                    await publishBounded(
+                      resolved.overrides,
+                      child.id,
+                      Math.min(HOST_DESCENDANT_TIMEOUT_MS, budget.remaining())
+                    );
+                  }
+                }
+              } catch (error) {
+                log.warn("[MCP] Evicting an affected workspace whose checkout did not respond", {
+                  workspaceId,
+                  affectedWorkspaceId: child.id,
+                  error: getErrorMessage(error),
+                });
+                action = "evict";
+              }
+            }
+            if (action === "evict") {
+              await publish(null, child.id);
+            }
+            return childrenOf(child.id).map(
+              (metadata): Step => ({ metadata, shares: false, action })
+            );
+          } catch (error) {
+            log.warn("[MCP] Failed to re-publish overrides to an affected workspace", {
+              workspaceId,
+              affectedWorkspaceId: child.id,
+              error: getErrorMessage(error),
+            });
+            return [];
+          }
+        }
+      );
+      for (const step of steps) published.add(step.metadata.id);
+      level = nextLevel.flat();
+    }
+  }
+
+  private canonicalOverridesPathFor(metadata: FrontendWorkspaceMetadata): string | undefined {
+    try {
+      const { workspacePath } = this.resolveWorkspace(metadata);
+      return this.getOverridesFilePaths(workspacePath, metadata.runtimeConfig)[0];
+    } catch {
+      return undefined;
+    }
+  }
+
+  /** Whether a workspace resolves overrides from its own storage rather than a parent. */
+  private async probeOwnOverrides(
+    metadata: FrontendWorkspaceMetadata,
+    snapshot: ConfigSnapshot
+  ): Promise<"own" | "inherits" | "indeterminate"> {
+    // Same normalization as resolveOverridesFor: legacy noise that normalizes
+    // to nothing does not make the workspace an owner.
+    let legacy: WorkspaceMCPOverrides | undefined;
+    try {
+      legacy = this.getLegacyOverridesFromConfig(metadata.id, snapshot.loadLegacyConfig());
+    } catch {
+      return "indeterminate";
+    }
+    if (
+      legacy !== undefined &&
+      (!isRecognizedOverridesDocument(legacy) ||
+        !isEmptyOverrides(normalizeWorkspaceMcpOverrides(legacy)))
+    ) {
+      return "own";
+    }
+    const { runtime, workspacePath } = this.resolveWorkspace(metadata);
+    const filePaths = this.getOverridesFilePaths(workspacePath, metadata.runtimeConfig);
+    const selected = selectProbedCandidate(
+      await Promise.all(filePaths.map((filePath) => probeOverridesFile(runtime, filePath)))
+    );
+    if (selected.kind === "indeterminate") return "indeterminate";
+    if (selected.kind === "absent") return "inherits";
+    // Same rule as resolveOverridesFor: a document that normalizes to nothing
+    // does not detach the workspace from its parent.
+    const read = await this.readOverridesFile(runtime, filePaths[selected.index], "lenient");
+    if (!read.authoritative) return "indeterminate";
+    return isEmptyOverrides(normalizeWorkspaceMcpOverrides(read.parsed)) &&
+      isRecognizedOverridesDocument(read.parsed)
+      ? "inherits"
+      : "own";
+  }
+
+  /**
+   * SECURITY: the fork target is a fresh checkout of repository-controlled
+   * content. A tracked symlink at `.xum` or `.xum/mcp.local.jsonc` would make
+   * the write below (which follows links on every runtime) land OUTSIDE the
+   * checkout, and a tracked regular file at that path is repo content this
+   * automatic copy must not clobber (the registration-time sanitizer handles
+   * it). Both are refused; the fork simply proceeds without the copy. The
+   * checkout root itself is trusted, so the two repo-controlled segments are
+   * the whole surface. Shell `test` keeps this uniform across host-local and
+   * exec-backed remote runtimes (mirrors removeOverridesFile).
+   */
+  private async isForkCopyTargetWritable(
+    runtime: ReturnType<typeof createRuntime>,
+    workspacePath: string
+  ): Promise<boolean> {
+    const relativeFile = MCP_OVERRIDES_GITIGNORE_PATTERNS[0];
+    const relativeDir = relativeFile.split("/")[0];
+    assert(relativeDir.length > 0 && relativeDir !== relativeFile, "canonical override path shape");
+    const guard = await execBuffered(
+      runtime,
+      `test ! -L "${relativeDir}" && test ! -L "${relativeFile}" && test ! -e "${relativeFile}"`,
+      { cwd: workspacePath, timeout: 10 }
+    );
+    if (guard.exitCode === 0) {
+      return true;
+    }
+    log.warn(
+      "[MCP] Not copying workspace MCP overrides into fork: target path is a symlink or already tracked",
+      { workspacePath, relativeFile }
+    );
+    return false;
+  }
+
+  /**
+   * Fork-time copy of the source workspace's overrides into the new checkout.
+   *
+   * Forks are independent workspaces (the source may later be archived or
+   * removed), so unlike sub-agents they get a snapshot rather than a
+   * read-through link. The target is not registered in config yet when
+   * WorkspaceService.fork calls this, hence the explicit runtime/path. Runs
+   * BEFORE the fork's plugin-override sanitization so stale `plugin:` enables
+   * are pruned exactly like a tracked file would be. Best-effort: a failed
+   * copy must never fail the fork.
+   *
+   * Lock scope: resolving the source at depth 0 may MIGRATE its legacy
+   * config.json value into the source file — outside the lock, a concurrent
+   * settings save could land between the legacy read and the migration write
+   * and be overwritten by the stale legacy value — and the raw document read
+   * must see a complete write. Only those two steps take the exclusive lock.
+   * Migration is possible only when the source still has a recognized,
+   * non-empty legacy value (nothing creates legacy values at runtime), and a
+   * source with one never traverses its inheritance chain; otherwise the
+   * resolution is read-only and runs OUTSIDE the lock, because an inheriting
+   * SSH source probes one round of remote paths per ancestor level and holding
+   * the global lock through that would stall every unrelated save/prune past
+   * the acquisition timeout (or the stale lease).
+   */
+  async copyOverridesToForkedCheckout(
+    sourceWorkspaceId: string,
+    target: {
+      runtime: ReturnType<typeof createRuntime>;
+      workspacePath: string;
+      runtimeConfig: RuntimeConfig | undefined;
+    }
+  ): Promise<void> {
+    assert(target.workspacePath.length > 0, "fork target workspacePath is required");
+    const deadlineAt = Date.now() + FORK_COPY_TIMEOUT_MS;
+    const remainingMs = () => Math.max(0, deadlineAt - Date.now());
+    try {
+      // The target side never takes the lock: it is not registered yet, so no
+      // settings writer contends with it, and its I/O may run against a slow
+      // remote runtime.
+      // Under the lock everything is re-derived from a FRESH config snapshot:
+      // the pre-lock legacy value / metadata may have been cleared, renamed
+      // or reparented by a save or rename that completed before we acquired
+      // the lock, and resolving from the stale snapshot would migrate a
+      // revoked legacy enable back into the source (and the fork).
+      // The hold deadline applies INSIDE the locked callback, so it bounds
+      // the lock HOLD time (a stalled NFS/FUSE checkout releases the lock
+      // after the budget and the copy is abandoned); the acquisition itself
+      // gives up at the operation's deadline, so a queued preparation the
+      // fork stopped waiting for never acquires and holds the lock later.
+      const underLock = async () => {
+        // The held path may WRITE into the source checkout (legacy migration /
+        // opaque-value materialization), so it takes the source's workspace
+        // lock first like every other writer of that document.
+        const outcome = await this.withWorkspaceLocks(
+          [sourceWorkspaceId],
+          (lockedKeys) =>
+            this.runExclusive(
+              async () => {
+                const unresolvable = lockedKeys.unresolvable[0];
+                if (unresolvable !== undefined) {
+                  throw unresolvable.error;
+                }
+                const locked = new ConfigSnapshot(
+                  this.config,
+                  /* hostFilesystemView */ true,
+                  undefined,
+                  /* writerLocksHeld */ true
+                );
+                try {
+                  return await withDeadline(
+                    (async () => {
+                      const lockedSource = await this.getRuntimeAndWorkspacePath(
+                        sourceWorkspaceId,
+                        locked
+                      );
+                      return this.prepareForkCopySource(
+                        sourceWorkspaceId,
+                        lockedSource,
+                        target,
+                        locked,
+                        "held"
+                      );
+                    })(),
+                    Math.min(FORK_COPY_LOCKED_TIMEOUT_MS, remainingMs()),
+                    "locked fork-copy preparation timed out",
+                    // The abandoned resolution must not START a migration write
+                    // after the lock is released (it could overwrite a newer save).
+                    () => locked.cancel()
+                  );
+                } finally {
+                  // …and a write that had already started keeps the lock until it
+                  // settles: it cannot be cancelled, and landing it under the
+                  // released lock could clobber a newer save. Holding is safe for
+                  // as long as it takes: the cross-process lock re-stamps its lease
+                  // while held (acquireCrossProcessLock's renewal), so a live
+                  // holder waiting on a stalled write never becomes reclaimable —
+                  // only a crashed process (which cannot complete the write) does.
+                  await locked.settleSideEffects();
+                }
+              },
+              { timeoutMs: remainingMs() }
+            ),
+          remainingMs()
+        );
+        assert(outcome !== "stale", "a locked fork-copy preparation cannot go stale");
+        return outcome;
+      };
+      // A save that lands between the unlocked resolution and the locked
+      // document read can change WHICH document is effective (a child-owned
+      // file appearing over the ancestor's, a removal, a cleared legacy value
+      // along the chain): the override epoch moves with every completed
+      // write, so a preparation is committed only if the epoch under the lock
+      // still matches the one read before resolving. Every attempt starts
+      // from its own epoch read and a config snapshot built AFTER it (nothing
+      // memoized survives a retry, or a cleared ancestor legacy enable would
+      // be serialized into the fork on the next attempt). Retry a few times
+      // against a busy writer, then fall back to resolving under the lock
+      // rather than copying a stale snapshot.
+      let prepared: ForkCopySource | undefined;
+      for (let attempt = 0; attempt < FORK_COPY_ATTEMPTS && remainingMs() > 0; attempt++) {
+        // Every step draws on the operation's deadline, this home-filesystem
+        // read included: a stalled home must not hold the fork here forever.
+        const epochBefore = await withDeadline(
+          readWorkspaceOverridesEpochToken(this.coordinationRootDir),
+          Math.max(1, remainingMs()),
+          "fork-copy epoch read timed out"
+        );
+        const snapshot = new ConfigSnapshot(this.config, /* hostFilesystemView */ true);
+        // The whole attempt — source metadata lookup included — draws on the
+        // operation's single deadline (see the free-path bound below); the
+        // lookup enumerates the registry, so it belongs inside it.
+        const attemptBudget = () => Math.max(1, remainingMs());
+        let source: ResolvedWorkspace;
+        try {
+          source = await withDeadline(
+            this.getRuntimeAndWorkspacePath(sourceWorkspaceId, snapshot),
+            attemptBudget(),
+            "fork source metadata did not resolve in time",
+            () => snapshot.cancel()
+          );
+        } catch (error) {
+          log.warn("[MCP] Not copying workspace MCP overrides into fork: preparation timed out", {
+            sourceWorkspaceId,
+            error: getErrorMessage(error),
+          });
+          break;
+        }
+        const legacy = this.getLegacyOverridesFromConfig(
+          sourceWorkspaceId,
+          snapshot.loadLegacyConfig()
+        );
+        // A recognized non-empty legacy value migrates into the source file;
+        // an opaque one is materialized there when the fork shares the
+        // checkout (see prepareForkCopySource). Both write the source's own
+        // document, so both need the lock.
+        const mayMigrate =
+          legacy !== undefined &&
+          (!isRecognizedOverridesDocument(legacy) ||
+            !isEmptyOverrides(normalizeWorkspaceMcpOverrides(legacy)));
+        if (mayMigrate) {
+          prepared = await underLock();
+          break;
+        }
+        // The unlocked resolution has no deadline of its own: host stats on
+        // a stalled filesystem can wait indefinitely and a deep SSH chain pays
+        // one remote probe round per ancestor. The fork awaits this before
+        // init/registration, so bound the whole attempt; the snapshot is
+        // cancelled so abandoned work starts no side effect later.
+        let outcome: ForkCopySource | undefined | "stale";
+        try {
+          outcome = await withDeadline(
+            this.prepareForkCopySource(
+              sourceWorkspaceId,
+              source,
+              target,
+              snapshot,
+              "free",
+              epochBefore,
+              remainingMs
+            ),
+            attemptBudget(),
+            "fork source did not respond in time",
+            () => snapshot.cancel()
+          );
+        } catch (error) {
+          log.warn("[MCP] Not copying workspace MCP overrides into fork: preparation timed out", {
+            sourceWorkspaceId,
+            error: getErrorMessage(error),
+          });
+          break;
+        }
+        if (outcome !== "stale") {
+          prepared = outcome;
+          break;
+        }
+        if (attempt === FORK_COPY_ATTEMPTS - 1) {
+          // Every attempt was invalidated by concurrent writes/renames (or the
+          // epoch is persistently unreadable). Resolving under the lock is the
+          // only way to pin the state — affordable for a host-local chain
+          // (fast filesystem probes), but an inheriting SSH chain would hold
+          // the global lock through one remote probe round per ancestor
+          // level; there, give up on the best-effort copy instead.
+          if (await this.forkSourceChainIsHostLocal(source.metadata, snapshot)) {
+            // Host filesystem I/O has no timeout of its own (a disconnected
+            // NFS/FUSE checkout would hold the lock indefinitely): the locked
+            // preparation is bounded (see underLock) and the best-effort copy
+            // abandoned on timeout.
+            try {
+              prepared = await underLock();
+            } catch (error) {
+              log.warn(
+                "[MCP] Not copying workspace MCP overrides into fork: preparation timed out",
+                {
+                  sourceWorkspaceId,
+                  error: getErrorMessage(error),
+                }
+              );
+            }
+          } else {
+            log.warn(
+              "[MCP] Not copying workspace MCP overrides into fork: source kept changing during preparation",
+              { sourceWorkspaceId, attempts: FORK_COPY_ATTEMPTS }
+            );
+          }
+        }
+      }
+      if (prepared !== undefined) {
+        // Cooperative cancellation: on timeout no further target step starts
+        // (the fork goes on to init and registration, after which a late write
+        // could overwrite settings the init hook or the user created). A write
+        // already in flight cannot be cancelled and would land at an unknown
+        // later time, so it is joined instead (together with its git exclude)
+        // — the only case in which the bound is exceeded, and only for as long
+        // as that unit takes.
+        const progress: ForkCopyProgress = { cancelled: false };
+        try {
+          await withDeadline(
+            this.writeForkCopy(sourceWorkspaceId, target, prepared, progress),
+            Math.max(1, remainingMs()),
+            "fork target did not respond in time; skipping the workspace MCP overrides copy",
+            () => {
+              progress.cancelled = true;
+            }
+          );
+        } catch (error) {
+          if (progress.mutation !== undefined) {
+            await progress.mutation.catch(() => undefined);
+          }
+          throw error;
+        }
+      }
+    } catch (error) {
+      log.warn("[MCP] Failed to copy workspace MCP overrides into forked workspace", {
+        sourceWorkspaceId,
+        targetWorkspacePath: target.workspacePath,
+        error: getErrorMessage(error),
+      });
+    }
+  }
+
+  /**
+   * Resolve the source and capture the document to copy. `lock` says whether
+   * the caller already holds the override lock ("held": migration possible,
+   * everything runs inside it) or not ("free": read-only resolution; only the
+   * raw document read below takes the lock — so it cannot observe a torn
+   * concurrent save — and returns "stale" when the override epoch no longer
+   * matches `epochBefore`, i.e. a write completed since the resolution).
+   */
+  private async prepareForkCopySource(
+    sourceWorkspaceId: string,
+    source: ResolvedWorkspace,
+    target: {
+      runtime: ReturnType<typeof createRuntime>;
+      workspacePath: string;
+      runtimeConfig: RuntimeConfig | undefined;
+    },
+    snapshot: ConfigSnapshot,
+    lock: "held" | "free",
+    epochBefore?: string,
+    /** Remaining budget of the whole copy operation ("free" only): bounds the commit section's lock wait and hold. */
+    remainingMs?: () => number
+  ): Promise<ForkCopySource | undefined | "stale"> {
+    // Resolve the source's EFFECTIVE overrides first: this migrates legacy
+    // config.json storage into the source file (so a shared-checkout fork
+    // finds it there) and resolves a sub-agent source's inherited state.
+    const resolved = await this.resolveOverridesFor(source.metadata, "lenient", snapshot);
+    if (!resolved.authoritative) {
+      // A hidden higher-priority document (indeterminate probe) may disable
+      // what the readable one enables; a snapshot of a guess must not
+      // become the fork's persistent configuration.
+      log.warn(
+        "[MCP] Not copying workspace MCP overrides into fork: source state is not authoritative",
+        { sourceWorkspaceId }
+      );
+      return;
+    }
+    const effective = resolved.overrides;
+    const sourcePaths = this.getOverridesFilePaths(
+      source.workspacePath,
+      source.metadata.runtimeConfig
+    );
+    const targetPath = this.getOverridesFilePaths(target.workspacePath, target.runtimeConfig)[0];
+    // Project-dir (`local` runtime) forks share the source checkout, so the
+    // file is already in place. Only that runtime shares storage: Docker
+    // reports `/src` for every container, so equal paths there still need
+    // the copy.
+    if (
+      targetPath === sourcePaths[0] &&
+      source.metadata.runtimeConfig.type === "local" &&
+      target.runtimeConfig?.type === "local"
+    ) {
+      if (resolved.opaqueLegacyValue !== undefined) {
+        // The source's only configuration is a legacy value this build cannot
+        // read, kept in its ID-scoped config entry (resolveOverridesFor never
+        // migrates it). The fork gets a NEW id, so the shared checkout is the
+        // only place it can reach the value from: materialize it into the
+        // shared file (the source keeps resolving identically — the document
+        // is child-owned and normalizes to nothing for this build, exactly
+        // like the legacy value did). Writing the source's own document needs
+        // the lock; the unlocked path defers to the locked fallback.
+        if (lock === "free") {
+          return "stale";
+        }
+        if (snapshot.cancelled) {
+          return;
+        }
+        await this.ensureOverridesDir(
+          source.runtime,
+          source.workspacePath,
+          source.metadata.runtimeConfig
+        );
+        // SECURITY: this automatic write lands in the SOURCE checkout, whose
+        // repository content can track `.xum` (or the file) as a symlink;
+        // refuse to write through one (same hardening as the other override
+        // mutations). Both runtimes are `local` here (checked above).
+        await assertHostOverrideWriteContained(targetPath, source.workspacePath);
+        if (snapshot.cancelled) {
+          return;
+        }
+        await snapshot.trackSideEffect(
+          writeFileString(
+            source.runtime,
+            targetPath,
+            JSON.stringify(resolved.opaqueLegacyValue, null, 2) + "\n"
+          )
+        );
+        await this.bumpOverridesEpoch();
+        await this.ensureOverridesGitignored(
+          source.runtime,
+          source.workspacePath,
+          source.metadata.runtimeConfig
+        );
+        log.info(
+          "[MCP] Materialized an opaque legacy workspace MCP override value for a shared-checkout fork",
+          {
+            sourceWorkspaceId,
+            filePath: targetPath,
+          }
+        );
+      }
+      return;
+    }
+    // Copy the raw document that actually supplied the overrides — the
+    // source's own file, or the ancestor's when the source is an inheriting
+    // sub-agent — even when it normalizes to nothing for THIS build: a
+    // wholesale rewrite of the normalized shape would drop comments and
+    // forward-compatible fields written by a newer release (upgrade↔downgrade
+    // rule). Fall back to the normalized effective value only when no
+    // document exists anywhere along the chain (legacy migration failed).
+    let content: string | undefined;
+    const sourceFile = resolved.sourceFile;
+    // SECURITY: the source document is copied RAW into the fork's checkout,
+    // where the repo's own init hook can read it. A repo-tracked symlink at
+    // the source path (`.mux/mcp.local.jsonc -> ../../../../providers.jsonc`)
+    // would make this read exfiltrate a host file — the devcontainer host
+    // view reads host files by design — into the target. Refuse symlinked
+    // segments on every runtime, and require host paths to resolve inside
+    // the source checkout, before reading.
+    const readDocument = () =>
+      sourceFile === undefined
+        ? undefined
+        : (async () => {
+            await assertOverrideSegmentsNotSymlinked(
+              sourceFile.runtime,
+              sourceFile.workspacePath,
+              sourceFile.hostFilesystem
+            );
+            if (sourceFile.hostFilesystem) {
+              await assertHostOverrideWriteContained(sourceFile.filePath, sourceFile.workspacePath);
+              // The guards above are point-in-time; the read itself must not
+              // follow a symlink swapped in meanwhile.
+              return readHostOverrideDocumentNoFollow(
+                sourceFile.filePath,
+                sourceFile.workspacePath
+              );
+            }
+            return readFileString(sourceFile.runtime, sourceFile.filePath);
+          })();
+    if (lock === "free") {
+      // Commit point: under the lock, no write is in flight; an epoch that
+      // moved (or cannot be read) means the resolution above may name the
+      // wrong document.
+      // The whole locked commit section is bounded: a slow or unreachable
+      // SSH source document (RemoteRuntime.readFile allows minutes) must not
+      // hold the lock past other writers' acquisition timeout. This section
+      // only READS, so releasing on timeout is safe; the attempt is stale.
+      assert(remainingMs !== undefined, "a free fork-copy preparation carries the copy budget");
+      // The lock wait is bounded too: an attempt the caller already abandoned
+      // must not acquire the lock later and hold it for a read nobody uses.
+      const outcome = await this.runExclusive(
+        () =>
+          withDeadline(
+            this.commitForkCopySource(source, resolved, snapshot, epochBefore, readDocument),
+            Math.min(FORK_COPY_LOCKED_TIMEOUT_MS, Math.max(1, remainingMs())),
+            "fork-copy commit section timed out"
+          ).catch(() => "stale" as const),
+        { timeoutMs: remainingMs() }
+      ).catch(() => "stale" as const);
+      if (outcome === "stale") {
+        return "stale";
+      }
+      content = outcome.content;
+    } else if (sourceFile !== undefined) {
+      try {
+        content = await readDocument();
+      } catch (error) {
+        return this.skipUnreadableSourceDocument(sourceWorkspaceId, error);
+      }
+    }
+    if (content === undefined && resolved.opaqueLegacyValue !== undefined) {
+      // The source's only configuration is a legacy value this build cannot
+      // read: still carry it, or the independent fork loses it for good.
+      content = JSON.stringify(resolved.opaqueLegacyValue, null, 2) + "\n";
+    }
+    if (content === undefined) {
+      if (isEmptyOverrides(effective)) {
+        return;
+      }
+      content = JSON.stringify(effective, null, 2) + "\n";
+    }
+    return this.finishForkCopySource(sourceWorkspaceId, content, targetPath);
+  }
+
+  /**
+   * Locked commit point of the unlocked fork-copy path (see
+   * prepareForkCopySource): verifies that nothing the resolution depended on
+   * changed, and reads the selected document verbatim. Read-only.
+   */
+  private async commitForkCopySource(
+    source: ResolvedWorkspace,
+    resolved: ResolvedOverrides,
+    snapshot: ConfigSnapshot,
+    epochBefore: string | undefined,
+    readDocument: () => Promise<string> | undefined
+  ): Promise<{ content: string | undefined } | "stale"> {
+    const epochNow = await readWorkspaceOverridesEpochToken(this.coordinationRootDir);
+    if (epochNow !== epochBefore || isWorkspaceOverridesEpochUnreadable(epochNow)) {
+      return "stale" as const;
+    }
+    // Renames/reparents rewrite config under this same lock but bump no
+    // epoch: the resolution above may have read documents at now-vacated
+    // paths (its own or an ancestor's). Compare the config the resolution
+    // used with the one visible now; any difference along the chain is a
+    // stale resolution.
+    if (!(await this.forkSourceChainUnchanged(source.metadata, snapshot))) {
+      return "stale" as const;
+    }
+    let read: string | undefined;
+    try {
+      read = await readDocument();
+    } catch {
+      // The document the unlocked resolution just read is now unreadable: a
+      // rename that completed before this lock was acquired vacated the path
+      // (its config rewrite is compared above, but the resolution may have
+      // read the old path), or the file was removed by a direct edit. Treat
+      // it as stale and re-resolve against the current config rather than
+      // silently dropping the fork's snapshot.
+      return "stale" as const;
+    }
+    // …and the same rename may have landed after the read: re-check.
+    if (!(await this.forkSourceChainUnchanged(source.metadata, snapshot))) {
+      return "stale" as const;
+    }
+    // Direct edits leave no trace in epoch or config: verify that no
+    // lower level acquired its own document since the resolution…
+    if (!(await this.forkSourcePrecedenceUnchanged(source.metadata, resolved, snapshot))) {
+      return "stale" as const;
+    }
+    // …and that the selected document itself did not change while those
+    // probes ran (a direct edit of the owner's file)…
+    let reread: string | undefined;
+    try {
+      reread = await readDocument();
+    } catch {
+      return "stale" as const;
+    }
+    if (reread !== read) {
+      return "stale" as const;
+    }
+    // …and, AFTER the content was confirmed, that precedence still holds. A
+    // child-owned document created between the first probe round and the
+    // re-read above is invisible to the re-read (the ancestor document it
+    // shadows is unchanged), so a probe on only one side of the content
+    // check would let the fork copy an ancestor enable the source itself
+    // now overrides. Bracketing the content check with probes on both
+    // sides makes the copy a consistent snapshot: precedence and content
+    // observed in one window with nothing changing in between.
+    if (!(await this.forkSourcePrecedenceUnchanged(source.metadata, resolved, snapshot))) {
+      return "stale" as const;
+    }
+    return { content: read };
+  }
+
+  /** Plugin-key stripping and the final consent scan shared by both fork paths. */
+  private finishForkCopySource(
+    sourceWorkspaceId: string,
+    content: string,
+    targetPath: string
+  ): ForkCopySource | undefined {
+    // Strip Agent Plugin enables NOW rather than relying on the fork's later
+    // registration-time sanitization: the init hook starts right after this
+    // copy and could rewrite the file behind the sanitizer, letting a copied
+    // default-disabled plugin enable start on the fork's first request
+    // without fresh consent. A fresh checkout has no live consent context,
+    // so the sanitizer would prune these keys anyway (same text transform).
+    try {
+      content = prunePluginKeysFromDocument(content, PLUGIN_SERVER_KEY_PREFIX, targetPath);
+    } catch (error) {
+      // A newer build's document shape this build cannot inspect. Unlike the
+      // uninstaller there is no retry tombstone here, so dropping the copy
+      // would lose that configuration for good (upgrade↔downgrade rule):
+      // keep it verbatim when the scan below proves it carries no key.
+      log.debug("[MCP] Fork copy could not prune plugin keys; relying on the document scan", {
+        sourceWorkspaceId,
+        error: getErrorMessage(error),
+      });
+    }
+    // Whatever survived pruning — including fields this build does not
+    // recognize — must not carry a canonical plugin key anywhere in its
+    // decoded strings: a later upgrade that understands such a field could
+    // otherwise reactivate a default-disabled plugin server without fresh
+    // consent. Consent wins; the copy is skipped.
+    if (documentMayContainPluginKey(content)) {
+      log.warn(
+        "[MCP] Not copying workspace MCP overrides into fork: document still carries plugin keys",
+        { sourceWorkspaceId }
+      );
+      return;
+    }
+    return { content, targetPath };
+  }
+
+  /**
+   * Whether the fork source and every ancestor it may inherit from are read
+   * from this host's filesystem. Devcontainers count: fork resolution uses
+   * the host filesystem view (ConfigSnapshot.hostFilesystemView), so their
+   * checkouts are probed through a local runtime, never by exec.
+   */
+  private async forkSourceChainIsHostLocal(
+    source: FrontendWorkspaceMetadata,
+    snapshot: ConfigSnapshot
+  ): Promise<boolean> {
+    assert(
+      snapshot.hostFilesystemView,
+      "fork chains are classified under the host filesystem view"
+    );
+    const byId = new Map((await snapshot.loadAllMetadata()).map((m) => [m.id, m]));
+    const seen = new Set<string>();
+    let current: FrontendWorkspaceMetadata | undefined = source;
+    while (current !== undefined && !seen.has(current.id)) {
+      if (
+        !isHostLocalRuntimeConfig(current.runtimeConfig) &&
+        !isDevcontainerRuntime(current.runtimeConfig)
+      ) {
+        return false;
+      }
+      seen.add(current.id);
+      current =
+        current.parentWorkspaceId === undefined ? undefined : byId.get(current.parentWorkspaceId);
+    }
+    return true;
+  }
+
+  /**
+   * Whether the document the unlocked resolution selected still takes
+   * precedence: no workspace between the source and that document's owner
+   * has acquired an own override file meanwhile, and no higher-priority
+   * candidate appeared at the owner itself. Direct edits of
+   * `.xum/mcp.local.jsonc` bump no epoch and rewrite no config, so neither
+   * of the other commit-point checks can see a child file appearing over the
+   * ancestor's. One PARALLEL probe round across those levels (bounded by one
+   * probe timeout, not one per level) under the lock; anything but positive
+   * absence is treated as a precedence change.
+   */
+  private async forkSourcePrecedenceUnchanged(
+    source: FrontendWorkspaceMetadata,
+    resolved: ResolvedOverrides,
+    snapshot: ConfigSnapshot
+  ): Promise<boolean> {
+    const byId = new Map((await snapshot.loadAllMetadata()).map((m) => [m.id, m]));
+    const probes: Array<Promise<OverridesFileProbe>> = [];
+    const seen = new Set<string>();
+    let current: FrontendWorkspaceMetadata | undefined = source;
+    while (current !== undefined && !seen.has(current.id)) {
+      seen.add(current.id);
+      const { runtime, workspacePath } = this.resolveWorkspace(current, snapshot);
+      const filePaths = this.getOverridesFilePaths(workspacePath, current.runtimeConfig);
+      // Owner match by workspace identity, not path alone: an inheriting
+      // Docker child and its parent both report `/src/.xum/mcp.local.jsonc`
+      // in different containers, and mistaking the child for the owner would
+      // stop probing before a child document created meanwhile is seen.
+      const ownerIndex =
+        resolved.sourceFile === undefined || resolved.sourceFile.ownerWorkspaceId !== current.id
+          ? -1
+          : filePaths.indexOf(resolved.sourceFile.filePath);
+      // At the owner level only the candidates that PRECEDE the selected path
+      // matter (a canonical `.xum/` file appearing over a legacy `.mux/` one);
+      // the selected document itself is re-read verbatim under the lock.
+      const candidates = ownerIndex === -1 ? filePaths : filePaths.slice(0, ownerIndex);
+      for (const filePath of candidates) {
+        probes.push(probeOverridesFile(runtime, filePath));
+      }
+      // A transparent owner (recognized-empty document kept only as the copy
+      // source) did not decide anything: an ancestor document created since
+      // the resolution would now supply the effective overrides, so keep
+      // probing the chain past it.
+      if (ownerIndex !== -1 && resolved.sourceFile?.transparent !== true) {
+        break;
+      }
+      current =
+        current.parentWorkspaceId === undefined ? undefined : byId.get(current.parentWorkspaceId);
+    }
+    if (probes.length === 0) {
+      return true;
+    }
+    try {
+      const results = await withDeadline(
+        Promise.all(probes),
+        HOST_DESCENDANT_TIMEOUT_MS,
+        "fork source precedence probe timed out"
+      );
+      return results.every((probe) => probe.kind === "absent");
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Whether the fork source and every ancestor it may inherit from are
+   * registered exactly as `snapshot` saw them (identity, checkout path,
+   * runtime, parent link) and still carry the same legacy `workspace.mcp`
+   * config.json value. A lifecycle mutation between the unlocked resolution
+   * and the locked commit point invalidates that resolution. So does a legacy
+   * edit: an ancestor's unmigrated legacy enable is honored read-only during
+   * inheritance (no document, so the commit point's re-read cannot see it),
+   * and a direct config edit or an older Xum process revoking it bumps no
+   * epoch — without this comparison the fork would persist the revoked
+   * enable. Throws (→ stale) when the fresh legacy config is unreadable.
+   */
+  private async forkSourceChainUnchanged(
+    source: FrontendWorkspaceMetadata,
+    snapshot: ConfigSnapshot
+  ): Promise<boolean> {
+    const fresh = new ConfigSnapshot(this.config, /* hostFilesystemView */ true);
+    const [before, after] = await Promise.all([
+      snapshot.loadAllMetadata(),
+      fresh.loadAllMetadata(),
+    ]);
+    const legacyBefore = snapshot.loadLegacyConfig();
+    const legacyAfter = fresh.loadLegacyConfig();
+    const byId = (list: FrontendWorkspaceMetadata[]) => new Map(list.map((m) => [m.id, m]));
+    const beforeById = byId(before);
+    const afterById = byId(after);
+    const identity = (m: FrontendWorkspaceMetadata | undefined, legacy: ProjectsConfig) => {
+      if (m === undefined) return undefined;
+      const legacyValue = this.getLegacyOverridesFromConfig(m.id, legacy);
+      return JSON.stringify([
+        m.projectPath,
+        m.name,
+        m.namedWorkspacePath,
+        m.runtimeConfig,
+        m.parentWorkspaceId,
+        // Absent and `null` (an opaque legacy VALUE) both serialize as null
+        // inside an array; tag absence so a `null` appearing counts as a change.
+        legacyValue === undefined ? "no-legacy" : ["legacy", legacyValue],
+      ]);
+    };
+    let current: FrontendWorkspaceMetadata | undefined = source;
+    const seen = new Set<string>();
+    while (current !== undefined && !seen.has(current.id)) {
+      seen.add(current.id);
+      if (
+        identity(beforeById.get(current.id), legacyBefore) !==
+        identity(afterById.get(current.id), legacyAfter)
+      ) {
+        return false;
+      }
+      current =
+        current.parentWorkspaceId === undefined
+          ? undefined
+          : beforeById.get(current.parentWorkspaceId);
+    }
+    return true;
+  }
+
+  /**
+   * The document exists (resolution just read it) but cannot be reread right
+   * now. Falling back to the normalized value would silently drop comments
+   * and newer-version fields from the fork (upgrade↔downgrade rule) — skip
+   * the copy instead; the source keeps its document.
+   */
+  private skipUnreadableSourceDocument(sourceWorkspaceId: string, error: unknown): undefined {
+    log.warn(
+      "[MCP] Not copying workspace MCP overrides into fork: source document could not be reread",
+      { sourceWorkspaceId, error: getErrorMessage(error) }
+    );
+    return undefined;
+  }
+
+  /** Outside the override lock: target-only I/O (see copyOverridesToForkedCheckout). */
+  private async writeForkCopy(
+    sourceWorkspaceId: string,
+    target: {
+      runtime: ReturnType<typeof createRuntime>;
+      workspacePath: string;
+      runtimeConfig: RuntimeConfig | undefined;
+    },
+    prepared: ForkCopySource,
+    progress: ForkCopyProgress
+  ): Promise<void> {
+    // Devcontainer checkouts are host worktrees whose container is only
+    // built by the fork's init (ensureReady): exec into it would fail here,
+    // so operate on the host filesystem directly. Decided from the runtime
+    // CONFIG: a multi-project fork's runtime is a MultiProjectRuntime wrapping
+    // the devcontainers, and its container path is a host directory too.
+    const hostFilesystem = isDevcontainerRuntime(target.runtimeConfig);
+    const fsRuntime = hostFilesystem
+      ? createRuntime({ type: "local" }, { projectPath: target.workspacePath })
+      : target.runtime;
+    const fsRuntimeConfig: RuntimeConfig | undefined = hostFilesystem
+      ? { type: "local" }
+      : target.runtimeConfig;
+    if (!(await this.isForkCopyTargetWritable(fsRuntime, target.workspacePath))) {
+      return;
+    }
+    if (progress.cancelled) return;
+    // Tracked like the writes below: a `mkdir -p` that outlives the copy's
+    // deadline must be joined, or it can recreate the checkout path after a
+    // failed registration sanitization deleted the fresh checkout, and the
+    // retry collides with an orphan directory.
+    progress.mutation = this.ensureOverridesDir(fsRuntime, target.workspacePath, fsRuntimeConfig);
+    await progress.mutation;
+    if (progress.cancelled) return;
+    // Ignore coverage FIRST, strictly: the fresh checkout has no override
+    // document yet, and one that Git can see could be committed by accident
+    // (workspace-local authorization settings). If coverage cannot be
+    // established the best-effort copy is skipped — nothing is written.
+    try {
+      // Tracked like the document write: a timed-out copy joins whatever
+      // mutation is in flight, so a slow exclude update on a remote target
+      // cannot replace `.git/info/exclude` after the fork's init moved on.
+      progress.mutation = this.ensureOverridesGitignored(
+        fsRuntime,
+        target.workspacePath,
+        fsRuntimeConfig,
+        "strict"
+      );
+      await progress.mutation;
+    } catch (error) {
+      log.warn(
+        "[MCP] Not copying workspace MCP overrides into fork: git exclude could not be installed",
+        { sourceWorkspaceId, error: getErrorMessage(error) }
+      );
+      return;
+    }
+    if (progress.cancelled) return;
+    // A timed-out copy joins the write (see copyOverridesToForkedCheckout).
+    progress.mutation = writeFileString(fsRuntime, prepared.targetPath, prepared.content);
+    await progress.mutation;
+    log.debug("[MCP] Copied workspace MCP overrides into forked workspace", {
+      sourceWorkspaceId,
+      targetPath: prepared.targetPath,
+    });
+  }
+
+  /**
+   * Bump the cross-process override-write epoch (see MCP_OVERRIDES_EPOCH_FILE).
+   * Called AFTER the disk write and AFTER in-process publication (so the
+   * writer's own process is consistent either way), and it THROWS on failure:
+   * a mutation without a durable cross-process signal must not be
+   * acknowledged as complete — a sibling would keep overlaying its stale
+   * snapshot indefinitely. Callers surface the error (the dialog save fails
+   * and can be retried; a prune keeps its retry tombstone). The retry must be
+   * able to reach this bump: the write already changed the stored revision,
+   * so setOverridesForWorkspace's CAS admits a stale expectedRevision when the
+   * incoming content is exactly what is on disk (isPersistedAsOwn).
+   */
+  private async bumpOverridesEpoch(): Promise<void> {
+    const token = randomUUID();
+    const target = path.join(this.coordinationRootDir, MCP_OVERRIDES_EPOCH_FILE);
+    const tempPath = `${target}.${token}.tmp`;
+    try {
+      await fsPromises.writeFile(tempPath, token, "utf-8");
+      await fsPromises.rename(tempPath, target);
+    } catch (error) {
+      await fsPromises.rm(tempPath, { force: true }).catch(() => undefined);
+      throw new Error(
+        `Workspace MCP overrides were written, but the cross-process change signal could not be persisted (${getErrorMessage(error)}). Other running Xum processes may serve stale MCP settings until this is retried.`
+      );
+    }
   }
 
   /**
@@ -511,16 +3369,39 @@ export class WorkspaceMcpOverridesService {
    */
   private writeQueue: Promise<unknown> = Promise.resolve();
 
-  private runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+  private runExclusive<T>(
+    fn: () => Promise<T>,
+    /**
+     * Give up WITHOUT acquiring when the caller's deadline passed or its
+     * signal aborted while this entry waited in the queue: an abandoned
+     * caller must not hold the lock later just to release it, delaying
+     * every queued writer behind it.
+     */
+    options?: { signal?: AbortSignal; timeoutMs?: number }
+  ): Promise<T> {
+    const deadlineAt =
+      options?.timeoutMs === undefined ? undefined : Date.now() + options.timeoutMs;
     const locked = async (): Promise<T> => {
+      if (options?.signal?.aborted) {
+        throw new Error("Workspace MCP override lock acquisition was aborted");
+      }
+      const remainingMs = deadlineAt === undefined ? undefined : deadlineAt - Date.now();
+      if (remainingMs !== undefined && remainingMs <= 0) {
+        throw new Error(
+          "Another Mux process is currently updating workspace MCP settings. Wait for it to finish and try again."
+        );
+      }
       const release = await acquireCrossProcessLock({
-        lockPath: path.join(this.config.rootDir, "mcp-overrides.lock"),
+        lockPath: path.join(this.coordinationRootDir, "mcp-overrides.lock"),
         // Writes are small file edits plus at most one discovery scan; a
         // minute of waiting outlasts any legitimate holder.
-        acquireTimeoutMs: 60_000,
+        acquireTimeoutMs: remainingMs === undefined ? 60_000 : Math.min(60_000, remainingMs),
         staleMs: 5 * 60_000,
         timeoutMessage:
           "Another Mux process is currently updating workspace MCP settings. Wait for it to finish and try again.",
+        // Escape during a sibling's hold: stop polling now rather than
+        // occupying the head of the queue for the rest of the budget.
+        ...(options?.signal !== undefined ? { signal: options.signal } : {}),
       });
       try {
         return await fn();
@@ -534,15 +3415,16 @@ export class WorkspaceMcpOverridesService {
   }
 
   /**
-   * Hold the exclusive override lock imperatively (same in-process queue and
-   * cross-process lock as every write here). For workspace lifecycle
-   * mutations that move a checkout and then rewrite config — a rename racing
-   * prunePluginOverrideKeysForWorkspaces would otherwise let the prune stat
-   * the vacated old path, find nothing, and retire a tombstone while the moved
-   * file still holds the plugin key. Resolves once the lock is held with a
-   * release function; the returned promise rejects if acquisition times out.
+   * Hold the exclusive (global) override lock imperatively — same in-process
+   * queue and cross-process lock as every write here. Used by served tool
+   * calls to fence their dispatch against sibling-process writes. Resolves
+   * once the lock is held with a release function; the returned promise
+   * rejects if acquisition times out.
    */
-  acquireExclusiveLock(): Promise<() => Promise<void>> {
+  acquireExclusiveLock(options?: {
+    signal?: AbortSignal;
+    timeoutMs?: number;
+  }): Promise<() => Promise<void>> {
     let release!: () => void;
     const held = new Promise<void>((resolve) => {
       release = resolve;
@@ -554,11 +3436,279 @@ export class WorkspaceMcpOverridesService {
           return done;
         });
         return held;
-      });
+      }, options);
       // Only acquisition can fail here: once the callback above runs, `done`
       // settles solely through the release function.
       done.catch(rejectAcquired);
     });
+  }
+
+  /**
+   * Per-workspace cross-process lock, scoped to ONE workspace's checkout and
+   * override document. Held by a workspace rename across its checkout move
+   * and config rewrite, and taken by every writer of that workspace's
+   * document before the global write lock: a settings save that passed its
+   * revision check on the old path could otherwise write into a recreated
+   * old path after the move, and the plugin-key prune could stat the vacated
+   * path, find nothing, and retire its cleanup tombstone while the moved file
+   * still holds the key. Scoping the fence to the workspace keeps unrelated
+   * saves responsive during a slow remote rename (the global lock is never
+   * held across a checkout move).
+   *
+   * LOCK ORDER: workspace locks are acquired in sorted order and ALWAYS
+   * before the global lock (runExclusive), never while holding it.
+   * Staleness (crashed holder) is handled by the lock's lease renewal and
+   * reclamation, like the global lock.
+   */
+  acquireWorkspaceLock(
+    workspaceId: string,
+    options?: { acquireTimeoutMs?: number }
+  ): Promise<() => Promise<void>> {
+    // Normalized like every workspace lookup (getWorkspaceMetadata trims): a
+    // save for " id " and a rename for "id" address one checkout and must
+    // contend for one lock.
+    const id = workspaceId.trim();
+    assert(id.length > 0, "acquireWorkspaceLock: workspaceId must be non-empty");
+    // Imperative handle over withWorkspaceLocks (same key derivation,
+    // verification and budget): resolves once every key of this checkout is
+    // held, with a release that ends the hold.
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    return new Promise((resolveAcquired, rejectAcquired) => {
+      const done = this.withWorkspaceLocks(
+        [id],
+        (locked) => {
+          const unresolvable = locked.unresolvable[0];
+          if (unresolvable !== undefined) {
+            throw unresolvable.error;
+          }
+          resolveAcquired(() => {
+            release();
+            return done;
+          });
+          return held;
+        },
+        options?.acquireTimeoutMs
+      );
+      done.catch(rejectAcquired);
+    });
+  }
+
+  private acquireCheckoutLock(
+    key: string,
+    acquireTimeoutMs = WORKSPACE_LOCK_ACQUIRE_TIMEOUT_MS
+  ): Promise<() => Promise<void>> {
+    return acquireCrossProcessLock({
+      lockPath: path.join(this.coordinationRootDir, "mcp-overrides-locks", `${key}.lock`),
+      acquireTimeoutMs,
+      staleMs: 5 * 60_000,
+      timeoutMessage: WORKSPACE_LOCK_TIMEOUT_MESSAGE,
+    });
+  }
+
+  /**
+   * The lock KEYS of each workspace's checkout. Keyed by checkout identity,
+   * not workspace id: aliases sharing one checkout (an isolation:none child
+   * and its parent, in-place registrations) hold distinct ids for one
+   * override document, and a rename through one id racing a save through the
+   * other must contend for the same lock.
+   *
+   * Every acquirer takes ALL keys of its checkout, so two acquirers contend
+   * whenever any key coincides — a stable fence regardless of filesystem
+   * state:
+   * - host checkouts: the SPELLED registry path (identical for every
+   *   registration of that path, present or not — a rename's old path and a
+   *   save resolving that old path after the move share it) plus, when it
+   *   resolves, the realpath (so symlinked spellings coincide);
+   * - shared remote filesystems (SSH host, devcontainer): identity + path;
+   * - per-workspace filesystems (Docker: every container reports `/src`, but
+   *   nothing is shared between containers): runtime + workspace id;
+   * - an id absent from the registry: the id (nothing shares an unregistered
+   *   checkout that this service can see).
+   * A host checkout whose realpath is INDETERMINATE (stalled mount, timeout —
+   * not a positively absent path) is reported as unresolvable: its symlink
+   * aliases could not be fenced, so the caller fails that workspace instead
+   * of proceeding under a weaker lock.
+   */
+  private async checkoutLockKeys(workspaceIds: readonly string[]): Promise<CheckoutLockKeys> {
+    // Authoritative (throwOnError): a transiently unreadable config.json
+    // must abort the acquisition, not degrade a registered workspace to its
+    // fallback id key — a writer deriving the real checkout key meanwhile
+    // would not contend with it.
+    let all: FrontendWorkspaceMetadata[];
+    try {
+      all = await this.config.getAllWorkspaceMetadata({
+        probeCheckouts: false,
+        throwOnError: true,
+      });
+    } catch (error) {
+      // The strict walk also fails on an UNRELATED id-less legacy entry whose
+      // metadata.json is unreadable or malformed. Rename and removal take
+      // this lock, so that must not brick every healthy workspace until the
+      // user repairs persisted state by hand (self-healing rule). The lenient
+      // walk skips such entries; it is trusted only when it still registers
+      // every requested id — a config.json failure degrades it to EMPTY, and
+      // "absent" would then wrongly fall through to the id-only key.
+      const lenient = await this.config.getAllWorkspaceMetadata({ probeCheckouts: false });
+      const registered = new Set(lenient.map((metadata) => metadata.id));
+      if (!workspaceIds.every((id) => registered.has(id))) {
+        throw error;
+      }
+      log.warn(
+        "[MCP] Deriving checkout lock keys from a lenient registry walk: another entry's metadata is unreadable",
+        { workspaceIds, error: getErrorMessage(error) }
+      );
+      all = lenient;
+    }
+    // Corrupted config can register one stable id on several entries; the
+    // sweep prunes EVERY such checkout, so the id's key set is the union over
+    // all of them (any indeterminate entry makes the id unresolvable).
+    const byId = groupMetadataById(all, /* hostLocalOnly */ false);
+    const digest = (parts: string[]): string =>
+      createHash("sha256").update(parts.join("\0")).digest("hex").slice(0, 32);
+    const keysFor = async (
+      id: string,
+      metadata: FrontendWorkspaceMetadata
+    ): Promise<string[] | Error> => {
+      const identity = runtimeFilesystemIdentity(metadata.runtimeConfig);
+      if (identity === undefined) {
+        return [digest(["workspace", metadata.runtimeConfig.type, id])];
+      }
+      const { workspacePath } = this.resolveWorkspace(metadata);
+      if (identity !== "host") {
+        const keys = [digest([identity, workspacePath])];
+        if (metadata.runtimeConfig.type === "ssh") {
+          // SSH `host` may be an ssh_config alias: two aliases can name one
+          // machine, and nothing here can resolve them to a stable remote
+          // identity. A rename through one alias and a save through the
+          // other must still contend, so every SSH registration of a
+          // remote path also takes a path-only fence shared across SSH
+          // identities (conservative: same path on different hosts
+          // serializes needlessly, which only costs a short wait).
+          keys.push(digest(["ssh-path", workspacePath]));
+        }
+        return keys;
+      }
+      const spelled = path.resolve(workspacePath);
+      const keys = [digest([identity, spelled])];
+      try {
+        const real = await withDeadline(
+          fsPromises.realpath(spelled),
+          REALPATH_TIMEOUT_MS,
+          "realpath timed out"
+        );
+        if (real !== spelled) keys.push(digest([identity, real]));
+      } catch (error) {
+        if (!isPositivelyAbsent(error)) {
+          return new Error(
+            `Could not establish the checkout identity of workspace ${id} (${getErrorMessage(error)}); retry once its filesystem responds.`
+          );
+        }
+      }
+      return keys;
+    };
+    const derived = await mapWithConcurrency(
+      workspaceIds,
+      CANONICALIZE_CONCURRENCY,
+      async (id): Promise<string[] | Error> => {
+        const entries = byId.get(id);
+        if (entries === undefined) {
+          return [digest(["id", id])];
+        }
+        const union = new Set<string>();
+        for (const metadata of entries) {
+          const result = await keysFor(id, metadata);
+          if (result instanceof Error) return result;
+          for (const key of result) union.add(key);
+        }
+        return [...union];
+      }
+    );
+    const keys = new Map<string, string[]>();
+    const unresolvable: Array<{ workspaceId: string; error: Error }> = [];
+    for (const [index, id] of workspaceIds.entries()) {
+      const result = derived[index];
+      if (result instanceof Error) unresolvable.push({ workspaceId: id, error: result });
+      else keys.set(id, result);
+    }
+    return { keys, unresolvable, registry: all };
+  }
+
+  /**
+   * Run `fn` holding the checkout locks of `workspaceIds`. ONE acquisition
+   * budget for the whole batch, and no unrelated lock is retained while
+   * waiting: the first lock is awaited (nothing else is held), every further
+   * lock is only TRIED; when one is busy, everything acquired so far is
+   * released and the batch retries after a short backoff until the budget
+   * runs out. A sweep over A and B therefore never keeps A's writers waiting
+   * behind a slow rename of B. The ids' checkout keys are re-derived under
+   * the locks: a rename that moved a checkout in between changes its key, and
+   * the batch then releases and retries with the current keys. `fn` receives
+   * the registry view that verification read under the locks.
+   */
+  private async withWorkspaceLocks<T>(
+    workspaceIds: readonly string[],
+    fn: (locked: CheckoutLockKeys) => Promise<T>,
+    budgetMs = WORKSPACE_LOCK_ACQUIRE_TIMEOUT_MS
+  ): Promise<T> {
+    const ids = [...new Set(workspaceIds.map((id) => id.trim()))];
+    const deadlineAt = Date.now() + budgetMs;
+    const remaining = () => Math.max(0, deadlineAt - Date.now());
+    // Key derivation probes checkouts (bounded realpaths, but hundreds of
+    // stalled ones add up): it draws from the same budget as the acquisition
+    // — and the verification run below happens while every lock is held.
+    const derive = () =>
+      withDeadline(this.checkoutLockKeys(ids), remaining(), WORKSPACE_LOCK_TIMEOUT_MESSAGE);
+    const fingerprint = (derived: CheckoutLockKeys) =>
+      JSON.stringify([
+        [...new Set([...derived.keys.values()].flat())].sort(),
+        derived.unresolvable.map((entry) => entry.workspaceId).sort(),
+      ]);
+    for (;;) {
+      const releases: Array<() => Promise<void>> = [];
+      let acquiredAll = false;
+      try {
+        const derived = await derive();
+        const keys = [...new Set([...derived.keys.values()].flat())].sort();
+        for (const [index, key] of keys.entries()) {
+          if (remaining() === 0) {
+            throw new Error(WORKSPACE_LOCK_TIMEOUT_MESSAGE);
+          }
+          releases.push(await this.acquireCheckoutLock(key, index === 0 ? remaining() : 0));
+        }
+        const verification = await derive();
+        if (fingerprint(verification) !== fingerprint(derived)) {
+          if (remaining() === 0) {
+            throw new Error(WORKSPACE_LOCK_TIMEOUT_MESSAGE);
+          }
+          throw new CheckoutKeysChangedError();
+        }
+        if (remaining() === 0) {
+          throw new Error(WORKSPACE_LOCK_TIMEOUT_MESSAGE);
+        }
+        acquiredAll = true;
+        return await fn(verification);
+      } catch (error) {
+        const retry =
+          !acquiredAll &&
+          error instanceof Error &&
+          (error instanceof CheckoutKeysChangedError ||
+            error.message === WORKSPACE_LOCK_TIMEOUT_MESSAGE) &&
+          Date.now() < deadlineAt;
+        if (!retry) {
+          throw error;
+        }
+      } finally {
+        for (const release of releases.reverse()) {
+          await release();
+        }
+      }
+      await new Promise((resolve) =>
+        setTimeout(resolve, WORKSPACE_LOCK_RETRY_BACKOFF_MS + Math.random() * 100)
+      );
+    }
   }
 
   /**
@@ -596,43 +3746,398 @@ export class WorkspaceMcpOverridesService {
        * publishing after this method returns can interleave with a concurrent
        * writer's publication and leave the cache holding the older snapshot.
        */
-      publish?: (persisted: WorkspaceMCPOverrides) => Promise<void>;
+      publish?: OverridesPublisher;
     }
   ): Promise<void> {
     assert(overrides && typeof overrides === "object", "overrides must be an object");
 
-    return this.runExclusive(async () => {
-      if (options?.expectedRevision !== undefined || options?.validateAgainstCurrent) {
-        const current = await this.loadOverrides(workspaceId);
-        if (
-          options.expectedRevision !== undefined &&
-          computeOverridesRevision(current) !== options.expectedRevision
-        ) {
-          throw new WorkspaceMcpOverridesConflictError();
+    // Workspace lock first (see acquireWorkspaceLock): a rename of THIS
+    // workspace holds it across its checkout move, so the path resolved
+    // below is the one the document is written to.
+    return this.withWorkspaceLocks([workspaceId], (locked) =>
+      this.runExclusive(async () => {
+        const unresolvable = locked.unresolvable[0];
+        if (unresolvable !== undefined) {
+          throw unresolvable.error;
         }
-        await options.validateAgainstCurrent?.(current, normalizeWorkspaceMcpOverrides(overrides));
+        // A FRESH registry read under the global lock, not the view captured
+        // before waiting for it: a workspace removal (which takes neither
+        // lock) may have deleted the checkout and its config entry meanwhile.
+        const snapshot = new ConfigSnapshot(
+          this.config,
+          false,
+          undefined,
+          /* writerLocksHeld */ true
+        );
+        try {
+          await this.writeOverridesLocked(workspaceId, overrides, options, snapshot);
+        } finally {
+          // A bounded resolution that timed out may have started a migration
+          // write; it must land before the locks are released.
+          await snapshot.settleSideEffects();
+        }
+      })
+    );
+  }
+
+  /** Body of setOverridesForWorkspace, run under the workspace and global locks. */
+  private async writeOverridesLocked(
+    workspaceId: string,
+    overrides: WorkspaceMCPOverrides,
+    options: Parameters<WorkspaceMcpOverridesService["setOverridesForWorkspace"]>[2],
+    snapshot: ConfigSnapshot
+  ): Promise<void> {
+    const { metadata, runtime, workspacePath } = await this.getRuntimeAndWorkspacePath(
+      workspaceId,
+      snapshot
+    );
+    const filePaths = this.getOverridesFilePaths(workspacePath, metadata.runtimeConfig);
+    const canonicalPath = filePaths[0];
+    const hostFilesystemSave = overridesOnHostFilesystem(metadata.runtimeConfig);
+    const normalized = normalizeWorkspaceMcpOverrides(overrides);
+    // Every resolution performed under the locks is bounded: an inheriting
+    // SSH/Docker child's current state is read through its parent chain,
+    // where one unreachable parent can consume RemoteRuntime's 300 s per
+    // level — and every other MCP settings operation waits behind these
+    // locks meanwhile. On timeout the save is refused (retryable) and the
+    // abandoned resolution is cancelled so it starts no migration write.
+    const bounded = <T>(work: Promise<T>): Promise<T> =>
+      withDeadline(
+        work,
+        SAVE_RESOLUTION_TIMEOUT_MS,
+        "Reading the workspace's current MCP settings timed out (an inherited parent checkout did not respond); the settings were not saved. Retry.",
+        () => snapshot.cancel()
+      );
+
+    // Resolved for every save (not only CAS ones): an inheriting child that
+    // detaches below must carry its effective source's opaque fields.
+    const current = await bounded(this.resolveOverridesFor(metadata, "lenient", snapshot));
+    if (options?.expectedRevision !== undefined || options?.validateAgainstCurrent) {
+      // Repair path: a dialog opened while the state could not be established
+      // (malformed document, unreadable checkout) carries the UNAVAILABLE
+      // sentinel. Its save replaces the document only while the state is
+      // STILL not authoritative — the user is fixing exactly what they were
+      // shown as broken; had the state become readable meanwhile, they must
+      // reopen and see it (conflict), like any other stale snapshot.
+      // Only the workspace's OWN state can be repaired this way: when
+      // authority was lost in an ancestor, the own document is intact and
+      // the `{}` shown to the user is a fallback for a parent document that
+      // may hold enables, disables and allowlists — writing a child-owned
+      // document from it would detach the child and drop all of them.
+      if (
+        options.expectedRevision === MCP_OVERRIDES_REVISION_UNAVAILABLE &&
+        !current.authoritative &&
+        current.authorityLostInherited
+      ) {
+        throw new Error(
+          "The inherited parent workspace's MCP settings could not be read; the settings were not saved. " +
+            "Retry once the parent checkout is reachable."
+        );
       }
+      const repairingUnavailable =
+        options.expectedRevision === MCP_OVERRIDES_REVISION_UNAVAILABLE && !current.authoritative;
+      if (
+        options.expectedRevision !== undefined &&
+        !repairingUnavailable &&
+        computeOverridesRevision(current.overrides) !== options.expectedRevision &&
+        !this.isPersistedAsOwn(workspaceId, current, normalized, filePaths, snapshot)
+      ) {
+        throw new WorkspaceMcpOverridesConflictError();
+      }
+      await options.validateAgainstCurrent?.(current.overrides, normalized);
+    }
 
-      const { metadata, runtime, workspacePath } =
-        await this.getRuntimeAndWorkspacePath(workspaceId);
-      const canonicalPath = this.getOverridesFilePaths(workspacePath, metadata.runtimeConfig)[0];
+    // Aliases registered on this same checkout (an isolation:none task,
+    // an in-place registration) read the document written below — and
+    // any legacy config.json value THEY still carry would be migrated
+    // back into it by their next own (depth 0) resolution, which is
+    // exactly what a cleared document invites: the user revokes a server
+    // and a cold alias's stale legacy enable resurrects it, trusted by
+    // every read after. The user's write wins: every sharer's legacy
+    // value is retired under the same lock. The sharer set is verified
+    // BEFORE anything is persisted (an unverifiable sharer carrying a
+    // legacy value refuses the save), and the values are cleared only
+    // AFTER the replacement state landed — like the writer's own legacy
+    // value below — so a failed write discards nobody's settings.
+    const sharersRetirement = await this.planSharersLegacyRetirement(
+      workspaceId,
+      metadata,
+      canonicalPath,
+      snapshot
+    );
+    const retireSharersLegacy = async (): Promise<void> => {
+      for (const sharerId of sharersRetirement.sharerIds) {
+        log.info("[MCP] Retiring a checkout sharer's legacy MCP overrides after a shared save", {
+          workspaceId,
+          sharerWorkspaceId: sharerId,
+        });
+        await this.clearLegacyOverridesInConfig(sharerId);
+      }
+    };
 
-      const normalized = normalizeWorkspaceMcpOverrides(overrides);
+    // Fields of the own document this build does not own survive the save
+    // (see readOpaqueOverrideFields). They also keep the document in place
+    // when the known fields are cleared: an unrecognized shape is the
+    // workspace's own configuration and never resumes inheritance.
+    // Bounded like the resolutions above: this probe/read runs while both
+    // locks are held, and a remote document that turned slow since the CAS
+    // resolution must not block unrelated saves for the runtime's command
+    // timeout (the save is refused, retryable).
+    const opaqueDocument = await bounded(
+      this.readOpaqueOverrideFields(runtime, filePaths, hostFilesystemSave, workspacePath)
+    );
+    if (
+      opaqueDocument.kind === "indeterminate" &&
+      (isEmptyOverrides(normalized) || opaqueDocument.canonicalUnprobed)
+    ) {
+      // A clear removes every candidate; a write replaces the canonical file.
+      // Either would destroy fields of a document that could not be read.
+      throw new Error(
+        "Could not read the workspace's current MCP settings document before replacing it; the settings were not saved. Retry."
+      );
+    }
+    if (opaqueDocument.kind === "unmergeable") {
+      throw new Error(
+        "This workspace's MCP settings document was written by a newer version of Xum in a form this version cannot preserve; the settings were not saved. Upgrade Xum to edit them."
+      );
+    }
+    const opaqueDocumentFields = opaqueDocument.kind === "fields" ? opaqueDocument.fields : {};
+    // A child WITHOUT an own document resolves from an ancestor's; the
+    // non-empty save below creates its own document, which shadows that
+    // ancestor from then on. Fields of the inherited document this build does
+    // not own (a newer version's) applied to the child through inheritance
+    // and must move into the new document like the document's own would —
+    // otherwise the detach silently drops them for this child on the next
+    // upgrade. (A transparent ancestor document — one that normalizes to
+    // nothing here — holds ONLY such fields.) A source this build cannot
+    // preserve refuses the detach.
+    // SECURITY: read like the fork copy (symlink guard, host containment).
+    let inheritedOpaqueFields: Record<string, unknown> = {};
+    const inheritedSource = current.sourceFile;
+    if (
+      !isEmptyOverrides(normalized) &&
+      opaqueDocument.kind === "fields" &&
+      inheritedSource !== undefined &&
+      inheritedSource.ownerWorkspaceId !== workspaceId
+    ) {
+      const inherited = await bounded(
+        (async () => {
+          await assertOverrideSegmentsNotSymlinked(
+            inheritedSource.runtime,
+            inheritedSource.workspacePath,
+            inheritedSource.hostFilesystem
+          );
+          if (inheritedSource.hostFilesystem) {
+            await assertHostOverrideWriteContained(
+              inheritedSource.filePath,
+              inheritedSource.workspacePath
+            );
+          }
+          return this.readOpaqueOverrideFields(
+            inheritedSource.runtime,
+            [inheritedSource.filePath],
+            inheritedSource.hostFilesystem,
+            inheritedSource.workspacePath
+          );
+        })()
+      );
+      if (inherited.kind !== "fields") {
+        throw new Error(
+          inherited.kind === "indeterminate"
+            ? "Could not read the inherited MCP settings document this workspace would detach from; the settings were not saved. Retry."
+            : "The inherited MCP settings document was written by a newer version of Xum in a form this version cannot preserve; the settings were not saved. Upgrade Xum to edit them."
+        );
+      }
+      inheritedOpaqueFields = inherited.fields;
+    }
+    // The legacy config.json value is cleared below; a value this build does
+    // not recognize (written by a newer Xum) is carried into the document
+    // first — its unknown fields exactly like the document's own — instead
+    // of being discarded with the clear. A shape that cannot be merged into
+    // a document at all refuses the save: only a build that understands it
+    // may replace it.
+    const opaqueLegacyFields = opaqueLegacyFieldsOf(
+      this.getLegacyOverridesFromConfig(workspaceId, snapshot.loadLegacyConfig())
+    );
+    if (opaqueLegacyFields === undefined) {
+      throw new Error(
+        "This workspace's MCP settings were written by a newer version of Xum in a form this version cannot preserve; the settings were not saved. Upgrade Xum to edit them."
+      );
+    }
+    // Retired legacy values must agree with each other on every unknown field
+    // (see mergeOpaqueFields); the document's own fields — the state every
+    // sharer already reads — take precedence over all of them.
+    const retiredOpaqueFields = mergeOpaqueFields(
+      { ...sharersRetirement.opaqueFields },
+      opaqueLegacyFields,
+      workspaceId
+    );
+    // Precedence: the own document's fields, then the inherited document's
+    // (the state the child effectively had), then retired legacy values.
+    const opaqueFields = {
+      ...retiredOpaqueFields,
+      ...inheritedOpaqueFields,
+      ...opaqueDocumentFields,
+    };
+    const document: Record<string, unknown> = { ...opaqueFields, ...normalized };
 
-      // Always clear any legacy storage so we converge on the workspace-local file.
+    // Legacy config.json storage is cleared only AFTER the replacement
+    // state is persisted (file written, or file removed for empty
+    // overrides). Clearing first would let a failed write — e.g. a repo
+    // that tracks `.xum` as a regular file so the directory cannot be
+    // created — leave a child with neither document nor legacy value, and
+    // its next read would inherit the parent's enables instead of the
+    // settings the legacy value carried. With the write first, a failure
+    // leaves the previous state fully intact.
+    if (isEmptyOverrides(normalized) && Object.keys(opaqueFields).length === 0) {
+      // Failure-atomic clear: the legacy values are retired FIRST, while the
+      // document (if any) still shadows them — a failed config edit leaves
+      // the effective state untouched. Removing the document first would
+      // expose a shadowed legacy enable as authoritative should a later step
+      // fail, re-enabling a globally disabled server after the save reported
+      // failure. (The non-empty branch orders the opposite way for the same
+      // reason: there the WRITE is the step that may fail.)
       await this.clearLegacyOverridesInConfig(workspaceId);
-
-      if (isEmptyOverrides(normalized)) {
-        await this.removeOverridesFile(runtime, workspacePath);
-        await options?.publish?.(normalized);
-        return;
+      await retireSharersLegacy();
+      await this.removeOverridesFile(runtime, workspacePath, metadata.runtimeConfig);
+      // The epoch moves as soon as the durable state has changed — never
+      // after the (bounded, possibly slow) publication: a sibling process
+      // about to launch a server this clear revoked must observe it (see
+      // MCPServerManager.assertOverridesEpochUnmovedBeforeStart), and a
+      // publication failure must not leave siblings unaware of the write.
+      await this.bumpOverridesEpoch();
+      if (options?.publish) {
+        // Clearing a sub-agent's own overrides resumes inheritance: publish
+        // the effective (inherited) state, not `{}`, or the manager cache
+        // would pin the child to "no overrides" until restart.
+        // A FRESH snapshot (not a scope of the outer one): the legacy
+        // value just cleared is memoized in the outer snapshot's config
+        // read and would otherwise be resolved — and migrated back.
+        const afterRemoval = new ConfigSnapshot(
+          this.config,
+          false,
+          undefined,
+          /* writerLocksHeld */ true
+        );
+        try {
+          let resolved: ResolvedOverrides;
+          try {
+            resolved = await withDeadline(
+              this.resolveOverridesFor(metadata, "lenient", afterRemoval),
+              SAVE_RESOLUTION_TIMEOUT_MS,
+              "Re-reading the workspace's inherited MCP settings timed out after clearing its own; caches were evicted.",
+              () => afterRemoval.cancel()
+            );
+          } catch (error) {
+            // The file is already gone; memory must not stay pinned to it.
+            // Evict, then surface the failure.
+            await options.publish(null, workspaceId);
+            throw error;
+          }
+          await this.publishEffectiveOverrides(
+            workspaceId,
+            resolved.authoritative ? resolved.overrides : null,
+            options.publish,
+            canonicalPath,
+            afterRemoval
+          );
+        } finally {
+          await afterRemoval.settleSideEffects();
+        }
       }
+      return;
+    }
 
-      await this.ensureOverridesDir(runtime, workspacePath, metadata.runtimeConfig);
-      await writeFileString(runtime, canonicalPath, JSON.stringify(normalized, null, 2) + "\n");
-      await this.ensureOverridesGitignored(runtime, workspacePath, metadata.runtimeConfig);
-      await options?.publish?.(normalized);
-    });
+    // Never (re)create a checkout: the registry was read under the locks, but
+    // a workspace removal takes neither lock, so the checkout may be gone by
+    // now — and `ensureDir` would materialize a stray `.xum` at that path.
+    await this.assertCheckoutExists(runtime, workspacePath);
+    // SECURITY: writes follow symlinks on every runtime (see
+    // assertOverrideSegmentsNotSymlinked); the host check adds realpath
+    // containment once the directory exists.
+    await assertOverrideSegmentsNotSymlinked(runtime, workspacePath, hostFilesystemSave);
+    await this.ensureOverridesDir(runtime, workspacePath, metadata.runtimeConfig);
+    if (hostFilesystemSave) {
+      await assertHostOverrideWriteContained(canonicalPath, workspacePath);
+    }
+    await writeFileString(runtime, canonicalPath, JSON.stringify(document, null, 2) + "\n");
+    // The document IS the durable state: it shadows the writer's and every
+    // sharer's legacy value on every read, so the epoch moves right here —
+    // before the config edits below (one per legacy-carrying sharer) and the
+    // publication — and a sibling about to launch a server this write revoked
+    // observes it without waiting on either (see the removal branch above).
+    await this.bumpOverridesEpoch();
+    // Clearing the shadowed legacy values afterwards converges storage on
+    // the workspace-local file.
+    await this.clearLegacyOverridesInConfig(workspaceId);
+    await retireSharersLegacy();
+    await this.ensureOverridesGitignored(runtime, workspacePath, metadata.runtimeConfig);
+    if (options?.publish) {
+      await this.publishEffectiveOverrides(workspaceId, normalized, options.publish, canonicalPath);
+    }
+  }
+
+  /**
+   * See setOverridesForWorkspace: the ids of every workspace sharing the
+   * written checkout that still carries a legacy `workspace.mcp` value (to be
+   * cleared once the replacement state is persisted). Throws (rejecting the
+   * save before anything is written) when the sharer set cannot be
+   * established while some candidate still carries a legacy value — the
+   * value would otherwise be able to overwrite the user's decision later.
+   */
+  private async planSharersLegacyRetirement(
+    workspaceId: string,
+    written: FrontendWorkspaceMetadata,
+    writtenPath: string,
+    snapshot: ConfigSnapshot
+  ): Promise<{
+    sharerIds: string[];
+    /** Fields this build does not own from the sharers' legacy values (see opaqueLegacyFieldsOf); carried into the written document. */
+    opaqueFields: Record<string, unknown>;
+  }> {
+    const legacyConfig = snapshot.loadLegacyConfig();
+    const all = await snapshot.loadAllMetadata();
+    const carriesLegacy = (m: FrontendWorkspaceMetadata): boolean =>
+      this.getLegacyOverridesFromConfig(m.id, legacyConfig) !== undefined;
+    const none = { sharerIds: [], opaqueFields: {} };
+    // Legacy values are pre-migration leftovers: skip the (realpath-heavy)
+    // sharer scan entirely when no other workspace carries one.
+    if (!all.some((m) => m.id !== written.id && carriesLegacy(m))) {
+      return none;
+    }
+    const scan = await this.findCheckoutSharers(
+      written,
+      writtenPath,
+      all,
+      snapshot,
+      PUBLICATION_TIMEOUT_MS,
+      new Set([workspaceId])
+    );
+    if (scan === "unverifiable" || scan === "timeout") {
+      throw new Error(
+        "Could not verify which workspaces share this checkout while other workspaces still carry legacy MCP settings; the settings were not saved. Retry."
+      );
+    }
+    const unverified = scan.indeterminate.filter(carriesLegacy);
+    if (unverified.length > 0) {
+      throw new Error(
+        `Workspace(s) ${unverified.map((m) => m.id).join(", ")} may share this checkout and still carry legacy MCP settings that could not be verified; the settings were not saved. Retry.`
+      );
+    }
+    const sharers = scan.sharers.filter(carriesLegacy);
+    const opaqueFields: Record<string, unknown> = {};
+    for (const sharer of sharers) {
+      const fields = opaqueLegacyFieldsOf(
+        this.getLegacyOverridesFromConfig(sharer.id, legacyConfig)
+      );
+      if (fields === undefined) {
+        throw new Error(
+          `Workspace ${sharer.id} shares this checkout and carries MCP settings written by a newer version of Xum in a form this version cannot preserve; the settings were not saved. Upgrade Xum to edit them.`
+        );
+      }
+      mergeOpaqueFields(opaqueFields, fields, sharer.id);
+    }
+    return { sharerIds: sharers.map((m) => m.id), opaqueFields };
   }
 
   /**
@@ -662,7 +4167,16 @@ export class WorkspaceMcpOverridesService {
        * save's publication can be overwritten by the stale pre-save snapshot
        * (in either direction).
        */
-      publish?: (persisted: WorkspaceMCPOverrides) => Promise<void>;
+      publish?: OverridesPublisher;
+      /**
+       * Registration-time sanitization of a NEW workspace identity: no earlier
+       * prune pass can owe this workspace an epoch bump (nothing has cached
+       * its overrides yet), so the cross-process signal is required only when
+       * THIS pass actually rewrote a document. Otherwise a fork copy that
+       * created a valid, key-free document (see copyOverridesToForkedCheckout)
+       * would be rolled back by a transiently unwritable epoch file.
+       */
+      epochOnlyWhenRewritten?: boolean;
     }
   ): Promise<void> {
     assert(keyPrefix.length > 0, "prunePluginOverrideKeys: keyPrefix must be non-empty");
@@ -670,16 +4184,82 @@ export class WorkspaceMcpOverridesService {
     // this on a hot path, and the batch's post-sweep re-resolution (a second
     // full config parse) only guards multi-workspace sweeps against
     // concurrent renames — a workspace still being created cannot be renamed.
-    return this.runExclusive(async () => {
-      const resolved = await this.getRuntimeAndWorkspacePath(workspaceId);
-      await this.pruneResolvedWorkspace(resolved, keyPrefix);
-      if (options?.publish) {
-        // Strict re-read: the prune above already threw on anything
-        // unreadable, so a failure here is a real regression and must keep
-        // the caller's retry tombstone rather than publish a guess.
-        await options.publish(await this.loadOverridesForResolved(resolved, "strict"));
-      }
-    });
+    // The workspace lock still applies (see acquireWorkspaceLock): it is the
+    // fence every writer of this document shares with a rename.
+    return this.withWorkspaceLocks([workspaceId], (locked) =>
+      this.runExclusive(async () => {
+        const unresolvable = locked.unresolvable[0];
+        if (unresolvable !== undefined) {
+          throw unresolvable.error;
+        }
+        // Same bound and write-join as the batch sweep (see
+        // prunePluginOverrideKeysForWorkspaces): locks are held throughout.
+        const budget = createPublicationBudget();
+        const snapshot = new ConfigSnapshot(
+          this.config,
+          false,
+          undefined,
+          /* writerLocksHeld */ true
+        );
+        try {
+          await this.pruneSingleWorkspace(workspaceId, keyPrefix, options, budget, snapshot);
+        } finally {
+          await snapshot.settleSideEffects();
+        }
+      })
+    );
+  }
+
+  private async pruneSingleWorkspace(
+    workspaceId: string,
+    keyPrefix: string,
+    options: { publish?: OverridesPublisher; epochOnlyWhenRewritten?: boolean } | undefined,
+    budget: PublicationBudget,
+    snapshot: ConfigSnapshot
+  ): Promise<void> {
+    const resolved = await withDeadline(
+      this.getRuntimeAndWorkspacePath(workspaceId, snapshot),
+      budget.remaining(),
+      "workspace enumeration exceeded the plugin-prune budget"
+    );
+    // Own cancellable scope (see sweepPluginOverrideKeys).
+    const step = snapshot.scoped();
+    const { filePaths, owesEpoch, rewrote } = await withDeadline(
+      this.pruneResolvedWorkspace(resolved, keyPrefix, step),
+      budget.remaining(),
+      `pruning workspace ${workspaceId} exceeded the plugin-prune budget`,
+      () => step.cancel()
+    );
+    if (options?.publish) {
+      // Strict re-read: the prune above already threw on anything
+      // unreadable, so a failure here is a real regression and must keep
+      // the caller's retry tombstone rather than publish a guess.
+      await this.publishEffectiveOverrides(
+        workspaceId,
+        (
+          await withDeadline(
+            this.resolveOverridesFor(resolved.metadata, "strict", snapshot),
+            budget.remaining(),
+            "override resolution exceeded the plugin-prune budget",
+            () => snapshot.cancel()
+          )
+        ).overrides,
+        options.publish,
+        filePaths[0],
+        snapshot,
+        undefined,
+        budget
+      );
+    }
+    // The durable cross-process signal is owed only when an override
+    // document exists (possibly rewritten by an earlier pass whose bump
+    // failed). Registration sanitizes every fresh checkout through this
+    // path — most have no override file at all — and a transiently
+    // unwritable epoch file must not turn that no-op into a failed
+    // (rolled-back) creation.
+    if (options?.epochOnlyWhenRewritten ? rewrote : owesEpoch) {
+      await this.bumpOverridesEpoch();
+    }
   }
 
   /**
@@ -696,114 +4276,268 @@ export class WorkspaceMcpOverridesService {
     workspaceIds: readonly string[],
     keyPrefix: string,
     options?: {
-      publish?: (workspaceId: string, persisted: WorkspaceMCPOverrides) => Promise<void>;
+      /** Same contract as prunePluginOverrideKeys's publish. */
+      publish?: OverridesPublisher;
     }
   ): Promise<Array<{ workspaceId: string; error: unknown }>> {
     assert(keyPrefix.length > 0, "prunePluginOverrideKeys: keyPrefix must be non-empty");
 
-    return this.runExclusive(async () => {
-      // Group, don't index: a corrupted config can list one ID under several
-      // entries (different checkouts). Every host-local checkout carrying the
-      // ID must be pruned, or retiring the tombstone would leave a stale
-      // enable behind in the entry a last-write-wins map dropped. Off-host
-      // entries (SSH/Docker) sharing the ID are skipped: plugin servers never
-      // run there, and the symlink guard below uses host fs semantics.
-      const groupMetadataById = (
-        all: FrontendWorkspaceMetadata[]
-      ): Map<string, FrontendWorkspaceMetadata[]> => {
-        const grouped = new Map<string, FrontendWorkspaceMetadata[]>();
-        for (const metadata of all) {
-          const runtimeType = metadata.runtimeConfig.type;
-          if (runtimeType !== "local" && runtimeType !== "worktree") {
-            continue;
-          }
-          const entries = grouped.get(metadata.id);
-          if (entries) {
-            entries.push(metadata);
-          } else {
-            grouped.set(metadata.id, [metadata]);
-          }
-        }
-        return grouped;
-      };
-      const checkoutPaths = (entries: FrontendWorkspaceMetadata[] | undefined): string =>
-        (entries ?? [])
-          .map((metadata) => this.resolveWorkspace(metadata).workspacePath)
-          .sort()
-          .join("\0");
-
-      const metadataById = groupMetadataById(await this.config.getAllWorkspaceMetadata());
-      // Lazy: only workspaces WITHOUT an override file consult legacy config.
-      let legacyConfig: ProjectsConfig | undefined;
-      const loadLegacyConfig = (): ProjectsConfig =>
-        (legacyConfig ??= this.config.loadConfigOrDefault());
-      const failures: Array<{ workspaceId: string; error: unknown }> = [];
-      const swept: string[] = [];
-      for (const workspaceId of workspaceIds) {
+    // Every swept workspace's lock first (sorted), then the global lock: a
+    // rename holding a workspace lock across its checkout move cannot be
+    // interleaved with this sweep's stat of that checkout.
+    return this.withWorkspaceLocks(workspaceIds, (locked) =>
+      this.runExclusive(async () => {
+        // ONE budget for the whole sweep — the registry scan, every target's
+        // prune and the cache fan-out afterwards: this runs under every
+        // selected workspace lock AND the global lock, and a single checkout
+        // on a stalled NFS/FUSE mount must not hold unrelated settings writes
+        // past their acquisition timeout. Timed-out targets become
+        // per-workspace failures (the caller keeps their tombstones); a
+        // rewrite already in flight is joined before the locks are released.
+        const budget = createPublicationBudget();
+        const snapshot = new ConfigSnapshot(
+          this.config,
+          false,
+          undefined,
+          /* writerLocksHeld */ true
+        );
         try {
-          const entries = metadataById.get(workspaceId.trim());
-          if (!entries) {
-            throw new Error(`Host-local workspace metadata not found for ${workspaceId.trim()}`);
-          }
-          for (const metadata of entries) {
-            await this.pruneResolvedWorkspace(this.resolveWorkspace(metadata), keyPrefix);
-          }
-          if (options?.publish) {
-            // Strict re-read: the prune above already threw on anything
-            // unreadable, so a failure here is a real regression and must keep
-            // the caller's retry tombstone rather than publish a guess. Reads
-            // the first entry, matching getWorkspaceMetadata's lookup.
-            await options.publish(
-              workspaceId,
-              await this.loadOverridesForResolved(
-                this.resolveWorkspace(entries[0]),
-                "strict",
-                loadLegacyConfig
+          // Workspaces whose checkout identity could not be established were
+          // not locked: they fail (tombstone kept) instead of being pruned
+          // under a fence their symlink aliases could bypass.
+          const failures = await this.sweepPluginOverrideKeys(
+            workspaceIds.filter(
+              (id) => !locked.unresolvable.some((entry) => entry.workspaceId === id.trim())
+            ),
+            keyPrefix,
+            options,
+            budget,
+            snapshot
+          );
+          return [
+            ...locked.unresolvable.map(({ workspaceId, error }) => ({ workspaceId, error })),
+            ...failures,
+          ];
+        } finally {
+          await snapshot.settleSideEffects();
+        }
+      })
+    );
+  }
+
+  /** Body of prunePluginOverrideKeysForWorkspaces, run under its locks. */
+  private async sweepPluginOverrideKeys(
+    workspaceIds: readonly string[],
+    keyPrefix: string,
+    options: { publish?: OverridesPublisher } | undefined,
+    budget: PublicationBudget,
+    snapshot: ConfigSnapshot
+  ): Promise<Array<{ workspaceId: string; error: unknown }>> {
+    // Group, don't index: a corrupted config can list one ID under several
+    // entries (different checkouts). Every host-local checkout carrying the
+    // ID must be pruned, or retiring the tombstone would leave a stale
+    // enable behind in the entry a last-write-wins map dropped. Off-host
+    // entries (SSH/Docker) sharing the ID are skipped: plugin servers never
+    // run there, and the symlink guard below uses host fs semantics.
+    const checkoutPaths = (entries: FrontendWorkspaceMetadata[] | undefined): string =>
+      (entries ?? [])
+        .map((metadata) => this.resolveWorkspace(metadata).workspacePath)
+        .sort()
+        .join("\0");
+
+    // Registry-only and bounded like every other enumeration held under
+    // the locks: the default enumeration probes each checkout with
+    // fs.access, which blocks indefinitely on a stalled mount.
+    const metadataById = groupMetadataById(
+      await withDeadline(
+        snapshot.loadAllMetadata(),
+        budget.remaining(),
+        "workspace enumeration exceeded the plugin-prune budget"
+      ),
+      /* hostLocalOnly */ true
+    );
+    const failures: Array<{ workspaceId: string; error: unknown }> = [];
+    const swept = new Map<
+      string,
+      { metadata: FrontendWorkspaceMetadata; filePaths: readonly string[] }
+    >();
+    let anyOwesEpoch = false;
+    for (const workspaceId of workspaceIds) {
+      try {
+        const entries = metadataById.get(workspaceId.trim());
+        if (!entries) {
+          throw new Error(`Host-local workspace metadata not found for ${workspaceId.trim()}`);
+        }
+        const pruned: Array<readonly string[]> = [];
+        for (const metadata of entries) {
+          // Bounded by the remaining sweep budget: local stat/read/write
+          // on a disconnected mount can block indefinitely. A timeout is
+          // this workspace's failure (tombstone kept); its write, if one
+          // started, is joined before the locks are released.
+          // Own cancellable scope: a losing prune that resumes after the
+          // deadline (a stat/read finally answering) must not start its
+          // rewrite once the caller moved on — settleSideEffects can only
+          // join a write that has been registered by then.
+          const step = snapshot.scoped();
+          const result = await withDeadline(
+            this.pruneResolvedWorkspace(this.resolveWorkspace(metadata), keyPrefix, step),
+            budget.remaining(),
+            `pruning workspace ${metadata.id} exceeded the plugin-prune budget`,
+            () => step.cancel()
+          );
+          pruned.push(result.filePaths);
+          anyOwesEpoch ||= result.owesEpoch;
+        }
+        // Publication reads the first entry, matching getWorkspaceMetadata's lookup.
+        swept.set(workspaceId, { metadata: entries[0], filePaths: pruned[0] });
+      } catch (error) {
+        failures.push({ workspaceId, error });
+      }
+    }
+    if (swept.size === 0) {
+      return failures;
+    }
+    // Files changed: siblings must learn about it BEFORE the bounded (and
+    // possibly slow) publication below, like a settings save (see
+    // writeOverridesLocked). Without the durable signal every swept workspace
+    // keeps its tombstone (retry re-bumps). No document anywhere → nothing to
+    // signal (see prunePluginOverrideKeys).
+    if (anyOwesEpoch) {
+      try {
+        await this.bumpOverridesEpoch();
+      } catch (error) {
+        for (const workspaceId of swept.keys()) {
+          failures.push({ workspaceId, error });
+        }
+      }
+    }
+
+    // A fresh post-sweep enumeration serves both checks below: the rename
+    // guard and every publication's inheritance/sharer resolution. (The
+    // pre-sweep snapshot memoized the registry read above; the config
+    // may have changed meanwhile, so a second snapshot re-reads it.)
+    const after = new ConfigSnapshot(this.config, false, undefined, /* writerLocksHeld */ true);
+    let afterById: Map<string, FrontendWorkspaceMetadata[]>;
+    try {
+      afterById = groupMetadataById(
+        await withDeadline(
+          after.loadAllMetadata(),
+          budget.remaining(),
+          "workspace enumeration exceeded the plugin-prune budget"
+        ),
+        /* hostLocalOnly */ true
+      );
+    } catch (error) {
+      // Nothing can be verified or published authoritatively: every swept
+      // workspace keeps its tombstone, and every cache is dropped so no
+      // pre-prune snapshot survives (recovery reads disk).
+      log.warn("[MCP] Workspace enumeration failed after a plugin override sweep; evicting all", {
+        error: getErrorMessage(error),
+      });
+      if (options?.publish) {
+        await options.publish(null, ALL_WORKSPACES_TARGET);
+      }
+      for (const workspaceId of swept.keys()) {
+        failures.push({ workspaceId, error });
+      }
+      return failures;
+    }
+
+    // A rename of a swept workspace is excluded by its workspace lock (held
+    // above across the whole sweep). Defense in depth against any other
+    // config mutation that changes a swept workspace's checkout set while
+    // the sweep runs: re-resolve once afterwards and fail such a workspace
+    // — the caller keeps its tombstone and retries.
+    for (const workspaceId of [...swept.keys()]) {
+      const id = workspaceId.trim();
+      if (checkoutPaths(metadataById.get(id)) !== checkoutPaths(afterById.get(id))) {
+        swept.delete(workspaceId);
+        failures.push({
+          workspaceId,
+          error: new Error(`Workspace ${id} moved while its MCP overrides were being pruned`),
+        });
+      }
+    }
+
+    if (options?.publish) {
+      // Publish AFTER every prune landed: an inheriting descendant swept
+      // before its parent would otherwise publish the parent's pre-prune
+      // state. Strict re-read: the prune above already threw on anything
+      // unreadable, so a failure here is a real regression and must keep the
+      // caller's retry tombstone rather than publish a guess. One `published`
+      // set for the whole batch: a swept descendant already re-published by
+      // its ancestor's fan-out still gets its own strict verification and
+      // authoritative publication here, but its subtree is not walked again.
+      const published = new Set<string>();
+      // The sweep's single budget continues here: each fan-out would
+      // otherwise reset its own 30 s while the locks stay held.
+      for (const [workspaceId, { metadata, filePaths }] of swept) {
+        try {
+          await this.publishEffectiveOverrides(
+            workspaceId,
+            (
+              await withDeadline(
+                this.resolveOverridesFor(metadata, "strict", after),
+                budget.remaining(),
+                "override resolution exceeded the plugin-prune budget",
+                () => after.cancel()
               )
-            );
-          }
-          swept.push(workspaceId);
+            ).overrides,
+            options.publish,
+            filePaths[0],
+            after,
+            published,
+            budget
+          );
         } catch (error) {
           failures.push({ workspaceId, error });
         }
       }
-
-      // Workspace renames move the checkout and rewrite config WITHOUT taking
-      // this lock, so a rename racing the sweep leaves the snapshot pointing
-      // at the old (now empty) path and the prune above "succeeds" against
-      // nothing. Re-resolve once afterwards and fail any swept workspace whose
-      // checkout set changed: the caller keeps its tombstone and retries.
-      if (swept.length > 0) {
-        const afterById = groupMetadataById(await this.config.getAllWorkspaceMetadata());
-        for (const workspaceId of swept) {
-          const id = workspaceId.trim();
-          if (checkoutPaths(metadataById.get(id)) !== checkoutPaths(afterById.get(id))) {
-            failures.push({
-              workspaceId,
-              error: new Error(`Workspace ${id} moved while its MCP overrides were being pruned`),
-            });
-          }
-        }
-      }
-      return failures;
-    });
+    }
+    return failures;
   }
 
-  /** One workspace's prune; see prunePluginOverrideKeys for the contract. */
+  /**
+   * One workspace's prune; see prunePluginOverrideKeys for the contract.
+   * Returns the candidate override paths (canonical first) for publication,
+   * whether the cross-process epoch is owed (see the inline note) and whether
+   * this pass rewrote a document.
+   */
   private async pruneResolvedWorkspace(
     resolved: ResolvedWorkspace,
-    keyPrefix: string
-  ): Promise<void> {
+    keyPrefix: string,
+    /**
+     * Cancellable scope of this prune: a rewrite is registered here so a
+     * caller whose deadline fired can join it before releasing its locks, and
+     * it is never STARTED once the scope was cancelled (the caller has moved
+     * on; a late write could overwrite a later save).
+     */
+    snapshot: ConfigSnapshot
+  ): Promise<{ filePaths: readonly string[]; owesEpoch: boolean; rewrote: boolean }> {
     const { metadata, runtime, workspacePath } = resolved;
+    let owesEpoch = false;
+    let rewrote = false;
     // Prune canonical AND legacy-named files: a stale plugin key in an old
     // .mux/mcp.local.jsonc would otherwise survive uninstall and reactivate
     // on a later canonical migration.
     const filePaths = this.getOverridesFilePaths(workspacePath, metadata.runtimeConfig);
 
+    // Two phases: every candidate is read and validated BEFORE any is
+    // rewritten. A rewrite of the first file followed by a throw on a later
+    // one would return nothing to the caller, which then never bumps the
+    // cross-process epoch for a revocation that is already durable — and
+    // every tombstone retry would fail on the same later file.
+    const rewrites: Array<{ filePath: string; text: string }> = [];
     for (const filePath of filePaths) {
       if (!(await statIsFile(runtime, filePath, "strict"))) {
         continue;
       }
+      // A document exists: the cross-process signal is owed whether or not
+      // THIS pass rewrites it — a previous pass may have rewritten it and
+      // failed its epoch bump (the caller then retried on its tombstone), so
+      // an idempotent retry must still publish the invalidation. Only a
+      // checkout with no override document at all owes nothing.
+      owesEpoch = true;
       // SECURITY: refuse to prune through a symlinked override file. A
       // contributor-controlled branch can track `.mux/mcp.local.jsonc` as
       // a symlink (or symlink a parent segment); the write below resolves
@@ -818,112 +4552,273 @@ export class WorkspaceMcpOverridesService {
       // Strict read: unreadable/unparseable content must throw so the
       // caller keeps its retry tombstone (mirrors readOverridesFile).
       const original = await readFileString(runtime, filePath);
-      const parseErrors: jsonc.ParseError[] = [];
-      const parsed: unknown = jsonc.parse(original, parseErrors) as unknown;
-      if (parseErrors.length > 0) {
-        throw new Error(`Workspace MCP overrides file has JSONC parse errors: ${filePath}`);
-      }
-      if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-        // A newer build may store the whole document in a non-object shape
-        // this build cannot inspect; "successfully pruning" it would retire
-        // the caller's tombstone while plugin keys embedded in that shape
-        // survive. Same doctrine as opaque owned-field shapes below.
-        throw new Error(
-          `Workspace MCP overrides file has an unrecognized root shape (written by a newer version?): ${filePath}`
-        );
-      }
-
-      // Duplicate properties make jsonc.parse (last value wins) and
-      // jsonc.modify (first matching path wins) disagree: the edit loop
-      // below could spin forever on an entry it can never remove, or
-      // declare success while a stale plugin key survives in the shadowed
-      // property. Reject up front — the caller keeps its retry tombstone
-      // until the malformed file is repaired.
-      const duplicateName = findDuplicateOverrideProperty(jsonc.parseTree(original));
-      if (duplicateName !== undefined) {
-        throw new Error(
-          `Workspace MCP overrides file has duplicate "${duplicateName}" properties: ${filePath}`
-        );
-      }
-
-      // Targeted jsonc edits, NOT JSON.stringify of the parsed object: the
-      // .jsonc file is user-maintained and may carry comments/formatting a
-      // wholesale rewrite would erase.
-      let text = original;
-      const removeAt = (jsonPath: jsonc.JSONPath): void => {
-        const next = jsonc.applyEdits(
-          text,
-          jsonc.modify(text, jsonPath, undefined, {
-            formattingOptions: { insertSpaces: true, tabSize: 2 },
-          })
-        );
-        // A no-op edit means parse and modify disagreed about the path;
-        // looping on it would never terminate.
-        assert(next !== text, "prunePluginOverrideKeys: targeted edit produced no change");
-        text = next;
-      };
-
-      // A newer release may represent an owned field with a shape this
-      // build cannot inspect. Declaring success would retire the caller's
-      // tombstone while plugin keys embedded in that shape survive —
-      // reactivating the server on reinstall. Throw instead: the tombstone
-      // stays retryable (same doctrine as unreadable files).
-      const opaqueShape = (field: string): Error =>
-        new Error(
-          `Workspace MCP overrides file has an unrecognized "${field}" shape (written by a newer version?): ${filePath}`
-        );
-
-      // Match only canonical `plugin:<16-hex>:<server>` keys under the
-      // requested prefix: MCP server names are otherwise arbitrary strings
-      // and user configuration may legitimately name a server "plugin:…" —
-      // pruning must never strip such an ordinary server's overrides.
-      // Canonical keys themselves are additionally RESERVED in ordinary
-      // config (MCPConfigService ignores them in global/project layers and
-      // addServer rejects them), so a key this shape can only belong to an
-      // Agent Plugin server — shape-based pruning cannot hit a user server.
-      const isPrunableKey = (key: unknown): boolean =>
-        typeof key === "string" && key.startsWith(keyPrefix) && isCanonicalPluginServerKey(key);
-
-      for (const field of ["enabledServers", "disabledServers"] as const) {
-        // Re-parse after each removal: array indices shift as items go.
-        for (;;) {
-          const current = jsonc.parse(text) as Record<string, unknown>;
-          const value = current[field];
-          if (value === undefined) {
-            break;
-          }
-          if (!Array.isArray(value)) {
-            throw opaqueShape(field);
-          }
-          const index = value.findIndex(isPrunableKey);
-          if (index === -1) {
-            break;
-          }
-          removeAt([field, index]);
+      let text: string;
+      try {
+        text = prunePluginKeysFromDocument(original, keyPrefix, filePath);
+      } catch (error) {
+        // A shape this build cannot edit (newer-version fields, non-object
+        // root, duplicate properties). When the full parse-tree scan proves
+        // no canonical plugin key is present anywhere in the document, there
+        // is nothing to prune: leave it verbatim (upgrade↔downgrade rule) —
+        // exactly the document a fork copy preserved on the same evidence,
+        // which registration would otherwise reject and roll the fork back
+        // for. Anything that MAY carry a key keeps throwing so the caller
+        // retains its retry tombstone.
+        if (documentMayContainPluginKey(original)) {
+          throw error;
         }
+        log.debug("[MCP] Leaving an uneditable override document that carries no plugin key", {
+          filePath,
+          error: getErrorMessage(error),
+        });
+        continue;
       }
-
-      const allowlist = (jsonc.parse(text) as Record<string, unknown>).toolAllowlist;
-      if (allowlist !== undefined) {
-        if (allowlist === null || typeof allowlist !== "object" || Array.isArray(allowlist)) {
-          throw opaqueShape("toolAllowlist");
-        }
-        for (const key of Object.keys(allowlist)) {
-          if (isPrunableKey(key)) {
-            removeAt(["toolAllowlist", key]);
-          }
-        }
-      }
-
       if (text !== original) {
-        await writeFileString(runtime, filePath, text);
+        rewrites.push({ filePath, text });
       }
     }
+    for (const { filePath, text } of rewrites) {
+      if (snapshot.cancelled) {
+        throw new Error(`pruning ${filePath} was cancelled before its rewrite started`);
+      }
+      try {
+        await snapshot.trackSideEffect(writeFileString(runtime, filePath, text));
+      } catch (error) {
+        if (rewrote) {
+          // An earlier candidate's revocation is already durable: publish it
+          // to sibling processes even though this pass fails (the caller's
+          // tombstone retry republishes anyway once the write succeeds).
+          await this.bumpOverridesEpoch().catch((epochError: unknown) =>
+            log.warn("[MCP] Could not publish the epoch after a partial override prune", {
+              filePath,
+              error: getErrorMessage(epochError),
+            })
+          );
+        }
+        throw error;
+      }
+      rewrote = true;
+    }
+    return { filePaths, owesEpoch, rewrote };
   }
 }
 
-/** Property names prunePluginOverrideKeys edits by JSON path. */
-const PRUNED_OVERRIDE_FIELDS = new Set(["enabledServers", "disabledServers", "toolAllowlist"]);
+/**
+ * Remove every canonical `plugin:` key starting with `keyPrefix` from a raw
+ * override document, PRESERVING all fields this build does not recognize.
+ * Pure text transform shared by prunePluginOverrideKeys (uninstall) and the
+ * fork copy; throws on shapes it cannot inspect (see the doctrine inline).
+ */
+function prunePluginKeysFromDocument(
+  original: string,
+  keyPrefix: string,
+  filePath: string
+): string {
+  const parseErrors: jsonc.ParseError[] = [];
+  const parsed: unknown = jsonc.parse(original, parseErrors) as unknown;
+  if (parseErrors.length > 0) {
+    throw new Error(`Workspace MCP overrides file has JSONC parse errors: ${filePath}`);
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    // A newer build may store the whole document in a non-object shape
+    // this build cannot inspect; "successfully pruning" it would retire
+    // the caller's tombstone while plugin keys embedded in that shape
+    // survive. Same doctrine as opaque owned-field shapes below.
+    throw new Error(
+      `Workspace MCP overrides file has an unrecognized root shape (written by a newer version?): ${filePath}`
+    );
+  }
+
+  // Duplicate properties make jsonc.parse (last value wins) and
+  // jsonc.modify (first matching path wins) disagree: the edit loop
+  // below could spin forever on an entry it can never remove, or
+  // declare success while a stale plugin key survives in the shadowed
+  // property. Reject up front — the caller keeps its retry tombstone
+  // until the malformed file is repaired.
+  const duplicateName = findDuplicateOverrideProperty(jsonc.parseTree(original));
+  if (duplicateName !== undefined) {
+    throw new Error(
+      `Workspace MCP overrides file has duplicate "${duplicateName}" properties: ${filePath}`
+    );
+  }
+
+  // Targeted jsonc edits, NOT JSON.stringify of the parsed object: the
+  // .jsonc file is user-maintained and may carry comments/formatting a
+  // wholesale rewrite would erase.
+  let text = original;
+  // Every edit must leave a parseable document behind: an editor defect
+  // here would corrupt a user-maintained file that the manager then treats
+  // as unreadable (fail closed) and the uninstaller retries forever.
+  const commit = (next: string, what: string): void => {
+    // A no-op edit means parse and the editor disagreed about the target;
+    // looping on it would never terminate.
+    assert(next !== text, `prunePluginOverrideKeys: ${what} produced no change`);
+    const errors: jsonc.ParseError[] = [];
+    jsonc.parse(next, errors);
+    assert(errors.length === 0, `prunePluginOverrideKeys: ${what} produced unparseable JSONC`);
+    text = next;
+  };
+  const removeAt = (jsonPath: jsonc.JSONPath): void => {
+    commit(
+      jsonc.applyEdits(
+        text,
+        jsonc.modify(text, jsonPath, undefined, {
+          formattingOptions: { insertSpaces: true, tabSize: 2 },
+        })
+      ),
+      `removing ${jsonPath.join(".")}`
+    );
+  };
+  // jsonc.modify (jsonc-parser 3.3.1) corrupts a COMPACT array when its LAST
+  // element is removed (`["a","b"]` → `["a""]`), so array elements are cut
+  // out of the text directly from the parse tree instead. Exactly two spans
+  // go: the element itself and ONE adjacent comma token — the comma before it
+  // (or, for the first element, the comma after it). Nothing else is touched,
+  // so every comment and all whitespace survive, including trivia attached
+  // to the neighbors (`["plugin", /* why */ "shots"]` → `[ /* why */ "shots"]`).
+  const removeArrayElement = (field: string, index: number): void => {
+    const root = jsonc.parseTree(text);
+    assert(root !== undefined, "prunePluginOverrideKeys: document has no parse tree");
+    const arrayNode = jsonc.findNodeAtLocation(root, [field]);
+    assert(
+      arrayNode?.type === "array" && arrayNode.children !== undefined,
+      `prunePluginOverrideKeys: "${field}" is not an array node`
+    );
+    const items = arrayNode.children;
+    const item = items[index];
+    assert(item !== undefined, `prunePluginOverrideKeys: "${field}"[${index}] is missing`);
+    const previous = items[index - 1];
+    const following = items[index + 1];
+    // Locate the comma token in a gap using the JSONC scanner (skips
+    // whitespace and comments, so a comment containing "," is never mistaken).
+    const commaSpan = (from: number, to: number): [number, number] => {
+      const scanner = jsonc.createScanner(text, /* ignoreTrivia */ true);
+      scanner.setPosition(from);
+      for (;;) {
+        const token = scanner.scan();
+        const offset = scanner.getTokenOffset();
+        assert(
+          token !== jsonc.SyntaxKind.EOF && offset < to,
+          `prunePluginOverrideKeys: no separator found in "${field}"`
+        );
+        if (token === jsonc.SyntaxKind.CommaToken) {
+          return [offset, offset + scanner.getTokenLength()];
+        }
+      }
+    };
+    const spans: Array<[number, number]> = [[item.offset, item.offset + item.length]];
+    if (previous !== undefined) {
+      spans.push(commaSpan(previous.offset + previous.length, item.offset));
+    } else if (following !== undefined) {
+      spans.push(commaSpan(item.offset + item.length, following.offset));
+    }
+    // Apply from the highest offset down so earlier spans stay valid.
+    let next = text;
+    for (const [start, end] of spans.sort((a, b) => b[0] - a[0])) {
+      next = next.slice(0, start) + next.slice(end);
+    }
+    commit(next, `removing ${field}[${index}]`);
+  };
+
+  // A newer release may represent an owned field with a shape this
+  // build cannot inspect. Declaring success would retire the caller's
+  // tombstone while plugin keys embedded in that shape survive —
+  // reactivating the server on reinstall. Throw instead: the tombstone
+  // stays retryable (same doctrine as unreadable files).
+  const opaqueShape = (field: string): Error =>
+    new Error(
+      `Workspace MCP overrides file has an unrecognized "${field}" shape (written by a newer version?): ${filePath}`
+    );
+
+  // Match only canonical `plugin:<16-hex>:<server>` keys under the
+  // requested prefix: MCP server names are otherwise arbitrary strings
+  // and user configuration may legitimately name a server "plugin:…" —
+  // pruning must never strip such an ordinary server's overrides.
+  // Canonical keys themselves are additionally RESERVED in ordinary
+  // config (MCPConfigService ignores them in global/project layers and
+  // addServer rejects them), so a key this shape can only belong to an
+  // Agent Plugin server — shape-based pruning cannot hit a user server.
+  const isPrunableKey = (key: unknown): boolean =>
+    typeof key === "string" && key.startsWith(keyPrefix) && isCanonicalPluginServerKey(key);
+
+  for (const field of ["enabledServers", "disabledServers"] as const) {
+    // Re-parse after each removal: array indices shift as items go.
+    for (;;) {
+      const current = jsonc.parse(text) as Record<string, unknown>;
+      const value = current[field];
+      if (value === undefined) {
+        break;
+      }
+      if (!Array.isArray(value)) {
+        throw opaqueShape(field);
+      }
+      const index = value.findIndex(isPrunableKey);
+      if (index === -1) {
+        break;
+      }
+      removeArrayElement(field, index);
+    }
+  }
+
+  const allowlist = (jsonc.parse(text) as Record<string, unknown>).toolAllowlist;
+  if (allowlist !== undefined) {
+    if (allowlist === null || typeof allowlist !== "object" || Array.isArray(allowlist)) {
+      throw opaqueShape("toolAllowlist");
+    }
+    for (const key of Object.keys(allowlist)) {
+      if (isPrunableKey(key)) {
+        removeAt(["toolAllowlist", key]);
+      }
+    }
+  }
+  // The edits above only reach the fields this build owns. A newer build may
+  // store the same key in a top-level field this build does not recognize
+  // (or nested inside a shape it kept verbatim): reporting success would
+  // retire the uninstaller's tombstone while that key survives, and a later
+  // upgrade or same-name reinstall could reactivate the plugin server without
+  // fresh consent. Reject when any retained decoded string still carries the
+  // pruned prefix in canonical key shape (an ordinary server named
+  // `myplugin:x` is not a hit) — the caller keeps its tombstone (uninstall)
+  // or skips the copy (fork) until a build that owns the field repairs it.
+  if (
+    documentStringsContain(
+      text,
+      (value) => value.includes(keyPrefix) && CANONICAL_PLUGIN_KEY_PATTERN.test(value)
+    )
+  ) {
+    throw new Error(
+      `Workspace MCP overrides file still carries "${keyPrefix}" keys in fields this version does not edit (written by a newer version?): ${filePath}`
+    );
+  }
+  return text;
+}
+
+/**
+ * Conservative "could any canonical plugin key hide in this document?" screen
+ * for text prunePluginKeysFromDocument refused to edit. Walks every DECODED
+ * string node (keys and values) of the JSONC parse TREE — not the parsed
+ * value, whose last-wins duplicate properties would hide a shadowed key — so
+ * JSON escapes such as `plugin\u003a…` cannot slip past a raw-text search.
+ * Unparseable text is treated as possibly containing one.
+ */
+function documentMayContainPluginKey(text: string): boolean {
+  return documentStringsContain(text, (value) => CANONICAL_PLUGIN_KEY_PATTERN.test(value));
+}
+
+/** Whether any decoded string node (key or value) of the JSONC parse tree satisfies `predicate`; unparseable text counts as a match. */
+function documentStringsContain(text: string, predicate: (value: string) => boolean): boolean {
+  const errors: jsonc.ParseError[] = [];
+  const root = jsonc.parseTree(text, errors);
+  if (errors.length > 0 || root === undefined) {
+    return true;
+  }
+  const visit = (node: jsonc.Node): boolean =>
+    (node.type === "string" && typeof node.value === "string" && predicate(node.value)) ||
+    (node.children?.some(visit) ?? false);
+  return visit(root);
+}
+/** Canonical `plugin:<16 hex>:<server>` key shape (mirrors isCanonicalPluginServerKey), searched inside strings. */
+const CANONICAL_PLUGIN_KEY_PATTERN = /plugin:[0-9a-f]{16}:/;
 
 /**
  * Detect duplicate JSONC properties that would break path-based edits in

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -9770,6 +9770,49 @@ describe("WorkspaceService rename lock", () => {
       expect(result.error).toContain("stream is active");
     }
   });
+
+  test("an SSH rename is serialized through the workspace's MCP-overrides lock", async () => {
+    // A settings save that passed its revision check on the old checkout path
+    // must not write into a recreated old path after the remote move: every
+    // runtime's rename holds THIS workspace's writer lock across move + config
+    // rewrite (scoped, so unrelated workspaces' saves are not blocked).
+    const workspaceId = "ssh-workspace";
+    (mockAIService.getWorkspaceMetadata as ReturnType<typeof mock>).mockResolvedValue({
+      success: true,
+      data: {
+        id: workspaceId,
+        name: "old-name",
+        projectPath: "/tmp/project",
+        projectName: "project",
+        runtimeConfig: { type: "ssh", host: "example.invalid", srcBaseDir: "/srv" },
+      },
+    });
+    const config = (workspaceService as unknown as { config: Record<string, unknown> }).config;
+    config.getAllWorkspaceMetadata = mock(() => Promise.resolve([]));
+    config.findWorkspace = mock(() => ({
+      projectPath: "/tmp/project",
+      workspacePath: "/srv/project/old-name",
+    }));
+    config.loadConfigOrDefault = mock(() => ({ projects: new Map() }));
+    const acquireWorkspaceLock = mock((_workspaceId: string) =>
+      Promise.reject(new Error("Another Mux process is currently updating workspace MCP settings"))
+    );
+    workspaceService.setWorkspaceMcpOverridesService({
+      acquireWorkspaceLock,
+      prunePluginOverrideKeys: () => Promise.resolve(),
+      copyOverridesToForkedCheckout: () => Promise.resolve(),
+    });
+
+    const result = await workspaceService.rename(workspaceId, "new-name");
+
+    // The lock is taken BEFORE any remote move; its failure fails the rename.
+    expect(acquireWorkspaceLock).toHaveBeenCalledTimes(1);
+    expect(acquireWorkspaceLock).toHaveBeenCalledWith(workspaceId);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("updating workspace MCP settings");
+    }
+  });
 });
 
 test.each([
@@ -13944,11 +13987,12 @@ describe("WorkspaceService registration-time plugin override sanitization", () =
     const service = makeService([{ id: "ws-new", path: "/tmp/proj" }]);
     const pruned: string[] = [];
     service.setWorkspaceMcpOverridesService({
-      acquireExclusiveLock: () => Promise.resolve(() => Promise.resolve()),
+      acquireWorkspaceLock: () => Promise.resolve(() => Promise.resolve()),
       prunePluginOverrideKeys: (workspaceId, keyPrefix) => {
         pruned.push(`${workspaceId}:${keyPrefix}`);
         return Promise.resolve();
       },
+      copyOverridesToForkedCheckout: () => Promise.resolve(),
     });
     const error = await (
       service as unknown as SanitizeAccess
@@ -13967,11 +14011,12 @@ describe("WorkspaceService registration-time plugin override sanitization", () =
     const service = makeService([{ id: "ws-new", path: "/tmp/proj" }]);
     const pruned: string[] = [];
     service.setWorkspaceMcpOverridesService({
-      acquireExclusiveLock: () => Promise.resolve(() => Promise.resolve()),
+      acquireWorkspaceLock: () => Promise.resolve(() => Promise.resolve()),
       prunePluginOverrideKeys: (workspaceId, keyPrefix) => {
         pruned.push(`${workspaceId}:${keyPrefix}`);
         return Promise.resolve();
       },
+      copyOverridesToForkedCheckout: () => Promise.resolve(),
     });
     const persistentWith = (workspacePath: string): Pick<Config, "loadConfigOrDefault"> =>
       ({
@@ -14012,11 +14057,12 @@ describe("WorkspaceService registration-time plugin override sanitization", () =
     const service = makeService([{ id: "ws-new", path: "/tmp/proj" }]);
     const pruned: string[] = [];
     service.setWorkspaceMcpOverridesService({
-      acquireExclusiveLock: () => Promise.resolve(() => Promise.resolve()),
+      acquireWorkspaceLock: () => Promise.resolve(() => Promise.resolve()),
       prunePluginOverrideKeys: (workspaceId, keyPrefix) => {
         pruned.push(`${workspaceId}:${keyPrefix}`);
         return Promise.resolve();
       },
+      copyOverridesToForkedCheckout: () => Promise.resolve(),
     });
     const broken = {
       loadConfigOrDefault: (options?: { throwOnError?: boolean }) => {
@@ -14043,11 +14089,12 @@ describe("WorkspaceService registration-time plugin override sanitization", () =
     ]);
     const pruned: string[] = [];
     service.setWorkspaceMcpOverridesService({
-      acquireExclusiveLock: () => Promise.resolve(() => Promise.resolve()),
+      acquireWorkspaceLock: () => Promise.resolve(() => Promise.resolve()),
       prunePluginOverrideKeys: (workspaceId, keyPrefix) => {
         pruned.push(`${workspaceId}:${keyPrefix}`);
         return Promise.resolve();
       },
+      copyOverridesToForkedCheckout: () => Promise.resolve(),
     });
     const error = await (
       service as unknown as SanitizeAccess
@@ -14059,9 +14106,10 @@ describe("WorkspaceService registration-time plugin override sanitization", () =
   test("a failed sanitize surfaces an error so creation aborts", async () => {
     const service = makeService([{ id: "ws-new", path: "/tmp/proj" }]);
     service.setWorkspaceMcpOverridesService({
-      acquireExclusiveLock: () => Promise.resolve(() => Promise.resolve()),
+      acquireWorkspaceLock: () => Promise.resolve(() => Promise.resolve()),
       prunePluginOverrideKeys: () =>
         Promise.reject(new Error('duplicate "enabledServers" properties')),
+      copyOverridesToForkedCheckout: () => Promise.resolve(),
     });
     const error = await (
       service as unknown as SanitizeAccess
@@ -14080,11 +14128,12 @@ describe("WorkspaceService registration-time plugin override sanitization", () =
     ]);
     const pruned: string[] = [];
     service.setWorkspaceMcpOverridesService({
-      acquireExclusiveLock: () => Promise.resolve(() => Promise.resolve()),
+      acquireWorkspaceLock: () => Promise.resolve(() => Promise.resolve()),
       prunePluginOverrideKeys: (workspaceId, keyPrefix) => {
         pruned.push(`${workspaceId}:${keyPrefix}`);
         return Promise.resolve();
       },
+      copyOverridesToForkedCheckout: () => Promise.resolve(),
     });
     const error = await (
       service as unknown as SanitizeAccess
@@ -14106,11 +14155,12 @@ describe("WorkspaceService registration-time plugin override sanitization", () =
       ]);
       const pruned: string[] = [];
       service.setWorkspaceMcpOverridesService({
-        acquireExclusiveLock: () => Promise.resolve(() => Promise.resolve()),
+        acquireWorkspaceLock: () => Promise.resolve(() => Promise.resolve()),
         prunePluginOverrideKeys: (workspaceId, keyPrefix) => {
           pruned.push(`${workspaceId}:${keyPrefix}`);
           return Promise.resolve();
         },
+        copyOverridesToForkedCheckout: () => Promise.resolve(),
       });
       const error = await (
         service as unknown as SanitizeAccess
@@ -14134,11 +14184,12 @@ describe("WorkspaceService registration-time plugin override sanitization", () =
     (service as unknown as SanitizeAccess).pendingPluginSanitizations.add("ws-concurrent");
     const pruned: string[] = [];
     service.setWorkspaceMcpOverridesService({
-      acquireExclusiveLock: () => Promise.resolve(() => Promise.resolve()),
+      acquireWorkspaceLock: () => Promise.resolve(() => Promise.resolve()),
       prunePluginOverrideKeys: (workspaceId, keyPrefix) => {
         pruned.push(`${workspaceId}:${keyPrefix}`);
         return Promise.resolve();
       },
+      copyOverridesToForkedCheckout: () => Promise.resolve(),
     });
     const error = await (
       service as unknown as SanitizeAccess

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -339,6 +339,7 @@ import {
 import { findWorkspaceEntry } from "@/node/services/taskUtils";
 import type { WorktreeArchiveSnapshotService } from "@/node/services/worktreeArchiveSnapshotService";
 import type { DevToolsService } from "@/node/services/devToolsService";
+import type { WorkspaceMcpOverridesService } from "@/node/services/workspaceMcpOverridesService";
 
 import { DisposableTempDir } from "@/node/services/tempDir";
 import { createBashTool } from "@/node/services/tools/bash";
@@ -654,6 +655,14 @@ type WorkspaceRuntimeStatus = "running" | "stopped" | "unknown" | "unsupported";
 
 /** Narrow DevTools cleanup surface used on archive/remove and by the startup sweep. */
 type WorkspaceDevToolsCleanup = Pick<DevToolsService, "hasWorkspaceData" | "removeWorkspaceData">;
+/**
+ * Narrow overrides surface: stale plugin-key sanitization on registration,
+ * fork-time copy, and the per-workspace lock rename holds across its checkout move.
+ */
+type WorkspaceServiceMcpOverridesPort = Pick<
+  WorkspaceMcpOverridesService,
+  "prunePluginOverrideKeys" | "copyOverridesToForkedCheckout" | "acquireWorkspaceLock"
+>;
 const POST_COMPACTION_METADATA_REFRESH_DEBOUNCE_MS = 100;
 
 const DESCENDANT_WORKSPACE_REMOVE_ERROR =
@@ -2740,10 +2749,7 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
   /** Cancels running /refine passes before removal deletes the session dir; wired post-construction (RefineService is built later). */
   private refinePassCanceller?: { cancelInFlightRefinePass(workspaceId: string): Promise<void> };
   /** Narrow overrides-cleanup surface; wired by ServiceContainer for stale plugin-key sanitization. */
-  private workspaceMcpOverridesService?: {
-    prunePluginOverrideKeys(workspaceId: string, keyPrefix: string): Promise<void>;
-    acquireExclusiveLock(): Promise<() => Promise<void>>;
-  };
+  private workspaceMcpOverridesService?: WorkspaceServiceMcpOverridesPort;
 
   setTimelineRecorder(recorder: TimelineRecorder): void {
     this.timelineRecorder = recorder;
@@ -2757,10 +2763,7 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
     this.mcpServerManager = manager;
   }
 
-  setWorkspaceMcpOverridesService(service: {
-    prunePluginOverrideKeys(workspaceId: string, keyPrefix: string): Promise<void>;
-    acquireExclusiveLock(): Promise<() => Promise<void>>;
-  }): void {
+  setWorkspaceMcpOverridesService(service: WorkspaceServiceMcpOverridesPort): void {
     this.workspaceMcpOverridesService = service;
   }
 
@@ -2989,7 +2992,13 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       }
     }
     try {
-      await this.workspaceMcpOverridesService.prunePluginOverrideKeys(workspaceId, "plugin:");
+      // A new identity owes no earlier pass an epoch bump: require the
+      // cross-process signal only when this pass actually rewrote a file, so
+      // a fork copy's valid key-free document is not rolled back by a
+      // transiently unwritable epoch file.
+      await this.workspaceMcpOverridesService.prunePluginOverrideKeys(workspaceId, "plugin:", {
+        epochOnlyWhenRewritten: true,
+      });
       return undefined;
     } catch (error) {
       // Abort creation instead of proceeding with the stale file: continuing
@@ -5797,7 +5806,11 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       this.initAbortControllers.delete(workspaceId);
     }
 
-    const persistedWorkspace = this.config.findWorkspace(workspaceId);
+    // The registered entry is read AFTER the MCP-overrides lock below is held
+    // (a sibling backend's rename retargets the lock onto the renamed checkout,
+    // and the deletion must address that checkout, not a stale path); this
+    // pre-lock view only serves the project-list refresh at the end.
+    let persistedWorkspace = this.config.findWorkspace(workspaceId);
     // Startup recovery or a queued dispatch can be one await from starting a stream that the single
     // stopStream() below cannot see, and the entry stays present and unarchived until removal has
     // finished with the runtime. Hold admission for the whole removal: success disposes the session,
@@ -5809,11 +5822,27 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       .filter((session): session is AgentSession => session != null)
       .map((session) => session.holdTurnAdmission());
 
+    // Removal deletes the checkout: hold THIS workspace's MCP-overrides lock
+    // like rename does (see rename), so a settings save that verified the
+    // checkout's existence cannot have its `mkdir -p` recreate the deleted
+    // path and write an orphaned override file while both operations report
+    // success. Scoped to this workspace; taken before any disk mutation and
+    // released once removal has settled (finally below).
+    let releaseOverridesLock: (() => Promise<void>) | undefined;
     // Try to remove from runtime (filesystem)
     try {
       if (this.agentTaskIntegration?.hasDescendantAgentTasks(workspaceId) === true) {
         return Err(DESCENDANT_WORKSPACE_REMOVE_ERROR);
       }
+      // Forced removals too (routine task cleanup uses force): proceeding
+      // while a stalled writer still owns the lock would let it resume after
+      // the deletion and recreate the removed path. The acquisition is
+      // bounded (and a crashed holder's lease is reclaimed), so a failure here
+      // is retryable rather than a permanent block.
+      releaseOverridesLock =
+        await this.workspaceMcpOverridesService?.acquireWorkspaceLock(workspaceId);
+      // Fresh under the lock (see above).
+      persistedWorkspace = this.config.findWorkspace(workspaceId) ?? persistedWorkspace;
 
       // The captured engine stop joins partial finalization and raw terminal delivery.
       try {
@@ -6429,6 +6458,16 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       const message = getErrorMessage(error);
       return Err(`Failed to remove workspace: ${message}`);
     } finally {
+      if (releaseOverridesLock !== undefined) {
+        try {
+          await releaseOverridesLock();
+        } catch (error) {
+          log.debug("Failed to release the MCP overrides lock after workspace removal", {
+            workspaceId,
+            error: getErrorMessage(error),
+          });
+        }
+      }
       for (const hold of admissionHolds) {
         hold[Symbol.dispose]();
       }
@@ -7137,13 +7176,21 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       const { projectPath: configProjectPath } = workspace;
       const configSnapshot = this.config.loadConfigOrDefault();
 
-      // Hold the workspace MCP-overrides lock across the checkout move AND the
-      // config rewrite below. The Agent Plugin override prune resolves
-      // checkouts from config under that lock; a rename interleaving between
-      // its filesystem move and its config write would let the prune stat the
-      // vacated old path, find nothing, and retire a cleanup tombstone while
-      // the moved .xum/mcp.local.jsonc still holds the plugin key.
-      releaseOverridesLock = await this.workspaceMcpOverridesService?.acquireExclusiveLock();
+      // Hold THIS workspace's MCP-overrides lock across the checkout move AND
+      // the config rewrite below, for every runtime. Every writer of the
+      // workspace's override document takes the same lock before the global
+      // write lock: the Agent Plugin override prune (host-local checkouts)
+      // would otherwise stat the vacated old path, find nothing, and retire a
+      // cleanup tombstone while the moved .xum/mcp.local.jsonc still holds the
+      // plugin key; and an MCP settings save (any runtime) that passed its
+      // revision check on the old path would write its disable into a
+      // recreated old path after the move while the renamed checkout keeps
+      // the prior enable. The lock is scoped to this workspace, so a slow
+      // remote move never blocks unrelated workspaces' settings saves; the
+      // lease is re-stamped while held, so a long hold is never reclaimed as
+      // stale.
+      releaseOverridesLock =
+        await this.workspaceMcpOverridesService?.acquireWorkspaceLock(workspaceId);
 
       let oldPath: string;
       let newPath: string;
@@ -10182,6 +10229,22 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
         sourceRuntimeConfigUpdate,
         sourceRuntimeConfigUpdated,
       } = forkResult.data;
+
+      // Per-workspace MCP enables live in the gitignored .xum/mcp.local.jsonc,
+      // which a fresh checkout never materializes; without this copy a server
+      // enabled only for the source workspace is silently gone in the fork.
+      // Runs before the init hook starts (so the hook sees the fork's initial
+      // configuration deterministically) and before the plugin-override
+      // sanitization below (so stale plugin enables are pruned from the copy).
+      // Target path = what WorkspaceMcpOverridesService will later derive for
+      // the registered fork (runtime.getWorkspacePath), NOT forkResult's
+      // primary-project checkout: they differ for multi-project forks, whose
+      // persisted root is the multi-project container.
+      await this.workspaceMcpOverridesService?.copyOverridesToForkedCheckout(sourceWorkspaceId, {
+        runtime: targetRuntime,
+        workspacePath: targetRuntime.getWorkspacePath(foundProjectPath, resolvedName),
+        runtimeConfig: forkedRuntimeConfig,
+      });
 
       // Run init for forked workspace (fire-and-forget like create()).
       // Multi-project forks need per-project secrets for each runtime's init hook.

--- a/src/node/utils/main/crossProcessLock.ts
+++ b/src/node/utils/main/crossProcessLock.ts
@@ -40,6 +40,14 @@ export interface CrossProcessLockOptions {
   staleMs: number;
   /** Error message thrown when the acquire timeout elapses. */
   timeoutMessage: string;
+  /**
+   * Abort waiting for a live holder. Checked before every attempt and wakes
+   * the inter-attempt sleep, so a caller whose own operation ended (a tool
+   * call interrupted with Escape) stops polling immediately instead of
+   * occupying its place in an in-process queue until `acquireTimeoutMs`.
+   * Never interrupts an acquisition that already succeeded.
+   */
+  signal?: AbortSignal;
 }
 
 export interface LockHolder {
@@ -102,8 +110,23 @@ function holderAlive(holder: LockHolder, staleMs: number): boolean {
   }
 }
 
-function sleepWithJitter(baseMs: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, baseMs + Math.floor(Math.random() * baseMs)));
+function sleepWithJitter(baseMs: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const delay = baseMs + Math.floor(Math.random() * baseMs);
+    if (signal === undefined) {
+      setTimeout(resolve, delay);
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, delay);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 /**
@@ -286,9 +309,14 @@ export async function reclaimStaleLock(
 export async function acquireCrossProcessLock(
   options: CrossProcessLockOptions
 ): Promise<() => Promise<void>> {
-  const { lockPath, acquireTimeoutMs, staleMs, timeoutMessage } = options;
+  const { lockPath, acquireTimeoutMs, staleMs, timeoutMessage, signal } = options;
   await fsPromises.mkdir(path.dirname(lockPath), { recursive: true });
   const deadline = Date.now() + acquireTimeoutMs;
+  const throwIfAborted = () => {
+    if (signal?.aborted) {
+      throw new Error("Lock acquisition was aborted");
+    }
+  };
 
   // LEASE RENEWAL: `acquiredAt` is a renewable lease timestamp, not a birth
   // time. A LIVE transaction legitimately exceeding staleMs (e.g. a plugin
@@ -407,6 +435,7 @@ export async function acquireCrossProcessLock(
   };
 
   for (;;) {
+    throwIfAborted();
     const token = randomBytes(16).toString("hex");
     // Publish atomically WITH content: write the holder record to a temp
     // file, hard-link it into place (exclusive: EEXIST when the path
@@ -442,9 +471,12 @@ export async function acquireCrossProcessLock(
     } finally {
       await fsPromises.rm(publishPath, { force: true }).catch(() => undefined);
     }
-    if (Date.now() > deadline) {
+    // `>=`: a zero timeout is a try-lock (batch acquirers release earlier
+    // locks immediately on contention) and must reject without sleeping even
+    // when the failed attempt completed within the deadline's millisecond.
+    if (Date.now() >= deadline) {
       throw new Error(timeoutMessage);
     }
-    await sleepWithJitter(250);
+    await sleepWithJitter(250, signal);
   }
 }

--- a/tests/ipc/config/mcpWorkspaceOverridesInheritance.test.ts
+++ b/tests/ipc/config/mcpWorkspaceOverridesInheritance.test.ts
@@ -1,0 +1,122 @@
+import * as path from "node:path";
+import { shouldRunIntegrationTests, setupWorkspaceWithoutProvider } from "../setup";
+import {
+  createWorkspace,
+  generateBranchName,
+  HAIKU_MODEL,
+  resolveOrpcClient,
+  sendMessageWithModel,
+} from "../helpers";
+import type { TestEnvironment } from "../setup";
+
+const describeIntegration = shouldRunIntegrationTests() ? describe : describe.skip;
+const MCP_SERVER_COMMAND = `node "${path.join(__dirname, "..", "fixtures", "mcp-screenshot-server.js")}"`;
+const SERVER_NAME = "shots";
+
+/**
+ * Names of the MCP-derived tools the model would be offered, captured from the
+ * assembled request. Mock mode bypasses TurnRequestBuilder, so instead the test
+ * intercepts StreamManager.startStream (the request is fully built by then) and
+ * aborts before any provider call happens.
+ */
+async function captureMcpToolSurface(
+  env: TestEnvironment,
+  workspaceId: string
+): Promise<{ tools: string[]; deferred: string[] }> {
+  const streamManager = env.services.streamManager as unknown as {
+    startStream: (...args: unknown[]) => unknown;
+  };
+  const original = streamManager.startStream;
+  let captured: unknown[] | undefined;
+  streamManager.startStream = (...args: unknown[]) => {
+    captured = args;
+    throw new Error("request captured; no provider call");
+  };
+  try {
+    await sendMessageWithModel(env, workspaceId, "hello", HAIKU_MODEL, {
+      agentId: "exec",
+      experiments: { toolSearch: true },
+    });
+  } finally {
+    streamManager.startStream = original;
+  }
+  const request = captured?.find(
+    (
+      arg
+    ): arg is {
+      tools: Record<string, unknown>;
+      toolSearchState?: { deferredToolNames: Set<string> };
+    } => typeof arg === "object" && arg !== null && "tools" in arg
+  );
+  if (!request) throw new Error("startStream was not reached");
+  return {
+    tools: Object.keys(request.tools)
+      .filter((name) => name.startsWith(`${SERVER_NAME}_`) || name === "tool_catalog_search")
+      .sort(),
+    deferred: [...(request.toolSearchState?.deferredToolNames ?? [])].sort(),
+  };
+}
+
+describeIntegration("workspace MCP overrides in derived workspaces", () => {
+  test("a globally disabled server enabled per-workspace reaches sub-agent children and forks", async () => {
+    const { env, workspaceId, tempGitRepo, cleanup } =
+      await setupWorkspaceWithoutProvider("mcp-inherit");
+    // Any provider config lets the request build; startStream is intercepted before I/O.
+    env.services.providersConfigStore.saveProvidersConfig({ anthropic: { apiKey: "dummy" } });
+    const client = resolveOrpcClient(env);
+    try {
+      expect(
+        (await client.mcp.add({ name: SERVER_NAME, command: MCP_SERVER_COMMAND })).success
+      ).toBe(true);
+      expect((await client.mcp.setEnabled({ name: SERVER_NAME, enabled: false })).success).toBe(
+        true
+      );
+      expect(await captureMcpToolSurface(env, workspaceId)).toEqual({ tools: [], deferred: [] });
+
+      const { revision } = await client.workspace.mcp.get({ workspaceId });
+      expect(
+        (
+          await client.workspace.mcp.set({
+            workspaceId,
+            overrides: { enabledServers: [SERVER_NAME] },
+            expectedRevision: revision,
+          })
+        ).success
+      ).toBe(true);
+      const expectedSurface = {
+        tools: [`${SERVER_NAME}_take_screenshot`, "tool_catalog_search"],
+        deferred: [`${SERVER_NAME}_take_screenshot`],
+      };
+      expect(await captureMcpToolSurface(env, workspaceId)).toEqual(expectedSurface);
+
+      // Sub-agent child: a fresh checkout linked to the parent via parentWorkspaceId.
+      const child = await createWorkspace(env, tempGitRepo, generateBranchName("mcp-child"));
+      if (!child.success) throw new Error(child.error);
+      await env.config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const entry = project.workspaces.find((w) => w.id === child.metadata.id);
+          if (entry) entry.parentWorkspaceId = workspaceId;
+        }
+        return cfg;
+      });
+      expect(
+        (await client.workspace.mcp.get({ workspaceId: child.metadata.id })).overrides
+      ).toEqual({
+        enabledServers: [SERVER_NAME],
+      });
+      expect(await captureMcpToolSurface(env, child.metadata.id)).toEqual(expectedSurface);
+
+      // Fork: independent workspace that snapshots the source's overrides.
+      const fork = await client.workspace.fork({ sourceWorkspaceId: workspaceId });
+      if (!fork.success) throw new Error(fork.error);
+      expect((await client.workspace.mcp.get({ workspaceId: fork.metadata.id })).overrides).toEqual(
+        {
+          enabledServers: [SERVER_NAME],
+        }
+      );
+      expect(await captureMcpToolSurface(env, fork.metadata.id)).toEqual(expectedSurface);
+    } finally {
+      await cleanup();
+    }
+  }, 120_000);
+});


### PR DESCRIPTION
## Summary

A server that is **disabled in global MCP config and enabled only for one workspace** silently disappeared for every sub-agent (`task`) child and for forks of that workspace — and with it the `tool_catalog_search` tool, which is only created when MCP tools exist. Children now inherit the parent's per-workspace overrides, and forks snapshot them.

## Background

Per-workspace MCP enables are stored in the gitignored `<checkout>/.xum/mcp.local.jsonc`. Sub-agent workspaces (`TaskService` → `runBackgroundInit`) and `workspace.fork` create a fresh worktree from committed state, so that file never reaches them. The child's `getOverridesForWorkspace` returned `{}`, the global `disabled: true` won in `applyServerOverrides`, `mcpTools` was empty, `TurnRequestBuilder` never created `toolSearchRuntime`, and the model saw neither the MCP tools nor `tool_catalog_search`. Only `isolation: "none"` tasks (shared checkout) were unaffected.

The same-workspace path was verified to work in every variant tried (exec/plan/ask agents, untrusted project, disable→enable sequencing); the failure is specific to derived workspaces.

## Implementation

- `WorkspaceMcpOverridesService.loadOverrides`: when a workspace has no local file and no legacy config overrides, resolve through `metadata.parentWorkspaceId` (read-through, no copy, depth-bounded). Parent edits and plugin-uninstall prunes therefore apply to children on their next request. A child that saves its own overrides opts out; clearing them resumes inheriting. Lenient reads tolerate a removed/unreachable parent (send never fails); strict reads surface it.
- `WorkspaceService.fork`: `copyOverridesToForkedCheckout` snapshots the source overrides into the new checkout (forks are independent workspaces, so no read-through link), placed **before** the existing plugin-override sanitization so stale `plugin:` enables are pruned exactly as for a tracked file. Best-effort; a failed copy never fails the fork. Shared-checkout (project-dir) forks are skipped.
- **Cache coherence for inheriting children:** every save/prune publishes the written workspace's effective overrides *and then re-publishes each descendant that inherits from it* (transitively; a descendant with its own file cuts off its subtree). The `publish` callback now carries the target workspaceId. Every workspace on the same runtime identity whose canonical override path equals the written file (`isolation: "none"` tasks share the parent's checkout — in either direction) is treated as affected and re-published too, followed by its inheriting descendants. Sharers are matched on filesystem identity (host / SSH host / devcontainer config; never Docker) with `realpath`-canonicalized paths on the host, not on the whole runtime config or path spelling. Publication is authoritative-or-evict: a workspace whose effective state cannot be established (unreachable checkout) — and its entire inheriting subtree — gets `publish(null)`, which `MCPServerManager.forgetWorkspaceOverrides` turns into an eviction of both the overlay cache and the recorded request options (the next serve of any kind, including prompt paths, re-reads disk) rather than a cached guess; a non-authoritative disk re-read (indeterminate probe, read or parse failure) keeps that invalidation alive — invalidations are generation-tracked so a forget landing mid-read is never retired by the older result — and the workspace fails closed (no MCP servers) until disk answers authoritatively. Resolution runs on already-loaded metadata (one config scan per save) and probes an ancestor's candidate paths in parallel. Clearing a child's own overrides publishes its inherited state instead of `{}`, so `MCPServerManager`'s `latestWorkspaceOverrides` never pins a child to stale enablement.
- **Positive-absence gate:** the file probe is three-way (`file` / `absent` / `indeterminate`). Inheritance requires every candidate path to be positively absent (errno `ENOENT`/`ENOTDIR`, or stat(1)'s *own* no-such-file diagnostic line on exec-backed remote runtimes — transport noise such as OpenSSH's identity-file warning stays indeterminate); an indeterminate probe keeps the pre-existing "no overrides" behaviour so a hidden child disable can never be overridden by the parent's enable.
- Fork copy details: the source's effective overrides are resolved first (performing the legacy `config.json` → file migration), the same-path skip applies only to `local` (project-dir) runtimes that genuinely share the checkout (Docker reports `/src` for every container), the copy runs **before** `runBackgroundInit` so the init hook sees the fork's initial configuration deterministically, and the raw document that actually supplied the overrides (the source's own, or the ancestor's when the source is an inheriting sub-agent) is copied whenever one exists — even if this build normalizes it to nothing — with only canonical `plugin:` keys stripped (the prune text transform was extracted from `prunePluginOverrideKeys` for this), so comments and forward-compatible fields survive per the upgrade↔downgrade rule while a fresh checkout never inherits a plugin enable it has no consent context for. Whatever survives pruning is scanned once more: any canonical plugin key in any decoded string of the parsed tree (including fields this build does not own; JSON escapes cannot slip past) refuses the copy. The write is refused when the target `.xum`/`.xum/mcp.local.jsonc` is a repo-controlled symlink or an already-tracked file (writes follow links on every runtime, so a tracked link could redirect the copy outside the checkout).
- The `WorkspaceService` overrides port is now a `Pick<WorkspaceMcpOverridesService, ...>` instead of an ad-hoc interface.
- **Reconciled with the batched plugin-override sweep (#4144):** `prunePluginOverrideKeysForWorkspaces` publishes *after* every prune landed (an inheriting descendant swept before its parent would otherwise publish the parent's pre-prune state) through the same fan-out publisher, and a `ConfigSnapshot` memoizes the authoritative workspace enumeration, the legacy `config.json` snapshot and host `realpath`s across one resolution/publication — or one whole sweep — so inheritance and sharer detection never re-parse config per workspace (the sweep stays one metadata load up front plus one post-sweep re-resolution). When the post-sweep enumeration fails, every cache is evicted and every swept workspace keeps its tombstone.
- Filesystem identity resolves Coder hosts exactly like `runtimeFactory` (`resolveCoderSSHHost`), so distinct Coder machines sharing the raw `coder://` placeholder never coincide; legacy `config.json` migration never writes over an existing document (even one this build normalizes to nothing).

## Validation

- Unit tests in `workspaceMcpOverridesService.test.ts`: parent-chain inheritance (grandchild), read-through (no file materialized in the child), child overrides win + CAS against the inherited revision, clearing resumes inheritance, removed-parent behaviour (strict re-reads must not throw, or the plugin uninstaller would retry an orphan's tombstone forever), descendant re-publication on save/prune/clear, raw fork copy, legacy migration before same-path skip.
- New integration test `tests/ipc/config/mcpWorkspaceOverridesInheritance.test.ts` reproduces the user-visible symptom end-to-end with the real `MCPServerManager` + fixture stdio server by capturing the assembled request at `StreamManager.startStream`: global disable → no tools; workspace enable → `shots_take_screenshot` + `tool_catalog_search` (deferred); the same surface in a `parentWorkspaceId` child and in a fork. Confirmed red on `main`, green with this change.
- `make static-check` green; `workspaceService`, `workspaceMcpOverridesService`, `mcpServerManager`, `installService` suites (755 tests) green.

- Exec-backed `stat` now runs with `LC_ALL=C` so the absence classifier is locale-stable on remote hosts; the fork copy targets `targetRuntime.getWorkspacePath(...)` (multi-project forks persist the container root, not the primary checkout).

## Risks

Low–moderate. Inheritance only kicks in when a child has **no** overrides of its own, and only via `parentWorkspaceId` (task children). The fork copy runs in the existing best-effort copy phase and is followed by the existing sanitization, so the plugin-consent security posture is unchanged. Every send in a child without its own file now performs one extra `stat` against the parent's checkout (remote for SSH parents), matching the cost of the child's own read.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `high` • Cost: `$12.80`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=high costs=12.80 -->









