### PR TITLE
🤖 refactor: centralize compaction observation state

### DIFF
--- a/src/node/services/agentSession.continuousCompaction.test.ts
+++ b/src/node/services/agentSession.continuousCompaction.test.ts
@@ -24,7 +24,7 @@ import {
   type AgentSessionHarness,
 } from "./agentSession.testHarness";
 import type { ContinuousCompactor } from "./continuousCompactor";
-import type { TurnCoordinator } from "./turnCoordinator";
+import type { CompactionToken, TurnCoordinator } from "./turnCoordinator";
 
 const workspaceId = "continuous-session";
 const model = "openai:gpt-4o";
@@ -35,6 +35,10 @@ const sendOptions: SendMessageOptions = {
 };
 
 interface SessionInternals {
+  coordinator: TurnCoordinator;
+  runContinuousCompactionObservation<T>(
+    observe: (token: CompactionToken) => Promise<T>
+  ): Promise<T | undefined>;
   continuousCompactor: ContinuousCompactor;
   activeStreamContext?: {
     modelString: string;
@@ -43,7 +47,8 @@ interface SessionInternals {
   };
   finishContinuousCompaction: (
     applied: boolean,
-    context: NonNullable<SessionInternals["activeStreamContext"]>
+    context: NonNullable<SessionInternals["activeStreamContext"]>,
+    token: CompactionToken
   ) => Promise<void>;
   interruptForContinuousCompaction: (
     apply: (followUp?: CompactionFollowUpRequest) => Promise<boolean>
@@ -61,9 +66,13 @@ async function applyThenFinish(
   const state = internals(session);
   const context = state.activeStreamContext;
   if (!context) throw new Error("Expected active stream context");
-  const applied = await state.interruptForContinuousCompaction(apply);
-  await state.finishContinuousCompaction(applied, context);
-  return applied;
+  const result = await state.runContinuousCompactionObservation(async (token) => {
+    const applied = await state.interruptForContinuousCompaction(apply);
+    await state.finishContinuousCompaction(applied, context, token);
+    return applied;
+  });
+  assert(result != null, "Expected the observation to complete");
+  return result;
 }
 
 function deferred<T>() {
@@ -367,16 +376,19 @@ describe("AgentSession continuous compaction wiring", () => {
     await h.historyService.writePartial(workspaceId, source);
     streaming = false;
     if (mode === "failed-consumed-apply") {
-      Reflect.set(h.session, "continuousCompactionStopped", true);
+      const { coordinator } = internals(h.session);
+      const token = coordinator.beginCompactionObservation("continuous");
+      assert(token != null, "Expected compaction observation");
+      coordinator.setCompactionStage(token, "stopped");
       const reset = spyOn(compactor, "reset");
-      await internals(h.session).finishContinuousCompaction(false, {
-        modelString: model,
-        options: sendOptions,
-        providersConfig: null,
-      });
+      await internals(h.session).finishContinuousCompaction(
+        false,
+        { modelString: model, options: sendOptions, providersConfig: null },
+        token
+      );
       expect(reset).not.toHaveBeenCalled();
       expect(await store.read()).not.toBeNull();
-      Reflect.set(h.session, "continuousCompactionStopped", false);
+      coordinator.finishCompactionObservation(token);
     }
     if (mode !== "startup") {
       const terminal = Reflect.get(h.session, "observeContinuousCompactionAtStreamEnd") as (
@@ -696,11 +708,8 @@ describe("AgentSession continuous compaction wiring", () => {
     const release = deferred<void>();
     const invoked = deferred<void>();
     const drain = spyOn(h.session, "drainQueuedMessagesIfIdle").mockImplementation(() => undefined);
-    const run = Reflect.get(h.session, "runContinuousCompactionObservation") as (
-      observe: () => Promise<void>
-    ) => Promise<void>;
-    const first = run.call(h.session, async () => {
-      Reflect.set(h.session, "midStreamCompactionPending", true);
+    const first = internals(h.session).runContinuousCompactionObservation(async (token) => {
+      internals(h.session).coordinator.setCompactionStage(token, "stopping");
       await release.promise;
     });
     const observe = spyOn(internals(h.session).continuousCompactor, "observe").mockImplementation(
@@ -924,6 +933,7 @@ describe("AgentSession continuous compaction wiring", () => {
         ).success
       ).toBe(true);
       const observationFinished = deferred<void>();
+      let observationToken: CompactionToken | undefined;
       if (eventType === "prefix-swap-invalidated") {
         spyOn(h.aiService, "isStreaming").mockReturnValue(true);
         spyOn(h.aiService, "getStreamInfo").mockReturnValue({
@@ -934,7 +944,10 @@ describe("AgentSession continuous compaction wiring", () => {
         spyOn(internals(h.session).continuousCompactor, "waitForIdle").mockReturnValueOnce(
           observationFinished.promise
         );
-        Reflect.set(h.session, "continuousCompactionObserving", true);
+        observationToken = internals(h.session).coordinator.beginCompactionObservation(
+          "continuous"
+        );
+        assert(observationToken != null, "Expected compaction observation");
       }
       h.aiEmitter.emit(eventType, {
         type: eventType,
@@ -944,7 +957,8 @@ describe("AgentSession continuous compaction wiring", () => {
       });
       if (eventType === "prefix-swap-invalidated") {
         expect(order).toEqual([]);
-        Reflect.set(h.session, "continuousCompactionObserving", false);
+        assert(observationToken != null, "Expected compaction observation");
+        internals(h.session).coordinator.finishCompactionObservation(observationToken);
         observationFinished.resolve();
       }
       await resumed.promise;
@@ -1024,6 +1038,71 @@ describe("AgentSession continuous compaction wiring", () => {
     });
     return streamMessage;
   }
+
+  test.each(["dispatch", "cleanup"] as const)(
+    "pending compaction waits and queued input outlast held follow-up %s",
+    async (phase) => {
+      const h = await setup();
+      spyOn(internals(h.session).continuousCompactor, "observe").mockResolvedValue("none");
+      const streamMessage = mockAbortableStream(h);
+      expect((await h.session.sendMessage("Working", sendOptions)).success).toBe(true);
+      const entered = deferred<void>();
+      const release = deferred<void>();
+      const dispatchQueue = spyOn(h.session, "sendQueuedMessages").mockImplementation(
+        () => undefined
+      );
+      const work = applyThenFinish(h.session, async (followUp) => {
+        await appendBoundary(h, followUp);
+        if (phase === "dispatch") {
+          const read = h.historyService.getLastMessages.bind(h.historyService);
+          spyOn(h.historyService, "getLastMessages").mockImplementationOnce(async (...args) => {
+            entered.resolve();
+            await release.promise;
+            return read(...args);
+          });
+        } else {
+          const update = h.historyService.updateHistory.bind(h.historyService);
+          spyOn(h.historyService, "updateHistory").mockImplementationOnce(async (...args) => {
+            entered.resolve();
+            await release.promise;
+            return update(...args);
+          });
+          await h.session.interruptStream({ abandonPartial: true });
+        }
+        return true;
+      });
+      try {
+        await entered.promise;
+        h.session.queueMessage("Queued during follow-up", sendOptions);
+        h.session.drainQueuedMessagesIfIdle();
+        let settled = false;
+        const pending = h.session.waitForMidStreamCompactionSettled().then(() => {
+          settled = true;
+        });
+        await Promise.resolve();
+        expect(settled).toBe(false);
+        expect(dispatchQueue).not.toHaveBeenCalled();
+        expect(h.session.hasActiveOrPendingTurnWork()).toBe(true);
+        expect(streamMessage).toHaveBeenCalledTimes(1);
+        release.resolve();
+        expect(await work).toBe(true);
+        await pending;
+        expect(settled).toBe(true);
+        const history = await rows(h);
+        if (phase === "cleanup") {
+          expect(history[0].metadata?.muxMetadata).not.toHaveProperty("pendingFollowUp");
+          expect(streamMessage).toHaveBeenCalledTimes(1);
+          expect(dispatchQueue).toHaveBeenCalledTimes(1);
+        } else {
+          expect(streamMessage).toHaveBeenCalledTimes(2);
+          expect(history.at(-1)?.parts).toMatchObject([{ type: "text", text: "Continue" }]);
+        }
+      } finally {
+        release.resolve();
+        await work;
+      }
+    }
+  );
 
   test("abandon during fast apply cannot resume the abandoned turn", async () => {
     const h = await setup();

--- a/src/node/services/agentSession.drainQueuedMessagesIfIdle.test.ts
+++ b/src/node/services/agentSession.drainQueuedMessagesIfIdle.test.ts
@@ -1,4 +1,5 @@
 import type { TurnCoordinator } from "./turnCoordinator";
+import assert from "@/common/utils/assert";
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { EventEmitter } from "events";
 import * as path from "node:path";
@@ -92,7 +93,9 @@ describe("AgentSession.drainQueuedMessagesIfIdle", () => {
     [
       "a pending mid-stream compaction owns the next dispatch",
       (s) => {
-        s.midStreamCompactionPending = true;
+        const token = s.coordinator.beginCompactionObservation("legacy");
+        assert(token != null, "Expected compaction observation");
+        s.coordinator.setCompactionStage(token, "stopping");
       },
       0,
     ],

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -48,6 +48,7 @@ import {
   type TurnId,
   type QueueDrainTrigger,
   type OperationId,
+  type CompactionToken,
   type StreamErrorRecoveryOutcome,
 } from "./turnCoordinator";
 export type { StreamErrorRecoveryOutcome } from "./turnCoordinator";
@@ -872,7 +873,6 @@ export class AgentSession {
     [];
   private readonly coordinator = new TurnCoordinator({
     streamStarted: (payload) => {
-      this.continuousCompactionAbandoned = false;
       this.dispatchingQueuedEntry = false;
       this.dispatchingQueuedEntryMuxMetadata = undefined;
       this.preparingWorkspaceTurnMetadata = undefined;
@@ -972,11 +972,15 @@ export class AgentSession {
   private lastSystemMessageTokens?: number;
 
   /** Prevent duplicate mid-stream compaction interrupts while we are already transitioning. */
-  private midStreamCompactionPending = false;
-  private midStreamCompactionSettledWaiters: Array<() => void> = [];
-  private continuousCompactionAbandoned = false;
-  private continuousCompactionStopped = false;
-  private continuousCompactionObserving = false;
+  private get midStreamCompactionPending(): boolean {
+    return this.coordinator.midStreamCompactionPending;
+  }
+  private get continuousCompactionAbandoned(): boolean {
+    return this.coordinator.compactionIntent.abandoned;
+  }
+  private get continuousCompactionObserving(): boolean {
+    return this.coordinator.compactionIntent.observation?.kind === "continuous";
+  }
   private continuousCompactionObservation: Promise<void> | null = null;
 
   /** Tracks file state for detecting external edits. */
@@ -1120,7 +1124,9 @@ export class AgentSession {
    * dispatch must target it by ID; null for default (RLM-off) compactions so
    * their "last message is the summary" staleness guard stays byte-identical.
    */
-  private pendingCompactionFollowUpSummaryId: string | null = null;
+  private get pendingCompactionFollowUpSummaryId(): string | null {
+    return this.coordinator.compactionIntent.summaryId;
+  }
 
   constructor(options: AgentSessionOptions) {
     assert(options, "AgentSession requires options");
@@ -1184,8 +1190,9 @@ export class AgentSession {
         // follow-up dispatch can target it directly.
         // Reset on every completion: a resumeless continuous fold may precede a
         // legacy compaction whose current follow-up is on its final summary row.
-        this.pendingCompactionFollowUpSummaryId =
-          (metadata.preservedTailMessageCount ?? 0) > 0 ? metadata.summaryMessageId : null;
+        this.coordinator.recordCompactionSummary(
+          (metadata.preservedTailMessageCount ?? 0) > 0 ? metadata.summaryMessageId : null
+        );
         onCompactionComplete?.(metadata);
       },
       onIdleCompactionOutcome,
@@ -6269,7 +6276,7 @@ export class AgentSession {
   }
 
   private async runContinuousCompactionObservation<T>(
-    observe: () => Promise<T>
+    observe: (token: CompactionToken) => Promise<T>
   ): Promise<T | undefined> {
     if (this.coordinator.closing) return undefined;
     // Own the actual apply and its continuation; the compactor separately owns detached eager work.
@@ -6278,14 +6285,15 @@ export class AgentSession {
       await this.continuousCompactionObservation;
       return undefined;
     }
+    const token = this.coordinator.beginCompactionObservation("continuous");
+    if (token == null) return undefined;
     let finish!: () => void;
     const observation = new Promise<void>((resolve) => {
       finish = resolve;
     });
     this.continuousCompactionObservation = observation;
-    this.continuousCompactionObserving = true;
     try {
-      return await observe();
+      return await observe(token);
     } catch (error) {
       await this.recoverContinuousCompactionFailure(error, true);
       return undefined;
@@ -6293,9 +6301,7 @@ export class AgentSession {
       // Reserve through dispatch and cleanup, not just the compactor's apply latch.
       // Waiters/duplicate invalidations never own or clear these flags.
       if (this.continuousCompactionObservation === observation) {
-        this.settleMidStreamCompaction();
-        this.continuousCompactionStopped = false;
-        this.continuousCompactionObserving = false;
+        this.coordinator.finishCompactionObservation(token);
         this.continuousCompactionObservation = null;
         try {
           this.drainQueuedMessagesIfIdle();
@@ -6311,7 +6317,9 @@ export class AgentSession {
     apply: (pendingFollowUp?: CompactionFollowUpRequest) => Promise<boolean>
   ): Promise<boolean> {
     const context = this.activeStreamContext;
+    const observation = this.coordinator.compactionIntent.observation;
     if (
+      observation?.kind !== "continuous" ||
       this.midStreamCompactionPending ||
       !context?.options ||
       this.coordinator.disposed ||
@@ -6319,12 +6327,12 @@ export class AgentSession {
     ) {
       return false;
     }
-    this.midStreamCompactionPending = true;
+    this.coordinator.setCompactionStage(observation.token, "stopping");
     const stopped = await this.streamManager.stopStream(this.workspaceId, {
       abortReason: "system",
     });
     if (!stopped.success) return false;
-    this.continuousCompactionStopped = true;
+    this.coordinator.setCompactionStage(observation.token, "stopped");
     await this.waitForIdle();
     if (
       this.coordinator.disposed ||
@@ -6358,13 +6366,15 @@ export class AgentSession {
 
   private async finishContinuousCompaction(
     applied: boolean,
-    context: NonNullable<AgentSession["activeStreamContext"]>
+    context: NonNullable<AgentSession["activeStreamContext"]>,
+    token: CompactionToken
   ): Promise<void> {
     assert(
       !this.continuousCompactor.isApplying(),
       "Continue must dispatch after the apply latch clears"
     );
-    if (!this.continuousCompactionStopped || !context.options) return;
+    const observation = this.coordinator.compactionIntent.observation;
+    if (observation?.token !== token || observation.stage !== "stopped" || !context.options) return;
     // A consumed journal is an outstanding durable obligation, not a failed
     // speculative summary. Leave it retryable instead of resetting into legacy compaction.
     if (!applied && this.continuousCompactor.hasConsumedSwap()) return;
@@ -6428,7 +6438,7 @@ export class AgentSession {
       () => this.continuousCompactionAbandoned
     );
     if (this.pendingCompactionFollowUpSummaryId === summaryId)
-      this.pendingCompactionFollowUpSummaryId = null;
+      this.coordinator.recordCompactionSummary(null);
   }
 
   private async interruptForCompaction(): Promise<void> {
@@ -6445,7 +6455,9 @@ export class AgentSession {
     const interruptedUserMessageId = this.activeStreamUserMessageId;
     this.continuousCompactor.reset("legacy-fallback");
 
-    this.midStreamCompactionPending = true;
+    const token = this.coordinator.beginCompactionObservation("legacy");
+    if (token == null) return;
+    this.coordinator.setCompactionStage(token, "stopping");
     try {
       const stopResult = await this.streamManager.stopStream(this.workspaceId, {
         abortReason: "system",
@@ -6526,7 +6538,7 @@ export class AgentSession {
         }
       }
     } finally {
-      this.settleMidStreamCompaction();
+      this.coordinator.finishCompactionObservation(token);
       // Preflight drains deferred to this pending compaction have no other retry: if the
       // compaction request never became a turn, release the queue now (no-op when it did).
       this.drainQueuedMessagesIfIdle();
@@ -6561,7 +6573,7 @@ export class AgentSession {
     const interruptedPolicy = this.coordinator.captureInterruptSettlement(options?.soft);
     this.clearContextBudgetState();
     if (options?.abandonPartial || this.midStreamCompactionPending) {
-      this.continuousCompactionAbandoned = true;
+      this.coordinator.abandonCompaction();
       this.continuousCompactor.reset("user-interrupt");
     }
 
@@ -8047,7 +8059,7 @@ export class AgentSession {
         // RLM keep-recent floor: when tail copies were appended the summary is
         // not the last row, so target it by ID (stashed in onCompactionComplete).
         const rlmSummaryId = this.pendingCompactionFollowUpSummaryId;
-        this.pendingCompactionFollowUpSummaryId = null;
+        this.coordinator.recordCompactionSummary(null);
         continuedAfterCompaction = await this.dispatchPendingFollowUp(rlmSummaryId ?? undefined);
         if (
           !this.coordinator.isCurrentTurn(turn) ||
@@ -8286,14 +8298,14 @@ export class AgentSession {
           !this.streamManager.isStreaming(this.workspaceId)
         )
           return;
-        await this.runContinuousCompactionObservation(async () => {
+        await this.runContinuousCompactionObservation(async (token) => {
           const result = await this.continuousCompactor.observe(0, {
             ...this.getContinuousCompactionContext(context.modelString, context.options),
             phase: "mid-stream",
           });
           // The observation's finally settles the pending window only after this dispatches the
           // continuation; settling earlier would let an idle waiter race the follow-up send.
-          await this.finishContinuousCompaction(result === "applied", context);
+          await this.finishContinuousCompaction(result === "applied", context, token);
         });
       } catch (error) {
         await this.recoverContinuousCompactionFailure(error);
@@ -8358,13 +8370,13 @@ export class AgentSession {
       if (continuousContext.enabled || consumedSwapPending) {
         // One usage handler owns the eventual resume; observe itself shares its
         // latch result, which must not dispatch the continuation twice.
-        const observed = await this.runContinuousCompactionObservation(async () => {
+        const observed = await this.runContinuousCompactionObservation(async (token) => {
           const result = await this.continuousCompactor.observe(usagePercent, {
             ...continuousContext,
             phase: "mid-stream",
           });
           if (this.midStreamCompactionPending) {
-            await this.finishContinuousCompaction(result === "applied", streamContext);
+            await this.finishContinuousCompaction(result === "applied", streamContext, token);
             return undefined;
           }
           if (result === "applied") this.clearUsageState();
@@ -8550,13 +8562,7 @@ export class AgentSession {
    * signal rather than the stream lifecycle.
    */
   waitForMidStreamCompactionSettled(): Promise<void> {
-    if (!this.midStreamCompactionPending) return Promise.resolve();
-    return new Promise((resolve) => this.midStreamCompactionSettledWaiters.push(resolve));
-  }
-
-  private settleMidStreamCompaction(): void {
-    this.midStreamCompactionPending = false;
-    for (const resolve of this.midStreamCompactionSettledWaiters.splice(0)) resolve();
+    return this.coordinator.waitForMidStreamCompactionSettled();
   }
 
   /**

--- a/src/node/services/turnCoordinator.test.ts
+++ b/src/node/services/turnCoordinator.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, mock, test } from "bun:test";
+import assert from "@/common/utils/assert";
 import { Effect, Exit, Scope } from "effect";
 import { defaultEffectRunner as runner } from "./di/effectRunner";
 import {
@@ -63,6 +64,82 @@ function reduce(events: CoordinatorEvent[]) {
 }
 
 describe("TurnCoordinator", () => {
+  test.each(["continuous", "legacy"] as const)(
+    "%s observation completion cannot change a replacement or release its waiter",
+    async (kind) => {
+      const { coordinator, callbacks } = setup();
+      const first = coordinator.beginCompactionObservation(kind);
+      assert(first != null, "Expected first observation");
+      expect(coordinator.beginCompactionObservation(kind)).toBeUndefined();
+      coordinator.setCompactionStage(first, "stopping");
+      const firstSettled = coordinator.waitForMidStreamCompactionSettled();
+      expect(coordinator.finishCompactionObservation(first)).toBe(true);
+      const replacement = coordinator.beginCompactionObservation(kind);
+      assert(replacement != null, "Expected replacement observation");
+      coordinator.setCompactionStage(replacement, "stopping");
+      let settled = false;
+      const replacementSettled = coordinator.waitForMidStreamCompactionSettled().then(() => {
+        settled = true;
+      });
+      await firstSettled;
+      coordinator.setCompactionStage(first, "stopped");
+      expect(coordinator.finishCompactionObservation(first)).toBe(false);
+      await Promise.resolve();
+      expect(coordinator.compactionIntent.observation?.stage).toBe("stopping");
+      expect(settled).toBe(false);
+      expect(callbacks.phaseChanged).not.toHaveBeenCalled();
+      expect(callbacks.drainQueue).not.toHaveBeenCalled();
+      coordinator.finishCompactionObservation(replacement);
+      await replacementSettled;
+      expect(settled).toBe(true);
+    }
+  );
+
+  test.each(["abandon", "shutdown", "dispose"] as const)(
+    "%s retains the compaction pending window until its owner finishes",
+    async (action) => {
+      const { coordinator } = setup();
+      const token = coordinator.beginCompactionObservation("continuous");
+      assert(token != null, "Expected observation");
+      coordinator.setCompactionStage(token, "stopping");
+      let settled = false;
+      const wait = coordinator.waitForMidStreamCompactionSettled().then(() => {
+        settled = true;
+      });
+      if (action === "abandon") coordinator.abandonCompaction();
+      else if (action === "shutdown") coordinator.beginShutdown();
+      else coordinator.dispose();
+      await Promise.resolve();
+      expect(settled).toBe(false);
+      expect(coordinator.midStreamCompactionPending).toBe(true);
+      expect(coordinator.beginCompactionObservation("legacy")).toBeUndefined();
+      // Stop may resolve after disposal; it still has to release its own pending window.
+      coordinator.setCompactionStage(token, "stopped");
+      expect(coordinator.finishCompactionObservation(token)).toBe(true);
+      await wait;
+      expect(settled).toBe(true);
+      expect(coordinator.midStreamCompactionPending).toBe(false);
+    }
+  );
+
+  test("compaction bookkeeping preserves admission policy and resets abandonment at stream start", () => {
+    const { coordinator } = setup();
+    coordinator.abandonCompaction();
+    using _admission = coordinator.reserve("admission");
+    using _edit = coordinator.reserve("edit");
+    const token = coordinator.beginCompactionObservation("continuous");
+    assert(token != null, "Observation policy remains with the session");
+    expect(coordinator.compactionIntent.abandoned).toBe(true);
+    coordinator.setCompactionStage(token, "stopped");
+    coordinator.recordCompactionSummary("saved-boundary");
+    coordinator.streamStarted(startEvent("resumed"));
+    expect(coordinator.compactionIntent.abandoned).toBe(false);
+    expect(coordinator.compactionIntent.summaryId).toBe("saved-boundary");
+    expect(coordinator.compactionIntent.observation?.token).toBe(token);
+    expect(coordinator.midStreamCompactionPending).toBe(true);
+    coordinator.finishCompactionObservation(token);
+  });
+
   test("observed terminal publishes before idle/drain and cannot retire a reentrant replacement", () => {
     const order: string[] = [];
     const { coordinator, callbacks } = setup({

--- a/src/node/services/turnCoordinator.ts
+++ b/src/node/services/turnCoordinator.ts
@@ -7,6 +7,7 @@ import type { ActiveTurnThinkingOverride } from "./thinkingOverride";
 
 export type TurnId = symbol;
 export type OperationId = symbol;
+export type CompactionToken = symbol;
 export type TurnPhase = "idle" | "preparing" | "streaming" | "completing";
 export type StreamErrorRecoveryOutcome = "retry-started" | "terminal";
 export type QueueDrainTrigger = "idle" | "terminal" | "provider-tool" | "send-immediately";
@@ -26,6 +27,17 @@ export type PreparationAdmission =
 type ReservationKind = "admission" | "edit" | "manual";
 type DecisionKind = "error" | "compaction";
 type DecisionOutcome = StreamErrorRecoveryOutcome | boolean;
+
+interface CompactionObservation {
+  readonly token: CompactionToken;
+  readonly kind: "continuous" | "legacy";
+  readonly stage: "observing" | "stopping" | "stopped";
+}
+interface CompactionIntent {
+  readonly abandoned: boolean;
+  readonly observation?: CompactionObservation;
+  readonly summaryId: string | null;
+}
 
 type Operation = {
   readonly id: OperationId;
@@ -64,6 +76,7 @@ export interface CoordinatorState {
   readonly reservations: ReadonlyArray<{ id: symbol; kind: ReservationKind }>;
   readonly retry?: symbol;
   readonly decisions: readonly Decision[];
+  readonly compaction: CompactionIntent;
 }
 
 export type CoordinatorEvent =
@@ -84,6 +97,11 @@ export type CoordinatorEvent =
   | { type: "reserve" | "release"; id: symbol; kind: ReservationKind }
   | { type: "retry-start" | "retry-finish"; id: symbol }
   | { type: "decision"; kind: DecisionKind; messageId: string; outcome?: DecisionOutcome }
+  | { type: "compaction-observe"; token: CompactionToken; kind: CompactionObservation["kind"] }
+  | { type: "compaction-stage"; token: CompactionToken; stage: CompactionObservation["stage"] }
+  | { type: "compaction-finish"; token: CompactionToken }
+  | { type: "compaction-abandon" }
+  | { type: "compaction-summary"; summaryId: string | null }
   | { type: "shutdown" | "dispose" };
 
 type CoordinatorCommand =
@@ -103,7 +121,13 @@ type CoordinatorCommand =
   | { type: "dispose" };
 
 export function initialCoordinatorState(id: TurnId): CoordinatorState {
-  return { lifetime: "open", turn: { phase: "idle", id }, reservations: [], decisions: [] };
+  return {
+    lifetime: "open",
+    turn: { phase: "idle", id },
+    reservations: [],
+    decisions: [],
+    compaction: { abandoned: false, summaryId: null },
+  };
 }
 
 function hasConflictingEdit(state: CoordinatorState, owner?: symbol): boolean {
@@ -159,7 +183,14 @@ export function transition(
     commands.push({ type: "decision", decision: value });
   };
   const current = state.turn.operation;
-  if (state.lifetime === "disposed")
+  // Physical observation and persistence may finish after disposal. They retain their
+  // bookkeeping until the owning finally, without admitting any new compaction work.
+  if (
+    state.lifetime === "disposed" &&
+    event.type !== "compaction-finish" &&
+    event.type !== "compaction-stage" &&
+    event.type !== "compaction-summary"
+  )
     return {
       state,
       commands,
@@ -279,6 +310,7 @@ export function transition(
       if (current?.delivery === "waiting") {
         operation({ ...current, stage: "started", messageId: event.payload.messageId });
       }
+      next = { ...next, compaction: { ...next.compaction, abandoned: false } };
       commands.push({ type: "record-start", turnId: state.turn.id, payload: event.payload });
       // Existing raw streams also restore sessions constructed around an already-running engine.
       phase({ ...next.turn, phase: "streaming" });
@@ -352,6 +384,36 @@ export function transition(
       break;
     case "decision":
       decision(event.kind, event.messageId, event.outcome);
+      break;
+    case "compaction-observe":
+      if (state.lifetime === "open" && !state.compaction.observation)
+        next = {
+          ...state,
+          compaction: {
+            ...state.compaction,
+            observation: { token: event.token, kind: event.kind, stage: "observing" },
+          },
+        };
+      break;
+    case "compaction-stage":
+      if (state.compaction.observation?.token === event.token)
+        next = {
+          ...state,
+          compaction: {
+            ...state.compaction,
+            observation: { ...state.compaction.observation, stage: event.stage },
+          },
+        };
+      break;
+    case "compaction-finish":
+      if (state.compaction.observation?.token === event.token)
+        next = { ...state, compaction: { ...state.compaction, observation: undefined } };
+      break;
+    case "compaction-abandon":
+      next = { ...state, compaction: { ...state.compaction, abandoned: true } };
+      break;
+    case "compaction-summary":
+      next = { ...state, compaction: { ...state.compaction, summaryId: event.summaryId } };
       break;
     case "shutdown":
       next = { ...state, lifetime: "shutting-down" };
@@ -517,6 +579,7 @@ export class TurnCoordinator {
   >();
   private idleWaiters = new Set<() => void>();
   private unbusyWaiters = new Set<() => void>();
+  private readonly compactionWaiters: Array<() => void> = [];
   private prepared?: { id: TurnId; controller: AbortController };
   private thinking: { holder: ActiveTurnThinkingOverride; resource?: Disposable } | null = null;
   private readonly execution = new TurnExecution(defaultEffectRunner);
@@ -532,6 +595,48 @@ export class TurnCoordinator {
   /** An opaque physical lease must never reserve semantic admission or change queue priority. */
   enterExecution(): Disposable {
     return this.execution.lease();
+  }
+
+  get compactionIntent(): CompactionIntent {
+    return this.state.compaction;
+  }
+
+  get midStreamCompactionPending(): boolean {
+    const stage = this.state.compaction.observation?.stage;
+    return stage === "stopping" || stage === "stopped";
+  }
+
+  beginCompactionObservation(kind: CompactionObservation["kind"]): CompactionToken | undefined {
+    // Ownership follows the session's existing policy; it does not reserve turn admission.
+    const token = Symbol("compaction observation");
+    this.dispatch({ type: "compaction-observe", token, kind });
+    return this.state.compaction.observation?.token === token ? token : undefined;
+  }
+
+  setCompactionStage(token: CompactionToken, stage: CompactionObservation["stage"]): void {
+    this.dispatch({ type: "compaction-stage", token, stage });
+  }
+
+  finishCompactionObservation(token: CompactionToken): boolean {
+    if (this.state.compaction.observation?.token !== token) return false;
+    this.dispatch({ type: "compaction-finish", token });
+    for (const resolve of this.compactionWaiters.splice(0)) resolve();
+    return true;
+  }
+
+  abandonCompaction(): void {
+    this.dispatch({ type: "compaction-abandon" });
+  }
+
+  recordCompactionSummary(summaryId: string | null): void {
+    this.dispatch({ type: "compaction-summary", summaryId });
+  }
+
+  waitForMidStreamCompactionSettled(): Promise<void> {
+    // Stop and shutdown cannot release the pending window while dispatch or cleanup
+    // still owns the next turn. Only that observation's physical finally settles it.
+    if (!this.midStreamCompactionPending) return Promise.resolve();
+    return new Promise((resolve) => this.compactionWaiters.push(resolve));
   }
 
   /** Physical completion, distinct from semantic idle and operation policy settlement. */

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -1880,7 +1880,10 @@ describe("WorkspaceService bash monitor wake reconciler wiring", () => {
       // Between the stopped stream and its compaction request the coordinator is idle and no
       // stream is running; only the session's pending flag marks the turn work.
       const session = service.getOrCreateSession(workspaceId);
-      Reflect.set(session, "midStreamCompactionPending", true);
+      const { coordinator } = session as unknown as { coordinator: TurnCoordinator };
+      const token = coordinator.beginCompactionObservation("legacy");
+      if (token == null) throw new Error("Expected compaction observation");
+      coordinator.setCompactionStage(token, "stopping");
       internal.scheduleBashMonitorWakeReconcileAfterIdle = afterIdle;
       internal.getDelegatedTurnContinuationSendOptions = () => Promise.resolve({});
       internal.sendMessage = sendMessage;
@@ -7503,9 +7506,11 @@ describe("WorkspaceService truncateHistory goal acknowledgment", () => {
     const { workspaceService, cleanup } = await createServices();
     const workspaceId = "idle-wait-pending-compaction";
     const session = workspaceService.getOrCreateSession(workspaceId);
-    const settle = Reflect.get(session, "settleMidStreamCompaction") as () => void;
+    const { coordinator } = session as unknown as { coordinator: TurnCoordinator };
+    const token = coordinator.beginCompactionObservation("legacy");
+    if (token == null) throw new Error("Expected compaction observation");
     try {
-      Reflect.set(session, "midStreamCompactionPending", true);
+      coordinator.setCompactionStage(token, "stopping");
       let resolved = false;
       const waitPromise = workspaceService.waitForIdleAndNoQueuedMessages(workspaceId).then(() => {
         resolved = true;
@@ -7514,7 +7519,7 @@ describe("WorkspaceService truncateHistory goal acknowledgment", () => {
       expect(resolved).toBe(false);
 
       // The compaction request never became a turn: no stream event fires, only the window closes.
-      settle.call(session);
+      coordinator.finishCompactionObservation(token);
       await waitPromise;
       expect(resolved).toBe(true);
     } finally {


### PR DESCRIPTION
Compaction observation state is split across several AgentSession flags and a separate waiter list. Centralize those transitions in the existing turn coordinator, with a token identifying the observation that may update or finish them.

This behavior-preserving layer sits above #4129. AgentSession retains its physical promise, and the pending window remains open through continuation dispatch and cleanup. Admission, terminal ordering, persistence and shutdown timing stay the same. Stale tokens cannot release a replacement observation's state or waiters.

This replaces the coordinator-extraction portion of closed #4121. Local pending-state ownership, continuation handoff changes and durable persistence protocols remain separate PRs.

Validation: 635 targeted tests and `make static-check` passed. Behavioral regressions cover stale-token isolation, waits through failed dispatch/cleanup, retained pending state during shutdown/disposal, summary targeting and A's eager-job leases. Independent local review found no issues.

Risk is concentrated in compaction waiting and queue release. Existing session promise ordering is retained to keep this extraction independently reviewable.

---

_Generated with `xum` • Model: `unavailable` • Thinking: `unavailable` • Cost: `$unavailable`_

<!-- mux-attribution: model=unavailable thinking=unavailable costs=unavailable -->
