### PR TITLE
🤖 fix: serialize compaction journal publication and cleanup

### DIFF
--- a/src/common/orpc/schemas/continuousCompaction.ts
+++ b/src/common/orpc/schemas/continuousCompaction.ts
@@ -75,6 +75,8 @@ const attachment: z.ZodType<PostCompactionAttachment> = z.discriminatedUnion("ty
 export const ContinuousCompactionJournalSchema = z
   .object({
     version: z.literal(1),
+    // Legacy journals are valid until a durable publication generation is advanced.
+    publicationGeneration: z.string().optional(),
     boundary: row,
     staticCopies: z.array(row),
     liveTailCopySpec: z.object({

--- a/src/constants/continuousCompaction.ts
+++ b/src/constants/continuousCompaction.ts
@@ -4,3 +4,5 @@ export const TAIL_MIN_TOKENS = 4_000;
 export const TAIL_MAX_TOKENS = 60_000;
 export const MIN_HEAD_TOKENS = 8_000;
 export const SUMMARIZER_INPUT_FRACTION = 0.7;
+export const CONTINUOUS_COMPACTION_JOURNAL_FILE = "continuous-compaction.json";
+export const CONTINUOUS_COMPACTION_GENERATION_FILE = "continuous-compaction-generation";

--- a/src/node/services/agentSession.continuousCompaction.test.ts
+++ b/src/node/services/agentSession.continuousCompaction.test.ts
@@ -25,6 +25,8 @@ import {
 } from "./agentSession.testHarness";
 import type { ContinuousCompactor } from "./continuousCompactor";
 import type { CompactionToken, TurnCoordinator } from "./turnCoordinator";
+import * as fileLock from "@/node/utils/concurrency/fileLock";
+import { historyWriteLockPath } from "./workspaceRemoval";
 
 const workspaceId = "continuous-session";
 const model = "openai:gpt-4o";
@@ -490,6 +492,41 @@ describe("AgentSession continuous compaction wiring", () => {
     expect(current.at(-1)?.parts).toMatchObject([
       { type: "text", text: "Current saved follow-up" },
     ]);
+  });
+
+  test("sends ordinary work when recovery finds no journal under a held history lock", async () => {
+    const h = await setup();
+    const stream = spyOn(h.aiService, "streamMessage");
+    const journal = h.historyService.getContinuousCompactionJournal(workspaceId);
+    expect(await journal.exists()).toBe(false);
+    const compactor = internals(h.session).continuousCompactor;
+    const recover = compactor.recover.bind(compactor);
+    const recovering = spyOn(compactor, "recover").mockImplementation(async () => {
+      // Contend at the recovery probe, then release before the send's actual history writes.
+      await using held = await fileLock.acquireProcessFileLock({
+        lockPath: historyWriteLockPath(h.config.rootDir, workspaceId),
+        timeoutMs: 1000,
+        label: "foreign history writer",
+      });
+      const acquire = fileLock.acquireProcessFileLock;
+      // Exercise the real timeout path without a ten-second wait on the broken implementation.
+      const timeout = spyOn(fileLock, "acquireProcessFileLock").mockImplementation((options) =>
+        acquire({ ...options, timeoutMs: 1 })
+      );
+      try {
+        const recovered = await recover();
+        expect(recovered).toBe(false);
+        await held.assertStillOwned();
+        return recovered;
+      } finally {
+        timeout.mockRestore();
+      }
+    });
+    expect((await h.session.sendMessage("Ordinary work", sendOptions)).success).toBe(true);
+    expect(recovering).toHaveBeenCalled();
+    expect(stream).toHaveBeenCalled();
+    expect((await rows(h)).at(-1)?.parts).toMatchObject([{ type: "text", text: "Ordinary work" }]);
+    expect(await journal.exists()).toBe(false);
   });
 
   test("on-send apply preserves the new user turn without running a compact turn", async () => {

--- a/src/node/services/compactionHandler.continuous.test.ts
+++ b/src/node/services/compactionHandler.continuous.test.ts
@@ -55,6 +55,65 @@ describe("continuous compaction provider replay", () => {
     expect((await makeHandler().peekPendingState())?.diffs).toEqual(diffs);
   });
 
+  it("retains committed pending state when a completion observer throws", async () => {
+    const sessionDir = path.join(store.tempDir, "pending");
+    const source = createMuxMessage("edited", "assistant", "Fixed the bug");
+    source.parts.push({
+      type: "dynamic-tool",
+      toolCallId: "edit",
+      toolName: "file_edit_replace_string",
+      state: "output-available",
+      input: { path: "/tmp/fix.ts" },
+      output: { success: true, diff: "@@ -1 +1 @@\n-old\n+new\n" },
+    });
+    expect((await store.historyService.appendToHistory(workspaceId, source)).success).toBe(true);
+    const handler = new CompactionHandler({
+      workspaceId,
+      historyService: store.historyService,
+      sessionDir,
+      emitter: new EventEmitter(),
+      onCompactionComplete: () => {
+        throw new Error("observer failed");
+      },
+    });
+    const publication = {
+      generation: await store.historyService
+        .getContinuousCompactionJournal(workspaceId)
+        .captureGeneration(),
+    };
+    expect(
+      await handler
+        .withContinuousPendingState([source], (boundaryMessageId, onCommitted) =>
+          handler.persistContinuousCompaction({
+            boundaryMessageId,
+            onCommitted,
+            publication,
+            shouldPersist: () => true,
+            messages: [source],
+            tail: [],
+            text: "Fix completed",
+            model: "anthropic:test",
+            systemMessageTokens: 0,
+            attachmentTokens: 0,
+          })
+        )
+        .catch((error: unknown) => error)
+    ).toEqual(new Error("observer failed"));
+    const restarted = new CompactionHandler({
+      workspaceId,
+      historyService: store.historyService,
+      sessionDir,
+      emitter: new EventEmitter(),
+    });
+    expect((await restarted.peekPendingState())?.diffs).toMatchObject([
+      { path: "/tmp/fix.ts", diff: "@@ -1 +1 @@\n-old\n+new\n" },
+    ]);
+    const rows = await store.historyService.getHistoryFromLatestBoundary(workspaceId);
+    assert(rows.success, "Expected committed boundary");
+    expect(rows.data).toHaveLength(1);
+    expect(rows.data[0].metadata?.compactionBoundary).toBe(true);
+  });
+
   for (const provider of ["anthropic", "openai"]) {
     it(`replays the durable summary, prompt, and sliced tool pairs through the ${provider} pipeline`, async () => {
       const old = createMuxMessage(

--- a/src/node/services/compactionHandler.ts
+++ b/src/node/services/compactionHandler.ts
@@ -7,6 +7,7 @@ import * as path from "path";
 import type { HistoryService } from "./historyService";
 
 import type { CompactionCompletionMetadata } from "@/common/types/compaction";
+import type { ContinuousCompactionPublication } from "./continuousCompactionJournal";
 import type { StreamEndEvent } from "@/common/types/stream";
 import type { WorkspaceChatMessage } from "@/common/orpc/types";
 import type { LoadedSkillSnapshot } from "@/common/types/attachment";
@@ -712,7 +713,7 @@ export class CompactionHandler {
 
   async withContinuousPendingState(
     messages: MuxMessage[],
-    apply: (boundaryMessageId: string) => Promise<boolean>,
+    apply: (boundaryMessageId: string, onCommitted: () => void) => Promise<boolean>,
     boundaryMessageId = createCompactionSummaryMessageId()
   ): Promise<boolean> {
     await this.loadPersistedPendingStateIfNeeded();
@@ -736,7 +737,12 @@ export class CompactionHandler {
     let applied = false;
     try {
       await this.preparePendingStateFromMessages(messages, boundaryMessageId, previousState);
-      applied = await apply(boundaryMessageId);
+      // A committed boundary must retain its pending attachments even if a later
+      // observer or cleanup throws before the apply promise returns.
+      const result = await apply(boundaryMessageId, () => {
+        applied = true;
+      });
+      applied ||= result;
       return applied;
     } finally {
       // Never roll an older apply back over a newer preparation/consumption.
@@ -1237,6 +1243,8 @@ export class CompactionHandler {
     params: Parameters<CompactionHandler["buildContinuousCompactionRows"]>[0] & {
       prepared?: { boundary: MuxMessage; copies: MuxMessage[] };
       shouldPersist: (messages: MuxMessage[]) => boolean;
+      publication?: ContinuousCompactionPublication;
+      onCommitted?: () => void;
     }
   ): Promise<boolean> {
     const { boundary, copies } = params.prepared ?? this.buildContinuousCompactionRows(params);
@@ -1258,7 +1266,15 @@ export class CompactionHandler {
       boundary,
       copies,
       false,
-      params.shouldPersist
+      params.shouldPersist,
+      params.publication
+        ? {
+            publication: params.publication,
+            onCommitted: () => {
+              params.onCommitted?.();
+            },
+          }
+        : undefined
     );
     if (!result.success) {
       log.warn("[continuous-compaction] persist failed", result.error);

--- a/src/node/services/continuousCompactionJournal.ts
+++ b/src/node/services/continuousCompactionJournal.ts
@@ -222,6 +222,14 @@ export class ContinuousCompactionJournalStore {
     }, "local");
   }
 
+  private async discardUnusableUnderHistoryLock(): Promise<null> {
+    // An unusable journal must not block recovery just because unlink is unavailable.
+    await fs.rm(this.path, { force: true }).catch((error: unknown) => {
+      log.warn("[continuous-compaction] unusable journal cleanup failed", error);
+    });
+    return null;
+  }
+
   read(
     isCurrent: () => boolean = () => true,
     onRead?: (journal: ContinuousCompactionJournal) => void
@@ -244,15 +252,10 @@ export class ContinuousCompactionJournalStore {
         journal = ContinuousCompactionJournalSchema.parse(JSON.parse(contents));
       } catch (error) {
         log.warn("[continuous-compaction] discarded invalid journal", error);
-        await fs.rm(this.path, { force: true }).catch((cleanupError: unknown) => {
-          // An unusable journal must not block recovery just because unlink is unavailable.
-          log.warn("[continuous-compaction] invalid journal cleanup failed", cleanupError);
-        });
-        return null;
+        return this.discardUnusableUnderHistoryLock();
       }
       if (journal.publicationGeneration !== (await this.captureGenerationUnderHistoryLock())) {
-        await fs.rm(this.path, { force: true });
-        return null;
+        return this.discardUnusableUnderHistoryLock();
       }
       if (!current()) return null;
       onRead?.(journal);

--- a/src/node/services/continuousCompactionJournal.ts
+++ b/src/node/services/continuousCompactionJournal.ts
@@ -2,6 +2,10 @@ import { prepareProviderRequestMessages } from "./turnContextAssembler";
 import { addInterruptedSentinel } from "@/browser/utils/messages/modelMessageTransform";
 import { applyCacheControl } from "@/common/utils/ai/cacheStrategy";
 import { promises as fs } from "node:fs";
+import { renameSync } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import * as path from "node:path";
+import { CONTINUOUS_COMPACTION_GENERATION_FILE } from "@/constants/continuousCompaction";
 import { isDeepStrictEqual } from "node:util";
 import { modelMessageSchema, type ModelMessage } from "ai";
 import writeFileAtomic from "write-file-atomic";
@@ -79,22 +83,119 @@ export async function rebuildContinuousPrefix(
   ];
 }
 
-/** Serialized journal I/O plus a synchronous invalidation fence shared by reset and prepareStep. */
+/** A captured generation plus the exact journal being folded; absence requires an empty slot. */
+export interface ContinuousCompactionPublication {
+  generation: string | undefined;
+  journal?: ContinuousCompactionJournal;
+}
+
+/** Publish the receipt before cleanup or lock release can admit a successor. */
+export async function publishCompactionFile(
+  filePath: string,
+  contents: string | Buffer,
+  isCurrent: () => boolean,
+  onCommitted?: () => void
+): Promise<boolean> {
+  const stagedPath = `${filePath}.continuous-${randomUUID()}`;
+  try {
+    await writeFileAtomic(stagedPath, contents, { mode: 0o600 });
+    if (!isCurrent()) return false;
+    renameSync(stagedPath, filePath);
+    try {
+      onCommitted?.();
+    } catch (error) {
+      // An observer cannot undo the rename or turn a committed boundary into a retry.
+      log.error("[continuous-compaction] commit observer failed", error);
+    }
+    return true;
+  } finally {
+    await fs.rm(stagedPath, { force: true }).catch((error: unknown) => {
+      log.warn("[continuous-compaction] staged file cleanup failed", error);
+    });
+  }
+}
+
+/** Journal publication and history folding serialize on the same cross-process history lock. */
 export class ContinuousCompactionJournalStore {
   private generation = 0;
   private pending: Promise<unknown> = Promise.resolve();
   constructor(
     readonly path: string,
-    private readonly workspaceId: string
+    private readonly workspaceId: string,
+    private readonly withHistoryLock: <T>(operation: () => Promise<T>) => Promise<T>
   ) {}
 
   private enqueue<T>(operation: () => Promise<T>): Promise<T> {
-    const result = this.pending.then(operation);
+    const result = this.pending.then(() => this.withHistoryLock(operation));
     this.pending = result.catch(() => undefined);
     return result;
   }
 
-  clear(): Promise<void> {
+  async captureGenerationUnderHistoryLock(): Promise<string | undefined> {
+    try {
+      // Opaque bytes also fence old work if the file is damaged; fresh capture can proceed.
+      const contents = await fs.readFile(
+        path.join(path.dirname(this.path), CONTINUOUS_COMPACTION_GENERATION_FILE)
+      );
+      return createHash("sha256").update(contents).digest("hex");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+      throw error;
+    }
+  }
+
+  captureGeneration(): Promise<string | undefined> {
+    return this.enqueue(() => this.captureGenerationUnderHistoryLock());
+  }
+
+  /** Caller already holds the history lock; never re-enter the journal queue here. */
+  async advanceGenerationUnderHistoryLock(): Promise<void> {
+    await writeFileAtomic(
+      path.join(path.dirname(this.path), CONTINUOUS_COMPACTION_GENERATION_FILE),
+      randomUUID(),
+      { mode: 0o600 }
+    );
+  }
+
+  advanceGeneration(): Promise<void> {
+    return this.enqueue(() => this.advanceGenerationUnderHistoryLock());
+  }
+
+  private async readUnderHistoryLock(): Promise<ContinuousCompactionJournal | null> {
+    try {
+      return ContinuousCompactionJournalSchema.parse(
+        JSON.parse(await fs.readFile(this.path, "utf8"))
+      );
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw error;
+    }
+  }
+
+  async isPublicationCurrentUnderHistoryLock(
+    publication: ContinuousCompactionPublication
+  ): Promise<boolean> {
+    return (
+      publication.generation === (await this.captureGenerationUnderHistoryLock()) &&
+      isDeepStrictEqual(await this.readUnderHistoryLock(), publication.journal ?? null)
+    );
+  }
+
+  clear(expected: ContinuousCompactionJournal | undefined): Promise<void> {
+    // No receipt means no authority to adopt and erase a successor's journal.
+    if (!expected) return this.pending.then(() => undefined);
+    return this.enqueue(() => this.clearOwnedUnderHistoryLock(expected));
+  }
+
+  private async clearOwnedUnderHistoryLock(expected: ContinuousCompactionJournal): Promise<void> {
+    if (isDeepStrictEqual(await this.readUnderHistoryLock(), expected))
+      await fs.rm(this.path, { force: true });
+  }
+
+  clearForReset(): Promise<void> {
+    // Migration seam: explicit destructive intent retains main's unconditional
+    // clearing and synchronous local fence. Exact asynchronous cleanup cannot
+    // assume this authority; durable cross-backend reset fencing is separate.
     this.generation++;
     return this.enqueue(() => fs.rm(this.path, { force: true }));
   }
@@ -112,23 +213,38 @@ export class ContinuousCompactionJournalStore {
     });
   }
 
-  read(): Promise<ContinuousCompactionJournal | null> {
+  read(
+    isCurrent: () => boolean = () => true,
+    onRead?: (journal: ContinuousCompactionJournal) => void
+  ): Promise<ContinuousCompactionJournal | null> {
+    const generation = this.generation;
+    const current = () => generation === this.generation && isCurrent();
     return this.enqueue(async () => {
+      if (!current()) return null;
+      let contents: string;
       try {
-        return ContinuousCompactionJournalSchema.parse(
-          JSON.parse(await fs.readFile(this.path, "utf8"))
-        );
+        contents = await fs.readFile(this.path, "utf8");
       } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-          log.warn("[continuous-compaction] discarded invalid journal", error);
-          await fs
-            .rm(this.path, { force: true })
-            .catch((cleanupError: unknown) =>
-              log.warn("[continuous-compaction] invalid journal cleanup failed", cleanupError)
-            );
-        }
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT")
+          log.warn("[continuous-compaction] journal unavailable", error);
         return null;
       }
+      if (!current()) return null;
+      let journal: ContinuousCompactionJournal;
+      try {
+        journal = ContinuousCompactionJournalSchema.parse(JSON.parse(contents));
+      } catch (error) {
+        log.warn("[continuous-compaction] discarded invalid journal", error);
+        await fs.rm(this.path, { force: true });
+        return null;
+      }
+      if (journal.publicationGeneration !== (await this.captureGenerationUnderHistoryLock())) {
+        await fs.rm(this.path, { force: true });
+        return null;
+      }
+      if (!current()) return null;
+      onRead?.(journal);
+      return journal;
     });
   }
 
@@ -140,15 +256,20 @@ export class ContinuousCompactionJournalStore {
       providerOptions?: Record<string, unknown>;
       system?: string | ModelMessage;
     },
-    isCurrent: () => boolean
+    isCurrent: () => boolean,
+    onCommitted?: (journal: ContinuousCompactionJournal) => void
   ): Promise<ContinuousCompactionJournal | null> {
     const generation = this.generation;
+    const current = () => generation === this.generation && isCurrent();
     return this.enqueue(async () => {
       try {
-        const current = ContinuousCompactionJournalSchema.parse(
-          JSON.parse(await fs.readFile(this.path, "utf8"))
-        );
-        if (generation !== this.generation || !isCurrent() || !isDeepStrictEqual(current, journal))
+        if (
+          !(await this.isPublicationCurrentUnderHistoryLock({
+            generation: journal.publicationGeneration,
+            journal,
+          })) ||
+          !current()
+        )
           return null;
         const prefix = request.prefix.map(exactJson);
         const parsedPrefix = prefix.map((message) => modelMessageSchema.parse(message));
@@ -157,24 +278,23 @@ export class ContinuousCompactionJournalStore {
           "Fallback prefix schema dropped request fields"
         );
         const payload = exactJson({
-          ...current,
-          fallbackPrefixes: [...(current.fallbackPrefixes ?? []), { ...request, prefix }],
+          ...journal,
+          fallbackPrefixes: [...(journal.fallbackPrefixes ?? []), { ...request, prefix }],
         });
         const updated = ContinuousCompactionJournalSchema.parse(payload);
         assert(
           isDeepStrictEqual(exactJson(updated), payload),
           "Fallback journal dropped request fields"
         );
-        if (generation !== this.generation || !isCurrent()) return null;
-        await writeFileAtomic(this.path, JSON.stringify(payload), { mode: 0o600 });
-        const reread = ContinuousCompactionJournalSchema.parse(
-          JSON.parse(await fs.readFile(this.path, "utf8"))
+        const committed = await publishCompactionFile(
+          this.path,
+          JSON.stringify(payload),
+          current,
+          () => {
+            onCommitted?.(updated);
+          }
         );
-        assert(
-          isDeepStrictEqual(exactJson(reread), payload),
-          "Fallback journal round-trip mismatch"
-        );
-        return generation === this.generation && isCurrent() ? reread : null;
+        return committed && current() ? updated : null;
       } catch (error) {
         // Unlike the initial write, this record already describes a consumed request.
         // Failure must keep it available for P1's durable fold or startup recovery.
@@ -190,11 +310,20 @@ export class ContinuousCompactionJournalStore {
   write(
     journal: ContinuousCompactionJournal,
     prefix: ModelMessage[],
-    isCurrent: () => boolean
+    isCurrent: () => boolean,
+    onCommitted?: (journal: ContinuousCompactionJournal) => void
   ): Promise<ContinuousCompactionJournal | null> {
     const generation = this.generation;
+    const current = () => generation === this.generation && isCurrent();
     return this.enqueue(async () => {
       try {
+        if (
+          !(await this.isPublicationCurrentUnderHistoryLock({
+            generation: journal.publicationGeneration,
+          })) ||
+          !current()
+        )
+          return null;
         let wire: ContinuousCompactionJournal["prefix"];
         try {
           wire = z.array(z.json()).parse(exactJson(prefix));
@@ -218,20 +347,23 @@ export class ContinuousCompactionJournalStore {
           isDeepStrictEqual(exactJson(parsed), payload),
           "Journal schema dropped request fields"
         );
-        if (generation !== this.generation || !isCurrent()) return null;
-        await writeFileAtomic(this.path, JSON.stringify(payload), { mode: 0o600 });
-        const reread = ContinuousCompactionJournalSchema.parse(
-          JSON.parse(await fs.readFile(this.path, "utf8"))
+        const committed = await publishCompactionFile(
+          this.path,
+          JSON.stringify(payload),
+          current,
+          () => {
+            onCommitted?.(parsed);
+          }
         );
-        assert(isDeepStrictEqual(exactJson(reread), payload), "Journal round-trip mismatch");
-        if (generation !== this.generation || !isCurrent()) {
-          await fs.rm(this.path, { force: true });
+        if (committed && !current()) {
+          // Ownership can change during staged-file cleanup after the receipt.
+          // This initial prefix was never consumed; retire only its exact record.
+          await this.clearOwnedUnderHistoryLock(parsed);
           return null;
         }
-        return reread;
+        return committed ? parsed : null;
       } catch (error) {
         log.warn("[continuous-compaction] prefix not swapped: journal failed", error);
-        await fs.rm(this.path, { force: true }).catch(() => undefined);
         return null;
       }
     });

--- a/src/node/services/continuousCompactionJournal.ts
+++ b/src/node/services/continuousCompactionJournal.ts
@@ -209,6 +209,7 @@ export class ContinuousCompactionJournalStore {
   }
 
   exists(): Promise<boolean> {
+    // Ordinary send recovery must not acquire a write lock just to discover no journal exists.
     return this.enqueue(async () => {
       try {
         await fs.access(this.path);
@@ -218,7 +219,7 @@ export class ContinuousCompactionJournalStore {
           log.warn("[continuous-compaction] journal unavailable", error);
         return false;
       }
-    });
+    }, "local");
   }
 
   read(

--- a/src/node/services/continuousCompactionJournal.ts
+++ b/src/node/services/continuousCompactionJournal.ts
@@ -115,7 +115,7 @@ export async function publishCompactionFile(
   }
 }
 
-/** Journal publication and history folding serialize on the same cross-process history lock. */
+/** Owned journal publication/cleanup and history folding share the cross-process history lock. */
 export class ContinuousCompactionJournalStore {
   private generation = 0;
   private pending: Promise<unknown> = Promise.resolve();
@@ -125,8 +125,13 @@ export class ContinuousCompactionJournalStore {
     private readonly withHistoryLock: <T>(operation: () => Promise<T>) => Promise<T>
   ) {}
 
-  private enqueue<T>(operation: () => Promise<T>): Promise<T> {
-    const result = this.pending.then(() => this.withHistoryLock(operation));
+  private enqueue<T>(
+    operation: () => Promise<T>,
+    lock: "history" | "local" = "history"
+  ): Promise<T> {
+    const result = this.pending.then(() =>
+      lock === "history" ? this.withHistoryLock(operation) : operation()
+    );
     this.pending = result.catch(() => undefined);
     return result;
   }
@@ -196,8 +201,11 @@ export class ContinuousCompactionJournalStore {
     // Migration seam: explicit destructive intent retains main's unconditional
     // clearing and synchronous local fence. Exact asynchronous cleanup cannot
     // assume this authority; durable cross-backend reset fencing is separate.
+    // Keep the legacy unlink on the local queue: making it acquire the history
+    // lock could time out and silently leave cancelled work recoverable. It does
+    // not create a directory or fence a foreign producer's future publication.
     this.generation++;
-    return this.enqueue(() => fs.rm(this.path, { force: true }));
+    return this.enqueue(() => fs.rm(this.path, { force: true }), "local");
   }
 
   exists(): Promise<boolean> {
@@ -235,7 +243,10 @@ export class ContinuousCompactionJournalStore {
         journal = ContinuousCompactionJournalSchema.parse(JSON.parse(contents));
       } catch (error) {
         log.warn("[continuous-compaction] discarded invalid journal", error);
-        await fs.rm(this.path, { force: true });
+        await fs.rm(this.path, { force: true }).catch((cleanupError: unknown) => {
+          // An unusable journal must not block recovery just because unlink is unavailable.
+          log.warn("[continuous-compaction] invalid journal cleanup failed", cleanupError);
+        });
         return null;
       }
       if (journal.publicationGeneration !== (await this.captureGenerationUnderHistoryLock())) {

--- a/src/node/services/continuousCompactor.test.ts
+++ b/src/node/services/continuousCompactor.test.ts
@@ -779,6 +779,69 @@ describe("ContinuousCompactor", () => {
     expect((await rows())[0].id).toBe(journal.boundary.id);
   });
 
+  for (const phase of ["new-fold", "already-folded", "mismatched-source"] as const) {
+    it.each(["same-generation", "reset-during-cleanup"] as const)(
+      `${phase} preserves its recovery result after cleanup times out (%s)`,
+      async (race) => {
+        const resetDuringCleanup = race === "reset-during-cleanup";
+        const applied = phase !== "mismatched-source";
+        const { journalStore, journal, dependencies } = await activateJournaledSwap();
+        streaming = false;
+        live = undefined;
+        if (phase === "already-folded") {
+          expect(await compactor.recover()).toBe(true);
+          // Recreate the crash window between durable history publication and journal unlink.
+          await writeFile(journalStore.path, JSON.stringify(journal));
+        }
+        if (phase === "mismatched-source")
+          await seed(createMuxMessage("new-user", "user", "New work after the journal"));
+        const before = await rows();
+        const clearPrefix = spyOn(dependencies.streamManager, "clearPrefixSwap");
+        const clear = journalStore.clear.bind(journalStore);
+        const failure = spyOn(journalStore, "clear").mockImplementation(async (expected) => {
+          await using held = await fileLock.acquireProcessFileLock({
+            lockPath: historyWriteLockPath(store.config.rootDir, workspaceId),
+            timeoutMs: 1000,
+            label: "foreign history writer during journal cleanup",
+          });
+          if (resetDuringCleanup) compactor.reset("shutdown");
+          const acquire = fileLock.acquireProcessFileLock;
+          const timeout = spyOn(fileLock, "acquireProcessFileLock").mockImplementation((options) =>
+            acquire({ ...options, timeoutMs: 1 })
+          );
+          try {
+            await clear(expected);
+          } finally {
+            timeout.mockRestore();
+            await held.assertStillOwned();
+          }
+        });
+        expect(await compactor.recover().catch((error: unknown) => error)).toBe(applied);
+        expect(compactor.hasConsumedSwap()).toBe(false);
+        // A reset during cleanup owns stream retirement; the old apply must not clear it again.
+        expect(clearPrefix).toHaveBeenCalledTimes(
+          resetDuringCleanup || phase === "new-fold" ? 1 : 0
+        );
+        expect(await journalStore.read()).toEqual(journal);
+        const once = await rows();
+        if (applied) {
+          expect(once[0].id).toBe(journal.boundary.id);
+          expect(once.at(-1)?.id).toBe(journal.liveTailCopySpec.copyId);
+        } else expect(once).toEqual(before);
+        expect(completed).toHaveBeenCalledTimes(applied ? 1 : 0);
+        expect(await compactor.recover()).toBe(applied);
+        expect(await journalStore.read()).toEqual(journal);
+        expect(await rows()).toEqual(once);
+        failure.mockRestore();
+        expect(await compactor.recover()).toBe(applied);
+        expect(await rows()).toEqual(once);
+        expect(completed).toHaveBeenCalledTimes(applied ? 1 : 0);
+        expect(await journalStore.read()).toBeNull();
+        expect(await compactor.recover()).toBe(false);
+      }
+    );
+  }
+
   it("clears explicit reset intent despite contention on the history lock", async () => {
     const { dependencies, journalStore } = await activateJournaledSwap();
     streaming = false;

--- a/src/node/services/continuousCompactor.test.ts
+++ b/src/node/services/continuousCompactor.test.ts
@@ -1,5 +1,5 @@
 import type { ContinuousPrefixSwap } from "./continuousCompactionJournal";
-import { writeFile } from "node:fs/promises";
+import { stat, writeFile } from "node:fs/promises";
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
 import * as atomicWrite from "write-file-atomic";
 import { EventEmitter } from "node:events";
@@ -18,6 +18,8 @@ import { ContinuousCompactor, type ContinuousCompactionContext } from "./continu
 import { CompactionHandler } from "./compactionHandler";
 import { createTestHistoryService } from "./testHistoryService";
 import { HistoryService } from "./historyService";
+import * as fileLock from "@/node/utils/concurrency/fileLock";
+import { historyWriteLockPath } from "./workspaceRemoval";
 
 type Dependencies = ConstructorParameters<typeof ContinuousCompactor>[0];
 type LiveSnapshot = NonNullable<ReturnType<Dependencies["streamManager"]["getStreamInfo"]>> & {
@@ -775,6 +777,46 @@ describe("ContinuousCompactor", () => {
     expect(await compactor.observe(0, context)).toBe("applied");
     expect((await foreign.read())?.boundary.id).toBe(successor.boundary.id);
     expect((await rows())[0].id).toBe(journal.boundary.id);
+  });
+
+  it("clears explicit reset intent despite contention on the history lock", async () => {
+    const { dependencies, journalStore } = await activateJournaledSwap();
+    streaming = false;
+    live = undefined;
+    const held = await fileLock.acquireProcessFileLock({
+      lockPath: historyWriteLockPath(store.config.rootDir, workspaceId),
+      timeoutMs: 1000,
+      label: "foreign history writer",
+    });
+    // Exercise the actual lock timeout branch without waiting ten seconds.
+    const acquire = fileLock.acquireProcessFileLock;
+    const timeout = spyOn(fileLock, "acquireProcessFileLock").mockImplementation((options) =>
+      acquire({ ...options, timeoutMs: 0 })
+    );
+    let clearing = Promise.resolve();
+    const clear = journalStore.clearForReset.bind(journalStore);
+    const observed = spyOn(journalStore, "clearForReset").mockImplementation(() => {
+      clearing = clear();
+      return clearing;
+    });
+    try {
+      compactor.reset("user-interrupt");
+      await clearing.catch(() => undefined);
+      expect(await stat(journalStore.path).catch((error: unknown) => error)).toHaveProperty(
+        "code",
+        "ENOENT"
+      );
+    } finally {
+      await held[Symbol.asyncDispose]();
+      timeout.mockRestore();
+      observed.mockRestore();
+    }
+    compactor = new ContinuousCompactor({
+      ...dependencies,
+      historyService: new HistoryService(store.config),
+    });
+    expect(await compactor.recover()).toBe(false);
+    expect((await rows())[0].id).toBe("old-user");
   });
 
   it.each(["failed-fast-apply", "legacy-fallback", "delete-message", "dispose"])(

--- a/src/node/services/continuousCompactor.test.ts
+++ b/src/node/services/continuousCompactor.test.ts
@@ -17,6 +17,7 @@ import { estimateMuxMessageTokens } from "@/common/utils/messages/keepRecentTail
 import { ContinuousCompactor, type ContinuousCompactionContext } from "./continuousCompactor";
 import { CompactionHandler } from "./compactionHandler";
 import { createTestHistoryService } from "./testHistoryService";
+import { HistoryService } from "./historyService";
 
 type Dependencies = ConstructorParameters<typeof ContinuousCompactor>[0];
 type LiveSnapshot = NonNullable<ReturnType<Dependencies["streamManager"]["getStreamInfo"]>> & {
@@ -677,7 +678,15 @@ describe("ContinuousCompactor", () => {
     expect(fastApply).not.toHaveBeenCalled();
     expect((await rows())[0].id).toBe("old-user");
     const journalStore = store.historyService.getContinuousCompactionJournal(workspaceId);
-    const journal = await journalStore.write(swap.journal, swap.prefix, () => true);
+    const publishedSwap = swap;
+    const journal = await journalStore.write(
+      swap.journal,
+      swap.prefix,
+      () => true,
+      (committed) => {
+        publishedSwap.journal = committed;
+      }
+    );
     assert(journal, "Expected reproducible journal");
     state = consumed ? "consumed" : "pending";
     swap.consumed = consumed;
@@ -716,6 +725,73 @@ describe("ContinuousCompactor", () => {
       expect(completed).not.toHaveBeenCalled();
     });
   }
+
+  it.each(["user-interrupt", "edit", "context-mutation"])(
+    "%s does not recover an interrupted startup journal on the next attempt",
+    async (reason) => {
+      const { dependencies, journalStore } = await activateJournaledSwap();
+      compactor.reset("shutdown");
+      streaming = false;
+      live = undefined;
+      compactor = new ContinuousCompactor(dependencies);
+      const entered = deferred();
+      const release = deferred();
+      const read = journalStore.read.bind(journalStore);
+      spyOn(journalStore, "read").mockImplementationOnce(async (...args) => {
+        entered.resolve();
+        await release.promise;
+        return read(...args);
+      });
+      const recovering = compactor.recover();
+      try {
+        await entered.promise;
+        compactor.reset(reason);
+        release.resolve();
+        expect(await recovering).toBe(false);
+        compactor = new ContinuousCompactor(dependencies);
+        expect(await compactor.recover()).toBe(false);
+        expect((await rows())[0].id).toBe("old-user");
+      } finally {
+        release.resolve();
+        await recovering;
+      }
+    }
+  );
+
+  it("preserves a successor published after exact postcommit cleanup releases its lock", async () => {
+    const { journalStore, journal, swap } = await activateJournaledSwap();
+    streaming = false;
+    live = undefined;
+    const foreign = new HistoryService(store.config).getContinuousCompactionJournal(workspaceId);
+    const successor = {
+      ...journal,
+      boundary: { ...journal.boundary, id: "successor-boundary" },
+    };
+    const clear = journalStore.clear.bind(journalStore);
+    spyOn(journalStore, "clear").mockImplementationOnce(async (expected) => {
+      await clear(expected);
+      expect(await foreign.write(successor, swap.prefix, () => true)).not.toBeNull();
+    });
+    expect(await compactor.observe(0, context)).toBe("applied");
+    expect((await foreign.read())?.boundary.id).toBe(successor.boundary.id);
+    expect((await rows())[0].id).toBe(journal.boundary.id);
+  });
+
+  it.each(["failed-fast-apply", "legacy-fallback", "delete-message", "dispose"])(
+    "%s only cleans its captured journal",
+    async (reason) => {
+      const { journalStore, journal, swap } = await activateJournaledSwap();
+      const foreign = new HistoryService(store.config).getContinuousCompactionJournal(workspaceId);
+      await foreign.clear(journal);
+      const successor = {
+        ...journal,
+        boundary: { ...journal.boundary, id: "foreign-successor" },
+      };
+      expect(await foreign.write(successor, swap.prefix, () => true)).not.toBeNull();
+      compactor.reset(reason);
+      expect((await journalStore.read())?.boundary.id).toBe(successor.boundary.id);
+    }
+  );
 
   it("uses P1 durable fallback when the first retained live step has no tool anchor", async () => {
     await seedLiveTurn(true, true);

--- a/src/node/services/continuousCompactor.ts
+++ b/src/node/services/continuousCompactor.ts
@@ -159,7 +159,7 @@ export class ContinuousCompactor {
     this.activeSwap = null;
     this.ownedJournal = undefined;
     this.deps.streamManager.clearPrefixSwap?.(this.deps.workspaceId);
-    // Shutdown retains recovery. Successful apply already performed exact cleanup;
+    // Shutdown retains recovery. Successful apply already attempted exact cleanup;
     // clearing again here could erase a successor published after that lock released.
     if (discardJournal && reason !== "shutdown" && reason !== "applied") {
       const store = this.deps.historyService.getContinuousCompactionJournal(this.deps.workspaceId);
@@ -588,6 +588,14 @@ export class ContinuousCompactor {
     }
   }
 
+  private async clearJournalBestEffort(journal: ContinuousCompactionJournal): Promise<void> {
+    const store = this.deps.historyService.getContinuousCompactionJournal(this.deps.workspaceId);
+    // Rejected or durably folded journals must not block recovery; exact cleanup can retry later.
+    await store.clear(journal).catch((error: unknown) => {
+      log.warn("[continuous-compaction] journal cleanup failed", error);
+    });
+  }
+
   private async finalizeJournal(pendingFollowUp?: CompactionFollowUpRequest): Promise<boolean> {
     const generation = this.generation;
     const store = this.deps.historyService.getContinuousCompactionJournal(this.deps.workspaceId);
@@ -611,10 +619,11 @@ export class ContinuousCompactor {
       journal.staticCopies.every((copy) => rows.some((row) => row.id === copy.id)) &&
       rows.some((row) => row.id === journal.liveTailCopySpec.copyId);
     if (rows.some((row) => row.id === journal.boundary.id) && copiesPresent) {
-      await store.clear(journal);
-      if (generation !== this.generation) return false;
-      this.ownedJournal = undefined;
-      this.activeSwap = null;
+      await this.clearJournalBestEffort(journal);
+      if (generation === this.generation) {
+        this.ownedJournal = undefined;
+        this.activeSwap = null;
+      }
       return true;
     }
     const spec = journal.liveTailCopySpec;
@@ -649,7 +658,7 @@ export class ContinuousCompactor {
       log.warn("[continuous-compaction] discarded mismatched journal", {
         workspaceId: this.deps.workspaceId,
       });
-      await store.clear(journal);
+      await this.clearJournalBestEffort(journal);
       if (generation !== this.generation) return false;
       this.ownedJournal = undefined;
       this.activeSwap = null;
@@ -706,7 +715,7 @@ export class ContinuousCompactor {
       boundary.id
     );
     if (applied && generation === this.generation) {
-      await store.clear(journal);
+      await this.clearJournalBestEffort(journal);
       if (generation === this.generation) {
         this.ownedJournal = undefined;
         this.reset("applied");

--- a/src/node/services/continuousCompactor.ts
+++ b/src/node/services/continuousCompactor.ts
@@ -76,6 +76,7 @@ interface Dependencies {
   ): Promise<boolean>;
 }
 interface StagedSummary {
+  publicationGeneration: string | undefined;
   generation: number;
   epoch: number;
   boundarySequence?: number;
@@ -134,6 +135,7 @@ export class ContinuousCompactor {
   private applying: Promise<Verdict> | null = null;
   private swapAttempted: StagedSummary | null = null;
   private activeSwap: ContinuousPrefixSwap | null = null;
+  private ownedJournal: ContinuousCompactionJournal | undefined;
 
   constructor(private readonly deps: Dependencies) {
     assert(deps.workspaceId.length > 0, "ContinuousCompactor requires a workspace");
@@ -148,19 +150,31 @@ export class ContinuousCompactor {
     // Hydrating settings must not erase a previous process's journal before recovery.
     // It also keeps the disabled hot path free of journal I/O when no swap ever activated.
     const discardJournal = !settingsOnly || this.activeSwap !== null || this.swapAttempted !== null;
+    const journal = this.ownedJournal ?? this.activeSwap?.journal;
     this.generation++;
     this.job?.abort.abort();
     this.job = null;
     this.staged = null;
     this.swapAttempted = null;
     this.activeSwap = null;
+    this.ownedJournal = undefined;
     this.deps.streamManager.clearPrefixSwap?.(this.deps.workspaceId);
-    // Graceful shutdown retains the write-ahead record for ordinary startup recovery.
-    if (discardJournal && reason !== "shutdown") {
-      this.deps.historyService
-        .getContinuousCompactionJournal(this.deps.workspaceId)
-        .clear()
-        .catch((error: unknown) => log.warn("[continuous-compaction] journal clear failed", error));
+    // Shutdown retains recovery. Successful apply already performed exact cleanup;
+    // clearing again here could erase a successor published after that lock released.
+    if (discardJournal && reason !== "shutdown" && reason !== "applied") {
+      const store = this.deps.historyService.getContinuousCompactionJournal(this.deps.workspaceId);
+      // Preserve legacy explicit reset authority until durable invalidation is added.
+      // Failed apply, fallback and settings changes only own their captured journal.
+      const explicitReset = [
+        "user-interrupt",
+        "edit",
+        "context-mutation",
+        "compaction-request",
+      ].includes(reason);
+      const clearing = explicitReset ? store.clearForReset() : store.clear(journal);
+      clearing.catch((error: unknown) =>
+        log.warn("[continuous-compaction] journal clear failed", error)
+      );
     }
     log.debug("[continuous-compaction] reset", { workspaceId: this.deps.workspaceId, reason });
   }
@@ -308,6 +322,10 @@ export class ContinuousCompactor {
     job: NonNullable<ContinuousCompactor["job"]>,
     context: ContinuousCompactionContext
   ): Promise<void> {
+    const publicationGeneration = await this.deps.historyService
+      .getContinuousCompactionJournal(this.deps.workspaceId)
+      .captureGeneration();
+    if (job.generation !== this.generation) return;
     await this.deps.prepare();
     if (job.generation !== this.generation) return;
     const rows = await this.readSnapshot();
@@ -341,6 +359,7 @@ export class ContinuousCompactor {
       "Rolling head must have a durable sequence"
     );
     const stagedBase = {
+      publicationGeneration,
       generation: job.generation,
       ...boundaryIdentity(rows),
       cut,
@@ -497,6 +516,7 @@ export class ContinuousCompactor {
     try {
       const journal: ContinuousCompactionJournal = {
         version: 1,
+        publicationGeneration: staged.publicationGeneration,
         boundary,
         staticCopies,
         liveTailCopySpec: {
@@ -571,7 +591,12 @@ export class ContinuousCompactor {
   private async finalizeJournal(pendingFollowUp?: CompactionFollowUpRequest): Promise<boolean> {
     const generation = this.generation;
     const store = this.deps.historyService.getContinuousCompactionJournal(this.deps.workspaceId);
-    const journal = await store.read();
+    const journal = await store.read(
+      () => generation === this.generation,
+      (read) => {
+        this.ownedJournal = read;
+      }
+    );
     if (generation !== this.generation) return false;
     if (!journal) {
       this.activeSwap = null;
@@ -586,7 +611,9 @@ export class ContinuousCompactor {
       journal.staticCopies.every((copy) => rows.some((row) => row.id === copy.id)) &&
       rows.some((row) => row.id === journal.liveTailCopySpec.copyId);
     if (rows.some((row) => row.id === journal.boundary.id) && copiesPresent) {
-      await store.clear();
+      await store.clear(journal);
+      if (generation !== this.generation) return false;
+      this.ownedJournal = undefined;
       this.activeSwap = null;
       return true;
     }
@@ -622,7 +649,9 @@ export class ContinuousCompactor {
       log.warn("[continuous-compaction] discarded mismatched journal", {
         workspaceId: this.deps.workspaceId,
       });
-      await store.clear();
+      await store.clear(journal);
+      if (generation !== this.generation) return false;
+      this.ownedJournal = undefined;
       this.activeSwap = null;
       return false;
     }
@@ -645,7 +674,7 @@ export class ContinuousCompactor {
       boundary.metadata.muxMetadata.pendingFollowUp = pendingFollowUp;
     const applied = await this.deps.compactionHandler.withContinuousPendingState(
       head,
-      async () => {
+      async (_boundaryMessageId, onCommitted) => {
         if (
           generation !== this.generation ||
           this.deps.streamManager.isStreaming(this.deps.workspaceId)
@@ -664,7 +693,10 @@ export class ContinuousCompactor {
             [],
             journal.postCompactionAttachments
           ).reduce((sum, row) => sum + estimateMuxMessageTokens(row), 0),
-          prepared: { boundary, copies: [...journal.staticCopies, liveCopy] },
+          // Sequence assignment must not mutate the exact journal receipt used by cleanup.
+          prepared: { boundary, copies: [...structuredClone(journal.staticCopies), liveCopy] },
+          publication: { generation: journal.publicationGeneration, journal },
+          onCommitted,
           shouldPersist: (current) =>
             generation === this.generation &&
             !this.deps.streamManager.isStreaming(this.deps.workspaceId) &&
@@ -673,9 +705,12 @@ export class ContinuousCompactor {
       },
       boundary.id
     );
-    if (applied) {
-      await store.clear();
-      this.reset("applied");
+    if (applied && generation === this.generation) {
+      await store.clear(journal);
+      if (generation === this.generation) {
+        this.ownedJournal = undefined;
+        this.reset("applied");
+      }
     }
     return applied;
   }
@@ -697,7 +732,7 @@ export class ContinuousCompactor {
     if (staged.generation !== this.generation) return false;
     return this.deps.compactionHandler.withContinuousPendingState(
       head,
-      async (boundaryMessageId) => {
+      async (boundaryMessageId, onCommitted) => {
         // Pending-state persistence yields; a reset/edit during it must still invalidate this job.
         rows = await this.readSnapshot();
         if (!rows || !this.isValid(staged, rows)) return false;
@@ -713,6 +748,8 @@ export class ContinuousCompactor {
         const snapshotFingerprint = fingerprint(rows);
         const applied = await this.deps.compactionHandler.persistContinuousCompaction({
           boundaryMessageId,
+          publication: { generation: staged.publicationGeneration },
+          onCommitted,
           shouldPersist: (currentRows) => {
             const current = sliceMessagesFromLatestCompactionBoundary(currentRows);
             return (
@@ -730,7 +767,7 @@ export class ContinuousCompactor {
           attachmentTokens: context.attachmentTokens ?? 0,
           pendingFollowUp,
         });
-        if (applied) this.reset("applied");
+        if (applied && staged.generation === this.generation) this.reset("applied");
         return applied;
       }
     );

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -17,10 +17,14 @@ import {
 import { getRequestPreludeMessageIds } from "@/common/utils/messages/requestPrelude";
 import { createContextBudgetRejectedMessage } from "@/common/utils/messages/contextBudgetRejection";
 import * as path from "path";
-import { createHash, randomUUID } from "node:crypto";
-import { renameSync } from "node:fs";
+import { createHash } from "node:crypto";
 import * as fs from "fs/promises";
-import { ContinuousCompactionJournalStore } from "./continuousCompactionJournal";
+import {
+  ContinuousCompactionJournalStore,
+  publishCompactionFile,
+  type ContinuousCompactionPublication,
+} from "./continuousCompactionJournal";
+import { CONTINUOUS_COMPACTION_JOURNAL_FILE } from "@/constants/continuousCompaction";
 import writeFileAtomic from "write-file-atomic";
 import assert from "node:assert";
 import type { CompactionCompletionMetadata } from "@/common/types/compaction";
@@ -324,8 +328,15 @@ export class HistoryService {
     let journal = this.continuousJournals.get(workspaceId);
     if (!journal) {
       journal = new ContinuousCompactionJournalStore(
-        path.join(this.getSessionDir(workspaceId), "continuous-compaction.json"),
-        workspaceId
+        path.join(this.getSessionDir(workspaceId), CONTINUOUS_COMPACTION_JOURNAL_FILE),
+        workspaceId,
+        (operation) =>
+          this.withHistoryWriteFileLock(workspaceId, async () => {
+            if (await isWorkspaceRemovalTombstoned(this.config.rootDir, workspaceId))
+              throw new Error(`workspace ${workspaceId} was removed; refusing journal mutation`);
+            await ensurePrivateDir(this.getSessionDir(workspaceId));
+            return operation();
+          })
       );
       this.continuousJournals.set(workspaceId, journal);
     }
@@ -2969,13 +2980,24 @@ export class HistoryService {
     summaryMessage: MuxMessage,
     tailCopies: readonly MuxMessage[],
     updateExisting: boolean,
-    shouldPersist?: (messages: MuxMessage[]) => boolean
+    shouldPersist?: (messages: MuxMessage[]) => boolean,
+    commit?: {
+      publication: ContinuousCompactionPublication;
+      onCommitted: () => void;
+    }
   ): Promise<Result<void>> {
     // Continuous compaction may intentionally keep no tail when no complete turn fits.
     return this.withRecoveredHistoryWriteResultLock(
       workspaceId,
       "Failed to persist compaction boundary with tail copies",
       async () => {
+        if (
+          commit &&
+          !(await this.getContinuousCompactionJournal(
+            workspaceId
+          ).isPublicationCurrentUnderHistoryLock(commit.publication))
+        )
+          return Err("Compaction publication changed");
         invalidateHistoryAppendProvenance();
         try {
           // r52: this path assigns fresh sequences (appended summary + every
@@ -3064,17 +3086,17 @@ export class HistoryService {
             messages.slice(sourceMessages.length)
           );
           if (shouldPersist) {
-            const stagedPath = `${historyPath}.continuous-${randomUUID()}`;
-            try {
-              await writeFileAtomic(stagedPath, serialized, { mode: 0o600 });
-              // Bulk I/O remains asynchronous, but the final generation check and
-              // publication must not yield to reset(), abandonment, or a new stream.
-              if (!shouldPersist(sourceMessages)) return Err("Compaction snapshot changed");
-              renameSync(stagedPath, historyPath);
-            } finally {
-              await fs.rm(stagedPath, { force: true });
-            }
+            if (
+              !(await publishCompactionFile(
+                historyPath,
+                serialized,
+                () => shouldPersist(sourceMessages),
+                commit?.onCommitted
+              ))
+            )
+              return Err("Compaction snapshot changed");
           } else {
+            assert(!commit, "Compaction commit receipts require a final ownership predicate");
             await writeFileAtomic(historyPath, serialized);
           }
 

--- a/src/node/services/streamManager.continuousCompaction.test.ts
+++ b/src/node/services/streamManager.continuousCompaction.test.ts
@@ -5,6 +5,11 @@ import { prepareMessagesForProvider } from "./messagePipeline";
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
 import * as ai from "ai";
 import * as atomicWrite from "write-file-atomic";
+import { promises as journalFs } from "node:fs";
+import * as fileLock from "@/node/utils/concurrency/fileLock";
+import * as path from "node:path";
+import { HistoryService } from "./historyService";
+import { historyWriteLockPath, removeSessionDirUnderMemoryLocks } from "./workspaceRemoval";
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { readFile, writeFile } from "node:fs/promises";
 import assert from "@/common/utils/assert";
@@ -171,6 +176,307 @@ describe("continuous prefix prepareStep and journal", () => {
     const store = history.historyService.getContinuousCompactionJournal(workspaceId);
     return { ...harness, store, tracker, swap, manager };
   }
+
+  it("cannot overwrite or clear a foreign journal revision in the same generation", async () => {
+    const { store, swap } = await setup();
+    const original = await store.write(swap.journal, swap.prefix, () => true);
+    assert(original, "Expected original journal");
+    const foreign = new HistoryService(history.config).getContinuousCompactionJournal(workspaceId);
+    expect(await foreign.write(swap.journal, swap.prefix, () => true)).toBeNull();
+    const successor = await foreign.recordFallbackPrefix(
+      original,
+      { modelString: "anthropic:fallback", prefix: swap.prefix },
+      () => true
+    );
+    assert(successor, "Expected fallback revision");
+    await store.clear(original);
+    await store.clear(undefined);
+    expect(
+      await store.recordFallbackPrefix(
+        original,
+        { modelString: "anthropic:stale", prefix: swap.prefix },
+        () => true
+      )
+    ).toBeNull();
+    const receipt = mock();
+    const folded = await history.historyService.persistBoundaryWithTailCopies(
+      workspaceId,
+      structuredClone(original.boundary),
+      [],
+      false,
+      () => true,
+      {
+        publication: { generation: original.publicationGeneration, journal: original },
+        onCommitted: receipt,
+      }
+    );
+    expect(folded.success).toBe(false);
+    expect(receipt).not.toHaveBeenCalled();
+    expect(await foreign.read()).toEqual(successor);
+    const rows = await history.historyService.getLastMessages(workspaceId, 10);
+    assert(rows.success, "Expected history");
+    expect(rows.data.map((row) => row.id)).toEqual(["live"]);
+    await foreign.clear(successor);
+    expect(await store.read()).toBeNull();
+  });
+
+  it("captures durable generations across instances without activating destructive resets", async () => {
+    const { store, swap } = await setup();
+    const foreign = new HistoryService(history.config).getContinuousCompactionJournal(workspaceId);
+    const original = await store.write(swap.journal, swap.prefix, () => true);
+    assert(original, "Expected legacy journal");
+    await foreign.advanceGeneration();
+    expect(await store.write(swap.journal, swap.prefix, () => true)).toBeNull();
+    expect(
+      await store.recordFallbackPrefix(
+        original,
+        { modelString: "anthropic:stale", prefix: swap.prefix },
+        () => true
+      )
+    ).toBeNull();
+    expect(await store.read()).toBeNull();
+    const generation = await store.captureGeneration();
+    expect(generation).toBeDefined();
+    const candidate = { ...swap.journal, publicationGeneration: generation };
+    const fresh = await store.write(candidate, swap.prefix, () => true);
+    expect(await foreign.read()).toEqual(fresh);
+    const failure = spyOn(foreign, "advanceGenerationUnderHistoryLock").mockRejectedValueOnce(
+      new Error("generation unavailable")
+    );
+    expect(await foreign.advanceGeneration().catch((error: unknown) => error)).toEqual(
+      new Error("generation unavailable")
+    );
+    failure.mockRestore();
+    expect(await store.captureGeneration()).toBe(generation);
+    expect(await store.read()).toEqual(fresh);
+  });
+
+  it.each(["initial", "fallback"] as const)(
+    "reset fences a queued %s publication even when its caller predicate stays true",
+    async (kind) => {
+      const { store, swap } = await setup();
+      const original =
+        kind === "fallback" ? await store.write(swap.journal, swap.prefix, () => true) : null;
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const capture = store.captureGenerationUnderHistoryLock.bind(store);
+      spyOn(store, "captureGenerationUnderHistoryLock").mockImplementationOnce(async () => {
+        entered.resolve();
+        await release.promise;
+        return capture();
+      });
+      const blocking = store.captureGeneration();
+      const receipt = mock();
+      const writing = original
+        ? store.recordFallbackPrefix(
+            original,
+            { modelString: "anthropic:next", prefix: swap.prefix },
+            () => true,
+            receipt
+          )
+        : store.write(swap.journal, swap.prefix, () => true, receipt);
+      let resetting: Promise<void> | undefined;
+      try {
+        await entered.promise;
+        resetting = store.clearForReset();
+        release.resolve();
+        await blocking;
+        expect(await writing).toBeNull();
+        await resetting;
+        expect(receipt).not.toHaveBeenCalled();
+        expect(await store.read()).toBeNull();
+      } finally {
+        release.resolve();
+        await Promise.all([blocking, writing, resetting]);
+      }
+    }
+  );
+
+  it.each(["initial", "fallback"] as const)(
+    "reset fences an in-flight %s publication through its final rename",
+    async (kind) => {
+      const { store, swap } = await setup();
+      const original =
+        kind === "fallback" ? await store.write(swap.journal, swap.prefix, () => true) : null;
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const atomic = atomicWrite.default;
+      spyOn(atomicWrite, "default").mockImplementationOnce(
+        Object.assign(
+          async (filename: string, data: string | Buffer) => {
+            await atomic(filename, data);
+            entered.resolve();
+            await release.promise;
+          },
+          { sync: atomic.sync }
+        )
+      );
+      const receipt = mock();
+      const writing = original
+        ? store.recordFallbackPrefix(
+            original,
+            { modelString: "anthropic:next", prefix: swap.prefix },
+            () => true,
+            receipt
+          )
+        : store.write(swap.journal, swap.prefix, () => true, receipt);
+      let resetting: Promise<void> | undefined;
+      try {
+        await entered.promise;
+        resetting = store.clearForReset();
+        release.resolve();
+        expect(await writing).toBeNull();
+        await resetting;
+        expect(receipt).not.toHaveBeenCalled();
+        expect(await store.read()).toBeNull();
+      } finally {
+        release.resolve();
+        await Promise.all([writing, resetting]);
+      }
+    }
+  );
+
+  it("publishes a receipt before cleanup and preserves success when cleanup or its observer fails", async () => {
+    const { store, swap } = await setup();
+    const receipt = mock<(journal: ContinuousCompactionJournal) => void>(() => {
+      throw new Error("observer failed");
+    });
+    let cleanupObserved = false;
+    const remove = journalFs.rm;
+    spyOn(journalFs, "rm").mockImplementation(async (...args) => {
+      if (String(args[0]).startsWith(`${store.path}.continuous-`)) {
+        cleanupObserved = true;
+        expect(receipt).toHaveBeenCalledTimes(1);
+        const persisted = JSON.parse(await readFile(store.path, "utf8")) as unknown;
+        expect(persisted).toEqual(receipt.mock.calls[0]?.[0]);
+        throw new Error("cleanup unavailable");
+      }
+      return remove(...args);
+    });
+    const published = await store.write(swap.journal, swap.prefix, () => true, receipt);
+    expect(cleanupObserved).toBe(true);
+    expect(published).not.toBeNull();
+    expect(await store.read()).toEqual(published);
+  });
+
+  it("cleans only the committed initial prefix when ownership changes during staged cleanup", async () => {
+    const { store, swap } = await setup();
+    let current = true;
+    const remove = journalFs.rm;
+    spyOn(journalFs, "rm").mockImplementation(async (...args) => {
+      if (String(args[0]).startsWith(`${store.path}.continuous-`)) current = false;
+      return remove(...args);
+    });
+    const receipt = mock();
+    expect(await store.write(swap.journal, swap.prefix, () => current, receipt)).toBeNull();
+    expect(receipt).toHaveBeenCalledTimes(1);
+    expect(await store.read()).toBeNull();
+  });
+
+  it("cannot recreate a removed workspace through journal capture, publication or cleanup", async () => {
+    const { store, swap } = await setup();
+    const original = await store.write(swap.journal, swap.prefix, () => true);
+    assert(original, "Expected journal");
+    const sessionDir = path.dirname(store.path);
+    await removeSessionDirUnderMemoryLocks({
+      rootDir: history.config.rootDir,
+      sessionDir,
+      workspaceId,
+      attemptId: "journal-removal-test",
+    });
+    for (const operation of [
+      () => store.captureGeneration(),
+      () => store.write(original, swap.prefix, () => true),
+      () => store.clear(original),
+    ])
+      expect(await operation().catch((error: unknown) => error)).toHaveProperty(
+        "message",
+        expect.stringContaining("was removed")
+      );
+    await store.clear(undefined);
+    expect(await journalFs.stat(sessionDir).catch((error: unknown) => error)).toHaveProperty(
+      "code",
+      "ENOENT"
+    );
+  });
+
+  it("publishes the history receipt before asynchronous cleanup without reporting a failed commit", async () => {
+    const { swap } = await setup();
+    const receipt = mock();
+    let cleanupObserved = false;
+    const remove = journalFs.rm;
+    spyOn(journalFs, "rm").mockImplementation(async (...args) => {
+      if (String(args[0]).includes("chat.jsonl.continuous-")) {
+        cleanupObserved = true;
+        expect(receipt).toHaveBeenCalledTimes(1);
+        throw new Error("history staging cleanup failed");
+      }
+      return remove(...args);
+    });
+    const result = await history.historyService.persistBoundaryWithTailCopies(
+      workspaceId,
+      structuredClone(swap.journal.boundary),
+      [],
+      false,
+      () => true,
+      { publication: { generation: undefined }, onCommitted: receipt }
+    );
+    expect(cleanupObserved).toBe(true);
+    expect(result.success).toBe(true);
+    const rows = await history.historyService.getHistoryFromLatestBoundary(workspaceId);
+    assert(rows.success, "Expected history");
+    expect(rows.data.map((row) => row.id)).toEqual([swap.journal.boundary.id]);
+  });
+
+  it("waits for a foreign process holding the history lock before admitting a journal write", async () => {
+    const { store, swap } = await setup();
+    const foreign = {
+      ...swap.journal,
+      boundary: { ...swap.journal.boundary, id: "foreign-boundary" },
+    };
+    const script = `
+      import { acquireProcessFileLock } from "./src/node/utils/concurrency/fileLock.ts";
+      import { writeFile } from "node:fs/promises";
+      const [lockPath, journalPath, journal] = process.argv.slice(-3);
+      await using lock = await acquireProcessFileLock({ lockPath, timeoutMs: 5000, label: "journal test" });
+      process.stdout.write("locked\\n");
+      await Bun.stdin.text();
+      await writeFile(journalPath, journal);
+    `;
+    const child = Bun.spawn(
+      [
+        process.execPath,
+        "--eval",
+        script,
+        historyWriteLockPath(history.config.rootDir, workspaceId),
+        store.path,
+        JSON.stringify(foreign),
+      ],
+      { stdin: "pipe", stdout: "pipe", stderr: "pipe" }
+    );
+    let writing: ReturnType<typeof store.write> | undefined;
+    try {
+      const reader = child.stdout.getReader();
+      expect(new TextDecoder().decode((await reader.read()).value)).toBe("locked\n");
+      reader.releaseLock();
+      const entered = Promise.withResolvers<void>();
+      const acquire = fileLock.acquireProcessFileLock;
+      spyOn(fileLock, "acquireProcessFileLock").mockImplementationOnce((options) => {
+        entered.resolve();
+        return acquire(options);
+      });
+      writing = store.write(swap.journal, swap.prefix, () => true);
+      await entered.promise;
+      await child.stdin.end();
+      expect(await child.exited).toBe(0);
+      expect(await writing).toBeNull();
+      expect(await store.read()).toEqual(foreign);
+    } finally {
+      child.kill();
+      await child.exited;
+      await writing;
+    }
+  });
 
   it("journals before returning, swaps once by content identity, and strips retained cache markers", async () => {
     const { run, tracker, store, swap } = await setup();
@@ -487,7 +793,7 @@ describe("continuous prefix prepareStep and journal", () => {
       let cleared = Promise.resolve();
       if (mode === "reset-before-write") {
         tracker.pendingPrefixSwap = undefined;
-        cleared = store.clear();
+        cleared = store.clearForReset();
       } else {
         controller.abort();
       }

--- a/src/node/services/streamManager.continuousCompaction.test.ts
+++ b/src/node/services/streamManager.continuousCompaction.test.ts
@@ -1203,19 +1203,40 @@ describe("continuous prefix prepareStep and journal", () => {
     expect(await store.read()).toBeNull();
   });
 
-  it("keeps corrupt-journal cleanup failure from blocking recovery", async () => {
-    const { store } = await setup();
-    await writeFile(store.path, "{");
-    const remove = journalFs.rm;
-    const failure = spyOn(journalFs, "rm").mockImplementation((...args) =>
-      args[0] === store.path ? Promise.reject(new Error("cleanup unavailable")) : remove(...args)
-    );
-    expect(await store.read().catch((error: unknown) => error)).toBeNull();
-    const rows = await history.historyService.getLastMessages(workspaceId, 10);
-    assert(rows.success, "Expected source history");
-    expect(rows.data.map((row) => row.id)).toEqual(["live"]);
-    failure.mockRestore();
-    expect(await store.read()).toBeNull();
-    expect(await store.exists()).toBe(false);
-  });
+  it.each(["corrupt", "stale-generation"] as const)(
+    "keeps %s journal cleanup failure from blocking recovery",
+    async (kind) => {
+      const { store, swap } = await setup();
+      if (kind === "corrupt") await writeFile(store.path, "{");
+      else {
+        const original = await store.write(swap.journal, swap.prefix, () => true);
+        assert(original, "Expected valid journal before generation change");
+        const foreign = new HistoryService(history.config).getContinuousCompactionJournal(
+          workspaceId
+        );
+        await foreign.advanceGeneration();
+        expect(await store.captureGeneration()).not.toBe(original.publicationGeneration);
+      }
+      const bytes = await readFile(store.path, "utf8");
+      const remove = journalFs.rm;
+      const failure = spyOn(journalFs, "rm").mockImplementation((...args) =>
+        args[0] === store.path ? Promise.reject(new Error("cleanup unavailable")) : remove(...args)
+      );
+      expect(await store.read().catch((error: unknown) => error)).toBeNull();
+      expect(await readFile(store.path, "utf8")).toBe(bytes);
+      const rows = await history.historyService.getLastMessages(workspaceId, 10);
+      assert(rows.success, "Expected source history");
+      expect(rows.data.map((row) => row.id)).toEqual(["live"]);
+      failure.mockRestore();
+      expect(await store.read()).toBeNull();
+      expect(await store.exists()).toBe(false);
+      const fresh = await store.write(
+        { ...swap.journal, publicationGeneration: await store.captureGeneration() },
+        swap.prefix,
+        () => true
+      );
+      expect(fresh).not.toBeNull();
+      expect(await store.read()).toEqual(fresh);
+    }
+  );
 });

--- a/src/node/services/streamManager.continuousCompaction.test.ts
+++ b/src/node/services/streamManager.continuousCompaction.test.ts
@@ -1202,4 +1202,20 @@ describe("continuous prefix prepareStep and journal", () => {
     expect(await store.read()).toBeNull();
     expect(await store.read()).toBeNull();
   });
+
+  it("keeps corrupt-journal cleanup failure from blocking recovery", async () => {
+    const { store } = await setup();
+    await writeFile(store.path, "{");
+    const remove = journalFs.rm;
+    const failure = spyOn(journalFs, "rm").mockImplementation((...args) =>
+      args[0] === store.path ? Promise.reject(new Error("cleanup unavailable")) : remove(...args)
+    );
+    expect(await store.read().catch((error: unknown) => error)).toBeNull();
+    const rows = await history.historyService.getLastMessages(workspaceId, 10);
+    assert(rows.success, "Expected source history");
+    expect(rows.data.map((row) => row.id)).toEqual(["live"]);
+    failure.mockRestore();
+    expect(await store.read()).toBeNull();
+    expect(await store.exists()).toBe(false);
+  });
 });

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -2635,7 +2635,10 @@ export class StreamManager {
             const journal = await store.write(
               { ...swap.journal, stepNumber },
               swap.prefix,
-              isCurrent
+              isCurrent,
+              (committed) => {
+                swap.journal = committed;
+              }
             );
             if (journal && isCurrent()) {
               swap.journal = journal;
@@ -2644,7 +2647,7 @@ export class StreamManager {
               effectiveMessages = swapped;
             } else if (journal && stepTracker.pendingPrefixSwap === swap) {
               // A thinking change can also arrive after write()'s last fence.
-              await store.clear();
+              await store.clear(journal);
             }
           }
           if (stepTracker.pendingPrefixSwap === swap) stepTracker.pendingPrefixSwap = undefined;
@@ -3640,7 +3643,10 @@ export class StreamManager {
                 providerOptions: nextRequest.providerOptions,
                 system: nextRequest.system,
               },
-              isCurrent
+              isCurrent,
+              (committed) => {
+                consumedSwap.journal = committed;
+              }
             );
           if (journal && isCurrent()) {
             consumedSwap.journal = journal;


### PR DESCRIPTION
Compaction journal writes and history folding use different serialization boundaries. A delayed fallback or cleanup can therefore operate on a journal that has already been replaced, and a failure after a committed history rename can still look like an uncommitted compaction to its caller.

Serialize journal publication and folding with the existing cross-process history lock. Compare the captured generation and exact journal, and publish ownership/commit receipts synchronously with the final rename. Keep a committed boundary's pending-state success latch set even if later cleanup fails.

Explicit reset remains a separate operation with its established local queue, clearing and invalidation behavior, including an unread startup journal. It does not acquire the shared history lock, so lock contention cannot abandon reset unlink. The advisory existence probe also uses the local queue; actual journal reads and mutations keep the shared lock. Asynchronous owned cleanup uses an exact receipt; completing an apply does not perform a second global clear. Invalid, stale, source-mismatched and durably applied journals preserve their recovery outcome when cleanup fails, leaving exact cleanup retryable. These boundaries let the change ship independently of later destructive-history fencing, attachment-persistence and durable Stop protocols.

This is the journal-publication slice replacing closed #4121 and starts a separate persistence stack.

Validation: the broader implementation suite passed 370 targeted tests; the final cleanup changes passed all 168 affected tests and `make static-check`. Regressions cover interrupted startup recovery, reset under a held history lock, failed cleanup and later recovery, successor preservation, queued fallback/reset ordering, cross-instance publication, commit receipts before cleanup, and no rollback or duplicate folding after a committed boundary. Independent local review approved the implementation and review fixes. Nix formatting was skipped because Nix is unavailable.

Risk centers on journal recovery and lock ordering. Under-lock operations avoid re-entering the journal queue; tests use real HistoryService storage and deterministic barriers. The ordered file protocol does not add a new power-loss durability guarantee.

---

_Generated with `xum` • Model: `unavailable` • Thinking: `unavailable` • Cost: `$unavailable`_

<!-- mux-attribution: model=unavailable thinking=unavailable costs=unavailable -->
