### PR TITLE
🤖 fix: condition compaction follow-up cleanup on its owner

### DIFF
--- a/src/node/services/agentSession.continueMessageAgentId.test.ts
+++ b/src/node/services/agentSession.continueMessageAgentId.test.ts
@@ -1,5 +1,5 @@
 import type { TurnCoordinator } from "./turnCoordinator";
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { createMuxMessage } from "@/common/types/message";
 import type { CompactionFollowUpRequest, MuxMessage } from "@/common/types/message";
 import type { FilePart, SendMessageOptions } from "@/common/orpc/types";
@@ -34,6 +34,8 @@ interface SessionInternals {
   ) => Promise<SendMessageResult>;
   runStartupRecovery: () => Promise<void>;
   lastAutoRetryResumeRequest?: AutoRetryResumeRequest;
+  coordinator: TurnCoordinator;
+  onPostCompactionStateChange?: () => void;
 }
 
 const idleFollowUp = (): CompactionFollowUpRequest => ({
@@ -147,6 +149,7 @@ describe("AgentSession continue-message agentId fallback", () => {
     }
     await historyCleanup?.();
     historyCleanup = undefined;
+    mock.restore();
   });
 
   const createSession = async (messages: MuxMessage[] = [], config = createConfig()) => {
@@ -172,6 +175,47 @@ describe("AgentSession continue-message agentId fallback", () => {
       internals: session as unknown as SessionInternals,
     };
   };
+
+  test.each([false, true])(
+    "a new turn during queued follow-up cleanup preserves the summary (heartbeat=%s)",
+    async (heartbeat) => {
+      const summary = heartbeat
+        ? heartbeatBoundaryMessage()
+        : compactionSummaryMessage("summary", idleFollowUp());
+      const { session, internals, historyService } = await createSession([summary]);
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const cleanup = historyService.cleanupCompactionFollowUp.bind(historyService);
+      spyOn(historyService, "cleanupCompactionFollowUp").mockImplementationOnce(async (...args) => {
+        entered.resolve();
+        await release.promise;
+        return cleanup(...args);
+      });
+      const changed = mock(() => undefined);
+      internals.onPostCompactionStateChange = changed;
+      session.queueMessage("manual work", { model: "openai:gpt-4o", agentId: "exec" });
+      const dispatch = internals.dispatchPendingFollowUp();
+      try {
+        await entered.promise;
+        const admission = internals.coordinator.prepare({
+          kind: "fresh",
+          intent: "direct",
+          expectedTurnId: internals.coordinator.turnId,
+        });
+        expect(admission.status).toBe("admitted");
+        release.resolve();
+        expect(await dispatch).toBe(false);
+        const history = await historyService.getLastMessages("ws", 1);
+        expect(history.success && history.data[0].metadata?.muxMetadata).toHaveProperty(
+          "pendingFollowUp"
+        );
+        expect(changed).not.toHaveBeenCalled();
+      } finally {
+        release.resolve();
+        await dispatch;
+      }
+    }
+  );
 
   test("legacy continueMessage.mode does not fall back to compact agent", async () => {
     let dispatchedMessage: string | undefined;

--- a/src/node/services/agentSession.continueMessageAgentId.test.ts
+++ b/src/node/services/agentSession.continueMessageAgentId.test.ts
@@ -2,6 +2,7 @@ import type { TurnCoordinator } from "./turnCoordinator";
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { createMuxMessage } from "@/common/types/message";
 import type { CompactionFollowUpRequest, MuxMessage } from "@/common/types/message";
+import assert from "@/common/utils/assert";
 import type { FilePart, SendMessageOptions } from "@/common/orpc/types";
 import type { Config } from "@/node/config";
 import { AgentSession } from "./agentSession";
@@ -176,9 +177,13 @@ describe("AgentSession continue-message agentId fallback", () => {
     };
   };
 
-  test.each([false, true])(
-    "a new turn during queued follow-up cleanup preserves the summary (heartbeat=%s)",
-    async (heartbeat) => {
+  test.each(
+    [false, true].flatMap((heartbeat) =>
+      [false, true].map((published) => ({ heartbeat, published }))
+    )
+  )(
+    "a new turn respects the follow-up cleanup receipt (heartbeat=$heartbeat, published=$published)",
+    async ({ heartbeat, published }) => {
       const summary = heartbeat
         ? heartbeatBoundaryMessage()
         : compactionSummaryMessage("summary", idleFollowUp());
@@ -187,9 +192,10 @@ describe("AgentSession continue-message agentId fallback", () => {
       const release = Promise.withResolvers<void>();
       const cleanup = historyService.cleanupCompactionFollowUp.bind(historyService);
       spyOn(historyService, "cleanupCompactionFollowUp").mockImplementationOnce(async (...args) => {
+        const result = published ? await cleanup(...args) : undefined;
         entered.resolve();
         await release.promise;
-        return cleanup(...args);
+        return result ?? cleanup(...args);
       });
       const changed = mock(() => undefined);
       internals.onPostCompactionStateChange = changed;
@@ -206,10 +212,15 @@ describe("AgentSession continue-message agentId fallback", () => {
         release.resolve();
         expect(await dispatch).toBe(false);
         const history = await historyService.getLastMessages("ws", 1);
-        expect(history.success && history.data[0].metadata?.muxMetadata).toHaveProperty(
-          "pendingFollowUp"
-        );
-        expect(changed).not.toHaveBeenCalled();
+        assert(history.success, "Expected history after follow-up cleanup");
+        if (!published) {
+          expect(history.data[0].metadata?.muxMetadata).toHaveProperty("pendingFollowUp");
+        } else if (heartbeat) {
+          expect(history.data).toHaveLength(0);
+        } else {
+          expect(history.data[0].metadata?.muxMetadata).not.toHaveProperty("pendingFollowUp");
+        }
+        expect(changed).toHaveBeenCalledTimes(published && heartbeat ? 1 : 0);
       } finally {
         release.resolve();
         await dispatch;

--- a/src/node/services/agentSession.continuousCompaction.test.ts
+++ b/src/node/services/agentSession.continuousCompaction.test.ts
@@ -1098,12 +1098,14 @@ describe("AgentSession continuous compaction wiring", () => {
             return read(...args);
           });
         } else {
-          const update = h.historyService.updateHistory.bind(h.historyService);
-          spyOn(h.historyService, "updateHistory").mockImplementationOnce(async (...args) => {
-            entered.resolve();
-            await release.promise;
-            return update(...args);
-          });
+          const update = h.historyService.cleanupCompactionFollowUp.bind(h.historyService);
+          spyOn(h.historyService, "cleanupCompactionFollowUp").mockImplementationOnce(
+            async (...args) => {
+              entered.resolve();
+              await release.promise;
+              return update(...args);
+            }
+          );
           await h.session.interruptStream({ abandonPartial: true });
         }
         return true;

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -9670,12 +9670,15 @@ export class AgentSession {
       hasUserContention &&
       !hasActiveNonCompletingTurn
     ) {
-      const rollbackResult =
-        await this.compactionHandler.rollbackHeartbeatContextResetBoundary(summaryMessage);
+      const turn = this.coordinator.turnId;
+      const rollbackResult = await this.compactionHandler.rollbackHeartbeatContextResetBoundary(
+        summaryMessage,
+        () => this.coordinator.turnId === turn
+      );
       if (!rollbackResult.success) {
         throw new Error(`Failed to rollback heartbeat reset boundary: ${rollbackResult.error}`);
       }
-      this.onPostCompactionStateChange?.();
+      if (rollbackResult.data === "applied") this.onPostCompactionStateChange?.();
     } else {
       await this.clearPendingFollowUpFromSummary(summaryMessage);
     }
@@ -9697,14 +9700,13 @@ export class AgentSession {
       return;
     }
 
-    const { pendingFollowUp: _pendingFollowUp, ...muxMetadataWithoutFollowUp } = muxMeta;
-    const updateResult = await this.historyService.updateHistory(this.workspaceId, {
-      ...summaryMessage,
-      metadata: {
-        ...(summaryMessage.metadata ?? {}),
-        muxMetadata: muxMetadataWithoutFollowUp,
-      },
-    });
+    const turn = this.coordinator.turnId;
+    const updateResult = await this.historyService.cleanupCompactionFollowUp(
+      this.workspaceId,
+      summaryMessage,
+      "clear",
+      () => this.coordinator.turnId === turn
+    );
     if (!updateResult.success) {
       throw new Error(`Failed to clear skipped pending follow-up: ${updateResult.error}`);
     }

--- a/src/node/services/compactionHandler.pendingOwnership.test.ts
+++ b/src/node/services/compactionHandler.pendingOwnership.test.ts
@@ -7,6 +7,7 @@ import { Err } from "@/common/types/result";
 import assert from "@/common/utils/assert";
 import { CompactionHandler } from "./compactionHandler";
 import { createTestHistoryService } from "./testHistoryService";
+import { historyWriteLockPath } from "./workspaceRemoval";
 
 const workspaceId = "pending-consumers";
 const followUp = { text: "wake", model: "openai:gpt-4o", agentId: "exec" };
@@ -323,6 +324,39 @@ describe("exact pending snapshot consumption", () => {
     }
   );
 
+  it.each([false, true])(
+    "committed heartbeat rollback restores its snapshot after admission changes (prior state=%s)",
+    async (hasPrevious) => {
+      const previous = hasPrevious ? await publish("a") : null;
+      await publish("b");
+      const rows = await store.historyService.getLastMessages(workspaceId, 1);
+      assert(rows.success && rows.data.length === 1, "Expected B boundary");
+      const historyPath = path.join(store.config.sessionsDir, workspaceId, "chat.jsonl");
+      const lockPath = historyWriteLockPath(store.config.rootDir, workspaceId);
+      const unlink = fs.unlink;
+      let current = true;
+      spyOn(fs, "unlink").mockImplementation(async (target) => {
+        if (String(target) === lockPath && current) {
+          // Admission changes during real lock release, after the boundary deletion committed.
+          expect((await fs.readFile(historyPath)).length).toBe(0);
+          current = false;
+        }
+        return unlink(target);
+      });
+      const emitted = spyOn(emitter, "emit");
+      expect(
+        await handler.rollbackHeartbeatContextResetBoundary(rows.data[0], () => current)
+      ).toEqual({ success: true, data: "applied" });
+      expect(current).toBe(false);
+      expect(await handler.peekPendingState()).toEqual(previous);
+      expect(await restart().peekPendingState()).toEqual(previous);
+      expect(emitted).toHaveBeenCalledWith("chat-event", {
+        workspaceId,
+        message: { type: "delete", historySequences: [rows.data[0].metadata?.historySequence] },
+      });
+    }
+  );
+
   it.each(["before-delete", "after-delete"] as const)(
     "held heartbeat cleanup preserves successor pending state (%s)",
     async (phase) => {
@@ -340,12 +374,14 @@ describe("exact pending snapshot consumption", () => {
           return result ?? cleanup(...args);
         }
       );
-      const rollback = handler.rollbackHeartbeatContextResetBoundary(rows.data[0]);
+      let current = true;
+      const rollback = handler.rollbackHeartbeatContextResetBoundary(rows.data[0], () => current);
       try {
         await entered.promise;
         const successor = await publish("b");
         const bytes = await fs.readFile(pendingPath, "utf8");
         const emitted = spyOn(emitter, "emit");
+        current = false;
         release.resolve();
         expect(await rollback).toEqual({
           success: true,
@@ -359,6 +395,7 @@ describe("exact pending snapshot consumption", () => {
           });
         expect(await fs.readFile(pendingPath, "utf8")).toBe(bytes);
         expect(await handler.peekPendingState()).toEqual(successor);
+        expect(await restart().peekPendingState()).toEqual(successor);
       } finally {
         release.resolve();
         await rollback;

--- a/src/node/services/compactionHandler.pendingOwnership.test.ts
+++ b/src/node/services/compactionHandler.pendingOwnership.test.ts
@@ -31,13 +31,14 @@ describe("exact pending snapshot consumption", () => {
   let handler: CompactionHandler;
   let sessionDir: string;
   let pendingPath: string;
+  let emitter: EventEmitter;
 
   function restart() {
     return new CompactionHandler({
       workspaceId,
       historyService: store.historyService,
       sessionDir,
-      emitter: new EventEmitter(),
+      emitter,
     });
   }
 
@@ -45,6 +46,7 @@ describe("exact pending snapshot consumption", () => {
     store = await createTestHistoryService();
     sessionDir = path.join(store.tempDir, "pending");
     pendingPath = path.join(sessionDir, "post-compaction.json");
+    emitter = new EventEmitter();
     handler = restart();
   });
 
@@ -318,6 +320,49 @@ describe("exact pending snapshot consumption", () => {
       else await handler.discardPendingState("context_exceeded", consumed);
       expect(await handler.peekPendingState()).toBeNull();
       expect(await restart().peekPendingState()).toBeNull();
+    }
+  );
+
+  it.each(["before-delete", "after-delete"] as const)(
+    "held heartbeat cleanup preserves successor pending state (%s)",
+    async (phase) => {
+      await publish("a");
+      const rows = await store.historyService.getLastMessages(workspaceId, 1);
+      assert(rows.success, "Expected A boundary");
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const cleanup = store.historyService.cleanupCompactionFollowUp.bind(store.historyService);
+      spyOn(store.historyService, "cleanupCompactionFollowUp").mockImplementationOnce(
+        async (...args) => {
+          const result = phase === "after-delete" ? await cleanup(...args) : undefined;
+          entered.resolve();
+          await release.promise;
+          return result ?? cleanup(...args);
+        }
+      );
+      const rollback = handler.rollbackHeartbeatContextResetBoundary(rows.data[0]);
+      try {
+        await entered.promise;
+        const successor = await publish("b");
+        const bytes = await fs.readFile(pendingPath, "utf8");
+        const emitted = spyOn(emitter, "emit");
+        release.resolve();
+        expect(await rollback).toEqual({
+          success: true,
+          data: phase === "before-delete" ? "skipped" : "applied",
+        });
+        if (phase === "before-delete") expect(emitted).not.toHaveBeenCalled();
+        else
+          expect(emitted).toHaveBeenCalledWith("chat-event", {
+            workspaceId,
+            message: { type: "delete", historySequences: [rows.data[0].metadata?.historySequence] },
+          });
+        expect(await fs.readFile(pendingPath, "utf8")).toBe(bytes);
+        expect(await handler.peekPendingState()).toEqual(successor);
+      } finally {
+        release.resolve();
+        await rollback;
+      }
     }
   );
 });

--- a/src/node/services/compactionHandler.ts
+++ b/src/node/services/compactionHandler.ts
@@ -4,7 +4,7 @@ import assert from "@/common/utils/assert";
 import { isNonNegativeInteger, isPositiveInteger } from "@/common/utils/numbers";
 import * as path from "path";
 
-import type { HistoryService } from "./historyService";
+import type { CompactionFollowUpCleanupOutcome, HistoryService } from "./historyService";
 
 import type { CompactionCompletionMetadata } from "@/common/types/compaction";
 import type { ContinuousCompactionPublication } from "./continuousCompactionJournal";
@@ -924,8 +924,9 @@ export class CompactionHandler {
   }
 
   async rollbackHeartbeatContextResetBoundary(
-    summaryMessage: MuxMessage
-  ): Promise<Result<void, string>> {
+    summaryMessage: MuxMessage,
+    isCurrent: () => boolean = () => true
+  ): Promise<Result<CompactionFollowUpCleanupOutcome, string>> {
     assert(
       summaryMessage.role === "assistant",
       "rollbackHeartbeatContextResetBoundary requires an assistant boundary message"
@@ -935,15 +936,21 @@ export class CompactionHandler {
       "rollbackHeartbeatContextResetBoundary requires a heartbeat reset boundary"
     );
 
-    const deleteResult = await this.historyService.deleteMessage(
+    const owner = this.pendingStateOwner;
+    const deleteResult = await this.historyService.cleanupCompactionFollowUp(
       this.workspaceId,
-      summaryMessage.id
+      summaryMessage,
+      "rollback-heartbeat",
+      () => this.pendingStateOwner === owner && isCurrent()
     );
     if (!deleteResult.success) {
       return Err(`Failed to delete heartbeat reset boundary: ${deleteResult.error}`);
     }
+    // A replacement retained its boundary, so its cached state and renderer row must survive too.
+    if (deleteResult.data === "skipped") return deleteResult;
 
-    await this.restoreHeartbeatResetRollbackState();
+    if (this.pendingStateOwner === owner && isCurrent())
+      await this.restoreHeartbeatResetRollbackState();
 
     const historySequence = summaryMessage.metadata?.historySequence;
     if (isNonNegativeInteger(historySequence)) {
@@ -953,7 +960,7 @@ export class CompactionHandler {
       });
     }
 
-    return Ok(undefined);
+    return Ok("applied");
   }
 
   /**

--- a/src/node/services/compactionHandler.ts
+++ b/src/node/services/compactionHandler.ts
@@ -949,8 +949,9 @@ export class CompactionHandler {
     // A replacement retained its boundary, so its cached state and renderer row must survive too.
     if (deleteResult.data === "skipped") return deleteResult;
 
-    if (this.pendingStateOwner === owner && isCurrent())
-      await this.restoreHeartbeatResetRollbackState();
+    // Once deletion commits, a new turn cannot cancel reconciliation of this owner's snapshot.
+    // A replacement pending-state owner still takes precedence over the rollback.
+    if (this.pendingStateOwner === owner) await this.restoreHeartbeatResetRollbackState();
 
     const historySequence = summaryMessage.metadata?.historySequence;
     if (isNonNegativeInteger(historySequence)) {

--- a/src/node/services/historyService.compactionFollowUpCleanup.test.ts
+++ b/src/node/services/historyService.compactionFollowUpCleanup.test.ts
@@ -110,6 +110,58 @@ describe("conditional compaction follow-up cleanup", () => {
   });
 
   for (const action of actions) {
+    test.each([undefined, null, -1, 0.5, "0"])(
+      `${action} skips invalid persisted sequence %p and permits later healthy cleanup`,
+      async (sequence) => {
+        const expected = summary();
+        await store.historyService.appendToHistory(workspaceId, expected);
+        const historyPath = path.join(store.config.sessionsDir, workspaceId, "chat.jsonl");
+        // Corrupt the persisted identity, then use the same reader as resumed cleanup.
+        const corrupted =
+          JSON.stringify({
+            ...expected,
+            workspaceId,
+            metadata: { ...expected.metadata, historySequence: sequence },
+          }) + "\n";
+        await fs.writeFile(historyPath, corrupted);
+        const loaded = await store.historyService.getLastMessages(workspaceId, 1);
+        assert(loaded.success && loaded.data.length === 1, "Expected persisted summary");
+        const invalid = loaded.data[0];
+        const persistedSequence: unknown = invalid.metadata?.historySequence;
+        expect(persistedSequence).toBe(sequence);
+        expect(
+          await store.historyService.cleanupCompactionFollowUp(
+            workspaceId,
+            invalid,
+            action,
+            () => true
+          )
+        ).toEqual(Ok("skipped"));
+        expect(await fs.readFile(historyPath, "utf8")).toBe(corrupted);
+
+        // Reusing the ID must not let a later healthy cleanup touch the unproven row.
+        const healthy = summary();
+        expect(await store.historyService.appendToHistory(workspaceId, healthy)).toEqual(
+          Ok(undefined)
+        );
+        expect(
+          await store.historyService.cleanupCompactionFollowUp(
+            workspaceId,
+            healthy,
+            action,
+            () => true
+          )
+        ).toEqual(Ok("applied"));
+        const history = await store.historyService.getLastMessages(workspaceId, 10);
+        assert(history.success, "Expected history after healthy cleanup");
+        expect(history.data[0]).toEqual(invalid);
+        expect(history.data).toHaveLength(action === "clear" ? 2 : 1);
+        if (action === "clear") {
+          expect(history.data[1].metadata?.muxMetadata).not.toHaveProperty("pendingFollowUp");
+        }
+      }
+    );
+
     test.each(["id", "sequence", "request"] as const)(
       `${action} skips a replaced %s after waiting for the history lock`,
       async (changed) => {

--- a/src/node/services/historyService.compactionFollowUpCleanup.test.ts
+++ b/src/node/services/historyService.compactionFollowUpCleanup.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as atomicWrite from "write-file-atomic";
+import { createMuxMessage } from "@/common/types/message";
+import { Ok } from "@/common/types/result";
+import assert from "@/common/utils/assert";
+import { workspaceFileLocks } from "@/node/utils/concurrency/workspaceFileLocks";
+import { createTestHistoryService } from "./testHistoryService";
+
+const workspaceId = "follow-up-cleanup";
+const actions = ["clear", "rollback-heartbeat"] as const;
+const request = { text: "resume", model: "openai:gpt-4o", agentId: "exec" };
+
+function summary() {
+  return createMuxMessage("summary", "assistant", "summary", {
+    compacted: "heartbeat",
+    compactionBoundary: true,
+    compactionEpoch: 1,
+    muxMetadata: { type: "compaction-summary", pendingFollowUp: request },
+  });
+}
+
+function afterNextAtomicWrite(after: () => Promise<void>) {
+  const write = atomicWrite.default;
+  spyOn(atomicWrite, "default").mockImplementationOnce(
+    Object.assign(
+      async (
+        filename: string,
+        contents: string | Buffer,
+        options?: atomicWrite.Options | BufferEncoding | ((error?: Error) => void)
+      ) => {
+        assert(typeof options !== "function", "Cleanup uses the Promise write interface");
+        await write(filename, contents, options);
+        await after();
+      },
+      { sync: write.sync }
+    )
+  );
+}
+
+describe("conditional compaction follow-up cleanup", () => {
+  let store: Awaited<ReturnType<typeof createTestHistoryService>>;
+  beforeEach(async () => {
+    store = await createTestHistoryService();
+  });
+  afterEach(async () => {
+    mock.restore();
+    await store.cleanup();
+  });
+
+  test("clearing a handoff preserves late summary finalization and unrelated rows", async () => {
+    const expected = summary();
+    expect(await store.historyService.appendToHistory(workspaceId, expected)).toEqual(
+      Ok(undefined)
+    );
+    const finalized = {
+      ...expected,
+      parts: [{ type: "text" as const, text: "finalized summary" }],
+      metadata: { ...expected.metadata, duration: 42 },
+    };
+    expect(await store.historyService.updateHistory(workspaceId, finalized)).toEqual(Ok(undefined));
+    const later = createMuxMessage("later", "user", "new input");
+    await store.historyService.appendToHistory(workspaceId, later);
+    expect(
+      await store.historyService.cleanupCompactionFollowUp(
+        workspaceId,
+        expected,
+        "clear",
+        () => true
+      )
+    ).toEqual(Ok("applied"));
+    const history = await store.historyService.getLastMessages(workspaceId, 2);
+    assert(history.success, "Expected history");
+    expect(history.data[0]).toMatchObject({
+      ...finalized,
+      metadata: { ...finalized.metadata, muxMetadata: { type: "compaction-summary" } },
+    });
+    expect(history.data[0].metadata?.muxMetadata).not.toHaveProperty("pendingFollowUp");
+    expect(history.data[1]).toMatchObject(later);
+    expect(
+      await store.historyService.cleanupCompactionFollowUp(
+        workspaceId,
+        expected,
+        "clear",
+        () => true
+      )
+    ).toEqual(Ok("skipped"));
+  });
+
+  test("staging failure preserves history and removes the incomplete cleanup file", async () => {
+    const expected = summary();
+    await store.historyService.appendToHistory(workspaceId, expected);
+    const sessionDir = path.join(store.config.sessionsDir, workspaceId);
+    const historyPath = path.join(sessionDir, "chat.jsonl");
+    const original = await fs.readFile(historyPath);
+    afterNextAtomicWrite(() => Promise.reject(new Error("staging failed")));
+    const result = await store.historyService.cleanupCompactionFollowUp(
+      workspaceId,
+      expected,
+      "clear",
+      () => true
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain("staging failed");
+    expect(await fs.readFile(historyPath)).toEqual(original);
+    expect((await fs.readdir(sessionDir)).filter((name) => name.includes(".follow-up-"))).toEqual(
+      []
+    );
+  });
+
+  for (const action of actions) {
+    test.each(["id", "sequence", "request"] as const)(
+      `${action} skips a replaced %s after waiting for the history lock`,
+      async (changed) => {
+        const expected = summary();
+        await store.historyService.appendToHistory(workspaceId, expected);
+        let replacementSummary = expected;
+        if (changed === "sequence") {
+          await store.historyService.deleteMessage(workspaceId, expected.id);
+          replacementSummary = summary();
+          await store.historyService.appendToHistory(workspaceId, replacementSummary);
+          expect(replacementSummary.metadata?.historySequence).not.toBe(
+            expected.metadata?.historySequence
+          );
+        }
+        const entered = Promise.withResolvers<void>();
+        const release = Promise.withResolvers<void>();
+        const held = workspaceFileLocks.withLock(workspaceId, async () => {
+          entered.resolve();
+          await release.promise;
+        });
+        await entered.promise;
+        // Queue the replacement before cleanup. Both execute through the real history lock.
+        const replacement = store.historyService.updateHistory(workspaceId, {
+          ...replacementSummary,
+          id: changed === "id" ? "replacement" : expected.id,
+          metadata: {
+            ...replacementSummary.metadata,
+            muxMetadata: {
+              type: "compaction-summary",
+              pendingFollowUp: changed === "request" ? { ...request, text: "new work" } : request,
+            },
+          },
+        });
+        const cleanup = store.historyService.cleanupCompactionFollowUp(
+          workspaceId,
+          expected,
+          action,
+          () => true
+        );
+        try {
+          release.resolve();
+          expect(await replacement).toEqual(Ok(undefined));
+          expect(await cleanup).toEqual(Ok("skipped"));
+          const history = await store.historyService.getLastMessages(workspaceId, 1);
+          assert(history.success, "Expected replacement history");
+          expect(history.data[0].metadata?.muxMetadata).toHaveProperty("pendingFollowUp");
+          expect(history.data[0].id).toBe(changed === "id" ? "replacement" : "summary");
+        } finally {
+          release.resolve();
+          await Promise.all([held, replacement, cleanup]);
+        }
+      }
+    );
+
+    test(`${action} rechecks local ownership after staged I/O and removes the unused file`, async () => {
+      const expected = summary();
+      await store.historyService.appendToHistory(workspaceId, expected);
+      const sessionDir = path.join(store.config.sessionsDir, workspaceId);
+      const historyPath = path.join(sessionDir, "chat.jsonl");
+      const original = await fs.readFile(historyPath);
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      afterNextAtomicWrite(async () => {
+        entered.resolve();
+        await release.promise;
+      });
+      let current = true;
+      const cleanup = store.historyService.cleanupCompactionFollowUp(
+        workspaceId,
+        expected,
+        action,
+        () => current
+      );
+      try {
+        await entered.promise;
+        current = false;
+        release.resolve();
+        expect(await cleanup).toEqual(Ok("skipped"));
+        expect(await fs.readFile(historyPath)).toEqual(original);
+        expect(
+          (await fs.readdir(sessionDir)).filter((name) => name.includes(".follow-up-"))
+        ).toEqual([]);
+      } finally {
+        release.resolve();
+        await cleanup;
+      }
+    });
+  }
+
+  test("heartbeat deletion preserves the archive and never reuses its removed sequence", async () => {
+    await store.historyService.appendToHistory(
+      workspaceId,
+      createMuxMessage("prior", "user", "context")
+    );
+    const expected = summary();
+    await store.historyService.appendToHistory(workspaceId, expected);
+    expect(
+      await store.historyService.cleanupCompactionFollowUp(
+        workspaceId,
+        expected,
+        "rollback-heartbeat",
+        () => true
+      )
+    ).toEqual(Ok("applied"));
+    const next = createMuxMessage("next", "user", "new input");
+    await store.historyService.appendToHistory(workspaceId, next);
+    expect(next.metadata!.historySequence!).toBeGreaterThan(expected.metadata!.historySequence!);
+    const history = await store.historyService.getLastMessages(workspaceId, 10);
+    assert(history.success, "Expected restored history");
+    expect(history.data.map((row) => row.id)).toEqual(["prior", "next"]);
+  });
+});

--- a/src/node/services/historyService.compactionFollowUpCleanup.test.ts
+++ b/src/node/services/historyService.compactionFollowUpCleanup.test.ts
@@ -110,6 +110,53 @@ describe("conditional compaction follow-up cleanup", () => {
   });
 
   for (const action of actions) {
+    test.each(["EBUSY", "EACCES"])(
+      `${action} preserves a retired owner's skip when staged-file removal fails with %s`,
+      async (code) => {
+        const expected = summary();
+        await store.historyService.appendToHistory(workspaceId, expected);
+        const sessionDir = path.join(store.config.sessionsDir, workspaceId);
+        const historyPath = path.join(sessionDir, "chat.jsonl");
+        const original = await fs.readFile(historyPath);
+        let current = true;
+        afterNextAtomicWrite(() => {
+          current = false;
+          spyOn(fs, "rm").mockRejectedValueOnce(
+            Object.assign(new Error("staged-file removal failed"), { code })
+          );
+          return Promise.resolve();
+        });
+        expect(
+          await store.historyService.cleanupCompactionFollowUp(
+            workspaceId,
+            expected,
+            action,
+            () => current
+          )
+        ).toEqual(Ok("skipped"));
+        expect(await fs.readFile(historyPath)).toEqual(original);
+        expect(
+          (await fs.readdir(sessionDir)).filter((name) => name.includes(".follow-up-"))
+        ).toHaveLength(1);
+
+        // An unused staging file must not prevent a later owner's healthy cleanup.
+        expect(
+          await store.historyService.cleanupCompactionFollowUp(
+            workspaceId,
+            expected,
+            action,
+            () => true
+          )
+        ).toEqual(Ok("applied"));
+        const history = await store.historyService.getLastMessages(workspaceId, 1);
+        assert(history.success, "Expected history after healthy cleanup");
+        expect(history.data).toHaveLength(action === "clear" ? 1 : 0);
+        if (action === "clear") {
+          expect(history.data[0].metadata?.muxMetadata).not.toHaveProperty("pendingFollowUp");
+        }
+      }
+    );
+
     test(`${action} skips duplicate persisted identities without changing history`, async () => {
       const expected = summary();
       await store.historyService.appendToHistory(workspaceId, expected);

--- a/src/node/services/historyService.compactionFollowUpCleanup.test.ts
+++ b/src/node/services/historyService.compactionFollowUpCleanup.test.ts
@@ -110,6 +110,59 @@ describe("conditional compaction follow-up cleanup", () => {
   });
 
   for (const action of actions) {
+    test(`${action} skips duplicate persisted identities without changing history`, async () => {
+      const expected = summary();
+      await store.historyService.appendToHistory(workspaceId, expected);
+      const historyPath = path.join(store.config.sessionsDir, workspaceId, "chat.jsonl");
+      const original = await fs.readFile(historyPath);
+      // Simulate a persisted duplicate that normal append sequence checks would reject.
+      await fs.appendFile(historyPath, original);
+      const duplicated = Buffer.concat([original, original]);
+      const loaded = await store.historyService.getLastMessages(workspaceId, 2);
+      assert(loaded.success && loaded.data.length === 2, "Expected readable duplicate summaries");
+      expect(loaded.data[0]).toEqual(loaded.data[1]);
+      expect(
+        await store.historyService.cleanupCompactionFollowUp(
+          workspaceId,
+          loaded.data[0],
+          action,
+          () => true
+        )
+      ).toEqual(Ok("skipped"));
+      expect(await fs.readFile(historyPath)).toEqual(duplicated);
+    });
+
+    test(`${action} preserves the same ID at a different persisted sequence`, async () => {
+      const expected = summary();
+      await store.historyService.appendToHistory(workspaceId, expected);
+      const sequence = expected.metadata?.historySequence;
+      assert(sequence != null, "Expected persisted summary sequence");
+      const unrelated = {
+        ...expected,
+        metadata: { ...expected.metadata, historySequence: sequence + 1 },
+      };
+      // Keep both rows active; normal boundary append would archive the cleanup target.
+      await fs.appendFile(
+        path.join(store.config.sessionsDir, workspaceId, "chat.jsonl"),
+        JSON.stringify({ ...unrelated, workspaceId }) + "\n"
+      );
+      expect(
+        await store.historyService.cleanupCompactionFollowUp(
+          workspaceId,
+          expected,
+          action,
+          () => true
+        )
+      ).toEqual(Ok("applied"));
+      const history = await store.historyService.getLastMessages(workspaceId, 2);
+      assert(history.success, "Expected history after cleanup");
+      expect(history.data).toHaveLength(action === "clear" ? 2 : 1);
+      expect(history.data.at(-1)).toMatchObject(unrelated);
+      if (action === "clear") {
+        expect(history.data[0].metadata?.muxMetadata).not.toHaveProperty("pendingFollowUp");
+      }
+    });
+
     test.each([undefined, null, -1, 0.5, "0"])(
       `${action} skips invalid persisted sequence %p and permits later healthy cleanup`,
       async (sequence) => {

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -2839,7 +2839,9 @@ export class HistoryService {
     const expected = summary.metadata?.muxMetadata;
     const sequence = summary.metadata?.historySequence;
     assert(summary.role === "assistant", "Follow-up cleanup requires an assistant summary");
-    assert(isNonNegativeInteger(sequence), "Follow-up cleanup requires a persisted summary");
+    // Corrupt persisted sequences cannot prove ownership; skip without blocking recovery
+    // or falling back to an ID-only mutation that could target a different summary.
+    if (!isNonNegativeInteger(sequence)) return Ok("skipped");
     assert(isCompactionSummaryMetadata(expected), "Follow-up cleanup requires summary metadata");
     assert(
       action !== "rollback-heartbeat" || summary.metadata?.compacted === "heartbeat",

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -2902,7 +2902,13 @@ export class HistoryService {
           }
           return Ok("applied");
         } finally {
-          if (!published) await fs.rm(stagedPath, { force: true });
+          if (!published) {
+            // A staging cleanup failure must not replace a retired owner's recoverable skip
+            // or hide the original publication error.
+            await fs.rm(stagedPath, { force: true }).catch((error: unknown) => {
+              log.warn("Failed to remove staged compaction follow-up file", error);
+            });
+          }
         }
       }
     );

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -17,7 +17,9 @@ import {
 import { getRequestPreludeMessageIds } from "@/common/utils/messages/requestPrelude";
 import { createContextBudgetRejectedMessage } from "@/common/utils/messages/contextBudgetRejection";
 import * as path from "path";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
+import { renameSync } from "node:fs";
+import { isDeepStrictEqual } from "node:util";
 import * as fs from "fs/promises";
 import {
   ContinuousCompactionJournalStore,
@@ -79,6 +81,8 @@ import {
  * workspace removal can hold it across its tombstone+delete critical section.
  */
 const HISTORY_WRITE_LOCK_TIMEOUT_MS = 10_000;
+
+export type CompactionFollowUpCleanupOutcome = "applied" | "skipped";
 
 interface HistoryTruncateHashes {
   finalArchiveHash: string | null;
@@ -2818,6 +2822,84 @@ export class HistoryService {
   async updateHistory(workspaceId: string, message: MuxMessage): Promise<Result<void>> {
     return this.withRecoveredHistoryWriteResultLock(workspaceId, "Failed to update history", () =>
       this.updateHistoryUnderWriteLock(workspaceId, message)
+    );
+  }
+
+  /**
+   * Cleanup owns the captured handoff, not the whole summary row. Revalidate under the
+   * history lock so queued cleanup cannot overwrite a replacement or late finalization.
+   * The pure ownership probe also runs immediately before publication, after staged I/O.
+   */
+  async cleanupCompactionFollowUp(
+    workspaceId: string,
+    summary: MuxMessage,
+    action: "clear" | "rollback-heartbeat",
+    isCurrent: () => boolean
+  ): Promise<Result<CompactionFollowUpCleanupOutcome>> {
+    const expected = summary.metadata?.muxMetadata;
+    const sequence = summary.metadata?.historySequence;
+    assert(summary.role === "assistant", "Follow-up cleanup requires an assistant summary");
+    assert(isNonNegativeInteger(sequence), "Follow-up cleanup requires a persisted summary");
+    assert(isCompactionSummaryMetadata(expected), "Follow-up cleanup requires summary metadata");
+    assert(
+      action !== "rollback-heartbeat" || summary.metadata?.compacted === "heartbeat",
+      "Heartbeat rollback requires a heartbeat boundary"
+    );
+    return this.withRecoveredHistoryWriteResultLock<CompactionFollowUpCleanupOutcome>(
+      workspaceId,
+      "Failed to clean up compaction follow-up",
+      async () => {
+        if (!isCurrent() || !expected.pendingFollowUp) return Ok("skipped");
+        const historyPath = this.getChatHistoryPath(workspaceId);
+        const { rows, messages } = await this.readHistoryForRewrite(historyPath);
+        // Archived summaries no longer own an active continuation or reset rollback.
+        const current = messages.find(
+          (row) => row.id === summary.id && row.metadata?.historySequence === sequence
+        );
+        const metadata = current?.metadata?.muxMetadata;
+        if (
+          !current ||
+          current.role !== "assistant" ||
+          !isCompactionSummaryMetadata(metadata) ||
+          !isDeepStrictEqual(metadata.pendingFollowUp, expected.pendingFollowUp) ||
+          (action === "rollback-heartbeat" && current.metadata?.compacted !== "heartbeat") ||
+          !isCurrent()
+        )
+          return Ok("skipped");
+
+        const { pendingFollowUp: _pending, ...remainingMetadata } = metadata;
+        const replacement =
+          action === "rollback-heartbeat"
+            ? null
+            : {
+                ...current,
+                metadata: { ...current.metadata, muxMetadata: remainingMetadata },
+              };
+        const serialized = this.serializeHistoryRewrite(rows, workspaceId, (row) =>
+          row === current ? replacement : row
+        );
+        const stagedPath = `${historyPath}.follow-up-${randomUUID()}`;
+        let published = false;
+        try {
+          await writeFileAtomic(stagedPath, serialized, { mode: 0o600 });
+          // Admission may change while the file is staged. The final check and rename
+          // are synchronous, so the retired owner cannot publish in that gap.
+          if (!isCurrent()) return Ok("skipped");
+          invalidateHistoryAppendProvenance();
+          renameSync(stagedPath, historyPath);
+          published = true;
+          if (action === "rollback-heartbeat") {
+            // Do not reuse the removed row's sequence within this process.
+            this.sequenceCounters.set(
+              workspaceId,
+              Math.max(this.sequenceCounters.get(workspaceId) ?? 0, sequence + 1)
+            );
+          }
+          return Ok("applied");
+        } finally {
+          if (!published) await fs.rm(stagedPath, { force: true });
+        }
+      }
     );
   }
 

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -2855,9 +2855,12 @@ export class HistoryService {
         const historyPath = this.getChatHistoryPath(workspaceId);
         const { rows, messages } = await this.readHistoryForRewrite(historyPath);
         // Archived summaries no longer own an active continuation or reset rollback.
-        const current = messages.find(
+        const matches = messages.filter(
           (row) => row.id === summary.id && row.metadata?.historySequence === sequence
         );
+        // Duplicate identities cannot prove which row owns the handoff; leave both untouched.
+        if (matches.length !== 1) return Ok("skipped");
+        const current = matches[0];
         const metadata = current?.metadata?.muxMetadata;
         if (
           !current ||


### PR DESCRIPTION
Queued compaction cleanup can resume after a replacement turn and overwrite newer summary metadata or delete its heartbeat boundary. Make these two cleanup operations conditional under the existing history lock: match the captured summary ID, sequence and pending request, transform the current row, and recheck local ownership immediately before rename.

Skipped heartbeat cleanup restores no pending state and emits no deletion. Ordinary history update/delete APIs and serialized cleanup waiting remain unchanged.

This small prerequisite above #4134 replaces part of closed #4121. Correlated continuation handoff will be a separate PR; this change does not enable overlapping retirement or add durable cancellation.

Validation: the original broader run passed 303 tests; the final adapted layer passes all 176 affected tests and full static checks. Coverage includes exact cleanup, 10 corrupt-sequence cases, duplicate-identity skips, same-ID/different-sequence controls, and session races while cleanup is queued or its committed result is delayed. Invalid or ambiguous identity evidence returns a recoverable skip without permitting deletion by ID alone. Independent review approved the adaptation; coordinator review approved the final uniqueness guard.

Risk: an incorrect match could clear the wrong pending follow-up or skip a valid cleanup. Tests cover current-owner success, stale-owner rejection, unrelated metadata preservation, staging failure, and preserved history sequence/archive behavior.

---

_Generated with `xum` • Model: `unavailable` • Thinking: `unavailable` • Cost: `$unavailable`_

<!-- mux-attribution: model=unavailable thinking=unavailable costs=unavailable -->
