### PR TITLE
🤖 refactor: add inactive pending attachment file primitives

### DIFF
--- a/src/common/utils/messages/compactionBoundary.test.ts
+++ b/src/common/utils/messages/compactionBoundary.test.ts
@@ -214,6 +214,28 @@ describe("context boundary helpers", () => {
     ).toBe(false);
     expect(hasProviderEligibleMessages([createMuxMessage("u1", "user", "after")])).toBe(true);
   });
+
+  it("optionally counts reasoning while excluding rejected payloads and reset markers", () => {
+    const reasoning = createMuxMessage("thinking", "assistant", "");
+    reasoning.parts = [{ type: "reasoning", text: "Preserved thinking" }];
+    expect(hasProviderEligibleMessages([reasoning])).toBe(false);
+    expect(hasProviderEligibleMessages([reasoning], { preserveReasoningOnly: true })).toBe(true);
+    for (const metadata of [
+      { contextBudgetRejected: true as const },
+      { contextBoundaryKind: "reset" as const },
+    ]) {
+      expect(
+        hasProviderEligibleMessages([{ ...reasoning, metadata }], {
+          preserveReasoningOnly: true,
+        })
+      ).toBe(false);
+    }
+    expect(
+      hasProviderEligibleMessages([createMuxMessage("empty", "assistant", "")], {
+        preserveReasoningOnly: true,
+      })
+    ).toBe(false);
+  });
 });
 
 describe("sliceMessagesFromLatestCompactionBoundary", () => {

--- a/src/common/utils/messages/compactionBoundary.ts
+++ b/src/common/utils/messages/compactionBoundary.ts
@@ -128,17 +128,23 @@ export function sliceMessagesFromLatestCompactionBoundary(messages: MuxMessage[]
   return sliced;
 }
 
-export function isProviderEligibleMessage(message: MuxMessage): boolean {
+export function isProviderEligibleMessage(
+  message: MuxMessage,
+  options?: Parameters<typeof hasProviderReplayableContent>[1]
+): boolean {
   if (isDurableContextResetBoundaryMarker(message)) {
     return false;
   }
 
-  return hasProviderReplayableContent(message);
+  return hasProviderReplayableContent(message, options);
 }
 
-export function hasProviderEligibleMessages(messages: MuxMessage[]): boolean {
+export function hasProviderEligibleMessages(
+  messages: MuxMessage[],
+  options?: Parameters<typeof hasProviderReplayableContent>[1]
+): boolean {
   assert(Array.isArray(messages), "hasProviderEligibleMessages requires a message array");
-  return messages.some(isProviderEligibleMessage);
+  return messages.some((message) => isProviderEligibleMessage(message, options));
 }
 
 /**

--- a/src/node/services/compactionPendingState.test.ts
+++ b/src/node/services/compactionPendingState.test.ts
@@ -190,11 +190,13 @@ describe("unactivated compaction pending-file protocol", () => {
     expect(await bytes()).toBe(raw);
   });
 
-  it("treats a directory sidecar as absent across repeated recovery loads", async () => {
+  it("repairs an empty directory sidecar across repeated recovery loads", async () => {
     await fs.mkdir(filePath);
     expect(await store.load(() => true)).toBeUndefined();
     expect(await restart().load(() => true)).toBeUndefined();
-    expect((await fs.stat(filePath)).isDirectory()).toBe(true);
+    expect(await fs.stat(filePath).catch((error: unknown) => error)).toMatchObject({
+      code: "ENOENT",
+    });
     expect(
       (
         await h.historyService.appendToHistory(
@@ -203,10 +205,46 @@ describe("unactivated compaction pending-file protocol", () => {
         )
       ).success
     ).toBe(true);
-    await fs.rmdir(filePath);
     await prepare("fresh");
     await boundary("fresh");
     expect((await restart().load(() => true))?.attachments.readFiles).toEqual(["/fresh.ts"]);
+  });
+
+  it.each(["prepare", "discard"] as const)(
+    "repairs an empty directory sidecar without an earlier load (%s)",
+    async (operation) => {
+      await fs.mkdir(filePath);
+      if (operation === "discard") {
+        await h.historyService.getContinuousCompactionJournal(workspaceId).advanceGeneration();
+        await store.discardAfterBoundary();
+        await store.discardAfterBoundary();
+        expect(await fs.stat(filePath).catch((error: unknown) => error)).toMatchObject({
+          code: "ENOENT",
+        });
+      }
+      const receipt = await prepare("fresh");
+      await boundary("fresh");
+      expect((await restart().load(() => true))?.attachments).toEqual(receipt.attachments);
+      expect(await store.consume(receipt)).toBe(true);
+      await prepare("next");
+      await boundary("next");
+      expect((await restart().load(() => true))?.attachments.readFiles).toEqual(["/next.ts"]);
+    }
+  );
+
+  it("preserves unrelated contents in a nonempty directory sidecar", async () => {
+    await fs.mkdir(filePath);
+    const unrelated = path.join(filePath, "keep.txt");
+    await fs.writeFile(unrelated, "unrelated content");
+    expect(await store.load(() => true)).toBeUndefined();
+    expect(await restart().load(() => true)).toBeUndefined();
+    expect(await prepare("refused").catch((error: unknown) => error)).toBeInstanceOf(Error);
+    await h.historyService.getContinuousCompactionJournal(workspaceId).advanceGeneration();
+    expect(await store.discardAfterBoundary().catch((error: unknown) => error)).toBeInstanceOf(
+      Error
+    );
+    expect(await fs.readFile(unrelated, "utf8")).toBe("unrelated content");
+    expect((await fs.stat(filePath)).isDirectory()).toBe(true);
   });
 
   it.each(["corrupt JSON", "invalid V1", "stale generation"] as const)(

--- a/src/node/services/compactionPendingState.test.ts
+++ b/src/node/services/compactionPendingState.test.ts
@@ -155,6 +155,21 @@ describe("unactivated compaction pending-file protocol", () => {
     }
   );
 
+  it.each(
+    ["null", "[]", JSON.stringify("invalid pending state")].flatMap((raw) =>
+      [false, true].map((loadFirst) => ({ raw, loadFirst }))
+    )
+  )("recovers non-object JSON roots before fresh publication (%j)", async ({ raw, loadFirst }) => {
+    await fs.writeFile(filePath, raw);
+    if (loadFirst) {
+      expect(await store.load(() => true)).toBeUndefined();
+      expect(await bytes().catch((error: unknown) => error)).toMatchObject({ code: "ENOENT" });
+    }
+    const receipt = await prepare("fresh");
+    await boundary("fresh");
+    expect((await restart().load(() => true))?.attachments).toEqual(receipt.attachments);
+  });
+
   it.each([
     { version: 2, publicationGeneration: "future-generation", ...attachments("future") },
     { schema: "future", data: { attachments: ["keep"] } },

--- a/src/node/services/compactionPendingState.test.ts
+++ b/src/node/services/compactionPendingState.test.ts
@@ -1,0 +1,430 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import assert from "node:assert/strict";
+import { readdirSync } from "node:fs";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { CHAT_ARCHIVE_FILE_NAME, CHAT_FILE_NAME } from "@/common/constants/paths";
+import { createMuxMessage } from "@/common/types/message";
+import { isDurableContextBoundaryMarker } from "@/common/utils/messages/compactionBoundary";
+import { acquireProcessFileLock } from "@/node/utils/concurrency/fileLock";
+import { workspaceFileLocks } from "@/node/utils/concurrency/workspaceFileLocks";
+import {
+  CompactionPendingState,
+  type CompactionPendingAttachments,
+  type CompactionPendingHistory,
+  type CompactionPendingReceipt,
+} from "./compactionPendingState";
+import { HistoryService } from "./historyService";
+import { readProviderHistoryFromLatestBoundary } from "./historyScanner";
+import { createTestHistoryService } from "./testHistoryService";
+import { historyWriteLockPath, isWorkspaceRemovalTombstoned } from "./workspaceRemoval";
+
+describe("unactivated compaction pending-file protocol", () => {
+  const workspaceId = "pending-protocol";
+  let h: Awaited<ReturnType<typeof createTestHistoryService>>;
+  let filePath: string;
+  let store: CompactionPendingState;
+
+  // This test adapter uses the existing locks and real history/journal readers. Production
+  // activation must expose the equivalent transaction on HistoryService; it must not nest locks.
+  function historyAdapter(history = h.historyService): CompactionPendingHistory {
+    return {
+      withLock: (operation) =>
+        workspaceFileLocks.withLock(workspaceId, async () => {
+          await using _lock = await acquireProcessFileLock({
+            lockPath: historyWriteLockPath(h.config.rootDir, workspaceId),
+            timeoutMs: 5000,
+            label: "pending protocol test",
+          });
+          if (await isWorkspaceRemovalTombstoned(h.config.rootDir, workspaceId))
+            throw new Error("Removed workspace");
+          const journal = history.getContinuousCompactionJournal(workspaceId);
+          const rows = await readProviderHistoryFromLatestBoundary(
+            {
+              chat: path.join(h.config.sessionsDir, workspaceId, CHAT_FILE_NAME),
+              archive: path.join(h.config.sessionsDir, workspaceId, CHAT_ARCHIVE_FILE_NAME),
+            },
+            0
+          );
+          return await operation({
+            generation: await journal.captureGenerationUnderHistoryLock(),
+            boundaryMessageId: rows.findLast(isDurableContextBoundaryMarker)?.id,
+            isPublicationCurrent: (publication) =>
+              journal.isPublicationCurrentUnderHistoryLock(publication),
+          });
+        }),
+    };
+  }
+
+  function attachments(name: string): CompactionPendingAttachments {
+    return {
+      diffs: [{ path: `/${name}.ts`, diff: `+${name}`, truncated: false }],
+      loadedSkills: [],
+      readFiles: [`/${name}.ts`],
+    };
+  }
+
+  async function prepare(name: string, target = store): Promise<CompactionPendingReceipt> {
+    const receipt = await target.prepare({
+      attachments: attachments(name),
+      boundaryMessageId: name,
+      publication: {
+        generation: await h.historyService
+          .getContinuousCompactionJournal(workspaceId)
+          .captureGeneration(),
+      },
+      isCurrent: () => true,
+    });
+    assert(receipt);
+    return receipt;
+  }
+
+  async function boundary(id: string) {
+    expect(
+      (
+        await h.historyService.appendToHistory(
+          workspaceId,
+          createMuxMessage(id, "assistant", id, {
+            compacted: "user",
+            compactionBoundary: true,
+            compactionEpoch: 1,
+          })
+        )
+      ).success
+    ).toBe(true);
+  }
+
+  async function bytes() {
+    return fs.readFile(filePath, "utf8");
+  }
+  function restart() {
+    return new CompactionPendingState(filePath, historyAdapter(new HistoryService(h.config)));
+  }
+
+  beforeEach(async () => {
+    h = await createTestHistoryService();
+    await h.historyService.appendToHistory(
+      workspaceId,
+      createMuxMessage("seed", "user", "Context")
+    );
+    filePath = path.join(h.config.sessionsDir, workspaceId, "post-compaction.json");
+    store = new CompactionPendingState(filePath, historyAdapter());
+  });
+  afterEach(async () => {
+    mock.restore();
+    await h.cleanup();
+  });
+
+  it("loads old V1 files, sanitizes individual attachments, and consumes across reload", async () => {
+    await fs.writeFile(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        createdAt: 1,
+        diffs: [null, { path: " /valid.ts ", diff: "+valid", truncated: false }, { path: 3 }],
+        loadedSkills: [null, { name: " guide ", scope: "project", body: "Keep context" }],
+      })
+    );
+    const loaded = await store.load(() => true);
+    assert(loaded);
+    expect(loaded.attachments.diffs).toEqual([
+      { path: "/valid.ts", diff: "+valid", truncated: false },
+    ]);
+    expect(loaded.attachments.loadedSkills.map((skill) => skill.name)).toEqual(["guide"]);
+    expect(loaded.attachments.readFiles).toEqual([]);
+    expect(await store.consume(loaded)).toBe(true);
+    expect(await restart().load(() => true)).toBeUndefined();
+  });
+
+  it.each([
+    "{",
+    JSON.stringify({ version: 2 }),
+    JSON.stringify({ version: 1, createdAt: 1, publicationGeneration: false }),
+  ])("heals unusable persisted state (%s)", async (raw) => {
+    await fs.writeFile(filePath, raw);
+    expect(await store.load(() => true)).toBeUndefined();
+    expect(await bytes().catch((error: unknown) => error)).toMatchObject({ code: "ENOENT" });
+    await prepare("fresh");
+    await boundary("fresh");
+    expect((await store.load(() => true))?.attachments.readFiles).toEqual(["/fresh.ts"]);
+  });
+
+  it("does not use provisional attachments before their exact boundary commits", async () => {
+    const receipt = await prepare("pending");
+    const raw = await bytes();
+    expect(await restart().load(() => true)).toBeUndefined();
+    expect(await bytes()).toBe(raw);
+    await boundary("pending");
+    expect((await restart().load(() => true))?.attachments).toEqual(receipt.attachments);
+    expect(await store.rollback(receipt, () => true)).toBe(false);
+  });
+
+  it.each([false, true])(
+    "equal payloads and timestamps have distinct ownership (foreign=%s)",
+    async (foreign) => {
+      spyOn(Date, "now").mockReturnValue(1000);
+      const first = await prepare("same");
+      const secondStore = foreign ? restart() : store;
+      const second = await prepare("same", secondStore);
+      const latest = await bytes();
+      expect(await store.consume(first)).toBe(false);
+      expect(await store.rollback(first, () => true)).toBe(false);
+      expect(await bytes()).toBe(latest);
+      expect(await secondStore.consume(second)).toBe(true);
+      expect(await store.consume(first)).toBe(false);
+    }
+  );
+
+  it.each([false, true])(
+    "consuming A removes only B's crash fallback (foreign=%s)",
+    async (foreign) => {
+      const a = await prepare("a");
+      await boundary("a");
+      const bStore = foreign ? restart() : store;
+      const b = await prepare("b", bStore);
+      expect((await restart().load(() => true))?.attachments).toEqual(a.attachments);
+      expect(await store.consume(a)).toBe(true);
+      // B remains intact and its receipt still owns rollback, but A cannot be resurrected.
+      expect(JSON.parse(await bytes())).toMatchObject({
+        boundaryMessageId: "b",
+        readFiles: ["/b.ts"],
+      });
+      expect(await bStore.rollback(b, () => true)).toBe(true);
+      expect(await restart().load(() => true)).toBeUndefined();
+    }
+  );
+
+  it("consuming a loaded fallback preserves a provisional successor that later commits", async () => {
+    await prepare("a");
+    await boundary("a");
+    await prepare("b");
+    const other = restart();
+    const fallback = await other.load(() => true);
+    assert(fallback);
+    expect(await other.consume(fallback)).toBe(true);
+    await boundary("b");
+    expect((await restart().load(() => true))?.attachments.readFiles).toEqual(["/b.ts"]);
+  });
+
+  it.each(["current", "generation changed", "local owner consumed"] as const)(
+    "qualifies rollback of legacy predecessor (%s)",
+    async (scenario) => {
+      await fs.writeFile(
+        filePath,
+        JSON.stringify({ version: 1, createdAt: 1, ...attachments("legacy") })
+      );
+      const b = await prepare("b");
+      if (scenario === "generation changed")
+        await h.historyService.getContinuousCompactionJournal(workspaceId).advanceGeneration();
+      expect(await store.rollback(b, () => scenario !== "local owner consumed")).toBe(true);
+      expect((await restart().load(() => true))?.attachments.readFiles).toEqual(
+        scenario === "current" ? ["/legacy.ts"] : undefined
+      );
+    }
+  );
+
+  it.each([false, true])(
+    "crash fallback requires its captured generation (changed=%s)",
+    async (changed) => {
+      await fs.writeFile(
+        filePath,
+        JSON.stringify({ version: 1, createdAt: 1, ...attachments("legacy") })
+      );
+      await prepare("b");
+      if (changed)
+        await h.historyService.getContinuousCompactionJournal(workspaceId).advanceGeneration();
+      expect((await restart().load(() => true))?.attachments.readFiles).toEqual(
+        changed ? undefined : ["/legacy.ts"]
+      );
+    }
+  );
+
+  it("rejects a stale publication but accepts a newly captured one", async () => {
+    const generation = await h.historyService
+      .getContinuousCompactionJournal(workspaceId)
+      .captureGeneration();
+    await h.historyService.getContinuousCompactionJournal(workspaceId).advanceGeneration();
+    expect(
+      await store.prepare({
+        attachments: attachments("stale"),
+        boundaryMessageId: "stale",
+        publication: { generation },
+        isCurrent: () => true,
+      })
+    ).toBeUndefined();
+    expect(await bytes().catch((error: unknown) => error)).toMatchObject({ code: "ENOENT" });
+    await prepare("fresh");
+    await boundary("fresh");
+    expect((await restart().load(() => true))?.attachments.readFiles).toEqual(["/fresh.ts"]);
+  });
+
+  it("checks ownership again after staging, before the pending file changes", async () => {
+    await prepare("a");
+    await boundary("a");
+    const original = await bytes();
+    const existingFiles = new Set(readdirSync(path.dirname(filePath)));
+    // Revoke as soon as preparatory file I/O occurs. A guard checked only before staging
+    // would publish B; the current file must still contain A when preparation settles.
+    const isCurrent = () =>
+      readdirSync(path.dirname(filePath)).every((name) => existingFiles.has(name));
+    expect(
+      await store.prepare({
+        attachments: attachments("b"),
+        boundaryMessageId: "b",
+        publication: {
+          generation: await h.historyService
+            .getContinuousCompactionJournal(workspaceId)
+            .captureGeneration(),
+        },
+        isCurrent,
+      })
+    ).toBeUndefined();
+    expect(await bytes()).toBe(original);
+    expect(new Set(readdirSync(path.dirname(filePath)))).toEqual(existingFiles);
+    await prepare("successor");
+    await boundary("successor");
+    expect((await restart().load(() => true))?.attachments.readFiles).toEqual(["/successor.ts"]);
+  });
+
+  it("restoration retains the predecessor's consumption authority", async () => {
+    const a = await prepare("a");
+    await boundary("a");
+    const b = await prepare("b");
+    expect(await store.rollback(b, () => true)).toBe(true);
+    expect((await restart().load(() => true))?.attachments).toEqual(a.attachments);
+    expect(await store.consume(a)).toBe(true);
+    expect(await restart().load(() => true)).toBeUndefined();
+  });
+
+  it.each([false, true])(
+    "legacy fallback without a generation needs boundary proof (linked=%s)",
+    async (linked) => {
+      await boundary("a");
+      await fs.writeFile(
+        filePath,
+        JSON.stringify({
+          version: 1,
+          createdAt: 2,
+          ...attachments("uncommitted"),
+          boundaryMessageId: "b",
+          previousState: {
+            version: 1,
+            createdAt: 1,
+            ...attachments("a"),
+            ...(linked && { boundaryMessageId: "a" }),
+          },
+        })
+      );
+      expect((await store.load(() => true))?.attachments.readFiles).toEqual(
+        linked ? ["/a.ts"] : undefined
+      );
+    }
+  );
+
+  it.each(["prepare", "load"] as const)(
+    "rechecks local ownership after a held file read (%s)",
+    async (operation) => {
+      await prepare("a");
+      await boundary("a");
+      const original = await bytes();
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const readFile = fs.readFile;
+      let held = false;
+      // Preserve every readFile overload: the wrapper only delays the delegated result.
+      spyOn(fs, "readFile").mockImplementation((async (...args: Parameters<typeof fs.readFile>) => {
+        const result = await readFile(...args);
+        if (args[0] === filePath && !held) {
+          held = true;
+          entered.resolve();
+          await release.promise;
+        }
+        return result;
+      }) as typeof fs.readFile);
+      let current = true;
+      const publication = {
+        generation: await h.historyService
+          .getContinuousCompactionJournal(workspaceId)
+          .captureGeneration(),
+      };
+      const pending =
+        operation === "load"
+          ? store.load(() => current)
+          : store.prepare({
+              attachments: attachments("retired"),
+              boundaryMessageId: "retired",
+              publication,
+              isCurrent: () => current,
+            });
+      try {
+        await entered.promise;
+        current = false;
+        release.resolve();
+        expect(await pending).toBeUndefined();
+        expect(await bytes()).toBe(original);
+      } finally {
+        release.resolve();
+        await pending;
+      }
+      await prepare("successor");
+      await boundary("successor");
+      expect((await store.load(() => true))?.attachments.readFiles).toEqual(["/successor.ts"]);
+    }
+  );
+
+  it("serializes a held unlink before a successor publication", async () => {
+    const a = await prepare("a");
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const unlink = fs.unlink;
+    spyOn(fs, "unlink").mockImplementation(async (file) => {
+      if (file === filePath) {
+        entered.resolve();
+        await release.promise;
+      }
+      return unlink(file);
+    });
+    const consuming = store.consume(a);
+    let successor: Promise<CompactionPendingReceipt> | undefined;
+    try {
+      await entered.promise;
+      successor = prepare("b", restart());
+      release.resolve();
+      expect(await consuming).toBe(true);
+      await successor;
+      await boundary("b");
+      expect((await restart().load(() => true))?.attachments.readFiles).toEqual(["/b.ts"]);
+    } finally {
+      release.resolve();
+      await consuming;
+      await successor;
+    }
+  });
+
+  it("durable reset cleanup preserves later publications and retries real unlink failures", async () => {
+    await prepare("old");
+    await h.historyService.getContinuousCompactionJournal(workspaceId).advanceGeneration();
+    const unlink = fs.unlink;
+    let failed = false;
+    spyOn(fs, "unlink").mockImplementation((file) => {
+      if (file === filePath && !failed) {
+        failed = true;
+        return Promise.reject(new Error("disk unavailable"));
+      }
+      return unlink(file);
+    });
+    expect(await store.discardAfterBoundary().catch((error: unknown) => error)).toMatchObject({
+      message: "disk unavailable",
+    });
+    await store.discardAfterBoundary();
+    expect(await bytes().catch((error: unknown) => error)).toMatchObject({ code: "ENOENT" });
+    await prepare("new");
+    const current = await bytes();
+    await store.discardAfterBoundary();
+    expect(await bytes()).toBe(current);
+    await boundary("new");
+    await h.historyService.getContinuousCompactionJournal(workspaceId).advanceGeneration();
+    await store.discardAfterBoundary();
+    expect((await restart().load(() => true))?.attachments.readFiles).toEqual(["/new.ts"]);
+  });
+});

--- a/src/node/services/compactionPendingState.test.ts
+++ b/src/node/services/compactionPendingState.test.ts
@@ -143,18 +143,89 @@ describe("unactivated compaction pending-file protocol", () => {
     expect(await restart().load(() => true)).toBeUndefined();
   });
 
+  it.each(["{", JSON.stringify({ version: 1, createdAt: 1, publicationGeneration: false })])(
+    "heals unusable persisted state (%s)",
+    async (raw) => {
+      await fs.writeFile(filePath, raw);
+      expect(await store.load(() => true)).toBeUndefined();
+      expect(await bytes().catch((error: unknown) => error)).toMatchObject({ code: "ENOENT" });
+      await prepare("fresh");
+      await boundary("fresh");
+      expect((await store.load(() => true))?.attachments.readFiles).toEqual(["/fresh.ts"]);
+    }
+  );
+
   it.each([
-    "{",
-    JSON.stringify({ version: 2 }),
-    JSON.stringify({ version: 1, createdAt: 1, publicationGeneration: false }),
-  ])("heals unusable persisted state (%s)", async (raw) => {
+    { version: 2, publicationGeneration: "future-generation", ...attachments("future") },
+    { schema: "future", data: { attachments: ["keep"] } },
+  ])("preserves unknown schema bytes across loads and restart (%j)", async (future) => {
+    const raw = JSON.stringify(future, null, 2);
     await fs.writeFile(filePath, raw);
     expect(await store.load(() => true)).toBeUndefined();
-    expect(await bytes().catch((error: unknown) => error)).toMatchObject({ code: "ENOENT" });
+    expect(await restart().load(() => true)).toBeUndefined();
+    expect(await bytes()).toBe(raw);
     await prepare("fresh");
     await boundary("fresh");
-    expect((await store.load(() => true))?.attachments.readFiles).toEqual(["/fresh.ts"]);
+    expect((await restart().load(() => true))?.attachments.readFiles).toEqual(["/fresh.ts"]);
   });
+
+  it.each(["corrupt JSON", "invalid V1", "stale generation"] as const)(
+    "load cleanup failure suppresses unusable attachments and remains retryable (%s)",
+    async (scenario) => {
+      if (scenario === "stale generation") {
+        await prepare("old");
+        await boundary("old");
+        await h.historyService.getContinuousCompactionJournal(workspaceId).advanceGeneration();
+      } else {
+        await fs.writeFile(
+          filePath,
+          scenario === "corrupt JSON" ? "{" : JSON.stringify({ version: 1 })
+        );
+      }
+      const original = await bytes();
+      const unlink = fs.unlink;
+      let failed = false;
+      spyOn(fs, "unlink").mockImplementation((file) => {
+        if (file === filePath && !failed) {
+          failed = true;
+          return Promise.reject(Object.assign(new Error("read-only sidecar"), { code: "EACCES" }));
+        }
+        return unlink(file);
+      });
+      expect(await store.load(() => true)).toBeUndefined();
+      expect(await bytes()).toBe(original);
+      expect(await store.load(() => true)).toBeUndefined();
+      expect(await bytes().catch((error: unknown) => error)).toMatchObject({ code: "ENOENT" });
+      await prepare("fresh");
+      await boundary("fresh");
+      expect((await store.load(() => true))?.attachments.readFiles).toEqual(["/fresh.ts"]);
+    }
+  );
+
+  it.each(["consume", "rollback"] as const)(
+    "exact cleanup failures remain visible and retryable (%s)",
+    async (operation) => {
+      const receipt = await prepare("pending");
+      const original = await bytes();
+      const unlink = fs.unlink;
+      let failed = false;
+      spyOn(fs, "unlink").mockImplementation((file) => {
+        if (file === filePath && !failed) {
+          failed = true;
+          return Promise.reject(new Error("disk unavailable"));
+        }
+        return unlink(file);
+      });
+      const cleanup = () =>
+        operation === "consume" ? store.consume(receipt) : store.rollback(receipt, () => true);
+      expect(await cleanup().catch((error: unknown) => error)).toMatchObject({
+        message: "disk unavailable",
+      });
+      expect(await bytes()).toBe(original);
+      expect(await cleanup()).toBe(true);
+      expect(await bytes().catch((error: unknown) => error)).toMatchObject({ code: "ENOENT" });
+    }
+  );
 
   it("does not use provisional attachments before their exact boundary commits", async () => {
     const receipt = await prepare("pending");
@@ -551,6 +622,37 @@ describe("unactivated compaction pending-file protocol", () => {
       );
       if (operation === "discard" && changed)
         expect(await bytes().catch((error: unknown) => error)).toMatchObject({ code: "ENOENT" });
+    }
+  );
+
+  it.each(["tagged after generation", "untagged before summary"] as const)(
+    "preserves ambiguous legacy bytes until fresh compaction (%s)",
+    async (scenario) => {
+      const tagged = scenario === "tagged after generation";
+      if (tagged) {
+        await boundary("summary");
+        await h.historyService.getContinuousCompactionJournal(workspaceId).advanceGeneration();
+      }
+      const raw = JSON.stringify(
+        {
+          version: 1,
+          createdAt: 1,
+          ...attachments("legacy"),
+          boundaryMessageId: tagged ? "summary" : undefined,
+        },
+        null,
+        2
+      );
+      await fs.writeFile(filePath, raw);
+      if (!tagged) await boundary("summary");
+      expect(await store.load(() => true)).toBeUndefined();
+      expect(await bytes()).toBe(raw);
+      expect(await restart().load(() => true)).toBeUndefined();
+      expect(await bytes()).toBe(raw);
+      await prepare("fresh");
+      expect(await restart().load(() => true)).toBeUndefined();
+      await boundary("fresh");
+      expect((await restart().load(() => true))?.attachments.readFiles).toEqual(["/fresh.ts"]);
     }
   );
 

--- a/src/node/services/compactionPendingState.test.ts
+++ b/src/node/services/compactionPendingState.test.ts
@@ -11,6 +11,7 @@ import { workspaceFileLocks } from "@/node/utils/concurrency/workspaceFileLocks"
 import {
   CompactionPendingState,
   type CompactionPendingAttachments,
+  type CompactionPendingBoundary,
   type CompactionPendingHistory,
   type CompactionPendingReceipt,
 } from "./compactionPendingState";
@@ -24,9 +25,11 @@ describe("unactivated compaction pending-file protocol", () => {
   let h: Awaited<ReturnType<typeof createTestHistoryService>>;
   let filePath: string;
   let store: CompactionPendingState;
+  let boundaryOverride: CompactionPendingBoundary | undefined;
 
   // This test adapter uses the existing locks and real history/journal readers. Production
   // activation must expose the equivalent transaction on HistoryService; it must not nest locks.
+  // Unsafe-floor cases supply scanner provenance explicitly; the real adapter tests the scan.
   function historyAdapter(history = h.historyService): CompactionPendingHistory {
     return {
       withLock: (operation) =>
@@ -46,9 +49,12 @@ describe("unactivated compaction pending-file protocol", () => {
             },
             0
           );
+          const boundaryId = rows.findLast(isDurableContextBoundaryMarker)?.id;
           return await operation({
             generation: await journal.captureGenerationUnderHistoryLock(),
-            boundaryMessageId: rows.findLast(isDurableContextBoundaryMarker)?.id,
+            boundary:
+              boundaryOverride ??
+              (boundaryId ? { kind: "identified", messageId: boundaryId } : { kind: "none" }),
             isPublicationCurrent: (publication) =>
               journal.isPublicationCurrentUnderHistoryLock(publication),
           });
@@ -102,6 +108,7 @@ describe("unactivated compaction pending-file protocol", () => {
   }
 
   beforeEach(async () => {
+    boundaryOverride = undefined;
     h = await createTestHistoryService();
     await h.historyService.appendToHistory(
       workspaceId,
@@ -239,6 +246,72 @@ describe("unactivated compaction pending-file protocol", () => {
     }
   );
 
+  it.each(
+    [false, true].flatMap((startingBoundary) =>
+      ["none", "identified", "unreadable-reset"].map((replacement) => ({
+        startingBoundary,
+        replacement,
+      }))
+    )
+  )(
+    "heartbeat rollback and restart qualify fallback by the starting boundary ($startingBoundary, replacement=$replacement)",
+    async ({ startingBoundary, replacement }) => {
+      if (startingBoundary) await boundary("start");
+      await fs.writeFile(
+        filePath,
+        JSON.stringify({
+          version: 1,
+          createdAt: 1,
+          ...attachments("legacy"),
+          boundaryMessageId: startingBoundary ? "start" : undefined,
+        })
+      );
+      const generation = await h.historyService
+        .getContinuousCompactionJournal(workspaceId)
+        .captureGeneration();
+      const b = await prepare("b");
+      expect(
+        (
+          await h.historyService.appendToHistory(
+            workspaceId,
+            createMuxMessage("b", "assistant", "Heartbeat", {
+              compacted: "heartbeat",
+              compactionBoundary: true,
+              compactionEpoch: 2,
+            })
+          )
+        ).success
+      ).toBe(true);
+      // The ordered fixture supplies an already-completed deletion; the real adapter's
+      // exact-delete proof is tested separately. A later boundary cannot revoke that fact.
+      const deleted = await h.historyService.deleteMessage(workspaceId, "b");
+      expect(deleted.success).toBe(true);
+      const foreign = new HistoryService(h.config);
+      if (replacement === "unreadable-reset") boundaryOverride = { kind: "unreadable-reset" };
+      if (replacement === "identified") {
+        expect(
+          (
+            await foreign.appendToHistory(
+              workspaceId,
+              createMuxMessage("c", "assistant", "Replacement", {
+                compacted: "user",
+                compactionBoundary: true,
+                compactionEpoch: 3,
+              })
+            )
+          ).success
+        ).toBe(true);
+      }
+      expect(await foreign.getContinuousCompactionJournal(workspaceId).captureGeneration()).toBe(
+        generation
+      );
+      const expected = replacement === "none" ? ["/legacy.ts"] : undefined;
+      expect((await restart().load(() => true))?.attachments.readFiles).toEqual(expected);
+      expect(await store.rollback(b, () => deleted.success)).toBe(true);
+      expect((await restart().load(() => true))?.attachments.readFiles).toEqual(expected);
+    }
+  );
+
   it("rejects a stale publication but accepts a newly captured one", async () => {
     const generation = await h.historyService
       .getContinuousCompactionJournal(workspaceId)
@@ -296,9 +369,14 @@ describe("unactivated compaction pending-file protocol", () => {
     expect(await restart().load(() => true)).toBeUndefined();
   });
 
-  it.each([false, true])(
-    "legacy fallback without a generation needs boundary proof (linked=%s)",
-    async (linked) => {
+  it.each([
+    { generation: undefined, proof: { kind: "identified", messageId: "a" } },
+    { generation: null, proof: undefined },
+    { generation: null, proof: { kind: "identified", messageId: 3 } },
+    { generation: null, proof: { kind: "unreadable-reset" } },
+  ])(
+    "incomplete legacy fallback proof suppresses inheritance but preserves the head (%j)",
+    async ({ generation, proof }) => {
       await boundary("a");
       await fs.writeFile(
         filePath,
@@ -307,17 +385,24 @@ describe("unactivated compaction pending-file protocol", () => {
           createdAt: 2,
           ...attachments("uncommitted"),
           boundaryMessageId: "b",
+          publicationGeneration: null,
+          previousStateGeneration: generation,
+          previousStateBoundary: proof,
           previousState: {
             version: 1,
             createdAt: 1,
             ...attachments("a"),
-            ...(linked && { boundaryMessageId: "a" }),
+            boundaryMessageId: "a",
           },
         })
       );
-      expect((await store.load(() => true))?.attachments.readFiles).toEqual(
-        linked ? ["/a.ts"] : undefined
-      );
+      const original = await bytes();
+      expect(await store.load(() => true)).toBeUndefined();
+      expect(await bytes()).toBe(original);
+      await boundary("b");
+      expect((await restart().load(() => true))?.attachments.readFiles).toEqual([
+        "/uncommitted.ts",
+      ]);
     }
   );
 
@@ -423,8 +508,97 @@ describe("unactivated compaction pending-file protocol", () => {
     await store.discardAfterBoundary();
     expect(await bytes()).toBe(current);
     await boundary("new");
-    await h.historyService.getContinuousCompactionJournal(workspaceId).advanceGeneration();
     await store.discardAfterBoundary();
     expect((await restart().load(() => true))?.attachments.readFiles).toEqual(["/new.ts"]);
   });
+
+  it.each(["load", "rollback", "discard"] as const)(
+    "a matching boundary cannot qualify a stale generation (%s)",
+    async (operation) => {
+      const receipt = await prepare("a");
+      await boundary("a");
+      await h.historyService.getContinuousCompactionJournal(workspaceId).advanceGeneration();
+      if (operation === "load") expect(await restart().load(() => true)).toBeUndefined();
+      else if (operation === "rollback")
+        expect(await store.rollback(receipt, () => true)).toBe(true);
+      else await store.discardAfterBoundary();
+      expect(await bytes().catch((error: unknown) => error)).toMatchObject({ code: "ENOENT" });
+    }
+  );
+
+  it.each(
+    (["load", "discard"] as const).flatMap((operation) =>
+      [false, true].map((changed) => ({ operation, changed }))
+    )
+  )(
+    "tagged legacy without generation proof only qualifies initial history (%j)",
+    async ({ operation, changed }) => {
+      await boundary("a");
+      await fs.writeFile(
+        filePath,
+        JSON.stringify({
+          version: 1,
+          createdAt: 1,
+          boundaryMessageId: "a",
+          ...attachments("legacy"),
+        })
+      );
+      if (changed)
+        await h.historyService.getContinuousCompactionJournal(workspaceId).advanceGeneration();
+      if (operation === "discard") await store.discardAfterBoundary();
+      expect((await restart().load(() => true))?.attachments.readFiles).toEqual(
+        changed ? undefined : ["/legacy.ts"]
+      );
+      if (operation === "discard" && changed)
+        expect(await bytes().catch((error: unknown) => error)).toMatchObject({ code: "ENOENT" });
+    }
+  );
+
+  it.each(
+    (
+      [
+        { kind: "none" },
+        { kind: "identified", messageId: "a" },
+        { kind: "unreadable-reset" },
+      ] as const
+    ).flatMap((startingBoundary) => [false, true].map((changed) => ({ startingBoundary, changed })))
+  )(
+    "untagged legacy requires proven initial history (%j)",
+    async ({ startingBoundary, changed }) => {
+      boundaryOverride = startingBoundary;
+      await fs.writeFile(
+        filePath,
+        JSON.stringify({ version: 1, createdAt: 1, ...attachments("legacy") })
+      );
+      if (changed)
+        await h.historyService.getContinuousCompactionJournal(workspaceId).advanceGeneration();
+      expect((await restart().load(() => true))?.attachments.readFiles).toEqual(
+        startingBoundary.kind === "none" && !changed ? ["/legacy.ts"] : undefined
+      );
+    }
+  );
+
+  it.each([false, true])(
+    "an unreadable floor permits fresh preparation without inheritance (commit=%s)",
+    async (commit) => {
+      boundaryOverride = { kind: "unreadable-reset" };
+      await fs.writeFile(
+        filePath,
+        JSON.stringify({ version: 1, createdAt: 1, ...attachments("legacy") })
+      );
+      const receipt = await prepare("fresh");
+      const provisional = await bytes();
+      expect(await restart().load(() => true)).toBeUndefined();
+      await store.discardAfterBoundary();
+      expect(await bytes()).toBe(provisional);
+      if (commit) {
+        await boundary("fresh");
+        boundaryOverride = undefined;
+        expect((await restart().load(() => true))?.attachments.readFiles).toEqual(["/fresh.ts"]);
+      } else {
+        expect(await store.rollback(receipt, () => true)).toBe(true);
+        expect(await bytes().catch((error: unknown) => error)).toMatchObject({ code: "ENOENT" });
+      }
+    }
+  );
 });

--- a/src/node/services/compactionPendingState.test.ts
+++ b/src/node/services/compactionPendingState.test.ts
@@ -164,6 +164,46 @@ describe("unactivated compaction pending-file protocol", () => {
     expect(await store.load(() => true)).toBeUndefined();
     expect(await restart().load(() => true)).toBeUndefined();
     expect(await bytes()).toBe(raw);
+    const publication = {
+      generation: await h.historyService
+        .getContinuousCompactionJournal(workspaceId)
+        .captureGeneration(),
+    };
+    expect(
+      await store.prepare({
+        attachments: attachments("fresh"),
+        boundaryMessageId: "fresh",
+        publication,
+        isCurrent: () => true,
+      })
+    ).toBeUndefined();
+    expect(await bytes()).toBe(raw);
+    spyOn(h.historyService, "appendToHistory").mockRejectedValueOnce(
+      new Error("boundary write failed")
+    );
+    expect(await boundary("fresh").catch((error: unknown) => error)).toMatchObject({
+      message: "boundary write failed",
+    });
+    expect(await bytes()).toBe(raw);
+    await boundary("fresh");
+    expect(await restart().load(() => true)).toBeUndefined();
+    expect(await bytes()).toBe(raw);
+  });
+
+  it("treats a directory sidecar as absent across repeated recovery loads", async () => {
+    await fs.mkdir(filePath);
+    expect(await store.load(() => true)).toBeUndefined();
+    expect(await restart().load(() => true)).toBeUndefined();
+    expect((await fs.stat(filePath)).isDirectory()).toBe(true);
+    expect(
+      (
+        await h.historyService.appendToHistory(
+          workspaceId,
+          createMuxMessage("continued", "user", "Continue")
+        )
+      ).success
+    ).toBe(true);
+    await fs.rmdir(filePath);
     await prepare("fresh");
     await boundary("fresh");
     expect((await restart().load(() => true))?.attachments.readFiles).toEqual(["/fresh.ts"]);

--- a/src/node/services/compactionPendingState.ts
+++ b/src/node/services/compactionPendingState.ts
@@ -24,6 +24,11 @@ export interface CompactionPendingAttachments {
   readFiles: string[];
 }
 
+export type CompactionPendingBoundary =
+  | { kind: "none" }
+  | { kind: "identified"; messageId: string }
+  | { kind: "unreadable-reset" };
+
 interface PersistedState extends CompactionPendingAttachments {
   version: 1;
   createdAt: number;
@@ -32,12 +37,16 @@ interface PersistedState extends CompactionPendingAttachments {
   publicationGeneration?: string | null;
   previousState?: PersistedState;
   previousStateGeneration?: string | null;
+  previousStateBoundary?: CompactionPendingBoundary;
 }
 
 export interface CompactionPendingHistoryView {
   generation: string | undefined;
-  /** Latest durable context boundary, read under the same lock as the generation. */
-  boundaryMessageId: string | undefined;
+  /**
+   * Provenance from the same verified chat/archive scan as the history rows. `none` requires
+   * exhausting both files without a boundary or raw reset floor; unreadable is never absence.
+   */
+  boundary: CompactionPendingBoundary;
   isPublicationCurrent(publication: ContinuousCompactionPublication): Promise<boolean>;
 }
 
@@ -59,6 +68,13 @@ function record(value: unknown): Record<string, unknown> | undefined {
   return value !== null && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : undefined;
+}
+
+function parseBoundary(value: unknown): CompactionPendingBoundary | undefined {
+  const input = record(value);
+  if (input?.kind === "none" || input?.kind === "unreadable-reset") return { kind: input.kind };
+  if (input?.kind === "identified" && typeof input.messageId === "string" && input.messageId)
+    return { kind: "identified", messageId: input.messageId };
 }
 
 function parseState(value: unknown, allowPrevious = true): PersistedState | undefined {
@@ -130,6 +146,7 @@ function parseState(value: unknown, allowPrevious = true): PersistedState | unde
     writeId: input.writeId as string | undefined,
     publicationGeneration: input.publicationGeneration as string | null | undefined,
     previousStateGeneration: input.previousStateGeneration as string | null | undefined,
+    previousStateBoundary: parseBoundary(input.previousStateBoundary),
     previousState: allowPrevious ? parseState(input.previousState, false) : undefined,
   };
 }
@@ -144,7 +161,12 @@ function decode(raw: string | undefined): PersistedState | undefined {
 
 /** A fallback is mutable bookkeeping; the immutable head is the receipt's identity. */
 function head(state: PersistedState): PersistedState {
-  return { ...state, previousState: undefined, previousStateGeneration: undefined };
+  return {
+    ...state,
+    previousState: undefined,
+    previousStateGeneration: undefined,
+    previousStateBoundary: undefined,
+  };
 }
 
 function identity(state: PersistedState): string {
@@ -159,23 +181,57 @@ function identity(state: PersistedState): string {
   ]);
 }
 
+function sameBoundary(
+  expected: CompactionPendingBoundary | undefined,
+  current: CompactionPendingBoundary
+): boolean {
+  return (
+    (expected?.kind === "none" && current.kind === "none") ||
+    (expected?.kind === "identified" &&
+      current.kind === "identified" &&
+      expected.messageId === current.messageId)
+  );
+}
+
+function isCurrentState(state: PersistedState, view: CompactionPendingHistoryView): boolean {
+  return (
+    sameBoundary(
+      state.boundaryMessageId
+        ? { kind: "identified", messageId: state.boundaryMessageId }
+        : { kind: "none" },
+      view.boundary
+    ) &&
+    // Untagged V1 files predate generation tracking; only proven initial history qualifies.
+    (state.boundaryMessageId !== undefined || view.generation === undefined) &&
+    // A destructive edit can preserve the boundary ID, so even tagged legacy state
+    // without generation proof must stop qualifying once a generation exists.
+    (state.publicationGeneration === undefined
+      ? view.generation === undefined
+      : state.publicationGeneration === (view.generation ?? null))
+  );
+}
+
+function eligiblePrevious(
+  state: PersistedState,
+  view: CompactionPendingHistoryView
+): PersistedState | undefined {
+  const previous = state.previousState;
+  // Restart and rollback require the same captured proof. Missing V1 proof may drop
+  // enrichments, but must not resurrect context across a reset or a same-generation boundary.
+  if (
+    previous &&
+    state.previousStateGeneration === (view.generation ?? null) &&
+    sameBoundary(state.previousStateBoundary, view.boundary) &&
+    isCurrentState(previous, view)
+  )
+    return previous;
+}
+
 function eligibleState(
   state: PersistedState | undefined,
   view: CompactionPendingHistoryView
 ): PersistedState | undefined {
-  if (!state) return;
-  if (!state.boundaryMessageId || state.boundaryMessageId === view.boundaryMessageId) return state;
-  const previous = state.previousState;
-  // Old standalone V1 files remain readable. An untagged legacy fallback needs positive
-  // boundary proof; absence alone must not restore pre-reset context after a crash.
-  if (
-    previous &&
-    (state.previousStateGeneration !== undefined
-      ? state.previousStateGeneration === (view.generation ?? null)
-      : previous.boundaryMessageId !== undefined) &&
-    (!previous.boundaryMessageId || previous.boundaryMessageId === view.boundaryMessageId)
-  )
-    return previous;
+  if (state) return isCurrentState(state, view) ? state : eligiblePrevious(state, view);
 }
 
 /**
@@ -191,6 +247,7 @@ export class CompactionPendingState {
       identity: string;
       generation: string | undefined;
       prepared: boolean;
+      startingBoundary?: CompactionPendingBoundary;
     }
   >();
 
@@ -215,7 +272,8 @@ export class CompactionPendingState {
   private receipt(
     state: PersistedState,
     generation: string | undefined,
-    prepared = false
+    prepared = false,
+    startingBoundary?: CompactionPendingBoundary
   ): CompactionPendingReceipt {
     const receipt = {
       attachments: {
@@ -224,7 +282,12 @@ export class CompactionPendingState {
         readFiles: state.readFiles,
       },
     };
-    this.receipts.set(receipt, { identity: identity(state), generation, prepared });
+    this.receipts.set(receipt, {
+      identity: identity(state),
+      generation,
+      prepared,
+      startingBoundary,
+    });
     return receipt;
   }
 
@@ -265,6 +328,7 @@ export class CompactionPendingState {
       await fs.mkdir(path.dirname(this.filePath), { recursive: true });
       const previous = eligibleState(decode(await this.readBytes()), view);
       if (!isCurrent()) return;
+      const startingBoundary = structuredClone(view.boundary);
       const state = parseState({
         ...captured,
         version: 1,
@@ -274,13 +338,14 @@ export class CompactionPendingState {
         publicationGeneration: publication.generation ?? null,
         previousState: previous && head(previous),
         previousStateGeneration: previous ? (view.generation ?? null) : undefined,
+        previousStateBoundary: previous ? startingBoundary : undefined,
       });
       if (!state) throw new Error("Invalid pending state");
       let receipt: CompactionPendingReceipt | undefined;
       // Staging also awaits I/O. The helper checks local ownership immediately before rename
       // and publishes the receipt before cleanup/lock release can admit a successor.
       await publishCompactionFile(this.filePath, JSON.stringify(state), isCurrent, () => {
-        receipt = this.receipt(state, publication.generation, true);
+        receipt = this.receipt(state, publication.generation, true, startingBoundary);
       });
       return receipt;
     });
@@ -310,15 +375,17 @@ export class CompactionPendingState {
     return this.enqueue(async (view) => {
       const state = decode(await this.readBytes());
       if (!state || identity(state) !== expected.identity) return false;
-      if (state.boundaryMessageId === view.boundaryMessageId) return false;
+      if (isCurrentState(state, view)) return false;
       // Restoring a committed heartbeat also needs the caller's exact history rollback proof.
       // A generation change permits exact cleanup, never restoration of the prior context.
-      const previous = state.previousState;
+      // A newer compaction can keep the generation unchanged; even an untagged legacy
+      // predecessor may only return to the boundary at which preparation began.
+      const previous = eligiblePrevious(state, view);
       if (
         previous &&
         expected.generation === view.generation &&
-        canRestorePrevious() &&
-        (!previous.boundaryMessageId || previous.boundaryMessageId === view.boundaryMessageId)
+        sameBoundary(expected.startingBoundary, view.boundary) &&
+        canRestorePrevious()
       ) {
         if (
           await publishCompactionFile(
@@ -342,9 +409,9 @@ export class CompactionPendingState {
       const state = decode(raw);
       if (
         state &&
-        ((state.boundaryMessageId !== undefined &&
-          state.boundaryMessageId === view.boundaryMessageId) ||
-          (state.publicationGeneration !== undefined &&
+        (isCurrentState(state, view) ||
+          (state.boundaryMessageId !== undefined &&
+            state.publicationGeneration !== undefined &&
             state.publicationGeneration === (view.generation ?? null)))
       )
         return;

--- a/src/node/services/compactionPendingState.ts
+++ b/src/node/services/compactionPendingState.ts
@@ -1,0 +1,354 @@
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import {
+  MAX_EDITED_FILES,
+  MAX_FILE_CONTENT_SIZE,
+  MAX_POST_COMPACTION_LOADED_SKILLS,
+} from "@/common/constants/attachments";
+import type { LoadedSkillSnapshot } from "@/common/types/attachment";
+import type { FileEditDiff } from "@/common/utils/messages/extractEditedFiles";
+import { mergeReadFilePaths } from "@/common/utils/messages/extractReadFiles";
+import {
+  createLoadedSkillSnapshot,
+  mergeLoadedSkillSnapshots,
+} from "./agentSkills/loadedSkillSnapshots";
+import {
+  publishCompactionFile,
+  type ContinuousCompactionPublication,
+} from "./continuousCompactionJournal";
+
+export interface CompactionPendingAttachments {
+  diffs: FileEditDiff[];
+  loadedSkills: LoadedSkillSnapshot[];
+  readFiles: string[];
+}
+
+interface PersistedState extends CompactionPendingAttachments {
+  version: 1;
+  createdAt: number;
+  boundaryMessageId?: string;
+  writeId?: string;
+  publicationGeneration?: string | null;
+  previousState?: PersistedState;
+  previousStateGeneration?: string | null;
+}
+
+export interface CompactionPendingHistoryView {
+  generation: string | undefined;
+  /** Latest durable context boundary, read under the same lock as the generation. */
+  boundaryMessageId: string | undefined;
+  isPublicationCurrent(publication: ContinuousCompactionPublication): Promise<boolean>;
+}
+
+export interface CompactionPendingHistory {
+  /**
+   * Hold BOTH existing history locks throughout the callback, reject removed workspaces,
+   * and provide a stable view without reacquiring history/journal queues inside the lock.
+   * Deliberately has no runtime adapter yet: every producer/consumer must activate together.
+   */
+  withLock<T>(operation: (view: CompactionPendingHistoryView) => Promise<T>): Promise<T>;
+}
+
+/** Only receipts returned by this store authorize consumption or rollback. */
+export interface CompactionPendingReceipt {
+  readonly attachments: CompactionPendingAttachments;
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function parseState(value: unknown, allowPrevious = true): PersistedState | undefined {
+  const input = record(value);
+  if (input?.version !== 1 || typeof input.createdAt !== "number") return;
+  for (const key of ["boundaryMessageId", "writeId"] as const) {
+    if (input[key] !== undefined && (typeof input[key] !== "string" || !input[key])) return;
+  }
+  for (const key of ["publicationGeneration", "previousStateGeneration"] as const) {
+    if (input[key] !== undefined && input[key] !== null && typeof input[key] !== "string") return;
+  }
+  const diffs: FileEditDiff[] = [];
+  for (const item of Array.isArray(input.diffs) ? input.diffs : []) {
+    const diff = record(item);
+    if (
+      !diff ||
+      typeof diff.path !== "string" ||
+      !diff.path.trim() ||
+      typeof diff.diff !== "string" ||
+      typeof diff.truncated !== "boolean"
+    )
+      continue;
+    diffs.push({
+      path: diff.path.trim(),
+      diff: diff.diff.slice(0, MAX_FILE_CONTENT_SIZE),
+      truncated: diff.truncated || diff.diff.length > MAX_FILE_CONTENT_SIZE,
+    });
+    if (diffs.length >= MAX_EDITED_FILES) break;
+  }
+  const skills: LoadedSkillSnapshot[] = [];
+  for (const item of Array.isArray(input.loadedSkills) ? input.loadedSkills : []) {
+    const skill = record(item);
+    if (
+      !skill ||
+      typeof skill.name !== "string" ||
+      !skill.name.trim() ||
+      typeof skill.body !== "string"
+    )
+      continue;
+    try {
+      skills.push(
+        createLoadedSkillSnapshot({
+          name: skill.name,
+          scope: skill.scope,
+          body: skill.body,
+          frontmatterYaml:
+            typeof skill.frontmatterYaml === "string" ? skill.frontmatterYaml : undefined,
+          alreadyNormalized: true,
+          truncated: skill.truncated === true,
+        })
+      );
+    } catch {
+      continue;
+    }
+    if (skills.length >= MAX_POST_COMPACTION_LOADED_SKILLS) break;
+  }
+  return {
+    version: 1,
+    createdAt: input.createdAt,
+    diffs,
+    loadedSkills: mergeLoadedSkillSnapshots(skills),
+    readFiles: mergeReadFilePaths(
+      [],
+      (Array.isArray(input.readFiles) ? input.readFiles : []).filter(
+        (item): item is string => typeof item === "string"
+      )
+    ),
+    boundaryMessageId: input.boundaryMessageId as string | undefined,
+    writeId: input.writeId as string | undefined,
+    publicationGeneration: input.publicationGeneration as string | null | undefined,
+    previousStateGeneration: input.previousStateGeneration as string | null | undefined,
+    previousState: allowPrevious ? parseState(input.previousState, false) : undefined,
+  };
+}
+
+function decode(raw: string | undefined): PersistedState | undefined {
+  try {
+    return raw === undefined ? undefined : parseState(JSON.parse(raw));
+  } catch {
+    return undefined;
+  }
+}
+
+/** A fallback is mutable bookkeeping; the immutable head is the receipt's identity. */
+function head(state: PersistedState): PersistedState {
+  return { ...state, previousState: undefined, previousStateGeneration: undefined };
+}
+
+function identity(state: PersistedState): string {
+  return JSON.stringify([
+    state.writeId,
+    state.createdAt,
+    state.boundaryMessageId,
+    state.publicationGeneration,
+    state.diffs,
+    state.loadedSkills,
+    state.readFiles,
+  ]);
+}
+
+function eligibleState(
+  state: PersistedState | undefined,
+  view: CompactionPendingHistoryView
+): PersistedState | undefined {
+  if (!state) return;
+  if (!state.boundaryMessageId || state.boundaryMessageId === view.boundaryMessageId) return state;
+  const previous = state.previousState;
+  // Old standalone V1 files remain readable. An untagged legacy fallback needs positive
+  // boundary proof; absence alone must not restore pre-reset context after a crash.
+  if (
+    previous &&
+    (state.previousStateGeneration !== undefined
+      ? state.previousStateGeneration === (view.generation ?? null)
+      : previous.boundaryMessageId !== undefined) &&
+    (!previous.boundaryMessageId || previous.boundaryMessageId === view.boundaryMessageId)
+  )
+    return previous;
+}
+
+/**
+ * Inactive pending-file protocol. CompactionHandler owns local caches/preparation; this owns disk.
+ * Failures propagate so callers can distinguish best-effort attachment writes from mandatory
+ * reset cleanup. Never call these queued operations from inside a held history lock.
+ */
+export class CompactionPendingState {
+  private pending: Promise<unknown> = Promise.resolve();
+  private readonly receipts = new WeakMap<
+    CompactionPendingReceipt,
+    {
+      identity: string;
+      generation: string | undefined;
+      prepared: boolean;
+    }
+  >();
+
+  constructor(
+    private readonly filePath: string,
+    private readonly history: CompactionPendingHistory
+  ) {}
+
+  private enqueue<T>(operation: (view: CompactionPendingHistoryView) => Promise<T>): Promise<T> {
+    const result = this.pending.then(() => this.history.withLock(operation));
+    this.pending = result.catch(() => undefined);
+    return result;
+  }
+
+  private async readBytes(): Promise<string | undefined> {
+    return fs.readFile(this.filePath, "utf8").catch((error: NodeJS.ErrnoException) => {
+      if (error.code !== "ENOENT") throw error;
+      return undefined;
+    });
+  }
+
+  private receipt(
+    state: PersistedState,
+    generation: string | undefined,
+    prepared = false
+  ): CompactionPendingReceipt {
+    const receipt = {
+      attachments: {
+        diffs: state.diffs,
+        loadedSkills: state.loadedSkills,
+        readFiles: state.readFiles,
+      },
+    };
+    this.receipts.set(receipt, { identity: identity(state), generation, prepared });
+    return receipt;
+  }
+
+  load(isCurrent: () => boolean): Promise<CompactionPendingReceipt | undefined> {
+    return this.enqueue(async (view) => {
+      const raw = await this.readBytes();
+      if (!isCurrent()) return;
+      const persisted = decode(raw);
+      const state = eligibleState(persisted, view);
+      if (state) return this.receipt(state, view.generation);
+      // A live writer may still be between pending-file publication and boundary commit.
+      // Missing boundary proof suppresses injection; it does not authorize deleting its file.
+      if (
+        raw !== undefined &&
+        (!persisted ||
+          (persisted.publicationGeneration !== undefined &&
+            persisted.publicationGeneration !== (view.generation ?? null)))
+      ) {
+        await fs.unlink(this.filePath);
+      }
+    });
+  }
+
+  prepare(input: {
+    attachments: CompactionPendingAttachments;
+    boundaryMessageId: string;
+    publication: ContinuousCompactionPublication;
+    isCurrent: () => boolean;
+  }): Promise<CompactionPendingReceipt | undefined> {
+    // Freeze before enqueueing: a caller may reuse its arrays while another write holds the lock.
+    const captured = structuredClone(input.attachments);
+    const publication = structuredClone(input.publication);
+    const boundaryMessageId = input.boundaryMessageId;
+    const isCurrent = input.isCurrent;
+    if (!boundaryMessageId.trim()) throw new Error("Pending state requires a boundary message ID");
+    return this.enqueue(async (view) => {
+      if (!isCurrent() || !(await view.isPublicationCurrent(publication))) return;
+      await fs.mkdir(path.dirname(this.filePath), { recursive: true });
+      const previous = eligibleState(decode(await this.readBytes()), view);
+      if (!isCurrent()) return;
+      const state = parseState({
+        ...captured,
+        version: 1,
+        createdAt: Date.now(),
+        boundaryMessageId,
+        writeId: randomUUID(),
+        publicationGeneration: publication.generation ?? null,
+        previousState: previous && head(previous),
+        previousStateGeneration: previous ? (view.generation ?? null) : undefined,
+      });
+      if (!state) throw new Error("Invalid pending state");
+      let receipt: CompactionPendingReceipt | undefined;
+      // Staging also awaits I/O. The helper checks local ownership immediately before rename
+      // and publishes the receipt before cleanup/lock release can admit a successor.
+      await publishCompactionFile(this.filePath, JSON.stringify(state), isCurrent, () => {
+        receipt = this.receipt(state, publication.generation, true);
+      });
+      return receipt;
+    });
+  }
+
+  consume(receipt: CompactionPendingReceipt): Promise<boolean> {
+    const expected = this.receipts.get(receipt);
+    if (!expected) return Promise.resolve(false);
+    return this.enqueue(async () => {
+      const state = decode(await this.readBytes());
+      if (!state) return false;
+      if (identity(state) === expected.identity) {
+        await fs.unlink(this.filePath);
+        return true;
+      }
+      if (!state.previousState || identity(state.previousState) !== expected.identity) return false;
+      // A may be consumed while B is provisional. Remove only A's fallback, durably, so
+      // B's later rollback/restart cannot resurrect it. B retains its immutable write identity.
+      await publishCompactionFile(this.filePath, JSON.stringify(head(state)), () => true);
+      return true;
+    });
+  }
+
+  rollback(receipt: CompactionPendingReceipt, canRestorePrevious: () => boolean): Promise<boolean> {
+    const expected = this.receipts.get(receipt);
+    if (!expected?.prepared) return Promise.resolve(false);
+    return this.enqueue(async (view) => {
+      const state = decode(await this.readBytes());
+      if (!state || identity(state) !== expected.identity) return false;
+      if (state.boundaryMessageId === view.boundaryMessageId) return false;
+      // Restoring a committed heartbeat also needs the caller's exact history rollback proof.
+      // A generation change permits exact cleanup, never restoration of the prior context.
+      const previous = state.previousState;
+      if (
+        previous &&
+        expected.generation === view.generation &&
+        canRestorePrevious() &&
+        (!previous.boundaryMessageId || previous.boundaryMessageId === view.boundaryMessageId)
+      ) {
+        if (
+          await publishCompactionFile(
+            this.filePath,
+            JSON.stringify(head(previous)),
+            canRestorePrevious
+          )
+        )
+          return true;
+      }
+      await fs.unlink(this.filePath);
+      return true;
+    });
+  }
+
+  /** Call only after the destructive boundary/generation change committed under the history lock. */
+  discardAfterBoundary(): Promise<void> {
+    return this.enqueue(async (view) => {
+      const raw = await this.readBytes();
+      if (raw === undefined) return;
+      const state = decode(raw);
+      if (
+        state &&
+        ((state.boundaryMessageId !== undefined &&
+          state.boundaryMessageId === view.boundaryMessageId) ||
+          (state.publicationGeneration !== undefined &&
+            state.publicationGeneration === (view.generation ?? null)))
+      )
+        return;
+      await fs.unlink(this.filePath);
+    });
+  }
+}

--- a/src/node/services/compactionPendingState.ts
+++ b/src/node/services/compactionPendingState.ts
@@ -268,7 +268,12 @@ export class CompactionPendingState {
   }
 
   private async readBytes(): Promise<string | undefined> {
-    return fs.readFile(this.filePath, "utf8").catch((error: NodeJS.ErrnoException) => {
+    return fs.readFile(this.filePath, "utf8").catch(async (error: NodeJS.ErrnoException) => {
+      if (error.code === "EISDIR") {
+        // Only empty directories are safe to remove; preserve unrelated contents and errors.
+        await fs.rmdir(this.filePath);
+        return undefined;
+      }
       if (error.code !== "ENOENT") throw error;
       return undefined;
     });

--- a/src/node/services/compactionPendingState.ts
+++ b/src/node/services/compactionPendingState.ts
@@ -298,7 +298,8 @@ export class CompactionPendingState {
 
   load(isCurrent: () => boolean): Promise<CompactionPendingReceipt | undefined> {
     return this.enqueue(async (view) => {
-      const raw = await this.readBytes();
+      // Optional enrichment must not brick recovery when its sidecar is unreadable.
+      const raw = await this.readBytes().catch(() => undefined);
       if (!isCurrent()) return;
       const parsed = parseJson(raw);
       // A downgraded reader must leave newer schemas intact for the version that owns them.
@@ -336,7 +337,11 @@ export class CompactionPendingState {
     return this.enqueue(async (view) => {
       if (!isCurrent() || !(await view.isPublicationCurrent(publication))) return;
       await fs.mkdir(path.dirname(this.filePath), { recursive: true });
-      const previous = eligibleState(parseState(parseJson(await this.readBytes())), view);
+      const parsed = parseJson(await this.readBytes());
+      // Unknown bytes require atomic history publication before replacement. This standalone
+      // preparation must decline enrichment; callers still own the mandatory history write.
+      if (parsed !== undefined && record(parsed)?.version !== 1) return;
+      const previous = eligibleState(parseState(parsed), view);
       if (!isCurrent()) return;
       const startingBoundary = structuredClone(view.boundary);
       const state = parseState({

--- a/src/node/services/compactionPendingState.ts
+++ b/src/node/services/compactionPendingState.ts
@@ -153,7 +153,8 @@ function parseState(value: unknown, allowPrevious = true): PersistedState | unde
 
 function parseJson(raw: string | undefined): unknown {
   try {
-    return raw === undefined ? undefined : JSON.parse(raw);
+    // Only object roots can represent an unsupported pending-state schema.
+    return raw === undefined ? undefined : record(JSON.parse(raw));
   } catch {
     return undefined;
   }

--- a/src/node/services/compactionPendingState.ts
+++ b/src/node/services/compactionPendingState.ts
@@ -151,9 +151,9 @@ function parseState(value: unknown, allowPrevious = true): PersistedState | unde
   };
 }
 
-function decode(raw: string | undefined): PersistedState | undefined {
+function parseJson(raw: string | undefined): unknown {
   try {
-    return raw === undefined ? undefined : parseState(JSON.parse(raw));
+    return raw === undefined ? undefined : JSON.parse(raw);
   } catch {
     return undefined;
   }
@@ -236,8 +236,13 @@ function eligibleState(
 
 /**
  * Inactive pending-file protocol. CompactionHandler owns local caches/preparation; this owns disk.
- * Failures propagate so callers can distinguish best-effort attachment writes from mandatory
- * reset cleanup. Never call these queued operations from inside a held history lock.
+ * Read-side cleanup is best-effort; mutation failures propagate so callers can distinguish
+ * attachment writes from mandatory reset cleanup.
+ *
+ * `prepare` alone does not atomically publish history. Activation requires caller coordination:
+ * enter the store queue, then hold the shared history locks through preparation, boundary
+ * publication, synchronous receipt delivery, and exact failure cleanup before unlocking.
+ * These standalone queued methods acquire their own locks; never call them inside held locks.
  */
 export class CompactionPendingState {
   private pending: Promise<unknown> = Promise.resolve();
@@ -295,18 +300,23 @@ export class CompactionPendingState {
     return this.enqueue(async (view) => {
       const raw = await this.readBytes();
       if (!isCurrent()) return;
-      const persisted = decode(raw);
+      const parsed = parseJson(raw);
+      // A downgraded reader must leave newer schemas intact for the version that owns them.
+      if (parsed !== undefined && record(parsed)?.version !== 1) return;
+      const persisted = parseState(parsed);
       const state = eligibleState(persisted, view);
       if (state) return this.receipt(state, view.generation);
       // A live writer may still be between pending-file publication and boundary commit.
       // Missing boundary proof suppresses injection; it does not authorize deleting its file.
+      // Preserve ambiguous legacy bytes too; fresh compaction must establish usable ownership.
       if (
         raw !== undefined &&
         (!persisted ||
           (persisted.publicationGeneration !== undefined &&
             persisted.publicationGeneration !== (view.generation ?? null)))
       ) {
-        await fs.unlink(this.filePath);
+        // Attachments are already suppressed; inability to prune them must not block a request.
+        await fs.unlink(this.filePath).catch(() => undefined);
       }
     });
   }
@@ -326,7 +336,7 @@ export class CompactionPendingState {
     return this.enqueue(async (view) => {
       if (!isCurrent() || !(await view.isPublicationCurrent(publication))) return;
       await fs.mkdir(path.dirname(this.filePath), { recursive: true });
-      const previous = eligibleState(decode(await this.readBytes()), view);
+      const previous = eligibleState(parseState(parseJson(await this.readBytes())), view);
       if (!isCurrent()) return;
       const startingBoundary = structuredClone(view.boundary);
       const state = parseState({
@@ -355,7 +365,7 @@ export class CompactionPendingState {
     const expected = this.receipts.get(receipt);
     if (!expected) return Promise.resolve(false);
     return this.enqueue(async () => {
-      const state = decode(await this.readBytes());
+      const state = parseState(parseJson(await this.readBytes()));
       if (!state) return false;
       if (identity(state) === expected.identity) {
         await fs.unlink(this.filePath);
@@ -373,7 +383,7 @@ export class CompactionPendingState {
     const expected = this.receipts.get(receipt);
     if (!expected?.prepared) return Promise.resolve(false);
     return this.enqueue(async (view) => {
-      const state = decode(await this.readBytes());
+      const state = parseState(parseJson(await this.readBytes()));
       if (!state || identity(state) !== expected.identity) return false;
       if (isCurrentState(state, view)) return false;
       // Restoring a committed heartbeat also needs the caller's exact history rollback proof.
@@ -406,7 +416,7 @@ export class CompactionPendingState {
     return this.enqueue(async (view) => {
       const raw = await this.readBytes();
       if (raw === undefined) return;
-      const state = decode(raw);
+      const state = parseState(parseJson(raw));
       if (
         state &&
         (isCurrentState(state, view) ||

--- a/src/node/services/historyService.test.ts
+++ b/src/node/services/historyService.test.ts
@@ -4,12 +4,13 @@ import { CONTEXT_BOUNDARY_KINDS } from "@/common/constants/contextBoundary";
 import { HistoryService } from "./historyService";
 import type { Config } from "@/node/config";
 import { createTestHistoryService } from "./testHistoryService";
+import type { ContinuousCompactionJournal } from "@/common/orpc/schemas/continuousCompaction";
 import { updateSubagentTranscriptArtifactsFile } from "./subagentTranscriptArtifacts";
 import { createMuxMessage, type MuxMessage } from "@/common/types/message";
 import assert from "node:assert";
 import { createHash } from "node:crypto";
 import * as fs from "fs/promises";
-import { acquireProcessFileLock } from "@/node/utils/concurrency/fileLock";
+import * as fileLock from "@/node/utils/concurrency/fileLock";
 import {
   historyWriteLockPath,
   workspaceRemovalTombstonePath,
@@ -388,7 +389,7 @@ describe("HistoryService", () => {
       // session-dir append lock: the batch's read+replace must wait, or its
       // replacement — built from contents read before the foreign append —
       // would silently delete the foreign row.
-      const foreign = await acquireProcessFileLock({
+      const foreign = await fileLock.acquireProcessFileLock({
         // r63: the history write lock lives outside the session directory so
         // removal can hold it across its tombstone+delete critical section.
         lockPath: historyWriteLockPath(config.rootDir, workspaceId),
@@ -461,7 +462,7 @@ describe("HistoryService", () => {
         JSON.stringify({ finalArchiveHash: "in-flight", finalChatHash: "in-flight" })
       );
 
-      const foreign = await acquireProcessFileLock({
+      const foreign = await fileLock.acquireProcessFileLock({
         lockPath: historyWriteLockPath(config.rootDir, workspaceId),
         timeoutMs: 5_000,
         label: "test foreign truncation",
@@ -988,6 +989,379 @@ describe("HistoryService", () => {
       expect(messages).toHaveLength(2);
       expect(messages[0].id).toBe("msg1");
       expect(messages[1].id).toBe("msg2");
+    });
+  });
+
+  describe("destructive context publication fencing", () => {
+    const ws = "context-publication";
+    const row = (id: string) => createMuxMessage(id, "user", `Context for ${id}`);
+    const display = () =>
+      createMuxMessage("display", "user", "Workflow display", {
+        muxMetadata: { type: "workflow-trigger-display", rawCommand: "/wf", runId: "run" },
+      });
+    const boundary = () =>
+      createMuxMessage("sealed", "assistant", "Compacted context", {
+        compacted: "user",
+        compactionBoundary: true,
+        compactionEpoch: 1,
+      });
+    const reset = (rollover = false) =>
+      createMuxMessage("reset", "assistant", "", {
+        contextBoundaryKind: CONTEXT_BOUNDARY_KINDS.RESET,
+        ...(rollover && {
+          muxMetadata: {
+            type: "context-window-rollover",
+            rolloverId: "rollover",
+            reason: "on-send",
+            previousWindowId: "w:0",
+            flushOpportunity: false,
+            contextTokens: 1000,
+            maxTokens: 1000,
+          } as const,
+        }),
+      });
+    const prefix = [{ role: "user" as const, content: "Discarded provider context" }];
+
+    async function capturePublication() {
+      const store = service.getContinuousCompactionJournal(ws);
+      const journal: ContinuousCompactionJournal = {
+        version: 1,
+        publicationGeneration: await store.captureGeneration(),
+        boundary: { ...boundary(), id: "compacted" },
+        staticCopies: [],
+        liveTailCopySpec: {
+          sourceMessageId: "live",
+          sourceHistorySequence: 0,
+          copyId: "copy",
+          partIndex: 0,
+          metadataTemplate: { synthetic: true, rlmPreservedTailCopy: true },
+        },
+        postCompactionAttachments: [],
+        prefixSourceRows: [row("old")],
+        systemPrefix: [],
+        cacheEnabled: false,
+        preparation: {
+          modelString: "anthropic:claude-sonnet-4-5",
+          providerForMessages: "anthropic",
+          effectiveThinkingLevel: "off",
+          effectiveAgentId: "exec",
+          toolNamesForSentinel: [],
+        },
+        providerFamily: "anthropic",
+        parentModel: "anthropic:claude-sonnet-4-5",
+        summaryModel: "anthropic:claude-sonnet-4-5",
+        headFingerprint: "head",
+        sourceFingerprint: "source",
+        headEnd: { id: "old", sequence: 0 },
+        epoch: 0,
+        streamMessageId: "live",
+        streamHistorySequence: 0,
+        stepNumber: 0,
+        firstTailToolCallId: "tool",
+      };
+      const receipt = await store.write(journal, prefix, () => true);
+      assert(receipt, "Expected a durable compaction publication");
+      return { store, receipt };
+    }
+
+    const destructiveCases = [
+      ...[false, true].flatMap((rollover) =>
+        [false, true].map((batch) => ({
+          name: `${rollover ? "rollover" : "reset"} ${batch ? "batch" : "single"}`,
+          rows: [row("old")],
+          mutate: () =>
+            batch
+              ? service.appendManyToHistory(ws, [reset(rollover), row("fresh")])
+              : service.appendToHistory(ws, reset(rollover)),
+          expected: batch ? ["old", "reset", "fresh"] : ["old", "reset"],
+        }))
+      ),
+      {
+        name: "matching-tail reset",
+        rows: [row("old")],
+        mutate: () => service.appendToHistoryIfTailMatches(ws, reset(), "old"),
+        expected: ["old", "reset"],
+      },
+      {
+        name: "full clear",
+        rows: [row("old"), row("tail")],
+        mutate: () => service.clearHistory(ws),
+        expected: [],
+      },
+      {
+        name: "display-only full clear",
+        rows: [display()],
+        mutate: () => service.clearHistory(ws),
+        expected: [],
+      },
+      {
+        name: "rounded full clear",
+        rows: [row("old"), row("tail")],
+        mutate: () => service.truncateHistory(ws, 0.99),
+        expected: [],
+      },
+      {
+        name: "active prefix",
+        rows: [row("old"), row("tail")],
+        mutate: () => service.truncateHistory(ws, 0.2),
+        expected: ["tail"],
+      },
+      {
+        name: "active edit",
+        rows: [row("old"), row("tail")],
+        mutate: () => service.truncateAfterMessage(ws, "tail"),
+        expected: ["old"],
+      },
+      {
+        name: "archived edit",
+        rows: [row("old"), boundary(), row("tail")],
+        mutate: () => service.truncateAfterMessage(ws, "old", { keepTargetMessage: true }),
+        expected: ["old"],
+      },
+    ];
+
+    it.each(destructiveCases)(
+      "$name prevents stale journal and history resurrection",
+      async (testCase) => {
+        for (const message of testCase.rows) {
+          assert((await service.appendToHistory(ws, structuredClone(message))).success);
+        }
+        const { store, receipt } = await capturePublication();
+        const foreign = new HistoryService(config);
+        assert((await testCase.mutate()).success);
+        const settled = await collectFullHistory(foreign, ws);
+        expect(settled.map((message) => message.id)).toEqual(testCase.expected);
+        expect(await store.captureGeneration()).not.toBe(receipt.publicationGeneration);
+
+        let committed = false;
+        const folded = await foreign.persistBoundaryWithTailCopies(
+          ws,
+          structuredClone(receipt.boundary),
+          [],
+          false,
+          () => true,
+          {
+            publication: { generation: receipt.publicationGeneration, journal: receipt },
+            onCommitted: () => {
+              committed = true;
+            },
+          }
+        );
+        expect(folded.success).toBe(false);
+        expect(committed).toBe(false);
+        const foreignStore = foreign.getContinuousCompactionJournal(ws);
+        expect(await foreignStore.read()).toBeNull();
+        // Rejection must survive cleanup of the old record, when the slot is empty.
+        expect(await foreignStore.write(receipt, prefix, () => true)).toBeNull();
+        expect(await collectFullHistory(foreign, ws)).toEqual(settled);
+        expect(
+          await foreignStore.write(
+            { ...receipt, publicationGeneration: await foreignStore.captureGeneration() },
+            prefix,
+            () => true
+          )
+        ).not.toBeNull();
+      }
+    );
+
+    it.each(destructiveCases)(
+      "$name leaves history intact if generation advancement fails",
+      async (testCase) => {
+        for (const message of testCase.rows) {
+          assert((await service.appendToHistory(ws, structuredClone(message))).success);
+        }
+        const { store, receipt } = await capturePublication();
+        const before = await collectFullHistory(service, ws);
+        const failure = spyOn(store, "advanceGenerationUnderHistoryLock").mockRejectedValueOnce(
+          new Error("generation unavailable")
+        );
+        try {
+          expect((await testCase.mutate()).success).toBe(false);
+          expect(await collectFullHistory(new HistoryService(config), ws)).toEqual(before);
+          expect(await store.read()).toEqual(receipt);
+        } finally {
+          failure.mockRestore();
+        }
+      }
+    );
+
+    it("holds the history file lock from generation advancement through deletion", async () => {
+      assert((await service.appendToHistory(ws, row("old"))).success);
+      const store = service.getContinuousCompactionJournal(ws);
+      // Exercise an existing durable generation too, rather than only legacy absence.
+      await store.advanceGeneration();
+      const { receipt } = await capturePublication();
+      await store.clear(receipt);
+      const historyPath = path.join(config.sessionsDir, ws, "chat.jsonl");
+      const before = await fs.readFile(historyPath, "utf8");
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const advance = store.advanceGenerationUnderHistoryLock.bind(store);
+      const advancing = spyOn(store, "advanceGenerationUnderHistoryLock").mockImplementationOnce(
+        async () => {
+          await fs.access(historyWriteLockPath(config.rootDir, ws));
+          await advance();
+          entered.resolve();
+          await release.promise;
+        }
+      );
+      const clearing = service.clearHistory(ws);
+      const foreign = new HistoryService(config).getContinuousCompactionJournal(ws);
+      const capture = spyOn(foreign, "captureGenerationUnderHistoryLock");
+      const acquire = fileLock.acquireProcessFileLock;
+      const attempted = Promise.withResolvers<void>();
+      let acquiring:
+        | ReturnType<typeof spyOn<typeof fileLock, "acquireProcessFileLock">>
+        | undefined;
+      let writing: ReturnType<typeof foreign.write> | undefined;
+      try {
+        await entered.promise;
+        acquiring = spyOn(fileLock, "acquireProcessFileLock").mockImplementation((options) => {
+          attempted.resolve();
+          return acquire(options);
+        });
+        writing = foreign.write(receipt, prefix, () => true);
+        await attempted.promise;
+        expect(capture).not.toHaveBeenCalled();
+        expect(await fs.readFile(historyPath, "utf8")).toBe(before);
+        release.resolve();
+        expect((await clearing).success).toBe(true);
+        expect(await writing).toBeNull();
+        expect(await foreign.captureGeneration()).not.toBe(receipt.publicationGeneration);
+        expect(await collectFullHistory(new HistoryService(config), ws)).toEqual([]);
+      } finally {
+        release.resolve();
+        await Promise.all([clearing, writing]);
+        acquiring?.mockRestore();
+        capture.mockRestore();
+        advancing.mockRestore();
+      }
+    });
+
+    it.each([
+      {
+        name: "zero prefix",
+        rows: [row("old")],
+        mutate: () => service.truncateHistory(ws, 0),
+        expected: ["old"],
+        success: true,
+      },
+      {
+        name: "rounded zero",
+        rows: [row("old")],
+        mutate: () => service.truncateHistory(ws, 0.0001),
+        expected: ["old"],
+        success: true,
+      },
+      {
+        name: "empty clear",
+        rows: [],
+        mutate: () => service.clearHistory(ws),
+        expected: [],
+        success: true,
+      },
+      {
+        name: "declined full",
+        rows: [row("old")],
+        mutate: () => service.truncateHistory(ws, 0.9, { refuseFullDelete: true }),
+        expected: ["old"],
+        success: false,
+      },
+      {
+        name: "declined removal",
+        rows: [row("old")],
+        mutate: () => service.truncateHistory(ws, 0.2, { refuseRowRemoval: true }),
+        expected: ["old"],
+        success: false,
+      },
+      {
+        name: "declined partial",
+        rows: [row("old"), row("tail")],
+        mutate: () => service.truncateHistory(ws, 0.2, { requireFullDelete: true }),
+        expected: ["old", "tail"],
+        success: false,
+      },
+      {
+        name: "missing edit",
+        rows: [row("old")],
+        mutate: () => service.truncateAfterMessage(ws, "missing"),
+        expected: ["old"],
+        success: false,
+      },
+      {
+        name: "retained tail",
+        rows: [row("old")],
+        mutate: () => service.truncateAfterMessage(ws, "old", { keepTargetMessage: true }),
+        expected: ["old"],
+        success: true,
+      },
+      {
+        name: "display edit",
+        rows: [row("old"), display()],
+        mutate: () => service.truncateAfterMessage(ws, "display"),
+        expected: ["old"],
+        success: true,
+      },
+      {
+        name: "display prefix",
+        rows: [display(), row("tail")],
+        mutate: () => service.truncateHistory(ws, 0.1),
+        expected: ["tail"],
+        success: true,
+      },
+      {
+        name: "sealed prefix",
+        rows: [row("old"), boundary(), row("tail")],
+        mutate: () => service.truncateHistory(ws, 0.1),
+        expected: ["sealed", "tail"],
+        success: true,
+      },
+      {
+        name: "mismatched reset",
+        rows: [row("old")],
+        mutate: () => service.appendToHistoryIfTailMatches(ws, reset(), "missing"),
+        expected: ["old"],
+        success: true,
+      },
+      {
+        name: "compaction boundary",
+        rows: [row("old")],
+        mutate: () => service.appendToHistory(ws, boundary()),
+        expected: ["old", "sealed"],
+        success: true,
+      },
+    ])("$name preserves a usable compaction publication", async (testCase) => {
+      for (const message of testCase.rows) {
+        assert((await service.appendToHistory(ws, message)).success);
+      }
+      const { store, receipt } = await capturePublication();
+      expect((await testCase.mutate()).success).toBe(testCase.success);
+      expect((await collectFullHistory(service, ws)).map((message) => message.id)).toEqual([
+        ...testCase.expected,
+      ]);
+      expect(await store.read()).toEqual(receipt);
+      expect(await store.captureGeneration()).toBe(receipt.publicationGeneration);
+      let committed = false;
+      const foreign = new HistoryService(config);
+      const folded = await foreign.persistBoundaryWithTailCopies(
+        ws,
+        structuredClone(receipt.boundary),
+        [],
+        false,
+        () => true,
+        {
+          publication: { generation: receipt.publicationGeneration, journal: receipt },
+          onCommitted: () => {
+            committed = true;
+          },
+        }
+      );
+      expect(folded.success).toBe(true);
+      expect(committed).toBe(true);
+      const active = await foreign.getHistoryFromLatestBoundary(ws);
+      assert(active.success);
+      expect(active.data.map((message) => message.id)).toEqual([receipt.boundary.id]);
+      expect(await store.captureGeneration()).toBe(receipt.publicationGeneration);
     });
   });
 

--- a/src/node/services/historyService.test.ts
+++ b/src/node/services/historyService.test.ts
@@ -996,6 +996,10 @@ describe("HistoryService", () => {
   describe("destructive context publication fencing", () => {
     const ws = "context-publication";
     const row = (id: string) => createMuxMessage(id, "user", `Context for ${id}`);
+    const reasoning = (id: string): MuxMessage => ({
+      ...createMuxMessage(id, "assistant", "", { synthetic: true }),
+      parts: [{ type: "reasoning", text: "Provider-visible thinking" }],
+    });
     const display = () =>
       createMuxMessage("display", "user", "Workflow display", {
         muxMetadata: { type: "workflow-trigger-display", rawCommand: "/wf", runId: "run" },
@@ -1118,6 +1122,33 @@ describe("HistoryService", () => {
         rows: [row("old"), row("tail")],
         mutate: () => service.truncateAfterMessage(ws, "tail"),
         expected: ["old"],
+      },
+      {
+        name: "reasoning-only active edit",
+        rows: [row("old"), reasoning("tail")],
+        mutate: () => service.truncateAfterMessage(ws, "tail"),
+        expected: ["old"],
+      },
+      {
+        name: "reasoning-only active prefix",
+        rows: [reasoning("old"), row("tail")],
+        mutate: () => service.truncateHistory(ws, 0.2),
+        expected: ["tail"],
+      },
+      {
+        name: "reasoning-only context-budget rejection",
+        // A quarantined trigger isolates a still-visible owned reasoning prelude on retry.
+        rows: [
+          row("old"),
+          reasoning("prelude"),
+          createContextBudgetRejectedMessage(
+            createMuxMessage("trigger", "user", "Rejected request", {
+              requestPreludeMessageIds: ["prelude"],
+            })
+          ),
+        ],
+        mutate: rejectLatestBudgetRequest,
+        expected: ["old", "prelude", "trigger"],
       },
       {
         name: "archived edit",
@@ -1374,6 +1405,13 @@ describe("HistoryService", () => {
       {
         name: "sealed prefix",
         rows: [row("old"), boundary(), row("tail")],
+        mutate: () => service.truncateHistory(ws, 0.1),
+        expected: ["sealed", "tail"],
+        success: true,
+      },
+      {
+        name: "sealed reasoning-only prefix",
+        rows: [reasoning("old"), boundary(), row("tail")],
         mutate: () => service.truncateHistory(ws, 0.1),
         expected: ["sealed", "tail"],
         success: true,

--- a/src/node/services/historyService.test.ts
+++ b/src/node/services/historyService.test.ts
@@ -5,6 +5,7 @@ import { HistoryService } from "./historyService";
 import type { Config } from "@/node/config";
 import { createTestHistoryService } from "./testHistoryService";
 import type { ContinuousCompactionJournal } from "@/common/orpc/schemas/continuousCompaction";
+import { createContextBudgetRejectedMessage } from "@/common/utils/messages/contextBudgetRejection";
 import { updateSubagentTranscriptArtifactsFile } from "./subagentTranscriptArtifacts";
 import { createMuxMessage, type MuxMessage } from "@/common/types/message";
 import assert from "node:assert";
@@ -1022,6 +1023,12 @@ describe("HistoryService", () => {
       });
     const prefix = [{ role: "user" as const, content: "Discarded provider context" }];
 
+    async function rejectLatestBudgetRequest() {
+      const latest = await service.getLastMessages(ws, 1);
+      assert(latest.success && latest.data.length === 1);
+      return service.rejectContextBudgetRequest(ws, latest.data[0]);
+    }
+
     async function capturePublication() {
       const store = service.getContinuousCompactionJournal(ws);
       const journal: ContinuousCompactionJournal = {
@@ -1117,6 +1124,25 @@ describe("HistoryService", () => {
         rows: [row("old"), boundary(), row("tail")],
         mutate: () => service.truncateAfterMessage(ws, "old", { keepTargetMessage: true }),
         expected: ["old"],
+      },
+      {
+        name: "context-budget rejection",
+        rows: [
+          row("old"),
+          createMuxMessage("prelude", "assistant", "Owned payload", { synthetic: true }),
+          createMuxMessage("trigger", "user", "Rejected request", {
+            requestPreludeMessageIds: ["prelude"],
+          }),
+        ],
+        mutate: async () => {
+          const result = await rejectLatestBudgetRequest();
+          if (result.success) {
+            expect(result.data.map((message) => message.id)).toEqual(["prelude", "trigger"]);
+            expect(result.data.every((message) => message.parts.length === 0)).toBe(true);
+          }
+          return result;
+        },
+        expected: ["old", "prelude", "trigger"],
       },
     ];
 
@@ -1330,6 +1356,24 @@ describe("HistoryService", () => {
         expected: ["old", "sealed"],
         success: true,
       },
+      {
+        name: "missing rejection trigger",
+        rows: [row("old")],
+        mutate: () =>
+          service.rejectContextBudgetRequest(
+            ws,
+            createMuxMessage("missing", "user", "Gone request", { historySequence: 0 })
+          ),
+        expected: ["old"],
+        success: false,
+      },
+      {
+        name: "repeated rejection capsule",
+        rows: [createContextBudgetRejectedMessage(row("old"))],
+        mutate: rejectLatestBudgetRequest,
+        expected: ["old"],
+        success: true,
+      },
     ])("$name preserves a usable compaction publication", async (testCase) => {
       for (const message of testCase.rows) {
         assert((await service.appendToHistory(ws, message)).success);
@@ -1363,6 +1407,62 @@ describe("HistoryService", () => {
       expect(active.data.map((message) => message.id)).toEqual([receipt.boundary.id]);
       expect(await store.captureGeneration()).toBe(receipt.publicationGeneration);
     });
+
+    it.each(
+      [
+        '{"metadata":{"contextBoundaryKind":"reset"},broken\n',
+        ' {\n"contextBoundaryKind"\n:\n"reset"\n}\n',
+        '{"id":"reset","role":"assistant","parts":[],"metadata":{"contextBoundaryKind":"reset"},"metadata":{}}\n',
+      ].flatMap((raw) =>
+        ["chat", "archive"].flatMap((artifact) =>
+          [0, 0.1, 0.5].map((percentage) => ({ raw, artifact, percentage }))
+        )
+      )
+    )(
+      "prefix $percentage respects the retained raw reset floor in $artifact ($raw)",
+      async ({ raw, artifact, percentage }) => {
+        const source = [
+          row("old"),
+          row("active"),
+          createMuxMessage("tail", "assistant", "Active reply", {
+            contextUsage: { inputTokens: 100, outputTokens: 10, totalTokens: 110 },
+          }),
+        ];
+        assert((await service.appendManyToHistory(ws, source)).success);
+        assert((await service.getHistoryFromLatestBoundary(ws)).success);
+        const chatPath = path.join(config.sessionsDir, ws, "chat.jsonl");
+        const archivePath = path.join(config.sessionsDir, ws, "chat-archive.jsonl");
+        const lines = (await fs.readFile(chatPath, "utf8")).trimEnd().split("\n");
+        const sealed = lines[0] + "\n" + raw;
+        const active = lines.slice(1).join("\n") + "\n";
+        if (artifact === "archive") await fs.writeFile(archivePath, sealed);
+        await fs.writeFile(chatPath, (artifact === "chat" ? sealed : "") + active);
+        const before = await service.getHistoryFromLatestBoundary(ws);
+        assert(before.success);
+        expect(before.data.map((message) => message.id)).toEqual(["active", "tail"]);
+        const { store, receipt } = await capturePublication();
+        const truncated = await service.truncateHistory(ws, percentage);
+        assert(truncated.success);
+        const changed = percentage === 0.5;
+        expect(truncated.data).toEqual(percentage === 0 ? [] : changed ? [0, 1] : [0]);
+        const restarted = new HistoryService(config);
+        const after = await restarted.getHistoryFromLatestBoundary(ws);
+        assert(after.success);
+        if (changed) {
+          expect(after.data.map((message) => message.id)).toEqual(["tail"]);
+          expect(after.data[0].metadata?.contextUsage).toBeUndefined();
+          expect(await store.read()).toBeNull();
+          expect(await store.captureGeneration()).not.toBe(receipt.publicationGeneration);
+        } else {
+          expect(after.data).toEqual(before.data);
+          expect(await store.captureGeneration()).toBe(receipt.publicationGeneration);
+          expect(await store.read()).toEqual(receipt);
+        }
+        expect(await fs.readFile(artifact === "chat" ? chatPath : archivePath, "utf8")).toContain(
+          raw
+        );
+      }
+    );
   });
 
   describe("clearHistory", () => {

--- a/src/node/services/historyService.test.ts
+++ b/src/node/services/historyService.test.ts
@@ -1125,6 +1125,21 @@ describe("HistoryService", () => {
         mutate: () => service.truncateAfterMessage(ws, "old", { keepTargetMessage: true }),
         expected: ["old"],
       },
+      ...[
+        { name: "reset", message: reset() },
+        { name: "rollover", message: reset(true) },
+        { name: "empty compaction", message: { ...boundary(), parts: [] } },
+      ].flatMap(({ name, message }) =>
+        ["active", "archived"].map((target) => ({
+          name: `${target} edit removing only ${name} boundary`,
+          rows: [row("old"), message],
+          mutate: () =>
+            target === "active"
+              ? service.truncateAfterMessage(ws, message.id)
+              : service.truncateAfterMessage(ws, "old", { keepTargetMessage: true }),
+          expected: ["old"],
+        }))
+      ),
       {
         name: "context-budget rejection",
         rows: [
@@ -1321,6 +1336,27 @@ describe("HistoryService", () => {
         expected: ["old"],
         success: true,
       },
+      ...[reset(), { ...boundary(), parts: [] }].map((message) => ({
+        name: `retained ${message.id} boundary`,
+        rows: [row("old"), message],
+        mutate: () => service.truncateAfterMessage(ws, message.id, { keepTargetMessage: true }),
+        expected: ["old", message.id],
+        success: true,
+      })),
+      {
+        name: "invalid empty compaction marker",
+        rows: [
+          row("old"),
+          createMuxMessage("invalid", "assistant", "", {
+            compactionBoundary: true,
+            compacted: "user",
+            compactionEpoch: 0,
+          }),
+        ],
+        mutate: () => service.truncateAfterMessage(ws, "invalid"),
+        expected: ["old"],
+        success: true,
+      },
       {
         name: "display edit",
         rows: [row("old"), display()],
@@ -1407,6 +1443,43 @@ describe("HistoryService", () => {
       expect(active.data.map((message) => message.id)).toEqual([receipt.boundary.id]);
       expect(await store.captureGeneration()).toBe(receipt.publicationGeneration);
     });
+
+    it.each(["active", "archived"])(
+      "%s display-only edit retains raw reset evidence and publication",
+      async (target) => {
+        assert((await service.appendManyToHistory(ws, [row("old"), display()])).success);
+        assert((await service.getHistoryFromLatestBoundary(ws)).success);
+        const chatPath = path.join(config.sessionsDir, ws, "chat.jsonl");
+        const archivePath = path.join(config.sessionsDir, ws, "chat-archive.jsonl");
+        const [oldLine, displayLine] = (await fs.readFile(chatPath, "utf8")).trimEnd().split("\n");
+        const raw = ' {\n"contextBoundaryKind"\n:\n"reset"\n}\n';
+        if (target === "archived") await fs.writeFile(archivePath, oldLine + "\n");
+        await fs.writeFile(
+          chatPath,
+          (target === "active" ? oldLine + "\n" : "") + raw + displayLine + "\n"
+        );
+        const { store, receipt } = await capturePublication();
+        const cut = await service.truncateAfterMessage(
+          ws,
+          target === "active" ? "display" : "old",
+          {
+            keepTargetMessage: target === "archived",
+          }
+        );
+        assert(cut.success);
+        expect(cut.data.removedMessages.map((message) => message.id)).toEqual(["display"]);
+        expect(await fs.readFile(chatPath, "utf8")).toContain(raw);
+        const restarted = new HistoryService(config);
+        const active = await restarted.getHistoryFromLatestBoundary(ws);
+        assert(active.success);
+        expect(active.data).toEqual([]);
+        expect((await collectFullHistory(restarted, ws)).map((message) => message.id)).toEqual([
+          "old",
+        ]);
+        expect(await store.captureGeneration()).toBe(receipt.publicationGeneration);
+        expect(await store.read()).toEqual(receipt);
+      }
+    );
 
     it.each(
       [

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -117,6 +117,15 @@ function hasDurableCompactionBoundary(metadata: MuxMetadata | undefined): boolea
   return isPositiveInteger(metadata.compactionEpoch);
 }
 
+function tailCutChangesProviderContext(removedMessages: MuxMessage[]): boolean {
+  // Even an empty boundary can hide older context. Removing it changes the
+  // provider view; unreadable reset evidence is preserved outside this parsed tail.
+  return (
+    removedMessages.some(isDurableContextBoundaryMarker) ||
+    hasProviderEligibleMessages(filterWorkflowDisplayOnlyMessages(removedMessages))
+  );
+}
+
 function stripContextUsage(message: MuxMessage): MuxMessage {
   if (!message.metadata) {
     return message;
@@ -3349,7 +3358,7 @@ export class HistoryService {
 
           // A real edit must retire captured provider context; missing targets,
           // keep-target-at-tail no-ops and display-only cuts retain publication.
-          if (hasProviderEligibleMessages(filterWorkflowDisplayOnlyMessages(removedMessages))) {
+          if (tailCutChangesProviderContext(removedMessages)) {
             await this.getContinuousCompactionJournal(
               workspaceId
             ).advanceGenerationUnderHistoryLock();
@@ -3434,7 +3443,7 @@ export class HistoryService {
       if (lastArchiveRow && lastArchiveRow.raw.at(-1) !== 10 && activeEpochRows.length > 0) {
         archiveRows.push({ raw: Buffer.from("\n"), message: undefined });
       }
-      if (hasProviderEligibleMessages(filterWorkflowDisplayOnlyMessages(removedMessages))) {
+      if (tailCutChangesProviderContext(removedMessages)) {
         await this.getContinuousCompactionJournal(workspaceId).advanceGenerationUnderHistoryLock();
       }
       await this.rewriteHistoryFilesUnlocked(

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -122,7 +122,10 @@ function tailCutChangesProviderContext(removedMessages: MuxMessage[]): boolean {
   // provider view; unreadable reset evidence is preserved outside this parsed tail.
   return (
     removedMessages.some(isDurableContextBoundaryMarker) ||
-    hasProviderEligibleMessages(filterWorkflowDisplayOnlyMessages(removedMessages))
+    // Shared history may be replayed with Anthropic thinking enabled.
+    hasProviderEligibleMessages(filterWorkflowDisplayOnlyMessages(removedMessages), {
+      preserveReasoningOnly: true,
+    })
   );
 }
 
@@ -2879,7 +2882,8 @@ export class HistoryService {
               (row.role === "assistant" && row.metadata?.synthetic === true));
           if (row !== persisted && !ownedPrelude) return row;
           providerContextChanged ||= hasProviderEligibleMessages(
-            filterWorkflowDisplayOnlyMessages([row])
+            filterWorkflowDisplayOnlyMessages([row]),
+            { preserveReasoningOnly: true }
           );
           const marked = createContextBudgetRejectedMessage(row);
           rejected.push(marked);
@@ -3669,7 +3673,8 @@ export class HistoryService {
             removeCount - (messages.length - activeMessages.length)
           );
           const activeContextChanged = hasProviderEligibleMessages(
-            filterWorkflowDisplayOnlyMessages(activeMessages.slice(0, activeRemoveCount))
+            filterWorkflowDisplayOnlyMessages(activeMessages.slice(0, activeRemoveCount)),
+            { preserveReasoningOnly: true }
           );
           const sanitize = activeContextChanged
             ? stripContextUsage

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -49,7 +49,6 @@ import { safeStringifyForCounting } from "@/common/utils/tokens/safeStringifyFor
 import { normalizeLegacyMuxMetadata } from "@/node/utils/messages/legacy";
 import { CONTEXT_BOUNDARY_KINDS } from "@/common/constants/contextBoundary";
 import {
-  findLatestContextBoundaryIndex,
   getContextBoundaryKind,
   hasProviderEligibleMessages,
   isDurableCompactedMarker,
@@ -116,19 +115,6 @@ function hasDurableCompactionBoundary(metadata: MuxMetadata | undefined): boolea
   }
 
   return isPositiveInteger(metadata.compactionEpoch);
-}
-
-function prefixCutChangesActiveContext(messages: MuxMessage[], removeCount: number): boolean {
-  const boundaryIndex = findLatestContextBoundaryIndex(messages);
-  const activeStart =
-    boundaryIndex < 0
-      ? 0
-      : getContextBoundaryKind(messages[boundaryIndex]) === CONTEXT_BOUNDARY_KINDS.RESET
-        ? boundaryIndex + 1
-        : boundaryIndex;
-  return hasProviderEligibleMessages(
-    filterWorkflowDisplayOnlyMessages(messages.slice(activeStart, removeCount))
-  );
 }
 
 function stripContextUsage(message: MuxMessage): MuxMessage {
@@ -2873,6 +2859,7 @@ export class HistoryService {
           )
         );
         const rejected: MuxMessage[] = [];
+        let providerContextChanged = false;
         const earlier = new Set(messages.slice(0, triggerIndex));
         const updated = this.serializeHistoryRewrite(rows, workspaceId, (row) => {
           const ownedPrelude =
@@ -2882,10 +2869,20 @@ export class HistoryService {
             (isSyntheticSnapshotUserMessage(row) ||
               (row.role === "assistant" && row.metadata?.synthetic === true));
           if (row !== persisted && !ownedPrelude) return row;
+          providerContextChanged ||= hasProviderEligibleMessages(
+            filterWorkflowDisplayOnlyMessages([row])
+          );
           const marked = createContextBudgetRejectedMessage(row);
           rejected.push(marked);
           return marked;
         });
+        // Rejection removes provider context just like truncation. Retire foreign
+        // compactors before rewriting, but preserve publication on capsule retries.
+        if (providerContextChanged) {
+          await this.getContinuousCompactionJournal(
+            workspaceId
+          ).advanceGenerationUnderHistoryLock();
+        }
         await writeFileAtomic(historyPath, updated);
         return Ok(rejected);
       }
@@ -3648,7 +3645,23 @@ export class HistoryService {
             return Ok(allSequences);
           }
 
-          const activeContextChanged = prefixCutChangesActiveContext(messages, removeCount);
+          // The raw-aware reader returns the active suffix of these parsed rows.
+          // Reuse its privacy floor: retained unreadable reset evidence can seal
+          // rows that parsed boundary markers alone would misclassify as active.
+          const activeMessages = await readProviderHistoryFromLatestBoundary(
+            {
+              chat: this.getChatHistoryPath(workspaceId),
+              archive: this.getChatArchivePath(workspaceId),
+            },
+            0
+          );
+          const activeRemoveCount = Math.max(
+            0,
+            removeCount - (messages.length - activeMessages.length)
+          );
+          const activeContextChanged = hasProviderEligibleMessages(
+            filterWorkflowDisplayOnlyMessages(activeMessages.slice(0, activeRemoveCount))
+          );
           const sanitize = activeContextChanged
             ? stripContextUsage
             : (message: MuxMessage) => message;

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -2458,6 +2458,7 @@ export class HistoryService {
         `[HISTORY APPEND] Assigned historySequence=${message.metadata.historySequence ?? "unknown"} role=${message.role}`
       );
 
+      await this.fenceContextResetUnderHistoryLock(workspaceId, [message]);
       await this.getAppendProvenance(workspaceId).appendChat(
         Buffer.from(JSON.stringify(historyEntry) + "\n")
       );
@@ -2465,6 +2466,20 @@ export class HistoryService {
     } catch (error) {
       const message = getErrorMessage(error);
       return Err(`Failed to append to history: ${message}`);
+    }
+  }
+
+  private async fenceContextResetUnderHistoryLock(
+    workspaceId: string,
+    messages: readonly MuxMessage[]
+  ): Promise<void> {
+    if (
+      messages.some((message) => getContextBoundaryKind(message) === CONTEXT_BOUNDARY_KINDS.RESET)
+    ) {
+      // Reset/rollover discards context captured by foreign compactors too. Advance
+      // after admission but before appending under the same lock, so a failed
+      // generation write cannot leave a durable reset open to stale publication.
+      await this.getContinuousCompactionJournal(workspaceId).advanceGenerationUnderHistoryLock();
     }
   }
 
@@ -2751,6 +2766,7 @@ export class HistoryService {
           // temp-and-rename helper the other history mutations use, under the
           // cross-process append lock (r50) so a foreign backend's row cannot
           // land between this read and the replace and be silently deleted.
+          await this.fenceContextResetUnderHistoryLock(workspaceId, messages);
           await this.getAppendProvenance(workspaceId).appendChat(
             Buffer.from(this.serializeHistoryEntries(messages, workspaceId)),
             true
@@ -3334,6 +3350,13 @@ export class HistoryService {
 
           const archiveMaxSeq = await this.getArchiveTailMaxSequence(workspaceId);
 
+          // A real edit must retire captured provider context; missing targets,
+          // keep-target-at-tail no-ops and display-only cuts retain publication.
+          if (hasProviderEligibleMessages(filterWorkflowDisplayOnlyMessages(removedMessages))) {
+            await this.getContinuousCompactionJournal(
+              workspaceId
+            ).advanceGenerationUnderHistoryLock();
+          }
           // Atomic write prevents corruption if app crashes mid-write
           await writeFileAtomic(historyPath, historyEntries);
 
@@ -3413,6 +3436,9 @@ export class HistoryService {
       const lastArchiveRow = archiveRows.at(-1);
       if (lastArchiveRow && lastArchiveRow.raw.at(-1) !== 10 && activeEpochRows.length > 0) {
         archiveRows.push({ raw: Buffer.from("\n"), message: undefined });
+      }
+      if (hasProviderEligibleMessages(filterWorkflowDisplayOnlyMessages(removedMessages))) {
+        await this.getContinuousCompactionJournal(workspaceId).advanceGenerationUnderHistoryLock();
       }
       await this.rewriteHistoryFilesUnlocked(
         workspaceId,
@@ -3551,6 +3577,13 @@ export class HistoryService {
             .filter((s): s is number => isNonNegativeInteger(s));
 
           if (percentage >= 1.0) {
+            // Explicit full-clear intent includes display-only or malformed history.
+            // An already-empty history remains a no-op for publication ownership.
+            if (archiveRows.length > 0 || chatRows.length > 0) {
+              await this.getContinuousCompactionJournal(
+                workspaceId
+              ).advanceGenerationUnderHistoryLock();
+            }
             await this.rewriteHistoryFilesUnlocked(workspaceId, null, null);
             this.sequenceCounters.set(workspaceId, 0);
             return Ok(allSequences);
@@ -3607,6 +3640,9 @@ export class HistoryService {
                 "Truncation would remove every remaining message; retry to run it as a full clear."
               );
             }
+            await this.getContinuousCompactionJournal(
+              workspaceId
+            ).advanceGenerationUnderHistoryLock();
             await this.rewriteHistoryFilesUnlocked(workspaceId, null, null);
             this.sequenceCounters.set(workspaceId, 0);
             return Ok(allSequences);
@@ -3634,6 +3670,13 @@ export class HistoryService {
             retainedMessages,
             sanitize
           );
+          // Trimming sealed or display-only rows does not change a compactor's
+          // active provider context, so only an active-context cut retires it.
+          if (activeContextChanged) {
+            await this.getContinuousCompactionJournal(
+              workspaceId
+            ).advanceGenerationUnderHistoryLock();
+          }
           await this.rewriteHistoryFilesUnlocked(
             workspaceId,
             remainingArchive.length > 0 ? remainingArchive : null,


### PR DESCRIPTION
Introduce an inactive pending-attachment file protocol with exact consumption and rollback receipts. Generation and boundary evidence gate which persisted snapshot can enrich a request; a consumed predecessor cannot return through a provisional successor's fallback. Ambiguous legacy bytes are preserved while uncertain attachment context is suppressed.

Optional sidecar read failures load as absent. Empty directory entries at the sidecar path heal through nonrecursive removal; nonempty contents remain intact and mutation errors stay visible. Non-object JSON roots follow invalid-state recovery. Standalone preparation leaves plausible unsupported schema objects untouched and returns no receipt, so a failed boundary publication cannot erase another version's state. No new backup envelope or marker is introduced. Valid V1 handling remains compatible.

Runtime activation is separate and must hold the existing history locks through preparation, boundary publication, synchronous receipt delivery, and failure cleanup. It must distinguish optional enrichment refusal from mandatory history publication.

This is the middle of fixed phase stack #4135 → #4138 → #4148. Every member will be queued together after current Codex approval, resolved findings, and passing CI.

Validation: 69 focused tests and full static checks pass on the integrated parent; independent review approved. Real filesystem cases cover exact receipts, predecessor consumption, generation/reset fences, ambiguous legacy files, directory repair and nonempty preservation, invalid JSON-root recovery, unreadable sidecars, and byte preservation across unsupported preparation and history-write outcomes. Nix formatting was skipped because Nix is unavailable.

---

_Generated with `xum` • Model: `unavailable` • Thinking: `unavailable` • Cost: `$unavailable`_

<!-- mux-attribution: model=unavailable thinking=unavailable costs=unavailable -->
