### PR TITLE
🤖 refactor: extract private history publication receipts

### DIFF
--- a/src/browser/stories/App.remoteConnection.stories.tsx
+++ b/src/browser/stories/App.remoteConnection.stories.tsx
@@ -267,7 +267,10 @@ export const BrowserWithoutBridge: AppStory = {
   render: () => <AppWithMocks setup={setupRemoteSettings} />,
   play: async ({ canvasElement }) => {
     const canvas = await openSettings(canvasElement);
-    await expect(await canvas.findByRole("button", { name: "Server Access" })).toBeVisible();
+    // Settings can mount while AppLoader's fade-in still makes the button invisible.
+    await waitFor(() =>
+      expect(canvas.getByRole("button", { name: "Server Access" })).toBeVisible()
+    );
     await expect(canvas.queryByRole("button", { name: "Remote Connection" })).toBeNull();
   },
 };

--- a/src/node/services/historyAppendProvenance.ts
+++ b/src/node/services/historyAppendProvenance.ts
@@ -277,7 +277,11 @@ export class HistoryAppendProvenance {
   }
 
   /** Low-level append certification; the start must match the whole transaction. */
-  async appendChat(bytes: Buffer, atomic = false): Promise<void> {
+  async appendChat(
+    bytes: Buffer,
+    atomic = false,
+    publishAtomic?: (filePath: string, bytes: Buffer) => Promise<void>
+  ): Promise<void> {
     const transaction = transactions.getStore();
     assert(
       transaction?.active === true && transaction.chatPath === this.chatPath,
@@ -303,7 +307,9 @@ export class HistoryAppendProvenance {
           bytes = Buffer.concat([Buffer.from("\n"), bytes]);
         }
         replacement = Buffer.concat([existing, bytes]);
-        await writeFileAtomic(this.chatPath, replacement);
+        // HistoryService supplies its commit-point observer without duplicating
+        // raw-byte preservation, torn-tail repair, or append certification here.
+        await (publishAtomic ?? writeFileAtomic)(this.chatPath, replacement);
         published = true;
       } else {
         const size = Number(before.chat?.size ?? 0);

--- a/src/node/services/historyService.publication.test.ts
+++ b/src/node/services/historyService.publication.test.ts
@@ -1,11 +1,18 @@
-import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, spyOn } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as nodeFs from "node:fs";
 import * as path from "node:path";
 import { createMuxMessage, type MuxMessage } from "@/common/types/message";
 import type { Result } from "@/common/types/result";
 import { HistoryAppendProvenance } from "./historyAppendProvenance";
+import type { HistoryService } from "./historyService";
 import { createTestHistoryService } from "./testHistoryService";
+
+type PublicationObserver = NonNullable<
+  Parameters<HistoryService["appendManyToHistoryUnderWriteLock"]>[2]
+>;
+// Compile-time assertion only; behavioral tests below check receipt timing at rename.
+expectTypeOf<() => Promise<undefined>>().not.toMatchTypeOf<PublicationObserver["onCommitted"]>();
 
 describe("HistoryService private publication seam", () => {
   let fixture: Awaited<ReturnType<typeof createTestHistoryService>>;
@@ -29,10 +36,7 @@ describe("HistoryService private publication seam", () => {
 
   // Exercise the inactive seam under its real recovery/provenance/removal locks,
   // without adding a public acceptance option just for tests.
-  function publish(
-    kind: "single" | "batch" | "update",
-    publication: { isCurrent: () => boolean; onCommitted: () => void }
-  ) {
+  function publish(kind: "single" | "batch" | "update", publication: PublicationObserver) {
     const service = fixture.historyService as unknown as {
       withRecoveredHistoryWriteResultLock(
         workspaceId: string,
@@ -131,7 +135,9 @@ describe("HistoryService private publication seam", () => {
             .some((name) => name.startsWith("chat.jsonl.publication-"));
           return false;
         },
-        onCommitted: () => commits++,
+        onCommitted: () => {
+          commits++;
+        },
       });
       expect(result.success).toBe(false);
       expect(staged).toBe(true);
@@ -151,7 +157,9 @@ describe("HistoryService private publication seam", () => {
       try {
         const result = await publish(kind, {
           isCurrent: () => true,
-          onCommitted: () => commits++,
+          onCommitted: () => {
+            commits++;
+          },
         });
         expect(result.success).toBe(false);
         expect(commits).toBe(0);

--- a/src/node/services/historyService.publication.test.ts
+++ b/src/node/services/historyService.publication.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as nodeFs from "node:fs";
+import * as path from "node:path";
+import { createMuxMessage, type MuxMessage } from "@/common/types/message";
+import type { Result } from "@/common/types/result";
+import { HistoryAppendProvenance } from "./historyAppendProvenance";
+import { createTestHistoryService } from "./testHistoryService";
+
+describe("HistoryService private publication seam", () => {
+  let fixture: Awaited<ReturnType<typeof createTestHistoryService>>;
+  let chatPath: string;
+  const workspaceId = "publication";
+
+  beforeEach(async () => {
+    fixture = await createTestHistoryService();
+    chatPath = path.join(fixture.config.sessionsDir, workspaceId, "chat.jsonl");
+    for (const row of [
+      createMuxMessage("user", "user", "question"),
+      createMuxMessage("assistant", "assistant", "answer"),
+    ]) {
+      expect((await fixture.historyService.appendToHistory(workspaceId, row)).success).toBe(true);
+    }
+  });
+
+  afterEach(async () => {
+    await fixture.cleanup();
+  });
+
+  // Exercise the inactive seam under its real recovery/provenance/removal locks,
+  // without adding a public acceptance option just for tests.
+  function publish(
+    kind: "single" | "batch" | "update",
+    publication: { isCurrent: () => boolean; onCommitted: () => void }
+  ) {
+    const service = fixture.historyService as unknown as {
+      withRecoveredHistoryWriteResultLock(
+        workspaceId: string,
+        errorPrefix: string,
+        operation: () => Promise<Result<void>>
+      ): Promise<Result<void>>;
+      updateHistoryUnderWriteLock(
+        workspaceId: string,
+        message: MuxMessage,
+        observer: typeof publication
+      ): Promise<Result<void>>;
+      appendManyToHistoryUnderWriteLock(
+        workspaceId: string,
+        messages: MuxMessage[],
+        observer: typeof publication
+      ): Promise<Result<void>>;
+    };
+    return service.withRecoveredHistoryWriteResultLock(workspaceId, "Publication failed", () => {
+      if (kind === "update") {
+        return service.updateHistoryUnderWriteLock(
+          workspaceId,
+          createMuxMessage("assistant", "assistant", "updated", { historySequence: 1 }),
+          publication
+        );
+      }
+      const rows = [createMuxMessage("replacement", "user", "next question")];
+      if (kind === "batch") rows.unshift(createMuxMessage("payload", "assistant", "payload"));
+      return service.appendManyToHistoryUnderWriteLock(workspaceId, rows, publication);
+    });
+  }
+
+  async function readHistory() {
+    const result = await fixture.historyService.getLastMessages(workspaceId, 10);
+    expect(result.success).toBe(true);
+    return result.success ? result.data : [];
+  }
+
+  for (const kind of ["single", "batch", "update"] as const) {
+    it(`${kind}: captures the complete publication before ownership can change`, async () => {
+      const provenance = new HistoryAppendProvenance(path.dirname(chatPath));
+      const before = (await provenance.read()).receipt;
+      expect(before?.state).toBe("stable");
+      let current = true;
+      let committedWhileCurrent = false;
+      let committedRows: MuxMessage[] = [];
+      let commits = 0;
+      const result = await publish(kind, {
+        isCurrent: () => {
+          queueMicrotask(() => {
+            current = false;
+          });
+          return current;
+        },
+        onCommitted: () => {
+          commits++;
+          committedWhileCurrent = current;
+          committedRows = nodeFs
+            .readFileSync(chatPath, "utf8")
+            .trim()
+            .split("\n")
+            .map((line) => JSON.parse(line) as MuxMessage);
+        },
+      });
+      expect(result.success).toBe(true);
+      expect(commits).toBe(1);
+      expect(current).toBe(false);
+      expect(committedWhileCurrent).toBe(true);
+      const persisted = await readHistory();
+      expect(committedRows).toEqual(persisted);
+      expect(persisted.map((row) => row.id)).toEqual(
+        kind === "update"
+          ? ["user", "assistant"]
+          : kind === "batch"
+            ? ["user", "assistant", "payload", "replacement"]
+            : ["user", "assistant", "replacement"]
+      );
+      expect(persisted.map((row) => row.metadata?.historySequence)).toEqual(
+        persisted.map((_, index) => index)
+      );
+      if (kind === "update")
+        expect(persisted[1].parts).toMatchObject([{ type: "text", text: "updated" }]);
+      const after = (await provenance.read()).receipt;
+      expect(after?.state).toBe("stable");
+      if (kind === "update") expect(after?.epoch).not.toBe(before?.epoch);
+      else expect(after?.epoch).toBe(before?.epoch);
+    });
+
+    it(`${kind}: rejects ownership after staging without publishing or notifying`, async () => {
+      const before = await fs.readFile(chatPath);
+      let staged = false;
+      let commits = 0;
+      const result = await publish(kind, {
+        isCurrent: () => {
+          staged = nodeFs
+            .readdirSync(path.dirname(chatPath))
+            .some((name) => name.startsWith("chat.jsonl.publication-"));
+          return false;
+        },
+        onCommitted: () => commits++,
+      });
+      expect(result.success).toBe(false);
+      expect(staged).toBe(true);
+      expect(commits).toBe(0);
+      expect(await fs.readFile(chatPath)).toEqual(before);
+      expect(
+        (await fs.readdir(path.dirname(chatPath))).filter((name) => name.includes(".publication-"))
+      ).toEqual([]);
+    });
+
+    it(`${kind}: a failed rename leaves the old history and no commit receipt`, async () => {
+      const before = await fs.readFile(chatPath);
+      let commits = 0;
+      const rename = spyOn(nodeFs, "renameSync").mockImplementationOnce(() => {
+        throw new Error("publication unavailable");
+      });
+      try {
+        const result = await publish(kind, {
+          isCurrent: () => true,
+          onCommitted: () => commits++,
+        });
+        expect(result.success).toBe(false);
+        expect(commits).toBe(0);
+        expect(await fs.readFile(chatPath)).toEqual(before);
+      } finally {
+        rename.mockRestore();
+      }
+    });
+
+    it(`${kind}: observer and staging-cleanup failures cannot turn a commit into a retry`, async () => {
+      let commits = 0;
+      let cleanupFailures = 0;
+      const remove = fs.rm;
+      const failure = spyOn(fs, "rm").mockImplementation((target, options) => {
+        if (String(target).startsWith(`${chatPath}.publication-`)) {
+          cleanupFailures++;
+          return Promise.reject(new Error("cleanup unavailable"));
+        }
+        return remove(target, options);
+      });
+      try {
+        const result = await publish(kind, {
+          isCurrent: () => true,
+          onCommitted: () => {
+            commits++;
+            throw new Error("observer unavailable");
+          },
+        });
+        expect(result.success).toBe(true);
+        expect(commits).toBe(1);
+        expect(cleanupFailures).toBe(1);
+      } finally {
+        failure.mockRestore();
+      }
+      const persisted = await readHistory();
+      if (kind === "update") {
+        expect(persisted).toHaveLength(2);
+        expect(persisted[1].parts).toMatchObject([{ type: "text", text: "updated" }]);
+      } else {
+        expect(persisted.filter((row) => row.id === "replacement")).toHaveLength(1);
+        expect(persisted).toHaveLength(kind === "batch" ? 4 : 3);
+      }
+    });
+  }
+});

--- a/src/node/services/historyService.publication.test.ts
+++ b/src/node/services/historyService.publication.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, expectTypeOf, it, spyOn } from
 import * as fs from "node:fs/promises";
 import * as nodeFs from "node:fs";
 import * as path from "node:path";
+import { randomUUID } from "node:crypto";
 import * as atomicWrite from "write-file-atomic";
 import { createMuxMessage, type MuxMessage } from "@/common/types/message";
 import type { Result } from "@/common/types/result";
@@ -99,53 +100,69 @@ describe("HistoryService private publication seam", () => {
   }
 
   for (const kind of ["single", "batch", "update"] as const) {
-    it(`${kind}: a reclaimed birth-less lock preserves the successor's history`, async () => {
-      const lockPath = historyWriteLockPath(fixture.config.rootDir, workspaceId);
-      const successorBytes = Buffer.concat([
-        await fs.readFile(chatPath),
-        Buffer.from(
-          JSON.stringify({
-            ...createMuxMessage("successor", "user", "foreign row", { historySequence: 2 }),
-            workspaceId,
-          }) + "\n"
-        ),
-      ]);
-      let successor: Awaited<ReturnType<typeof acquireProcessFileLock>> | undefined;
-      let commits = 0;
-      const staging = afterPublicationStaging(async () => {
-        // Model an expired birth-less lease while staging is held, then let
-        // the real lock protocol reclaim it and a successor publish new bytes.
-        const token = await fs.readFile(lockPath, "utf8");
-        await fs.writeFile(lockPath, token.split(":").slice(0, 2).join(":"));
-        await fs.utimes(lockPath, new Date(0), new Date(0));
-        successor = await acquireProcessFileLock({
-          lockPath,
-          timeoutMs: 1000,
-          label: "successor history writer",
+    it.each(["pending", "stable"] as const)(
+      `${kind}: a reclaimed birth-less lock preserves the successor's history and %s receipt`,
+      async (receiptState) => {
+        const lockPath = historyWriteLockPath(fixture.config.rootDir, workspaceId);
+        const successorBytes = Buffer.concat([
+          await fs.readFile(chatPath),
+          Buffer.from(
+            JSON.stringify({
+              ...createMuxMessage("successor", "user", "foreign row", { historySequence: 2 }),
+              workspaceId,
+            }) + "\n"
+          ),
+        ]);
+        const provenance = new HistoryAppendProvenance(path.dirname(chatPath));
+        let successorReceiptBytes = Buffer.alloc(0);
+        let successor: Awaited<ReturnType<typeof acquireProcessFileLock>> | undefined;
+        let commits = 0;
+        const staging = afterPublicationStaging(async () => {
+          // Model an expired birth-less lease while staging is held, then let
+          // the real lock protocol reclaim it and a successor publish new bytes.
+          const token = await fs.readFile(lockPath, "utf8");
+          await fs.writeFile(lockPath, token.split(":").slice(0, 2).join(":"));
+          await fs.utimes(lockPath, new Date(0), new Date(0));
+          successor = await acquireProcessFileLock({
+            lockPath,
+            timeoutMs: 1000,
+            label: "successor history writer",
+          });
+          await fs.writeFile(chatPath, successorBytes);
+          successorReceiptBytes = Buffer.from(
+            JSON.stringify({
+              version: 1,
+              epoch: randomUUID(),
+              state: receiptState,
+              files: await provenance.stamps(),
+            })
+          );
+          await fs.writeFile(provenance.receiptPath, successorReceiptBytes);
+          expect((await provenance.read()).receipt?.state).toBe(receiptState);
         });
-        await fs.writeFile(chatPath, successorBytes);
-      });
-      try {
-        const result = await publish(kind, {
-          isCurrent: () => true,
-          onCommitted: () => {
-            commits++;
-          },
-        });
-        expect(successor).toBeDefined();
-        expect(result.success).toBe(false);
-        expect(commits).toBe(0);
-        expect(await fs.readFile(chatPath)).toEqual(successorBytes);
-        expect(
-          (await fs.readdir(path.dirname(chatPath))).filter((name) =>
-            name.includes(".publication-")
-          )
-        ).toEqual([]);
-      } finally {
-        staging.mockRestore();
-        await successor?.[Symbol.asyncDispose]();
+        try {
+          const result = await publish(kind, {
+            isCurrent: () => true,
+            onCommitted: () => {
+              commits++;
+            },
+          });
+          expect(successor).toBeDefined();
+          expect(result.success).toBe(false);
+          expect(commits).toBe(0);
+          expect(await fs.readFile(chatPath)).toEqual(successorBytes);
+          expect(await fs.readFile(provenance.receiptPath)).toEqual(successorReceiptBytes);
+          expect(
+            (await fs.readdir(path.dirname(chatPath))).filter((name) =>
+              name.includes(".publication-")
+            )
+          ).toEqual([]);
+        } finally {
+          staging.mockRestore();
+          await successor?.[Symbol.asyncDispose]();
+        }
       }
-    });
+    );
 
     it(`${kind}: rechecks logical ownership after the awaited file-lock check`, async () => {
       const before = await fs.readFile(chatPath);

--- a/src/node/services/historyService.publication.test.ts
+++ b/src/node/services/historyService.publication.test.ts
@@ -2,11 +2,14 @@ import { afterEach, beforeEach, describe, expect, expectTypeOf, it, spyOn } from
 import * as fs from "node:fs/promises";
 import * as nodeFs from "node:fs";
 import * as path from "node:path";
+import * as atomicWrite from "write-file-atomic";
 import { createMuxMessage, type MuxMessage } from "@/common/types/message";
 import type { Result } from "@/common/types/result";
+import { acquireProcessFileLock } from "@/node/utils/concurrency/fileLock";
 import { HistoryAppendProvenance } from "./historyAppendProvenance";
 import type { HistoryService } from "./historyService";
 import { createTestHistoryService } from "./testHistoryService";
+import { historyWriteLockPath } from "./workspaceRemoval";
 
 type PublicationObserver = NonNullable<
   Parameters<HistoryService["appendManyToHistoryUnderWriteLock"]>[2]
@@ -36,36 +39,44 @@ describe("HistoryService private publication seam", () => {
 
   // Exercise the inactive seam under its real recovery/provenance/removal locks,
   // without adding a public acceptance option just for tests.
-  function publish(kind: "single" | "batch" | "update", publication: PublicationObserver) {
+  function publish(
+    kind: "single" | "batch" | "update",
+    publication: Omit<PublicationObserver, "assertStillOwned">
+  ) {
     const service = fixture.historyService as unknown as {
       withRecoveredHistoryWriteResultLock(
         workspaceId: string,
         errorPrefix: string,
-        operation: () => Promise<Result<void>>
+        operation: (assertStillOwned: () => Promise<void>) => Promise<Result<void>>
       ): Promise<Result<void>>;
       updateHistoryUnderWriteLock(
         workspaceId: string,
         message: MuxMessage,
-        observer: typeof publication
+        observer: PublicationObserver
       ): Promise<Result<void>>;
       appendManyToHistoryUnderWriteLock(
         workspaceId: string,
         messages: MuxMessage[],
-        observer: typeof publication
+        observer: PublicationObserver
       ): Promise<Result<void>>;
     };
-    return service.withRecoveredHistoryWriteResultLock(workspaceId, "Publication failed", () => {
-      if (kind === "update") {
-        return service.updateHistoryUnderWriteLock(
-          workspaceId,
-          createMuxMessage("assistant", "assistant", "updated", { historySequence: 1 }),
-          publication
-        );
+    return service.withRecoveredHistoryWriteResultLock(
+      workspaceId,
+      "Publication failed",
+      (assertStillOwned) => {
+        const observer = { ...publication, assertStillOwned };
+        if (kind === "update") {
+          return service.updateHistoryUnderWriteLock(
+            workspaceId,
+            createMuxMessage("assistant", "assistant", "updated", { historySequence: 1 }),
+            observer
+          );
+        }
+        const rows = [createMuxMessage("replacement", "user", "next question")];
+        if (kind === "batch") rows.unshift(createMuxMessage("payload", "assistant", "payload"));
+        return service.appendManyToHistoryUnderWriteLock(workspaceId, rows, observer);
       }
-      const rows = [createMuxMessage("replacement", "user", "next question")];
-      if (kind === "batch") rows.unshift(createMuxMessage("payload", "assistant", "payload"));
-      return service.appendManyToHistoryUnderWriteLock(workspaceId, rows, publication);
-    });
+    );
   }
 
   async function readHistory() {
@@ -74,7 +85,106 @@ describe("HistoryService private publication seam", () => {
     return result.success ? result.data : [];
   }
 
+  function afterPublicationStaging(action: () => void | Promise<void>) {
+    const atomic = atomicWrite.default;
+    return spyOn(atomicWrite, "default").mockImplementation(
+      new Proxy(atomic, {
+        async apply(target, _thisArg, args: Parameters<typeof atomic>) {
+          const result = await target(...args);
+          if (String(args[0]).startsWith(`${chatPath}.publication-`)) await action();
+          return result;
+        },
+      })
+    );
+  }
+
   for (const kind of ["single", "batch", "update"] as const) {
+    it(`${kind}: a reclaimed birth-less lock preserves the successor's history`, async () => {
+      const lockPath = historyWriteLockPath(fixture.config.rootDir, workspaceId);
+      const successorBytes = Buffer.concat([
+        await fs.readFile(chatPath),
+        Buffer.from(
+          JSON.stringify({
+            ...createMuxMessage("successor", "user", "foreign row", { historySequence: 2 }),
+            workspaceId,
+          }) + "\n"
+        ),
+      ]);
+      let successor: Awaited<ReturnType<typeof acquireProcessFileLock>> | undefined;
+      let commits = 0;
+      const staging = afterPublicationStaging(async () => {
+        // Model an expired birth-less lease while staging is held, then let
+        // the real lock protocol reclaim it and a successor publish new bytes.
+        const token = await fs.readFile(lockPath, "utf8");
+        await fs.writeFile(lockPath, token.split(":").slice(0, 2).join(":"));
+        await fs.utimes(lockPath, new Date(0), new Date(0));
+        successor = await acquireProcessFileLock({
+          lockPath,
+          timeoutMs: 1000,
+          label: "successor history writer",
+        });
+        await fs.writeFile(chatPath, successorBytes);
+      });
+      try {
+        const result = await publish(kind, {
+          isCurrent: () => true,
+          onCommitted: () => {
+            commits++;
+          },
+        });
+        expect(successor).toBeDefined();
+        expect(result.success).toBe(false);
+        expect(commits).toBe(0);
+        expect(await fs.readFile(chatPath)).toEqual(successorBytes);
+        expect(
+          (await fs.readdir(path.dirname(chatPath))).filter((name) =>
+            name.includes(".publication-")
+          )
+        ).toEqual([]);
+      } finally {
+        staging.mockRestore();
+        await successor?.[Symbol.asyncDispose]();
+      }
+    });
+
+    it(`${kind}: rechecks logical ownership after the awaited file-lock check`, async () => {
+      const before = await fs.readFile(chatPath);
+      const lockPath = historyWriteLockPath(fixture.config.rootDir, workspaceId);
+      let staged = false;
+      let current = true;
+      let commits = 0;
+      const staging = afterPublicationStaging(() => {
+        staged = true;
+      });
+      const readFile = fs.readFile;
+      const ownershipRead = spyOn(fs, "readFile").mockImplementation(
+        new Proxy(readFile, {
+          async apply(target, _thisArg, args: Parameters<typeof readFile>) {
+            const bytes = await target(...args);
+            // Retire the logical owner before the awaited ownership read returns.
+            if (staged && args[0] === lockPath) current = false;
+            return bytes;
+          },
+        })
+      );
+      try {
+        const result = await publish(kind, {
+          isCurrent: () => current,
+          onCommitted: () => {
+            commits++;
+          },
+        });
+        expect(staged).toBe(true);
+        expect(current).toBe(false);
+        expect(result.success).toBe(false);
+        expect(commits).toBe(0);
+        expect(await fs.readFile(chatPath)).toEqual(before);
+      } finally {
+        ownershipRead.mockRestore();
+        staging.mockRestore();
+      }
+    });
+
     it(`${kind}: captures the complete publication before ownership can change`, async () => {
       const provenance = new HistoryAppendProvenance(path.dirname(chatPath));
       const before = (await provenance.read()).receipt;

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -92,6 +92,11 @@ interface HistoryTruncateTransaction extends HistoryTruncateHashes {
   rawHashes?: HistoryTruncateHashes & { version: 1 };
 }
 
+interface HistoryPublicationObserver {
+  isCurrent: () => boolean;
+  onCommitted: () => void;
+}
+
 interface HistoryRewriteRow {
   raw: Buffer;
   message: MuxMessage | undefined;
@@ -2863,51 +2868,58 @@ export class HistoryService {
    */
   async appendManyToHistory(workspaceId: string, messages: MuxMessage[]): Promise<Result<void>> {
     assert(messages.length > 0, "appendManyToHistory requires at least one message");
-    return this.withRecoveredHistoryWriteResultLock(
-      workspaceId,
-      "Failed to append history",
-      async () => {
-        try {
-          await this.refreshSequenceCounterUnderWriteLock(workspaceId);
-          const workspaceDir = this.getSessionDir(workspaceId);
-          await ensurePrivateDir(workspaceDir);
-          for (const message of messages) {
-            assert(
-              message.metadata?.historySequence === undefined,
-              "appendManyToHistory messages must not carry pre-assigned historySequence values"
-            );
-            const nextSeqNum = await this.getNextHistorySequence(workspaceId);
-            assert(
-              isNonNegativeInteger(nextSeqNum),
-              "getNextHistorySequence must return a non-negative integer"
-            );
-            message.metadata = { ...message.metadata, historySequence: nextSeqNum };
-            this.sequenceCounters.set(workspaceId, nextSeqNum + 1);
-          }
-          // Atomic all-or-nothing commit (r48): fs.appendFile is not
-          // transactional — an ENOSPC or crash mid-write could persist the
-          // payload line without the trigger line, and the caller registers
-          // rollback IDs only after this returns, so the torn prefix would
-          // survive as an undelivered assistant row in future provider
-          // requests. Rewrite the whole file through the same
-          // temp-and-rename helper the other history mutations use, under the
-          // cross-process append lock (r50) so a foreign backend's row cannot
-          // land between this read and the replace and be silently deleted.
-          await this.fenceContextResetUnderHistoryLock(workspaceId, messages);
-          await this.getAppendProvenance(workspaceId).appendChat(
-            Buffer.from(this.serializeHistoryEntries(messages, workspaceId)),
-            true
-          );
-          // Publish the entire batch before sealing its previous epoch. Rotation
-          // is best-effort: a storage failure must not invite a duplicate batch.
-          const boundary = messages.findLast(isDurableContextBoundaryMarker);
-          if (boundary) await this.rotateAfterBoundaryWriteUnlocked(workspaceId, boundary);
-          return Ok(undefined);
-        } catch (error) {
-          return Err(`Failed to append to history: ${getErrorMessage(error)}`);
-        }
-      }
+    return this.withRecoveredHistoryWriteResultLock(workspaceId, "Failed to append history", () =>
+      this.appendManyToHistoryUnderWriteLock(workspaceId, messages)
     );
+  }
+
+  // Replacement acceptance can reuse allocation and provenance under the already-held locks.
+  private async appendManyToHistoryUnderWriteLock(
+    workspaceId: string,
+    messages: MuxMessage[],
+    publication?: HistoryPublicationObserver
+  ): Promise<Result<void>> {
+    try {
+      await this.refreshSequenceCounterUnderWriteLock(workspaceId);
+      const workspaceDir = this.getSessionDir(workspaceId);
+      await ensurePrivateDir(workspaceDir);
+      for (const message of messages) {
+        assert(
+          message.metadata?.historySequence === undefined,
+          "appendManyToHistory messages must not carry pre-assigned historySequence values"
+        );
+        const nextSeqNum = await this.getNextHistorySequence(workspaceId);
+        assert(
+          isNonNegativeInteger(nextSeqNum),
+          "getNextHistorySequence must return a non-negative integer"
+        );
+        message.metadata = { ...message.metadata, historySequence: nextSeqNum };
+        this.sequenceCounters.set(workspaceId, nextSeqNum + 1);
+      }
+      // Atomic all-or-nothing commit (r48): fs.appendFile is not
+      // transactional — an ENOSPC or crash mid-write could persist the
+      // payload line without the trigger line, and the caller registers
+      // rollback IDs only after this returns, so the torn prefix would
+      // survive as an undelivered assistant row in future provider
+      // requests. Rewrite the whole file through the same
+      // temp-and-rename helper the other history mutations use, under the
+      // cross-process append lock (r50) so a foreign backend's row cannot
+      // land between this read and the replace and be silently deleted.
+      await this.fenceContextResetUnderHistoryLock(workspaceId, messages);
+      await this.getAppendProvenance(workspaceId).appendChat(
+        Buffer.from(this.serializeHistoryEntries(messages, workspaceId)),
+        true,
+        publication &&
+          ((filePath, bytes) => this.publishHistoryUnderWriteLock(filePath, bytes, publication))
+      );
+      // Publish the entire batch before sealing its previous epoch. Rotation
+      // is best-effort: a storage failure must not invite a duplicate batch.
+      const boundary = messages.findLast(isDurableContextBoundaryMarker);
+      if (boundary) await this.rotateAfterBoundaryWriteUnlocked(workspaceId, boundary);
+      return Ok(undefined);
+    } catch (error) {
+      return Err(`Failed to append to history: ${getErrorMessage(error)}`);
+    }
   }
 
   /**
@@ -3120,9 +3132,41 @@ export class HistoryService {
     );
   }
 
+  /** Caller holds both history locks. Ordinary writes retain their existing publication behavior. */
+  private async publishHistoryUnderWriteLock(
+    historyPath: string,
+    bytes: Buffer,
+    publication?: HistoryPublicationObserver
+  ): Promise<void> {
+    if (!publication) return writeFileAtomic(historyPath, bytes);
+
+    const stagedPath = `${historyPath}.publication-${randomUUID()}`;
+    let committed = false;
+    try {
+      await writeFileAtomic(stagedPath, bytes, { mode: 0o600 });
+      // Replacement acceptance must capture its receipt in the same synchronous
+      // turn as ownership validation and rename, before any observer can yield.
+      if (!publication.isCurrent()) throw new Error("History publication no longer owned");
+      renameSync(stagedPath, historyPath);
+      committed = true;
+      try {
+        publication.onCommitted();
+      } catch (error) {
+        log.warn("History published but commit observer failed", { error });
+      }
+    } finally {
+      await fs.rm(stagedPath, { force: true }).catch((error: unknown) => {
+        // A durable write must not invite retry because staging cleanup failed.
+        if (!committed) throw error;
+        log.warn("History published but staging cleanup failed", { error });
+      });
+    }
+  }
+
   private async updateHistoryUnderWriteLock(
     workspaceId: string,
-    message: MuxMessage
+    message: MuxMessage,
+    publication?: HistoryPublicationObserver
   ): Promise<Result<void>> {
     invalidateHistoryAppendProvenance();
     try {
@@ -3187,7 +3231,7 @@ export class HistoryService {
       );
 
       // Atomic write prevents corruption if app crashes mid-write
-      await writeFileAtomic(historyPath, historyEntries);
+      await this.publishHistoryUnderWriteLock(historyPath, historyEntries, publication);
 
       // Compaction updates the streamed summary row in-place with boundary
       // metadata — seal the previous epoch once that lands. Check the persisted

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -93,6 +93,7 @@ interface HistoryTruncateTransaction extends HistoryTruncateHashes {
 }
 
 interface HistoryPublicationObserver {
+  assertStillOwned: () => Promise<void>;
   isCurrent: () => boolean;
   // Returning undefined excludes async callbacks: receipt capture must not yield after rename.
   onCommitted: () => undefined;
@@ -2743,14 +2744,14 @@ export class HistoryService {
    */
   private async withCrossProcessWriteLock<T>(
     workspaceId: string,
-    operation: () => Promise<T>
+    operation: (assertStillOwned: () => Promise<void>) => Promise<T>
   ): Promise<T> {
     const sessionDir = this.getSessionDir(workspaceId);
     // Lock BEFORE any directory creation (r63): the lockfile lives outside
     // the session dir, and removal holds this same lock while it tombstones
     // and deletes — so a mutation serializes with removal instead of racing
     // its own ensurePrivateDir against the deletion.
-    return this.withHistoryWriteFileLock(workspaceId, async () => {
+    return this.withHistoryWriteFileLock(workspaceId, async (assertStillOwned) => {
       // Removal gate (r63), checked IN-LOCK: a foreign backend's in-flight
       // stream survives the remover's process-local cancellation entirely; its
       // late append would otherwise recreate the deleted session directory via
@@ -2771,7 +2772,7 @@ export class HistoryService {
         if (await this.truncateRecoveryArtifactsPresent(workspaceId))
           invalidateHistoryAppendProvenance();
         await this.recoverTruncateTransactionUnlocked(workspaceId);
-        return operation();
+        return operation(assertStillOwned);
       });
     });
   }
@@ -2820,15 +2821,15 @@ export class HistoryService {
   private async withRecoveredHistoryWriteResultLock<T>(
     workspaceId: string,
     errorPrefix: string,
-    operation: () => Promise<Result<T>>
+    operation: (assertStillOwned: () => Promise<void>) => Promise<Result<T>>
   ): Promise<Result<T>> {
     // Not composed from withRecoveredHistoryLock: recovery for write paths
     // runs INSIDE withCrossProcessWriteLock (r64); the read-side conditional
     // recovery would redundantly acquire and release the same file lock.
     try {
       return await this.fileLocks.withLock(workspaceId, () =>
-        this.withCrossProcessWriteLock(workspaceId, async () => {
-          const result = await operation();
+        this.withCrossProcessWriteLock(workspaceId, async (assertStillOwned) => {
+          const result = await operation(assertStillOwned);
           if (!result.success) invalidateHistoryAppendProvenance();
           return result;
         })
@@ -3145,6 +3146,8 @@ export class HistoryService {
     let committed = false;
     try {
       await writeFileAtomic(stagedPath, bytes, { mode: 0o600 });
+      // Staging can outlive a filesystem lease even while the logical owner is current.
+      await publication.assertStillOwned();
       // Replacement acceptance must capture its receipt in the same synchronous
       // turn as ownership validation and rename, before any observer can yield.
       if (!publication.isCurrent()) throw new Error("History publication no longer owned");

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -94,7 +94,8 @@ interface HistoryTruncateTransaction extends HistoryTruncateHashes {
 
 interface HistoryPublicationObserver {
   isCurrent: () => boolean;
-  onCommitted: () => void;
+  // Returning undefined excludes async callbacks: receipt capture must not yield after rename.
+  onCommitted: () => undefined;
 }
 
 interface HistoryRewriteRow {

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -2768,12 +2768,13 @@ export class HistoryService {
       // crashed transaction from another backend's live rewrite — rolling
       // back a live transaction mid-flight resurrects discarded history with
       // mismatched archive/chat state.
+      // Receipt finalization must also leave a successor's provenance untouched after reclamation.
       return this.getAppendProvenance(workspaceId).runMutation(async () => {
         if (await this.truncateRecoveryArtifactsPresent(workspaceId))
           invalidateHistoryAppendProvenance();
         await this.recoverTruncateTransactionUnlocked(workspaceId);
         return operation(assertStillOwned);
-      });
+      }, assertStillOwned);
     });
   }
 


### PR DESCRIPTION
Replacement acceptance needs to validate ownership and record acceptance at the exact history commit point. Extract private locked batch and update publication helpers with an optional synchronous receipt callback. Existing public callers continue through the ordinary history writer; the new receipt hook remains private and inactive.

The private publisher stages the write, awaits the existing filesystem lock's ownership assertion, then synchronously rechecks logical ownership, renames, and records commitment. Its callback returns `undefined` so TypeScript rejects async implementations. The same lock assertion protects provenance receipt publication and finalization, preserving a successor's receipt if the old lease is reclaimed. Post-commit observer or cleanup failures cannot turn accepted history into a retry. The extracted batch helper preserves main's reset-generation fence immediately before append while reusing sequence allocation, raw-byte preservation, torn-tail repair, and append provenance.

Validation on the current `ef685f5c6d` change: full static checks and 461 tests across ten affected history/provenance/cancellation/file-lock suites pass. The 21 publication cases cover lock reclamation, logical retirement during the awaited lock check, preservation of pending and stable successor receipts, synchronous receipt timing, failed rename, cleanup failures, and provenance epochs. Tests reproduced the ownership races and all six successor-receipt overwrites before their corrections. An incorrect physical/logical check order fails the three logical-retirement cases. Tests use canonical `TMPDIR=/private/tmp`; Nix formatting is skipped because Nix is unavailable.

CI also exposed a repeated `BrowserWithoutBridge` Storybook race: Server Access can mount while AppLoader still has zero opacity. The story now retries a fresh role query plus its existing visibility assertion, preserving its Remote Connection absence assertion. A temporary visibility probe makes the original assertion fail and the correction pass; all seven affected stories also pass normally. Storybook passed in CI on the preceding head. Both the test repair and ownership corrections received independent review.

Risk: history writes are critical. Filesystem ownership, logical ownership, reset fencing, and commit ordering must remain intact through publication and provenance finalization. Replacement acceptance policy remains a later slice.

---

_Generated with `xum` • Model: `unavailable` • Thinking: `unavailable` • Cost: `$unavailable`_

<!-- mux-attribution: model=unavailable thinking=unavailable costs=unavailable -->
