### PR TITLE
🤖 tests: isolate version fixtures and await reconnect responses

### DIFF
--- a/src/browser/contexts/API.test.tsx
+++ b/src/browser/contexts/API.test.tsx
@@ -247,6 +247,8 @@ describe("API reconnection", () => {
       if (scenario === "cross-origin") process.env.VITE_BACKEND_URL = "https://api.example.com";
       const reload = spyOn(window.location, "reload").mockImplementation(() => undefined);
       const requests: string[] = [];
+      const jsonReady = Promise.withResolvers<void>();
+      let responseJson: Promise<unknown> | undefined;
       fetchImpl = (input) => {
         requests.push(
           typeof input === "string" ? input : input instanceof URL ? input.href : input.url
@@ -265,7 +267,12 @@ describe("API reconnection", () => {
             ),
             { status: 200 }
           )
-        );
+        ).then((response) => {
+          const parsedJson = response.json();
+          responseJson = jsonReady.promise.then(() => parsedJson);
+          spyOn(response, "json").mockReturnValue(responseJson);
+          return response;
+        });
       };
       window.location.href = "https://coder.example.com/@u/ws/apps/mux/";
       let latestState: UseAPIResult | null = null;
@@ -294,6 +301,14 @@ describe("API reconnection", () => {
       expect(requests).toEqual(
         scenario === "cross-origin" ? [] : ["https://coder.example.com/@u/ws/apps/mux/version"]
       );
+      expect(latestState!.status).toBe("connected");
+      expect(reload).not.toHaveBeenCalled();
+      // Reconnection does not await the version probe. Finish its JSON response explicitly
+      // so the reload assertion cannot race body parsing under CI load.
+      await act(async () => {
+        jsonReady.resolve();
+        await responseJson;
+      });
       const reloads = scenario === "changed" || scenario === "rebuilt" ? 1 : 0;
       expect(reload).toHaveBeenCalledTimes(reloads);
       if (reloads === 0) expect(latestState!.status).toBe("connected");

--- a/src/browser/hooks/useAnalytics.test.tsx
+++ b/src/browser/hooks/useAnalytics.test.tsx
@@ -142,14 +142,11 @@ let currentApiClient: RouterClient<AppRouter> | null = null;
 let analyticsServiceCalls: AnalyticsServiceCalls | null = null;
 
 function importCreateOrpcServer(): typeof OrpcServerModule.createOrpcServer {
-  void mock.module("@/version", () => ({
-    VERSION: "test-version",
-  }));
-
+  // Bun module mocks survive mock.restore(); use the real VERSION so later reconnect
+  // tests receive valid build metadata instead of a leaked analytics-only fixture.
   const { createOrpcServer } = requireTestModule<{
     createOrpcServer: typeof OrpcServerModule.createOrpcServer;
   }>("@/node/orpc/server");
-  mock.restore();
   return createOrpcServer;
 }
 


### PR DESCRIPTION
The analytics server fixture mocks VERSION as a string. Bun retains that module mock after mock.restore(), so a later reconnect test builds a response without git_commit and correctly receives no reload. Remove the unnecessary version mock and its ineffective restore, retaining real build metadata.

The reconnect test also explicitly awaits completion of its JSON response before asserting the reload. Both changes are test-only; production version validation remains unchanged.

The actual ordered-suite failure is reproduced with `bun test --randomize --seed 1 src/browser/hooks/useAnalytics.test.tsx src/browser/contexts/API.test.tsx -t 'loads summary from a real ORPC client|checks the server version on reconnect'`: the original fixture gives 6 passes and 1 failure; the corrected fixture gives 7 passes. Both full affected suites pass together (37 tests, 1,931 assertions). Full static checks pass. Nix formatting is skipped because Nix is unavailable.

The earlier isolated JSON-delay control exposed a separate assertion race; the confirmed merge-queue failure was the leaked version fixture.

---

_Generated with `xum` • Model: `unavailable` • Thinking: `unavailable` • Cost: `$unavailable`_

<!-- mux-attribution: model=unavailable thinking=unavailable costs=unavailable -->
