### PR TITLE
🤖 perf: batch plugin MCP-override prunes so installs don't crawl per workspace

### DIFF
--- a/src/node/services/agentPlugins/installService.test.ts
+++ b/src/node/services/agentPlugins/installService.test.ts
@@ -7,6 +7,7 @@ import * as path from "node:path";
 import { Config } from "@/node/config";
 import type { MCPServerManager } from "@/node/services/mcpServerManager";
 import type { WorkspaceMcpOverridesService } from "@/node/services/workspaceMcpOverridesService";
+import type { WorkspaceMCPOverrides } from "@/common/types/mcp";
 import { shellQuote } from "@/common/utils/shell";
 import { execFileAsync } from "@/node/utils/disposableExec";
 import {
@@ -32,6 +33,38 @@ import { AGENT_PLUGIN_SCHEMA_ID_1_0_0 } from "./manifest";
 async function git(cwd: string, ...args: string[]): Promise<string> {
   using proc = execFileAsync("git", ["-C", cwd, ...args]);
   return (await proc.result).stdout;
+}
+
+/**
+ * WorkspaceMcpOverridesService stub built from a per-workspace prune
+ * function: mirrors the real batch contract (per-workspace failures are
+ * collected, publish runs with the pruned overrides inside the same step).
+ */
+function overridesServiceStub(
+  prune: (
+    workspaceId: string,
+    keyPrefix: string,
+    options?: { publish?: (persisted: unknown) => Promise<void> }
+  ) => Promise<void>
+): WorkspaceMcpOverridesService {
+  const stub: Pick<WorkspaceMcpOverridesService, "prunePluginOverrideKeysForWorkspaces"> = {
+    prunePluginOverrideKeysForWorkspaces: async (workspaceIds, keyPrefix, options) => {
+      const failures: Array<{ workspaceId: string; error: unknown }> = [];
+      for (const workspaceId of workspaceIds) {
+        try {
+          await prune(workspaceId, keyPrefix, {
+            publish: (persisted) =>
+              options?.publish?.(workspaceId, persisted as WorkspaceMCPOverrides) ??
+              Promise.resolve(),
+          });
+        } catch (error) {
+          failures.push({ workspaceId, error });
+        }
+      }
+      return failures;
+    },
+  };
+  return stub as WorkspaceMcpOverridesService;
 }
 
 async function initRemote(dir: string): Promise<void> {
@@ -1182,10 +1215,10 @@ describe("AgentPluginInstallService", () => {
     const instanceId = computePluginInstanceId(path.join(pluginsDir(), "demo-plugin"));
     const serverKey = `plugin:${instanceId}:echo`;
     let storedOverrides: { enabledServers: string[] } = { enabledServers: [serverKey] };
-    const overridesStub = {
-      // Mirrors the real service's contract: publish runs with the pruned
-      // persisted overrides inside the same (stubbed) write step.
-      prunePluginOverrideKeys: async (
+    // Mirrors the real service's contract: publish runs with the pruned
+    // persisted overrides inside the same (stubbed) write step.
+    const overridesStub = overridesServiceStub(
+      async (
         _id: string,
         keyPrefix: string,
         options?: { publish?: (persisted: unknown) => Promise<void> }
@@ -1196,8 +1229,8 @@ describe("AgentPluginInstallService", () => {
           ),
         };
         await options?.publish?.(storedOverrides);
-      },
-    };
+      }
+    );
     const applied: Array<{ workspaceId: string; overrides: unknown }> = [];
     const mcpStub = {
       stopServersWithKeyPrefix: () => Promise.resolve(),
@@ -1208,7 +1241,7 @@ describe("AgentPluginInstallService", () => {
     };
     const serviceWithDeps = new AgentPluginInstallService(config, {
       isEnabled: () => true,
-      workspaceMcpOverridesService: overridesStub as unknown as WorkspaceMcpOverridesService,
+      workspaceMcpOverridesService: overridesStub,
       mcpServerManager: mcpStub as unknown as MCPServerManager,
     });
     const metadataSpy = spyOn(config, "getAllWorkspaceMetadata").mockImplementation(() =>
@@ -1622,15 +1655,13 @@ describe("AgentPluginInstallService", () => {
     // then-present server). The post-commit re-enumeration must fold it in,
     // or a same-name reinstall would silently reactivate the server there.
     const prunedIds: string[] = [];
-    const overridesStub = {
-      prunePluginOverrideKeys: (workspaceId: string) => {
-        prunedIds.push(workspaceId);
-        return Promise.resolve();
-      },
-    };
+    const overridesStub = overridesServiceStub((workspaceId: string) => {
+      prunedIds.push(workspaceId);
+      return Promise.resolve();
+    });
     const serviceWithDeps = new AgentPluginInstallService(config, {
       isEnabled: () => true,
-      workspaceMcpOverridesService: overridesStub as unknown as WorkspaceMcpOverridesService,
+      workspaceMcpOverridesService: overridesStub,
     });
     const preview = await serviceWithDeps.preview({ input: remoteDir });
     await serviceWithDeps.install({ source: preview.source, expectedSha: preview.lockedSha });
@@ -1766,15 +1797,13 @@ describe("AgentPluginInstallService", () => {
     // when the sweep cannot run.
     const instanceId = computePluginInstanceId(path.join(pluginsDir(), "demo-plugin"));
     const pruned: Array<{ workspaceId: string; prefix: string }> = [];
-    const overridesStub = {
-      prunePluginOverrideKeys: (workspaceId: string, prefix: string) => {
-        pruned.push({ workspaceId, prefix });
-        return Promise.resolve();
-      },
-    };
+    const overridesStub = overridesServiceStub((workspaceId: string, prefix: string) => {
+      pruned.push({ workspaceId, prefix });
+      return Promise.resolve();
+    });
     const serviceWithOverrides = new AgentPluginInstallService(config, {
       isEnabled: () => true,
-      workspaceMcpOverridesService: overridesStub as unknown as WorkspaceMcpOverridesService,
+      workspaceMcpOverridesService: overridesStub,
     });
     const metadataSpy = spyOn(config, "getAllWorkspaceMetadata").mockImplementation(() =>
       Promise.resolve([{ id: "ws-1", runtimeConfig: { type: "local" } }] as unknown as Awaited<
@@ -2307,13 +2336,11 @@ describe("AgentPluginInstallService", () => {
     // post-commit failure would strand stale enabled-server overrides with
     // no Settings row left to retry from, and a reinstall (same instance ID)
     // would silently re-enable those servers.
-    const overridesStub = {
-      prunePluginOverrideKeys: () => Promise.resolve(),
-    };
+    const overridesStub = overridesServiceStub(() => Promise.resolve());
     const serviceWithMcp = new AgentPluginInstallService(config, {
       isEnabled: () => true,
       mcpServerManager: mcpStub,
-      workspaceMcpOverridesService: overridesStub as unknown as WorkspaceMcpOverridesService,
+      workspaceMcpOverridesService: overridesStub,
     });
 
     const preview = await serviceWithMcp.preview({ input: remoteDir });
@@ -2352,22 +2379,20 @@ describe("AgentPluginInstallService", () => {
     // hygiene sweep must succeed for the install to complete).
     let overridesBroken = false;
     let storedOverrides: Record<string, unknown> = { enabledServers: [serverKey] };
-    const overridesStub = {
-      prunePluginOverrideKeys: (_id: string, keyPrefix: string) => {
-        if (overridesBroken) {
-          return Promise.reject(new Error("checkout unavailable"));
-        }
-        storedOverrides = {
-          enabledServers: (storedOverrides.enabledServers as string[]).filter(
-            (key) => !key.startsWith(keyPrefix)
-          ),
-        };
-        return Promise.resolve();
-      },
-    };
+    const overridesStub = overridesServiceStub((_id: string, keyPrefix: string) => {
+      if (overridesBroken) {
+        return Promise.reject(new Error("checkout unavailable"));
+      }
+      storedOverrides = {
+        enabledServers: (storedOverrides.enabledServers as string[]).filter(
+          (key) => !key.startsWith(keyPrefix)
+        ),
+      };
+      return Promise.resolve();
+    });
     const serviceWithOverrides = new AgentPluginInstallService(config, {
       isEnabled: () => true,
-      workspaceMcpOverridesService: overridesStub as unknown as WorkspaceMcpOverridesService,
+      workspaceMcpOverridesService: overridesStub,
     });
     const metadataSpy = spyOn(config, "getAllWorkspaceMetadata").mockImplementation(() =>
       Promise.resolve([{ id: "ws-1", runtimeConfig: { type: "local" } }] as unknown as Awaited<
@@ -2425,13 +2450,12 @@ describe("AgentPluginInstallService", () => {
     const instanceId = computePluginInstanceId(path.join(pluginsDir(), "demo-plugin"));
     // Healthy during install (its hygiene sweep must pass); broken afterwards.
     let overridesBroken = false;
-    const overridesStub = {
-      prunePluginOverrideKeys: () =>
-        overridesBroken ? Promise.reject(new Error("checkout unavailable")) : Promise.resolve(),
-    };
+    const overridesStub = overridesServiceStub(() =>
+      overridesBroken ? Promise.reject(new Error("checkout unavailable")) : Promise.resolve()
+    );
     const serviceWithOverrides = new AgentPluginInstallService(config, {
       isEnabled: () => true,
-      workspaceMcpOverridesService: overridesStub as unknown as WorkspaceMcpOverridesService,
+      workspaceMcpOverridesService: overridesStub,
     });
     const metadataSpy = spyOn(config, "getAllWorkspaceMetadata").mockImplementation(() =>
       Promise.resolve([{ id: "ws-1", runtimeConfig: { type: "local" } }] as unknown as Awaited<
@@ -2490,12 +2514,12 @@ describe("AgentPluginInstallService", () => {
     const instanceId = computePluginInstanceId(path.join(pluginsDir(), "demo-plugin"));
     // Overrides service that permanently throws (as it would for a workspace
     // that no longer exists in config).
-    const overridesStub = {
-      prunePluginOverrideKeys: () => Promise.reject(new Error("Workspace metadata not found")),
-    };
+    const overridesStub = overridesServiceStub(() =>
+      Promise.reject(new Error("Workspace metadata not found"))
+    );
     const serviceWithOverrides = new AgentPluginInstallService(config, {
       isEnabled: () => true,
-      workspaceMcpOverridesService: overridesStub as unknown as WorkspaceMcpOverridesService,
+      workspaceMcpOverridesService: overridesStub,
     });
 
     // Seed a tombstone naming a workspace that is not in config anymore.
@@ -2529,15 +2553,13 @@ describe("AgentPluginInstallService", () => {
     // live workspaces and only clear after the full sweep succeeded.
     const instanceId = computePluginInstanceId(path.join(pluginsDir(), "demo-plugin"));
     const prunedIds: string[] = [];
-    const overridesStub = {
-      prunePluginOverrideKeys: (workspaceId: string) => {
-        prunedIds.push(workspaceId);
-        return Promise.resolve();
-      },
-    };
+    const overridesStub = overridesServiceStub((workspaceId: string) => {
+      prunedIds.push(workspaceId);
+      return Promise.resolve();
+    });
     const serviceWithOverrides = new AgentPluginInstallService(config, {
       isEnabled: () => true,
-      workspaceMcpOverridesService: overridesStub as unknown as WorkspaceMcpOverridesService,
+      workspaceMcpOverridesService: overridesStub,
     });
     // Live workspaces: the recorded ws-1 plus a delta workspace the record
     // never held.
@@ -2578,15 +2600,14 @@ describe("AgentPluginInstallService", () => {
     // and the next successful ws-1-only retry would clear the record while
     // ws-delta still holds the stale enable.
     const instanceId = computePluginInstanceId(path.join(pluginsDir(), "demo-plugin"));
-    const overridesStub = {
-      prunePluginOverrideKeys: (workspaceId: string) =>
-        workspaceId === "ws-delta"
-          ? Promise.reject(new Error("checkout unavailable"))
-          : Promise.resolve(),
-    };
+    const overridesStub = overridesServiceStub((workspaceId: string) =>
+      workspaceId === "ws-delta"
+        ? Promise.reject(new Error("checkout unavailable"))
+        : Promise.resolve()
+    );
     const serviceWithOverrides = new AgentPluginInstallService(config, {
       isEnabled: () => true,
-      workspaceMcpOverridesService: overridesStub as unknown as WorkspaceMcpOverridesService,
+      workspaceMcpOverridesService: overridesStub,
     });
     const metadataSpy = spyOn(config, "getAllWorkspaceMetadata").mockImplementation(() =>
       Promise.resolve([
@@ -2625,15 +2646,13 @@ describe("AgentPluginInstallService", () => {
     // reinstall gate must clear it only after a full live sweep.
     const instanceId = computePluginInstanceId(path.join(pluginsDir(), "demo-plugin"));
     const prunedIds: string[] = [];
-    const overridesStub = {
-      prunePluginOverrideKeys: (workspaceId: string) => {
-        prunedIds.push(workspaceId);
-        return Promise.resolve();
-      },
-    };
+    const overridesStub = overridesServiceStub((workspaceId: string) => {
+      prunedIds.push(workspaceId);
+      return Promise.resolve();
+    });
     const serviceWithOverrides = new AgentPluginInstallService(config, {
       isEnabled: () => true,
-      workspaceMcpOverridesService: overridesStub as unknown as WorkspaceMcpOverridesService,
+      workspaceMcpOverridesService: overridesStub,
     });
     const preview = await serviceWithOverrides.preview({ input: remoteDir });
     await serviceWithOverrides.install({ source: preview.source, expectedSha: preview.lockedSha });
@@ -2689,9 +2708,7 @@ describe("AgentPluginInstallService", () => {
     const instanceId = computePluginInstanceId(path.join(pluginsDir(), "demo-plugin"));
     const serviceWithOverrides = new AgentPluginInstallService(config, {
       isEnabled: () => true,
-      workspaceMcpOverridesService: {
-        prunePluginOverrideKeys: () => Promise.resolve(),
-      } as unknown as WorkspaceMcpOverridesService,
+      workspaceMcpOverridesService: overridesServiceStub(() => Promise.resolve()),
     });
     await fsPromises.mkdir(path.dirname(registryFile()), { recursive: true });
     await fsPromises.writeFile(
@@ -2764,15 +2781,13 @@ describe("AgentPluginInstallService", () => {
     // enabled/disabled/tool-allowlist key from workspace overrides. Such a
     // tombstone must be treated as unrecognized: preserved, never retried.
     const pruneCalls: string[] = [];
-    const overridesStub = {
-      prunePluginOverrideKeys: (_workspaceId: string, prefix: string) => {
-        pruneCalls.push(prefix);
-        return Promise.resolve();
-      },
-    };
+    const overridesStub = overridesServiceStub((_workspaceId: string, prefix: string) => {
+      pruneCalls.push(prefix);
+      return Promise.resolve();
+    });
     const serviceWithOverrides = new AgentPluginInstallService(config, {
       isEnabled: () => true,
-      workspaceMcpOverridesService: overridesStub as unknown as WorkspaceMcpOverridesService,
+      workspaceMcpOverridesService: overridesStub,
     });
     // The named workspace exists, so a recognized tombstone WOULD be retried
     // (and its prefix executed) on section open.
@@ -2808,18 +2823,16 @@ describe("AgentPluginInstallService", () => {
     // the per-prefix rewrite (which replaces every matching item) as one
     // merged tombstone instead of being silently discarded.
     const pruned: string[] = [];
-    const overridesStub = {
-      prunePluginOverrideKeys: (workspaceId: string) => {
-        if (workspaceId === "ws-2") {
-          return Promise.reject(new Error("checkout unavailable"));
-        }
-        pruned.push(workspaceId);
-        return Promise.resolve();
-      },
-    };
+    const overridesStub = overridesServiceStub((workspaceId: string) => {
+      if (workspaceId === "ws-2") {
+        return Promise.reject(new Error("checkout unavailable"));
+      }
+      pruned.push(workspaceId);
+      return Promise.resolve();
+    });
     const serviceWithOverrides = new AgentPluginInstallService(config, {
       isEnabled: () => true,
-      workspaceMcpOverridesService: overridesStub as unknown as WorkspaceMcpOverridesService,
+      workspaceMcpOverridesService: overridesStub,
     });
     const metadataSpy = spyOn(config, "getAllWorkspaceMetadata").mockImplementation(() =>
       Promise.resolve([
@@ -2915,12 +2928,10 @@ describe("AgentPluginInstallService", () => {
   });
 
   test("uninstall refuses to clobber an opaque pendingOverridePrunes shape when cleanup must be recorded", async () => {
-    const overridesStub = {
-      prunePluginOverrideKeys: () => Promise.resolve(),
-    };
+    const overridesStub = overridesServiceStub(() => Promise.resolve());
     const serviceWithOverrides = new AgentPluginInstallService(config, {
       isEnabled: () => true,
-      workspaceMcpOverridesService: overridesStub as unknown as WorkspaceMcpOverridesService,
+      workspaceMcpOverridesService: overridesStub,
     });
     const metadataSpy = spyOn(config, "getAllWorkspaceMetadata").mockImplementation(() =>
       Promise.resolve([{ id: "ws-1", runtimeConfig: { type: "local" } }] as unknown as Awaited<
@@ -2968,14 +2979,12 @@ describe("AgentPluginInstallService", () => {
     const pruneGate = new Promise<void>((resolve) => {
       releasePrune = resolve;
     });
-    const overridesStub = {
-      prunePluginOverrideKeys: async () => {
-        await pruneGate;
-      },
-    };
+    const overridesStub = overridesServiceStub(async () => {
+      await pruneGate;
+    });
     const serviceWithOverrides = new AgentPluginInstallService(config, {
       isEnabled: () => true,
-      workspaceMcpOverridesService: overridesStub as unknown as WorkspaceMcpOverridesService,
+      workspaceMcpOverridesService: overridesStub,
     });
     const metadataSpy = spyOn(config, "getAllWorkspaceMetadata").mockImplementation(() =>
       Promise.resolve([{ id: "ws-1", runtimeConfig: { type: "local" } }] as unknown as Awaited<

--- a/src/node/services/agentPlugins/installService.ts
+++ b/src/node/services/agentPlugins/installService.ts
@@ -3149,42 +3149,53 @@ export class AgentPluginInstallService {
     if (!overridesService) {
       return [];
     }
-    const failedWorkspaceIds: string[] = [];
-    for (const workspaceId of workspaceIds) {
-      try {
-        // Raw in-queue patch: preserves unknown fields written by newer
-        // builds, throws on unreadable files (tombstone retry), and cannot
-        // interleave with a dialog save (shared exclusive write queue).
-        //
-        // The publish hook repairs MCPServerManager's in-memory override
-        // cache INSIDE that same write queue: latestWorkspaceOverrides wins
-        // over freshly read overrides, so a workspace that once enabled this
-        // plugin's server would otherwise keep serving the stale enable — and
-        // a same-name reinstall's default-disabled server could start without
-        // a fresh user action. In-queue publication also keeps the ordering
-        // consistent with concurrent dialog saves (whichever writes disk last
-        // publishes last). A failure keeps the tombstone so cache repair is
-        // retried too.
-        const mcpServerManager = this.deps.mcpServerManager;
-        await overridesService.prunePluginOverrideKeys(
-          workspaceId,
-          serverKeyPrefix,
-          mcpServerManager
-            ? {
-                publish: (persisted) =>
-                  mcpServerManager.applyWorkspaceOverrides(workspaceId, persisted),
-              }
-            : undefined
-        );
-      } catch (error) {
-        failedWorkspaceIds.push(workspaceId);
-        log.warn("Failed to prune plugin MCP overrides for workspace", {
-          workspaceId,
-          error: getErrorMessage(error),
-        });
-      }
+    if (workspaceIds.length === 0) {
+      return [];
     }
-    return failedWorkspaceIds;
+    // Raw in-queue patch: preserves unknown fields written by newer
+    // builds, throws on unreadable files (tombstone retry), and cannot
+    // interleave with a dialog save (shared exclusive write queue).
+    //
+    // The publish hook repairs MCPServerManager's in-memory override
+    // cache INSIDE that same write queue: latestWorkspaceOverrides wins
+    // over freshly read overrides, so a workspace that once enabled this
+    // plugin's server would otherwise keep serving the stale enable — and
+    // a same-name reinstall's default-disabled server could start without
+    // a fresh user action. In-queue publication also keeps the ordering
+    // consistent with concurrent dialog saves (whichever writes disk last
+    // publishes last). A failure keeps the tombstone so cache repair is
+    // retried too.
+    //
+    // One batched call, not one prune per workspace: every workspace in
+    // config is swept here, and the per-workspace variant re-resolves
+    // metadata from a full config.json parse each time — with thousands of
+    // workspaces that made installs sit on "Installing…" for half an hour.
+    const mcpServerManager = this.deps.mcpServerManager;
+    let failures: Array<{ workspaceId: string; error: unknown }>;
+    try {
+      failures = await overridesService.prunePluginOverrideKeysForWorkspaces(
+        workspaceIds,
+        serverKeyPrefix,
+        mcpServerManager
+          ? {
+              publish: (workspaceId, persisted) =>
+                mcpServerManager.applyWorkspaceOverrides(workspaceId, persisted),
+            }
+          : undefined
+      );
+    } catch (error) {
+      // Wholesale failure (lock timeout, unreadable config): no workspace was
+      // verified, so every one keeps its tombstone.
+      log.warn("Failed to prune plugin MCP overrides", { error: getErrorMessage(error) });
+      return [...workspaceIds];
+    }
+    for (const failure of failures) {
+      log.warn("Failed to prune plugin MCP overrides for workspace", {
+        workspaceId: failure.workspaceId,
+        error: getErrorMessage(failure.error),
+      });
+    }
+    return failures.map((failure) => failure.workspaceId);
   }
 
   /**

--- a/src/node/services/workspaceMcpOverridesService.test.ts
+++ b/src/node/services/workspaceMcpOverridesService.test.ts
@@ -504,6 +504,43 @@ describe("WorkspaceMcpOverridesService", () => {
     }
   });
 
+  it("prunePluginOverrideKeysForWorkspaces skips off-host entries sharing a duplicated ID", async () => {
+    const service = new WorkspaceMcpOverridesService(config);
+    const local = await registerWorkspace("dup-local");
+    // Corrupted config: an SSH entry reuses the local workspace's ID. Plugin
+    // servers never run off-host, and reaching for it would attempt remote
+    // I/O against an unreachable host.
+    await config.editConfig((cfg) => {
+      cfg.projects.set("/fake/remote", {
+        workspaces: [
+          {
+            path: "/remote/checkout",
+            id: local.workspaceId,
+            name: "remote-branch",
+            runtimeConfig: { type: "ssh", host: "unreachable.invalid", srcBaseDir: "/remote" },
+          },
+        ],
+      });
+      return cfg;
+    });
+    await fs.mkdir(path.join(local.workspacePath, ".xum"), { recursive: true });
+    await fs.writeFile(
+      path.join(local.workspacePath, ".xum", "mcp.local.jsonc"),
+      JSON.stringify({ enabledServers: ["plugin:0123456789abcdef:echo"] })
+    );
+
+    const failures = await service.prunePluginOverrideKeysForWorkspaces(
+      [local.workspaceId],
+      "plugin:0123456789abcdef:"
+    );
+
+    expect(failures).toEqual([]);
+    const after = jsoncParse(
+      await fs.readFile(path.join(local.workspacePath, ".xum", "mcp.local.jsonc"), "utf-8")
+    ) as Record<string, unknown>;
+    expect(after.enabledServers).toEqual([]);
+  });
+
   it("acquireExclusiveLock holds the prune sweep until released", async () => {
     const service = new WorkspaceMcpOverridesService(config);
     const { workspaceId } = await registerWorkspace("locked");

--- a/src/node/services/workspaceMcpOverridesService.test.ts
+++ b/src/node/services/workspaceMcpOverridesService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import * as fs from "fs/promises";
 import { parse as jsoncParse } from "jsonc-parser";
 import * as os from "os";
@@ -413,6 +413,58 @@ describe("WorkspaceMcpOverridesService", () => {
     // workspace-local files).
     await fs.rm(filePath);
     await service.prunePluginOverrideKeys(workspaceId, "plugin:0123456789abcdef:");
+  });
+
+  it("prunePluginOverrideKeysForWorkspaces sweeps many workspaces with one metadata load", async () => {
+    const service = new WorkspaceMcpOverridesService(config);
+    const pruned = await registerWorkspace("pruned");
+    const untouched = await registerWorkspace("untouched");
+    const broken = await registerWorkspace("broken");
+    const write = (workspacePath: string, content: string) =>
+      fs
+        .mkdir(path.join(workspacePath, ".xum"), { recursive: true })
+        .then(() => fs.writeFile(path.join(workspacePath, ".xum", "mcp.local.jsonc"), content));
+    await write(
+      pruned.workspacePath,
+      JSON.stringify({ enabledServers: ["plugin:0123456789abcdef:echo", "other"] })
+    );
+    await write(broken.workspacePath, "{ not json");
+
+    // Warm-up: getAllWorkspaceMetadata persists read-time migrations
+    // (createdAt backfill) on first load, which would skew the call counts.
+    await config.getAllWorkspaceMetadata();
+    const metadataSpy = spyOn(config, "getAllWorkspaceMetadata");
+    const configSpy = spyOn(config, "loadConfigOrDefault");
+
+    const published: Array<[string, unknown]> = [];
+    const failures = await service.prunePluginOverrideKeysForWorkspaces(
+      [pruned.workspaceId, untouched.workspaceId, broken.workspaceId, "ws-missing"],
+      "plugin:0123456789abcdef:",
+      {
+        publish: (workspaceId, persisted) => {
+          published.push([workspaceId, persisted]);
+          return Promise.resolve();
+        },
+      }
+    );
+
+    // One failure per broken workspace; the healthy ones still completed.
+    expect(failures.map((failure) => failure.workspaceId).sort()).toEqual([
+      broken.workspaceId,
+      "ws-missing",
+    ]);
+    expect(String(failures.find((f) => f.workspaceId === broken.workspaceId)?.error)).toMatch(
+      /parse errors/
+    );
+    expect(published).toEqual([
+      [pruned.workspaceId, { enabledServers: ["other"] }],
+      [untouched.workspaceId, {}],
+    ]);
+    // The sweep cost must not scale with a full config parse per workspace:
+    // getAllWorkspaceMetadata itself loads config once, plus the batch's
+    // single legacy-config snapshot.
+    expect(metadataSpy).toHaveBeenCalledTimes(1);
+    expect(configSpy).toHaveBeenCalledTimes(2);
   });
 
   it("prunePluginOverrideKeys refuses symlinked override files", async () => {

--- a/src/node/services/workspaceMcpOverridesService.test.ts
+++ b/src/node/services/workspaceMcpOverridesService.test.ts
@@ -504,6 +504,27 @@ describe("WorkspaceMcpOverridesService", () => {
     }
   });
 
+  it("acquireExclusiveLock holds the prune sweep until released", async () => {
+    const service = new WorkspaceMcpOverridesService(config);
+    const { workspaceId } = await registerWorkspace("locked");
+
+    const release = await service.acquireExclusiveLock();
+    let sweepDone = false;
+    const sweep = service
+      .prunePluginOverrideKeysForWorkspaces([workspaceId], "plugin:0123456789abcdef:")
+      .then((failures) => {
+        sweepDone = true;
+        return failures;
+      });
+    // Give the sweep every chance to run if the lock were not honored.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(sweepDone).toBe(false);
+
+    await release();
+    expect(await sweep).toEqual([]);
+    expect(sweepDone).toBe(true);
+  });
+
   it("prunePluginOverrideKeysForWorkspaces fails a workspace renamed during the sweep", async () => {
     const service = new WorkspaceMcpOverridesService(config);
     const stable = await registerWorkspace("stable");

--- a/src/node/services/workspaceMcpOverridesService.test.ts
+++ b/src/node/services/workspaceMcpOverridesService.test.ts
@@ -461,10 +461,78 @@ describe("WorkspaceMcpOverridesService", () => {
       [untouched.workspaceId, {}],
     ]);
     // The sweep cost must not scale with a full config parse per workspace:
-    // getAllWorkspaceMetadata itself loads config once, plus the batch's
-    // single legacy-config snapshot.
-    expect(metadataSpy).toHaveBeenCalledTimes(1);
-    expect(configSpy).toHaveBeenCalledTimes(2);
+    // one metadata load up front and one post-sweep re-resolution (each
+    // loading config once), plus the batch's single legacy-config snapshot.
+    expect(metadataSpy).toHaveBeenCalledTimes(2);
+    expect(configSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it("prunePluginOverrideKeysForWorkspaces prunes every checkout sharing a duplicated ID", async () => {
+    const service = new WorkspaceMcpOverridesService(config);
+    const first = await registerWorkspace("dup-a");
+    const second = await registerWorkspace("dup-b");
+    // Corrupted config: both entries carry the same workspace ID.
+    await config.editConfig((cfg) => {
+      for (const project of cfg.projects.values()) {
+        for (const workspace of project.workspaces) {
+          if (workspace.id === second.workspaceId) {
+            workspace.id = first.workspaceId;
+          }
+        }
+      }
+      return cfg;
+    });
+    for (const workspacePath of [first.workspacePath, second.workspacePath]) {
+      await fs.mkdir(path.join(workspacePath, ".xum"), { recursive: true });
+      await fs.writeFile(
+        path.join(workspacePath, ".xum", "mcp.local.jsonc"),
+        JSON.stringify({ enabledServers: ["plugin:0123456789abcdef:echo"] })
+      );
+    }
+
+    const failures = await service.prunePluginOverrideKeysForWorkspaces(
+      [first.workspaceId, first.workspaceId],
+      "plugin:0123456789abcdef:"
+    );
+
+    expect(failures).toEqual([]);
+    for (const workspacePath of [first.workspacePath, second.workspacePath]) {
+      const after = jsoncParse(
+        await fs.readFile(path.join(workspacePath, ".xum", "mcp.local.jsonc"), "utf-8")
+      ) as Record<string, unknown>;
+      expect(after.enabledServers).toEqual([]);
+    }
+  });
+
+  it("prunePluginOverrideKeysForWorkspaces fails a workspace renamed during the sweep", async () => {
+    const service = new WorkspaceMcpOverridesService(config);
+    const stable = await registerWorkspace("stable");
+    const moved = await registerWorkspace("moved");
+    await config.getAllWorkspaceMetadata();
+    const realGetAll = config.getAllWorkspaceMetadata.bind(config);
+    // Second load (the post-sweep re-resolution) sees the workspace under a
+    // new name — exactly what a concurrent rename leaves behind.
+    spyOn(config, "getAllWorkspaceMetadata")
+      .mockImplementationOnce(realGetAll)
+      .mockImplementationOnce(async () =>
+        (await realGetAll()).map((metadata) =>
+          metadata.id === moved.workspaceId
+            ? {
+                ...metadata,
+                name: "renamed",
+                namedWorkspacePath: path.join(path.dirname(moved.workspacePath), "renamed"),
+              }
+            : metadata
+        )
+      );
+
+    const failures = await service.prunePluginOverrideKeysForWorkspaces(
+      [stable.workspaceId, moved.workspaceId],
+      "plugin:0123456789abcdef:"
+    );
+
+    expect(failures.map((failure) => failure.workspaceId)).toEqual([moved.workspaceId]);
+    expect(String(failures[0].error)).toMatch(/moved while/);
   });
 
   it("prunePluginOverrideKeys refuses symlinked override files", async () => {

--- a/src/node/services/workspaceMcpOverridesService.ts
+++ b/src/node/services/workspaceMcpOverridesService.ts
@@ -534,6 +534,34 @@ export class WorkspaceMcpOverridesService {
   }
 
   /**
+   * Hold the exclusive override lock imperatively (same in-process queue and
+   * cross-process lock as every write here). For workspace lifecycle
+   * mutations that move a checkout and then rewrite config — a rename racing
+   * prunePluginOverrideKeysForWorkspaces would otherwise let the prune stat
+   * the vacated old path, find nothing, and retire a tombstone while the moved
+   * file still holds the plugin key. Resolves once the lock is held with a
+   * release function; the returned promise rejects if acquisition times out.
+   */
+  acquireExclusiveLock(): Promise<() => Promise<void>> {
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    return new Promise((resolveAcquired, rejectAcquired) => {
+      const done = this.runExclusive(() => {
+        resolveAcquired(() => {
+          release();
+          return done;
+        });
+        return held;
+      });
+      // Only acquisition can fail here: once the callback above runs, `done`
+      // settles solely through the release function.
+      done.catch(rejectAcquired);
+    });
+  }
+
+  /**
    * Persist workspace MCP overrides to <workspace>/.xum/mcp.local.jsonc.
    *
    * Empty overrides remove the workspace-local file.

--- a/src/node/services/workspaceMcpOverridesService.ts
+++ b/src/node/services/workspaceMcpOverridesService.ts
@@ -10,7 +10,7 @@ import assert from "@/common/utils/assert";
 import type { WorkspaceMCPOverrides } from "@/common/types/mcp";
 import type { RuntimeConfig } from "@/common/types/runtime";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
-import type { Config } from "@/node/config";
+import type { Config, ProjectsConfig } from "@/node/config";
 import { type createRuntime } from "@/node/runtime/runtimeFactory";
 import { createRuntimeForWorkspace } from "@/node/runtime/runtimeHelpers";
 import { execBuffered, readFileString, writeFileString } from "@/node/utils/runtime/helpers";
@@ -185,6 +185,13 @@ async function statIsFile(
   }
 }
 
+/** A workspace's metadata with its runtime and checkout path resolved. */
+interface ResolvedWorkspace {
+  metadata: FrontendWorkspaceMetadata;
+  runtime: ReturnType<typeof createRuntime>;
+  workspacePath: string;
+}
+
 export class WorkspaceMcpOverridesService {
   constructor(private readonly config: Config) {
     assert(config, "WorkspaceMcpOverridesService requires a Config instance");
@@ -204,9 +211,10 @@ export class WorkspaceMcpOverridesService {
     return metadata;
   }
 
-  private getLegacyOverridesFromConfig(workspaceId: string): WorkspaceMCPOverrides | undefined {
-    const config = this.config.loadConfigOrDefault();
-
+  private getLegacyOverridesFromConfig(
+    workspaceId: string,
+    config: ProjectsConfig = this.config.loadConfigOrDefault()
+  ): WorkspaceMCPOverrides | undefined {
     for (const [_projectPath, projectConfig] of config.projects) {
       const workspace = projectConfig.workspaces.find((w) => w.id === workspaceId);
       if (workspace) {
@@ -232,13 +240,11 @@ export class WorkspaceMcpOverridesService {
     });
   }
 
-  private async getRuntimeAndWorkspacePath(workspaceId: string): Promise<{
-    metadata: FrontendWorkspaceMetadata;
-    runtime: ReturnType<typeof createRuntime>;
-    workspacePath: string;
-  }> {
-    const metadata = await this.getWorkspaceMetadata(workspaceId);
+  private async getRuntimeAndWorkspacePath(workspaceId: string): Promise<ResolvedWorkspace> {
+    return this.resolveWorkspace(await this.getWorkspaceMetadata(workspaceId));
+  }
 
+  private resolveWorkspace(metadata: FrontendWorkspaceMetadata): ResolvedWorkspace {
     const runtime = createRuntimeForWorkspace(metadata);
 
     // In-place workspaces (CLI/benchmarks) store the workspace path directly by setting
@@ -427,7 +433,21 @@ export class WorkspaceMcpOverridesService {
     workspaceId: string,
     mode: "lenient" | "strict" = "lenient"
   ): Promise<WorkspaceMCPOverrides> {
-    const { metadata, runtime, workspacePath } = await this.getRuntimeAndWorkspacePath(workspaceId);
+    return this.loadOverridesForResolved(await this.getRuntimeAndWorkspacePath(workspaceId), mode);
+  }
+
+  /**
+   * `legacyConfig` lets batch callers reuse one config snapshot: loading
+   * config.json is a synchronous full parse, so re-reading it per workspace
+   * made a 2000-workspace sweep take tens of minutes.
+   */
+  private async loadOverridesForResolved(
+    resolved: ResolvedWorkspace,
+    mode: "lenient" | "strict",
+    legacyConfig?: ProjectsConfig
+  ): Promise<WorkspaceMCPOverrides> {
+    const { metadata, runtime, workspacePath } = resolved;
+    const workspaceId = metadata.id;
     const filePaths = this.getOverridesFilePaths(workspacePath, metadata.runtimeConfig);
     const canonicalPath = filePaths[0];
 
@@ -440,7 +460,7 @@ export class WorkspaceMcpOverridesService {
     }
 
     // No workspace-local file => try migrating legacy config.json storage.
-    const legacy = this.getLegacyOverridesFromConfig(workspaceId);
+    const legacy = this.getLegacyOverridesFromConfig(workspaceId, legacyConfig);
     if (!legacy || isEmptyOverrides(legacy)) {
       return {};
     }
@@ -617,142 +637,193 @@ export class WorkspaceMcpOverridesService {
       publish?: (persisted: WorkspaceMCPOverrides) => Promise<void>;
     }
   ): Promise<void> {
+    const failures = await this.prunePluginOverrideKeysForWorkspaces([workspaceId], keyPrefix, {
+      publish: (_workspaceId, persisted) => options?.publish?.(persisted) ?? Promise.resolve(),
+    });
+    if (failures.length > 0) {
+      throw failures[0].error;
+    }
+  }
+
+  /**
+   * prunePluginOverrideKeys across many workspaces under ONE lock acquisition
+   * and ONE workspace-metadata/config load. The Agent Plugin installer sweeps
+   * every local/worktree workspace (thousands in long-lived setups); resolving
+   * each workspace via getAllWorkspaceMetadata() — an uncached synchronous
+   * parse of the whole config.json — made that sweep take ~1s per workspace
+   * and the install appear hung. Per-workspace failures are collected (the
+   * caller persists a retry tombstone for them) instead of aborting the sweep;
+   * only wholesale failures (lock timeout, unreadable config) throw.
+   */
+  async prunePluginOverrideKeysForWorkspaces(
+    workspaceIds: readonly string[],
+    keyPrefix: string,
+    options?: {
+      publish?: (workspaceId: string, persisted: WorkspaceMCPOverrides) => Promise<void>;
+    }
+  ): Promise<Array<{ workspaceId: string; error: unknown }>> {
     assert(keyPrefix.length > 0, "prunePluginOverrideKeys: keyPrefix must be non-empty");
 
     return this.runExclusive(async () => {
-      const { metadata, runtime, workspacePath } =
-        await this.getRuntimeAndWorkspacePath(workspaceId);
-      // Prune canonical AND legacy-named files: a stale plugin key in an old
-      // .mux/mcp.local.jsonc would otherwise survive uninstall and reactivate
-      // on a later canonical migration.
-      const filePaths = this.getOverridesFilePaths(workspacePath, metadata.runtimeConfig);
-
-      for (const filePath of filePaths) {
-        if (!(await statIsFile(runtime, filePath, "strict"))) {
-          continue;
-        }
-        // SECURITY: refuse to prune through a symlinked override file. A
-        // contributor-controlled branch can track `.mux/mcp.local.jsonc` as
-        // a symlink (or symlink a parent segment); the write below resolves
-        // links (LocalBaseRuntime.writeFile writes the TARGET), so following
-        // one would let repo content redirect this rewrite into another
-        // predictable file — e.g. silently stripping a sibling workspace's
-        // plugin enables. Pruning only ever targets host-local (local/
-        // worktree) workspaces, so node fs semantics apply directly. Throwing
-        // keeps the caller's retry semantics (creation aborts / tombstone
-        // survives) until the link is removed.
-        await assertPruneTargetNotSymlinked(filePath, workspacePath);
-        // Strict read: unreadable/unparseable content must throw so the
-        // caller keeps its retry tombstone (mirrors readOverridesFile).
-        const original = await readFileString(runtime, filePath);
-        const parseErrors: jsonc.ParseError[] = [];
-        const parsed: unknown = jsonc.parse(original, parseErrors) as unknown;
-        if (parseErrors.length > 0) {
-          throw new Error(`Workspace MCP overrides file has JSONC parse errors: ${filePath}`);
-        }
-        if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-          // A newer build may store the whole document in a non-object shape
-          // this build cannot inspect; "successfully pruning" it would retire
-          // the caller's tombstone while plugin keys embedded in that shape
-          // survive. Same doctrine as opaque owned-field shapes below.
-          throw new Error(
-            `Workspace MCP overrides file has an unrecognized root shape (written by a newer version?): ${filePath}`
-          );
-        }
-
-        // Duplicate properties make jsonc.parse (last value wins) and
-        // jsonc.modify (first matching path wins) disagree: the edit loop
-        // below could spin forever on an entry it can never remove, or
-        // declare success while a stale plugin key survives in the shadowed
-        // property. Reject up front — the caller keeps its retry tombstone
-        // until the malformed file is repaired.
-        const duplicateName = findDuplicateOverrideProperty(jsonc.parseTree(original));
-        if (duplicateName !== undefined) {
-          throw new Error(
-            `Workspace MCP overrides file has duplicate "${duplicateName}" properties: ${filePath}`
-          );
-        }
-
-        // Targeted jsonc edits, NOT JSON.stringify of the parsed object: the
-        // .jsonc file is user-maintained and may carry comments/formatting a
-        // wholesale rewrite would erase.
-        let text = original;
-        const removeAt = (jsonPath: jsonc.JSONPath): void => {
-          const next = jsonc.applyEdits(
-            text,
-            jsonc.modify(text, jsonPath, undefined, {
-              formattingOptions: { insertSpaces: true, tabSize: 2 },
-            })
-          );
-          // A no-op edit means parse and modify disagreed about the path;
-          // looping on it would never terminate.
-          assert(next !== text, "prunePluginOverrideKeys: targeted edit produced no change");
-          text = next;
-        };
-
-        // A newer release may represent an owned field with a shape this
-        // build cannot inspect. Declaring success would retire the caller's
-        // tombstone while plugin keys embedded in that shape survive —
-        // reactivating the server on reinstall. Throw instead: the tombstone
-        // stays retryable (same doctrine as unreadable files).
-        const opaqueShape = (field: string): Error =>
-          new Error(
-            `Workspace MCP overrides file has an unrecognized "${field}" shape (written by a newer version?): ${filePath}`
-          );
-
-        // Match only canonical `plugin:<16-hex>:<server>` keys under the
-        // requested prefix: MCP server names are otherwise arbitrary strings
-        // and user configuration may legitimately name a server "plugin:…" —
-        // pruning must never strip such an ordinary server's overrides.
-        // Canonical keys themselves are additionally RESERVED in ordinary
-        // config (MCPConfigService ignores them in global/project layers and
-        // addServer rejects them), so a key this shape can only belong to an
-        // Agent Plugin server — shape-based pruning cannot hit a user server.
-        const isPrunableKey = (key: unknown): boolean =>
-          typeof key === "string" && key.startsWith(keyPrefix) && isCanonicalPluginServerKey(key);
-
-        for (const field of ["enabledServers", "disabledServers"] as const) {
-          // Re-parse after each removal: array indices shift as items go.
-          for (;;) {
-            const current = jsonc.parse(text) as Record<string, unknown>;
-            const value = current[field];
-            if (value === undefined) {
-              break;
-            }
-            if (!Array.isArray(value)) {
-              throw opaqueShape(field);
-            }
-            const index = value.findIndex(isPrunableKey);
-            if (index === -1) {
-              break;
-            }
-            removeAt([field, index]);
+      const allMetadata = await this.config.getAllWorkspaceMetadata();
+      const metadataById = new Map(allMetadata.map((metadata) => [metadata.id, metadata]));
+      const legacyConfig = this.config.loadConfigOrDefault();
+      const failures: Array<{ workspaceId: string; error: unknown }> = [];
+      for (const workspaceId of workspaceIds) {
+        try {
+          const metadata = metadataById.get(workspaceId.trim());
+          if (!metadata) {
+            throw new Error(`Workspace metadata not found for ${workspaceId.trim()}`);
           }
-        }
-
-        const allowlist = (jsonc.parse(text) as Record<string, unknown>).toolAllowlist;
-        if (allowlist !== undefined) {
-          if (allowlist === null || typeof allowlist !== "object" || Array.isArray(allowlist)) {
-            throw opaqueShape("toolAllowlist");
+          const resolved = this.resolveWorkspace(metadata);
+          await this.pruneResolvedWorkspace(resolved, keyPrefix);
+          if (options?.publish) {
+            // Strict re-read: the prune above already threw on anything
+            // unreadable, so a failure here is a real regression and must keep
+            // the caller's retry tombstone rather than publish a guess.
+            await options.publish(
+              workspaceId,
+              await this.loadOverridesForResolved(resolved, "strict", legacyConfig)
+            );
           }
-          for (const key of Object.keys(allowlist)) {
-            if (isPrunableKey(key)) {
-              removeAt(["toolAllowlist", key]);
-            }
-          }
-        }
-
-        if (text !== original) {
-          await writeFileString(runtime, filePath, text);
+        } catch (error) {
+          failures.push({ workspaceId, error });
         }
       }
-      if (options?.publish) {
-        // Strict re-read: the prune above already threw on anything
-        // unreadable, so a failure here is a real regression and must keep
-        // the caller's retry tombstone rather than publish a guess.
-        await options.publish(await this.loadOverrides(workspaceId, "strict"));
-      }
+      return failures;
     });
+  }
+
+  /** One workspace's prune; see prunePluginOverrideKeys for the contract. */
+  private async pruneResolvedWorkspace(
+    resolved: ResolvedWorkspace,
+    keyPrefix: string
+  ): Promise<void> {
+    const { metadata, runtime, workspacePath } = resolved;
+    // Prune canonical AND legacy-named files: a stale plugin key in an old
+    // .mux/mcp.local.jsonc would otherwise survive uninstall and reactivate
+    // on a later canonical migration.
+    const filePaths = this.getOverridesFilePaths(workspacePath, metadata.runtimeConfig);
+
+    for (const filePath of filePaths) {
+      if (!(await statIsFile(runtime, filePath, "strict"))) {
+        continue;
+      }
+      // SECURITY: refuse to prune through a symlinked override file. A
+      // contributor-controlled branch can track `.mux/mcp.local.jsonc` as
+      // a symlink (or symlink a parent segment); the write below resolves
+      // links (LocalBaseRuntime.writeFile writes the TARGET), so following
+      // one would let repo content redirect this rewrite into another
+      // predictable file — e.g. silently stripping a sibling workspace's
+      // plugin enables. Pruning only ever targets host-local (local/
+      // worktree) workspaces, so node fs semantics apply directly. Throwing
+      // keeps the caller's retry semantics (creation aborts / tombstone
+      // survives) until the link is removed.
+      await assertPruneTargetNotSymlinked(filePath, workspacePath);
+      // Strict read: unreadable/unparseable content must throw so the
+      // caller keeps its retry tombstone (mirrors readOverridesFile).
+      const original = await readFileString(runtime, filePath);
+      const parseErrors: jsonc.ParseError[] = [];
+      const parsed: unknown = jsonc.parse(original, parseErrors) as unknown;
+      if (parseErrors.length > 0) {
+        throw new Error(`Workspace MCP overrides file has JSONC parse errors: ${filePath}`);
+      }
+      if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+        // A newer build may store the whole document in a non-object shape
+        // this build cannot inspect; "successfully pruning" it would retire
+        // the caller's tombstone while plugin keys embedded in that shape
+        // survive. Same doctrine as opaque owned-field shapes below.
+        throw new Error(
+          `Workspace MCP overrides file has an unrecognized root shape (written by a newer version?): ${filePath}`
+        );
+      }
+
+      // Duplicate properties make jsonc.parse (last value wins) and
+      // jsonc.modify (first matching path wins) disagree: the edit loop
+      // below could spin forever on an entry it can never remove, or
+      // declare success while a stale plugin key survives in the shadowed
+      // property. Reject up front — the caller keeps its retry tombstone
+      // until the malformed file is repaired.
+      const duplicateName = findDuplicateOverrideProperty(jsonc.parseTree(original));
+      if (duplicateName !== undefined) {
+        throw new Error(
+          `Workspace MCP overrides file has duplicate "${duplicateName}" properties: ${filePath}`
+        );
+      }
+
+      // Targeted jsonc edits, NOT JSON.stringify of the parsed object: the
+      // .jsonc file is user-maintained and may carry comments/formatting a
+      // wholesale rewrite would erase.
+      let text = original;
+      const removeAt = (jsonPath: jsonc.JSONPath): void => {
+        const next = jsonc.applyEdits(
+          text,
+          jsonc.modify(text, jsonPath, undefined, {
+            formattingOptions: { insertSpaces: true, tabSize: 2 },
+          })
+        );
+        // A no-op edit means parse and modify disagreed about the path;
+        // looping on it would never terminate.
+        assert(next !== text, "prunePluginOverrideKeys: targeted edit produced no change");
+        text = next;
+      };
+
+      // A newer release may represent an owned field with a shape this
+      // build cannot inspect. Declaring success would retire the caller's
+      // tombstone while plugin keys embedded in that shape survive —
+      // reactivating the server on reinstall. Throw instead: the tombstone
+      // stays retryable (same doctrine as unreadable files).
+      const opaqueShape = (field: string): Error =>
+        new Error(
+          `Workspace MCP overrides file has an unrecognized "${field}" shape (written by a newer version?): ${filePath}`
+        );
+
+      // Match only canonical `plugin:<16-hex>:<server>` keys under the
+      // requested prefix: MCP server names are otherwise arbitrary strings
+      // and user configuration may legitimately name a server "plugin:…" —
+      // pruning must never strip such an ordinary server's overrides.
+      // Canonical keys themselves are additionally RESERVED in ordinary
+      // config (MCPConfigService ignores them in global/project layers and
+      // addServer rejects them), so a key this shape can only belong to an
+      // Agent Plugin server — shape-based pruning cannot hit a user server.
+      const isPrunableKey = (key: unknown): boolean =>
+        typeof key === "string" && key.startsWith(keyPrefix) && isCanonicalPluginServerKey(key);
+
+      for (const field of ["enabledServers", "disabledServers"] as const) {
+        // Re-parse after each removal: array indices shift as items go.
+        for (;;) {
+          const current = jsonc.parse(text) as Record<string, unknown>;
+          const value = current[field];
+          if (value === undefined) {
+            break;
+          }
+          if (!Array.isArray(value)) {
+            throw opaqueShape(field);
+          }
+          const index = value.findIndex(isPrunableKey);
+          if (index === -1) {
+            break;
+          }
+          removeAt([field, index]);
+        }
+      }
+
+      const allowlist = (jsonc.parse(text) as Record<string, unknown>).toolAllowlist;
+      if (allowlist !== undefined) {
+        if (allowlist === null || typeof allowlist !== "object" || Array.isArray(allowlist)) {
+          throw opaqueShape("toolAllowlist");
+        }
+        for (const key of Object.keys(allowlist)) {
+          if (isPrunableKey(key)) {
+            removeAt(["toolAllowlist", key]);
+          }
+        }
+      }
+
+      if (text !== original) {
+        await writeFileString(runtime, filePath, text);
+      }
+    }
   }
 }
 

--- a/src/node/services/workspaceMcpOverridesService.ts
+++ b/src/node/services/workspaceMcpOverridesService.ts
@@ -665,29 +665,78 @@ export class WorkspaceMcpOverridesService {
     assert(keyPrefix.length > 0, "prunePluginOverrideKeys: keyPrefix must be non-empty");
 
     return this.runExclusive(async () => {
-      const allMetadata = await this.config.getAllWorkspaceMetadata();
-      const metadataById = new Map(allMetadata.map((metadata) => [metadata.id, metadata]));
+      // Group, don't index: a corrupted config can list one ID under several
+      // entries (different checkouts). Every checkout carrying the ID must be
+      // pruned, or retiring the tombstone would leave a stale enable behind
+      // in the entry a last-write-wins map dropped.
+      const groupMetadataById = (
+        all: FrontendWorkspaceMetadata[]
+      ): Map<string, FrontendWorkspaceMetadata[]> => {
+        const grouped = new Map<string, FrontendWorkspaceMetadata[]>();
+        for (const metadata of all) {
+          const entries = grouped.get(metadata.id);
+          if (entries) {
+            entries.push(metadata);
+          } else {
+            grouped.set(metadata.id, [metadata]);
+          }
+        }
+        return grouped;
+      };
+      const checkoutPaths = (entries: FrontendWorkspaceMetadata[] | undefined): string =>
+        (entries ?? [])
+          .map((metadata) => this.resolveWorkspace(metadata).workspacePath)
+          .sort()
+          .join("\0");
+
+      const metadataById = groupMetadataById(await this.config.getAllWorkspaceMetadata());
       const legacyConfig = this.config.loadConfigOrDefault();
       const failures: Array<{ workspaceId: string; error: unknown }> = [];
+      const swept: string[] = [];
       for (const workspaceId of workspaceIds) {
         try {
-          const metadata = metadataById.get(workspaceId.trim());
-          if (!metadata) {
+          const entries = metadataById.get(workspaceId.trim());
+          if (!entries) {
             throw new Error(`Workspace metadata not found for ${workspaceId.trim()}`);
           }
-          const resolved = this.resolveWorkspace(metadata);
-          await this.pruneResolvedWorkspace(resolved, keyPrefix);
+          for (const metadata of entries) {
+            await this.pruneResolvedWorkspace(this.resolveWorkspace(metadata), keyPrefix);
+          }
           if (options?.publish) {
             // Strict re-read: the prune above already threw on anything
             // unreadable, so a failure here is a real regression and must keep
-            // the caller's retry tombstone rather than publish a guess.
+            // the caller's retry tombstone rather than publish a guess. Reads
+            // the first entry, matching getWorkspaceMetadata's lookup.
             await options.publish(
               workspaceId,
-              await this.loadOverridesForResolved(resolved, "strict", legacyConfig)
+              await this.loadOverridesForResolved(
+                this.resolveWorkspace(entries[0]),
+                "strict",
+                legacyConfig
+              )
             );
           }
+          swept.push(workspaceId);
         } catch (error) {
           failures.push({ workspaceId, error });
+        }
+      }
+
+      // Workspace renames move the checkout and rewrite config WITHOUT taking
+      // this lock, so a rename racing the sweep leaves the snapshot pointing
+      // at the old (now empty) path and the prune above "succeeds" against
+      // nothing. Re-resolve once afterwards and fail any swept workspace whose
+      // checkout set changed: the caller keeps its tombstone and retries.
+      if (swept.length > 0) {
+        const afterById = groupMetadataById(await this.config.getAllWorkspaceMetadata());
+        for (const workspaceId of swept) {
+          const id = workspaceId.trim();
+          if (checkoutPaths(metadataById.get(id)) !== checkoutPaths(afterById.get(id))) {
+            failures.push({
+              workspaceId,
+              error: new Error(`Workspace ${id} moved while its MCP overrides were being pruned`),
+            });
+          }
         }
       }
       return failures;

--- a/src/node/services/workspaceMcpOverridesService.ts
+++ b/src/node/services/workspaceMcpOverridesService.ts
@@ -213,7 +213,7 @@ export class WorkspaceMcpOverridesService {
 
   private getLegacyOverridesFromConfig(
     workspaceId: string,
-    config: ProjectsConfig = this.config.loadConfigOrDefault()
+    config: ProjectsConfig
   ): WorkspaceMCPOverrides | undefined {
     for (const [_projectPath, projectConfig] of config.projects) {
       const workspace = projectConfig.workspaces.find((w) => w.id === workspaceId);
@@ -437,14 +437,14 @@ export class WorkspaceMcpOverridesService {
   }
 
   /**
-   * `legacyConfig` lets batch callers reuse one config snapshot: loading
+   * `loadLegacyConfig` lets batch callers share one config snapshot: loading
    * config.json is a synchronous full parse, so re-reading it per workspace
    * made a 2000-workspace sweep take tens of minutes.
    */
   private async loadOverridesForResolved(
     resolved: ResolvedWorkspace,
     mode: "lenient" | "strict",
-    legacyConfig?: ProjectsConfig
+    loadLegacyConfig: () => ProjectsConfig = () => this.config.loadConfigOrDefault()
   ): Promise<WorkspaceMCPOverrides> {
     const { metadata, runtime, workspacePath } = resolved;
     const workspaceId = metadata.id;
@@ -460,7 +460,7 @@ export class WorkspaceMcpOverridesService {
     }
 
     // No workspace-local file => try migrating legacy config.json storage.
-    const legacy = this.getLegacyOverridesFromConfig(workspaceId, legacyConfig);
+    const legacy = this.getLegacyOverridesFromConfig(workspaceId, loadLegacyConfig());
     if (!legacy || isEmptyOverrides(legacy)) {
       return {};
     }
@@ -665,12 +665,21 @@ export class WorkspaceMcpOverridesService {
       publish?: (persisted: WorkspaceMCPOverrides) => Promise<void>;
     }
   ): Promise<void> {
-    const failures = await this.prunePluginOverrideKeysForWorkspaces([workspaceId], keyPrefix, {
-      publish: (_workspaceId, persisted) => options?.publish?.(persisted) ?? Promise.resolve(),
+    assert(keyPrefix.length > 0, "prunePluginOverrideKeys: keyPrefix must be non-empty");
+    // Deliberately NOT routed through the batch: workspace creation calls
+    // this on a hot path, and the batch's post-sweep re-resolution (a second
+    // full config parse) only guards multi-workspace sweeps against
+    // concurrent renames — a workspace still being created cannot be renamed.
+    return this.runExclusive(async () => {
+      const resolved = await this.getRuntimeAndWorkspacePath(workspaceId);
+      await this.pruneResolvedWorkspace(resolved, keyPrefix);
+      if (options?.publish) {
+        // Strict re-read: the prune above already threw on anything
+        // unreadable, so a failure here is a real regression and must keep
+        // the caller's retry tombstone rather than publish a guess.
+        await options.publish(await this.loadOverridesForResolved(resolved, "strict"));
+      }
     });
-    if (failures.length > 0) {
-      throw failures[0].error;
-    }
   }
 
   /**
@@ -694,14 +703,20 @@ export class WorkspaceMcpOverridesService {
 
     return this.runExclusive(async () => {
       // Group, don't index: a corrupted config can list one ID under several
-      // entries (different checkouts). Every checkout carrying the ID must be
-      // pruned, or retiring the tombstone would leave a stale enable behind
-      // in the entry a last-write-wins map dropped.
+      // entries (different checkouts). Every host-local checkout carrying the
+      // ID must be pruned, or retiring the tombstone would leave a stale
+      // enable behind in the entry a last-write-wins map dropped. Off-host
+      // entries (SSH/Docker) sharing the ID are skipped: plugin servers never
+      // run there, and the symlink guard below uses host fs semantics.
       const groupMetadataById = (
         all: FrontendWorkspaceMetadata[]
       ): Map<string, FrontendWorkspaceMetadata[]> => {
         const grouped = new Map<string, FrontendWorkspaceMetadata[]>();
         for (const metadata of all) {
+          const runtimeType = metadata.runtimeConfig.type;
+          if (runtimeType !== "local" && runtimeType !== "worktree") {
+            continue;
+          }
           const entries = grouped.get(metadata.id);
           if (entries) {
             entries.push(metadata);
@@ -718,14 +733,17 @@ export class WorkspaceMcpOverridesService {
           .join("\0");
 
       const metadataById = groupMetadataById(await this.config.getAllWorkspaceMetadata());
-      const legacyConfig = this.config.loadConfigOrDefault();
+      // Lazy: only workspaces WITHOUT an override file consult legacy config.
+      let legacyConfig: ProjectsConfig | undefined;
+      const loadLegacyConfig = (): ProjectsConfig =>
+        (legacyConfig ??= this.config.loadConfigOrDefault());
       const failures: Array<{ workspaceId: string; error: unknown }> = [];
       const swept: string[] = [];
       for (const workspaceId of workspaceIds) {
         try {
           const entries = metadataById.get(workspaceId.trim());
           if (!entries) {
-            throw new Error(`Workspace metadata not found for ${workspaceId.trim()}`);
+            throw new Error(`Host-local workspace metadata not found for ${workspaceId.trim()}`);
           }
           for (const metadata of entries) {
             await this.pruneResolvedWorkspace(this.resolveWorkspace(metadata), keyPrefix);
@@ -740,7 +758,7 @@ export class WorkspaceMcpOverridesService {
               await this.loadOverridesForResolved(
                 this.resolveWorkspace(entries[0]),
                 "strict",
-                legacyConfig
+                loadLegacyConfig
               )
             );
           }

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -13586,6 +13586,7 @@ describe("WorkspaceService registration-time plugin override sanitization", () =
     const service = makeService([{ id: "ws-new", path: "/tmp/proj" }]);
     const pruned: string[] = [];
     service.setWorkspaceMcpOverridesService({
+      acquireExclusiveLock: () => Promise.resolve(() => Promise.resolve()),
       prunePluginOverrideKeys: (workspaceId, keyPrefix) => {
         pruned.push(`${workspaceId}:${keyPrefix}`);
         return Promise.resolve();
@@ -13608,6 +13609,7 @@ describe("WorkspaceService registration-time plugin override sanitization", () =
     const service = makeService([{ id: "ws-new", path: "/tmp/proj" }]);
     const pruned: string[] = [];
     service.setWorkspaceMcpOverridesService({
+      acquireExclusiveLock: () => Promise.resolve(() => Promise.resolve()),
       prunePluginOverrideKeys: (workspaceId, keyPrefix) => {
         pruned.push(`${workspaceId}:${keyPrefix}`);
         return Promise.resolve();
@@ -13652,6 +13654,7 @@ describe("WorkspaceService registration-time plugin override sanitization", () =
     const service = makeService([{ id: "ws-new", path: "/tmp/proj" }]);
     const pruned: string[] = [];
     service.setWorkspaceMcpOverridesService({
+      acquireExclusiveLock: () => Promise.resolve(() => Promise.resolve()),
       prunePluginOverrideKeys: (workspaceId, keyPrefix) => {
         pruned.push(`${workspaceId}:${keyPrefix}`);
         return Promise.resolve();
@@ -13682,6 +13685,7 @@ describe("WorkspaceService registration-time plugin override sanitization", () =
     ]);
     const pruned: string[] = [];
     service.setWorkspaceMcpOverridesService({
+      acquireExclusiveLock: () => Promise.resolve(() => Promise.resolve()),
       prunePluginOverrideKeys: (workspaceId, keyPrefix) => {
         pruned.push(`${workspaceId}:${keyPrefix}`);
         return Promise.resolve();
@@ -13697,6 +13701,7 @@ describe("WorkspaceService registration-time plugin override sanitization", () =
   test("a failed sanitize surfaces an error so creation aborts", async () => {
     const service = makeService([{ id: "ws-new", path: "/tmp/proj" }]);
     service.setWorkspaceMcpOverridesService({
+      acquireExclusiveLock: () => Promise.resolve(() => Promise.resolve()),
       prunePluginOverrideKeys: () =>
         Promise.reject(new Error('duplicate "enabledServers" properties')),
     });
@@ -13717,6 +13722,7 @@ describe("WorkspaceService registration-time plugin override sanitization", () =
     ]);
     const pruned: string[] = [];
     service.setWorkspaceMcpOverridesService({
+      acquireExclusiveLock: () => Promise.resolve(() => Promise.resolve()),
       prunePluginOverrideKeys: (workspaceId, keyPrefix) => {
         pruned.push(`${workspaceId}:${keyPrefix}`);
         return Promise.resolve();
@@ -13742,6 +13748,7 @@ describe("WorkspaceService registration-time plugin override sanitization", () =
       ]);
       const pruned: string[] = [];
       service.setWorkspaceMcpOverridesService({
+        acquireExclusiveLock: () => Promise.resolve(() => Promise.resolve()),
         prunePluginOverrideKeys: (workspaceId, keyPrefix) => {
           pruned.push(`${workspaceId}:${keyPrefix}`);
           return Promise.resolve();
@@ -13769,6 +13776,7 @@ describe("WorkspaceService registration-time plugin override sanitization", () =
     (service as unknown as SanitizeAccess).pendingPluginSanitizations.add("ws-concurrent");
     const pruned: string[] = [];
     service.setWorkspaceMcpOverridesService({
+      acquireExclusiveLock: () => Promise.resolve(() => Promise.resolve()),
       prunePluginOverrideKeys: (workspaceId, keyPrefix) => {
         pruned.push(`${workspaceId}:${keyPrefix}`);
         return Promise.resolve();

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -2736,6 +2736,7 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
   /** Narrow overrides-cleanup surface; wired by ServiceContainer for stale plugin-key sanitization. */
   private workspaceMcpOverridesService?: {
     prunePluginOverrideKeys(workspaceId: string, keyPrefix: string): Promise<void>;
+    acquireExclusiveLock(): Promise<() => Promise<void>>;
   };
 
   setTimelineRecorder(recorder: TimelineRecorder): void {
@@ -2752,6 +2753,7 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
 
   setWorkspaceMcpOverridesService(service: {
     prunePluginOverrideKeys(workspaceId: string, keyPrefix: string): Promise<void>;
+    acquireExclusiveLock(): Promise<() => Promise<void>>;
   }): void {
     this.workspaceMcpOverridesService = service;
   }
@@ -7057,6 +7059,7 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
   }
 
   async rename(workspaceId: string, newName: string): Promise<Result<{ newWorkspaceId: string }>> {
+    let releaseOverridesLock: (() => Promise<void>) | undefined;
     try {
       if (this.shuttingDown) return Err("Server is shutting down");
       if (this.aiService.isStreaming(workspaceId)) {
@@ -7098,6 +7101,14 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       }
       const { projectPath: configProjectPath } = workspace;
       const configSnapshot = this.config.loadConfigOrDefault();
+
+      // Hold the workspace MCP-overrides lock across the checkout move AND the
+      // config rewrite below. The Agent Plugin override prune resolves
+      // checkouts from config under that lock; a rename interleaving between
+      // its filesystem move and its config write would let the prune stat the
+      // vacated old path, find nothing, and retire a cleanup tombstone while
+      // the moved .xum/mcp.local.jsonc still holds the plugin key.
+      releaseOverridesLock = await this.workspaceMcpOverridesService?.acquireExclusiveLock();
 
       let oldPath: string;
       let newPath: string;
@@ -7350,6 +7361,7 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       const message = getErrorMessage(error);
       return Err(`Failed to rename workspace: ${message}`);
     } finally {
+      await releaseOverridesLock?.();
       // Always clear renaming flag, even on error
       this.renamingWorkspaces.delete(workspaceId);
     }

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -7335,6 +7335,18 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
         }
         return config;
       });
+      // Checkout and config agree again: let MCP-settings writers proceed
+      // instead of queueing behind plan-file moves and .code-workspace sync.
+      const releaseNow = releaseOverridesLock;
+      releaseOverridesLock = undefined;
+      await releaseNow?.().catch((error: unknown) => {
+        // The rename itself is complete; a lock-file cleanup failure must not
+        // report it as failed. The lease simply ages out for other holders.
+        log.warn("Failed to release MCP-overrides lock after rename", {
+          workspaceId,
+          error: getErrorMessage(error),
+        });
+      });
 
       // Rename plan file if it exists (uses workspace name, not ID)
       await movePlanFile(runtimeForPlanFile, oldName, newName, oldMetadata.projectName);
@@ -7361,7 +7373,14 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       const message = getErrorMessage(error);
       return Err(`Failed to rename workspace: ${message}`);
     } finally {
-      await releaseOverridesLock?.();
+      // Still held only when the move/config section exited early. Never let
+      // a release failure skip clearing the renaming flag below.
+      await releaseOverridesLock?.().catch((error: unknown) => {
+        log.warn("Failed to release MCP-overrides lock after rename", {
+          workspaceId,
+          error: getErrorMessage(error),
+        });
+      });
       // Always clear renaming flag, even on error
       this.renamingWorkspaces.delete(workspaceId);
     }


### PR DESCRIPTION
## Summary

Agent Plugin installs (and uninstalls/updates) appeared to hang on "Installing…" for 20–30 minutes in a setup with ~2000 workspaces. The stale-override sweep pruned each workspace separately, and each prune re-parsed the entire `config.json` two to three times. This batches the sweep into one lock acquisition, one workspace-metadata load, and one config snapshot.

## Background

`install()` → `assertNoResidualInstanceState` sweeps every local/worktree workspace for stale `plugin:<instanceId>:` MCP overrides (so a same-name reinstall can never inherit an old enable). `pruneWorkspaceOverrides` called `WorkspaceMcpOverridesService.prunePluginOverrideKeys` once per workspace; each call:

- acquired the cross-process `mcp-overrides.lock`,
- resolved the workspace through `config.getAllWorkspaceMetadata()` — an uncached synchronous parse of the whole `config.json` (~115 ms for a 2.9 MB config) — for the prune, **again** for the publish re-read, plus a `loadConfigOrDefault()` for the legacy fallback.

That is O(N²) in workspace count. Live diagnosis on the affected host: the mutation lock held for 20 minutes, the staged clone complete with `.git` still present (i.e. stalled between clone and promote), and `mcp-overrides.lock` churning once per second.

## Implementation

- `WorkspaceMcpOverridesService.prunePluginOverrideKeysForWorkspaces(workspaceIds, keyPrefix, { publish(workspaceId, persisted) })`: one `runExclusive`, one `getAllWorkspaceMetadata()`, one config snapshot; per-workspace failures are returned as `{ workspaceId, error }[]` so the installer keeps persisting retry tombstones exactly as before. Only wholesale failures (lock timeout, unreadable config) throw; the installer then treats every workspace as failed (conservative, same outcome as before).
- The single-workspace `prunePluginOverrideKeys` (still used by `WorkspaceService` sanitization) delegates to the batch — same contract.
- The prune body itself is unchanged, only extracted into `pruneResolvedWorkspace`; strict reads, symlink refusal, duplicate/opaque-shape rejection all remain.
- Metadata is grouped by workspace ID (not indexed last-write-wins), so every checkout under a duplicated ID is pruned.
- `WorkspaceService.rename()` now holds the same exclusive overrides lock (`acquireExclusiveLock`) across its checkout move + config rewrite, so a rename cannot interleave with the sweep; the sweep additionally re-resolves metadata once afterwards and fails (→ tombstone retained) any workspace whose checkout set changed.

## Validation

Benchmark against a copy of the real 2.9 MB config (2011 local/worktree workspaces), Bun harness:

| | |
|---|---|
| old per-workspace loop | 199 ms/workspace → ~6.7 min (live Node server observed ~1 s/workspace → 20–30 min) |
| new batch | **555 ms for all 2011 workspaces** |

New tests assert per-workspace failure collection, per-workspace publish, that `getAllWorkspaceMetadata`/`loadConfigOrDefault` call counts do not scale with the number of workspaces, duplicate-ID pruning, rename-during-sweep detection, and that `acquireExclusiveLock` blocks the sweep until released.

## Risks

Low–medium. The prune runs under one lock for the whole sweep instead of per workspace, so a concurrent Workspace MCP dialog save waits for the sweep (now sub-second) rather than interleaving between workspaces — the per-workspace ordering guarantees that mattered (publish inside the write step) are preserved. The cross-process lock renews its lease while held, so a long sweep cannot be reclaimed from under a live holder. Workspace rename now takes that lock too (60 s acquire timeout); a rename issued during a sweep waits well under a second. Failure semantics for tombstones are unchanged; the install-service test suite covering them passes unmodified apart from the stub shape.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `high` • Cost: `$8.31`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=high costs=8.31 -->

