### PR TITLE
🤖 tests: await token-budget warning visibility

### DIFF
--- a/src/browser/contexts/API.test.tsx
+++ b/src/browser/contexts/API.test.tsx
@@ -247,6 +247,8 @@ describe("API reconnection", () => {
       if (scenario === "cross-origin") process.env.VITE_BACKEND_URL = "https://api.example.com";
       const reload = spyOn(window.location, "reload").mockImplementation(() => undefined);
       const requests: string[] = [];
+      const jsonReady = Promise.withResolvers<void>();
+      let responseJson: Promise<unknown> | undefined;
       fetchImpl = (input) => {
         requests.push(
           typeof input === "string" ? input : input instanceof URL ? input.href : input.url
@@ -265,7 +267,12 @@ describe("API reconnection", () => {
             ),
             { status: 200 }
           )
-        );
+        ).then((response) => {
+          const parsedJson = response.json();
+          responseJson = jsonReady.promise.then(() => parsedJson);
+          spyOn(response, "json").mockReturnValue(responseJson);
+          return response;
+        });
       };
       window.location.href = "https://coder.example.com/@u/ws/apps/mux/";
       let latestState: UseAPIResult | null = null;
@@ -294,6 +301,14 @@ describe("API reconnection", () => {
       expect(requests).toEqual(
         scenario === "cross-origin" ? [] : ["https://coder.example.com/@u/ws/apps/mux/version"]
       );
+      expect(latestState!.status).toBe("connected");
+      expect(reload).not.toHaveBeenCalled();
+      // Reconnection does not await the version probe. Finish its JSON response explicitly
+      // so the reload assertion cannot race body parsing under CI load.
+      await act(async () => {
+        jsonReady.resolve();
+        await responseJson;
+      });
       const reloads = scenario === "changed" || scenario === "rebuilt" ? 1 : 0;
       expect(reload).toHaveBeenCalledTimes(reloads);
       if (reloads === 0) expect(latestState!.status).toBe("connected");

--- a/src/browser/hooks/useAnalytics.test.tsx
+++ b/src/browser/hooks/useAnalytics.test.tsx
@@ -142,14 +142,11 @@ let currentApiClient: RouterClient<AppRouter> | null = null;
 let analyticsServiceCalls: AnalyticsServiceCalls | null = null;
 
 function importCreateOrpcServer(): typeof OrpcServerModule.createOrpcServer {
-  void mock.module("@/version", () => ({
-    VERSION: "test-version",
-  }));
-
+  // Bun module mocks survive mock.restore(); use the real VERSION so later reconnect
+  // tests receive valid build metadata instead of a leaked analytics-only fixture.
   const { createOrpcServer } = requireTestModule<{
     createOrpcServer: typeof OrpcServerModule.createOrpcServer;
   }>("@/node/orpc/server");
-  mock.restore();
   return createOrpcServer;
 }
 

--- a/src/browser/stories/App.tokenBudget.stories.tsx
+++ b/src/browser/stories/App.tokenBudget.stories.tsx
@@ -133,7 +133,7 @@ export const Rollover: AppStory = {
     await expect(canvas.queryByText(WARNING)).not.toBeInTheDocument();
     const warning = await canvas.findByRole("button", { name: /Context budget warning/ });
     await userEvent.click(warning);
-    await expect(canvas.getByText(WARNING)).toBeVisible();
+    await waitFor(() => expect(canvas.getByText(WARNING)).toBeVisible());
     await userEvent.click(warning);
     const tool = await canvas.findByText("session_history", { exact: true });
     await userEvent.click(tool);


### PR DESCRIPTION
The TokenBudget story immediately checks visibility after opening a warning. It can find and click the control while an ancestor is still transparent, making the one-shot assertion fail. Await the existing visibility assertion with waitFor, retaining the same requirement and failure timeout.

Stacked above #4143: full unit CI on this otherwise unchanged one-line patch reproduced that PR's confirmed reconnect version-fixture leak. After integrating the prerequisite, both affected API/analytics suites pass in the proven analytics-first order (seed 1): 37 tests, 1,949 assertions. Final full static checks also pass; the Storybook patch is identical.

This changes one test line; application behavior is unchanged. The HighUsage smoke test failed on backend-only PRs #4133 and #4135. CI logs do not capture ancestor styles, so the original opacity cause remains unconfirmed.

Validation: a controlled real-browser test held the actual entrance wrapper at zero opacity. The old assertion failed; the new play remained pending, passed after release, and still failed when permanently held. All 10 TokenBudget Storybook tests passed. All 20 built-Storybook manager cases (10 stories, dark/light) emitted explicit success events at their declared desktop or 375px mobile viewport. Production Storybook build and full static checks passed; Nix formatting skipped because Nix is unavailable.

---

_Generated with `xum` • Model: `unavailable` • Thinking: `unavailable` • Cost: `$unavailable`_

<!-- mux-attribution: model=unavailable thinking=unavailable costs=unavailable -->
