### PR TITLE
🤖 refactor: persist cancellation ownership under history locks

### DIFF
--- a/src/constants/continuousCompaction.ts
+++ b/src/constants/continuousCompaction.ts
@@ -6,3 +6,4 @@ export const MIN_HEAD_TOKENS = 8_000;
 export const SUMMARIZER_INPUT_FRACTION = 0.7;
 export const CONTINUOUS_COMPACTION_JOURNAL_FILE = "continuous-compaction.json";
 export const CONTINUOUS_COMPACTION_GENERATION_FILE = "continuous-compaction-generation";
+export const COMPACTION_CANCELLATION_FILE = "compaction-cancellation.json";

--- a/src/node/services/compactionCancellation.storage.test.ts
+++ b/src/node/services/compactionCancellation.storage.test.ts
@@ -15,6 +15,7 @@ import { createTestHistoryService } from "./testHistoryService";
 import { historyWriteLockPath, removeSessionDirUnderMemoryLocks } from "./workspaceRemoval";
 import {
   CompactionCancellation,
+  CompactionCancellationReadRefusedError,
   FileCompactionCancellationStorage,
   MalformedCompactionCancellationError,
   type CompactionCancellationMutation,
@@ -237,14 +238,20 @@ describe("inactive real cancellation storage", () => {
         nodeFs.writeFileSync(generationPath, "foreign-generation");
       };
       if (phase === "retirement") {
-        const read = nodeFs.promises.readFile;
-        spyOn(nodeFs.promises, "readFile").mockImplementation((async (
-          ...args: Parameters<typeof read>
-        ) => {
-          const result = await read(...args);
-          if (args[0] === storage.path && !displaced) displace();
-          return result;
-        }) as typeof read);
+        const open = nodeFs.promises.open;
+        spyOn(nodeFs.promises, "open").mockImplementation(
+          async (...args: Parameters<typeof open>) => {
+            const handle = await open(...args);
+            if (args[0] === storage.path) {
+              const close = handle.close.bind(handle);
+              spyOn(handle, "close").mockImplementation(async () => {
+                await close();
+                if (!displaced) displace();
+              });
+            }
+            return handle;
+          }
+        );
       } else {
         const target = phase === "generation" ? generationPath : storage.path;
         afterCompactionStaging(target, () => {
@@ -414,6 +421,71 @@ describe("inactive real cancellation storage", () => {
       for (const [file, contents] of expected)
         expect(await fs.readFile(file, "utf8")).toBe(contents);
       expect(await fs.readFile(lockPath, "utf8")).toBe(`${process.pid}:foreign-repair-holder`);
+    }
+  );
+
+  it.each(["limit", "oversized", "malformed", "read error"] as const)(
+    "bounds short descriptor reads and closes the handle for %s sidecars",
+    async (kind) => {
+      const valid = JSON.stringify(record("bounded"));
+      const contents =
+        kind === "malformed"
+          ? "{invalid"
+          : valid.padEnd(SESSION_HISTORY_MAX_LINE_BYTES * (kind === "oversized" ? 2 : 1), " ");
+      await fs.writeFile(storage.path, contents);
+      let reads = 0;
+      let totalRead = 0;
+      let largestBuffer = 0;
+      let closed = false;
+      const open = nodeFs.promises.open;
+      spyOn(nodeFs.promises, "open").mockImplementation(
+        async (...args: Parameters<typeof open>) => {
+          const handle = await open(...args);
+          if (args[0] === storage.path) {
+            const close = handle.close.bind(handle);
+            spyOn(handle, "close").mockImplementation(async () => {
+              await close();
+              closed = true;
+            });
+            const read = handle.read.bind(handle);
+            spyOn(handle, "read").mockImplementation((async (
+              buffer: Buffer,
+              offset: number,
+              length: number,
+              position: number
+            ) => {
+              reads++;
+              largestBuffer = Math.max(largestBuffer, buffer.byteLength);
+              if (kind === "read error") throw new Error("descriptor read failed");
+              // Exercise legal short reads; a single read must not mistake them for EOF.
+              const result = await read(
+                buffer,
+                offset,
+                Math.min(length, SESSION_HISTORY_MAX_LINE_BYTES / 16),
+                position
+              );
+              totalRead += result.bytesRead;
+              return result;
+            }) as typeof handle.read);
+          }
+          return handle;
+        }
+      );
+      if (kind === "limit") expect(await storage.read()).toEqual(record("bounded"));
+      else
+        await assert.rejects(
+          storage.read(),
+          kind === "oversized"
+            ? CompactionCancellationReadRefusedError
+            : kind === "malformed"
+              ? MalformedCompactionCancellationError
+              : /descriptor read failed/
+        );
+      expect(reads).toBeGreaterThan(kind === "read error" ? 0 : 1);
+      expect(totalRead).toBeLessThanOrEqual(SESSION_HISTORY_MAX_LINE_BYTES + 1);
+      expect(largestBuffer).toBeLessThanOrEqual(SESSION_HISTORY_MAX_LINE_BYTES + 1);
+      expect(closed).toBe(true);
+      expect(await fs.readFile(storage.path, "utf8")).toBe(contents);
     }
   );
 

--- a/src/node/services/compactionCancellation.storage.test.ts
+++ b/src/node/services/compactionCancellation.storage.test.ts
@@ -16,7 +16,25 @@ import {
   MalformedCompactionCancellationError,
   type CompactionCancellationMutation,
   type CompactionCancellationRecord,
+  type CompactionCancellationStorage,
 } from "./compactionCancellation";
+
+type RejectsAsync<Observer> = (() => Promise<void>) extends Observer ? false : true;
+type RequireTrue<T extends true> = T;
+// Type-only contracts: widening any commit observer to void would admit async state installation.
+export type SynchronousCancellationObservers = [
+  RequireTrue<RejectsAsync<Parameters<CompactionCancellationStorage["repair"]>[1]>>,
+  RequireTrue<RejectsAsync<Parameters<FileCompactionCancellationStorage["repair"]>[1]>>,
+  RequireTrue<
+    RejectsAsync<
+      Parameters<
+        ReturnType<
+          HistoryService["getContinuousCompactionJournal"]
+        >["advanceGenerationUnderHistoryLock"]
+      >[0]
+    >
+  >,
+];
 
 const workspaceId = "cancellation-storage";
 const followUp = (text = "Continue") => ({ text, model: "test:model", agentId: "exec" });

--- a/src/node/services/compactionCancellation.storage.test.ts
+++ b/src/node/services/compactionCancellation.storage.test.ts
@@ -25,6 +25,8 @@ type RejectsAsync<Observer> = (() => Promise<void>) extends Observer ? false : t
 type RequireTrue<T extends true> = T;
 // Type-only contracts: widening any commit observer to void would admit async state installation.
 export type SynchronousCancellationObservers = [
+  RequireTrue<RejectsAsync<Parameters<CompactionCancellationStorage["mutate"]>[2]>>,
+  RequireTrue<RejectsAsync<Parameters<FileCompactionCancellationStorage["mutate"]>[2]>>,
   RequireTrue<RejectsAsync<Parameters<CompactionCancellationStorage["repair"]>[1]>>,
   RequireTrue<RejectsAsync<Parameters<FileCompactionCancellationStorage["repair"]>[1]>>,
   RequireTrue<
@@ -76,8 +78,10 @@ describe("inactive real cancellation storage", () => {
   let state: CompactionCancellation;
   let foreign: HistoryService;
   let sessionDir: string;
+  const mutationCommitted = mock((_record: CompactionCancellationRecord | null) => undefined);
 
   beforeEach(async () => {
+    mutationCommitted.mockClear();
     h = await createTestHistoryService();
     foreign = new HistoryService(h.config);
     storage = new FileCompactionCancellationStorage(h.historyService, workspaceId);
@@ -96,6 +100,64 @@ describe("inactive real cancellation storage", () => {
     mock.restore();
     await h.cleanup();
   });
+
+  it.each(["publish", "narrow", "confirm", "retire"] as const)(
+    "reports the exact %s receipt before cleanup or lock release",
+    async (phase) => {
+      const narrowed: CompactionCancellationRecord = {
+        ...record("existing"),
+        scope: { kind: "summary", ...summary },
+      };
+      const existing = phase === "confirm" ? narrowed : record("existing");
+      if (phase === "publish") existing.retainUntilReplacement = true;
+      await fs.writeFile(storage.path, JSON.stringify(existing));
+      const mutation: CompactionCancellationMutation =
+        phase === "publish"
+          ? publication("replacement")
+          : phase === "retire"
+            ? { kind: "retire", nonce: existing.nonce }
+            : { kind: "narrow", record: narrowed };
+      const expected =
+        phase === "publish"
+          ? { ...record("replacement"), retainUntilReplacement: true }
+          : phase === "retire"
+            ? null
+            : narrowed;
+      const lockPath = historyWriteLockPath(h.config.rootDir, workspaceId);
+      const cleanup = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      // Pause real post-commit work so promise settlement cannot masquerade as a receipt.
+      const pauseCleanup = async () => {
+        cleanup.resolve();
+        await release.promise;
+      };
+      if (phase === "publish" || phase === "narrow") {
+        const remove = nodeFs.promises.rm;
+        spyOn(nodeFs.promises, "rm").mockImplementation(async (file, options) => {
+          if (String(file).startsWith(`${storage.path}.continuous-`)) await pauseCleanup();
+          await remove(file, options);
+        });
+      } else {
+        const unlink = fs.unlink;
+        spyOn(fs, "unlink").mockImplementation(async (file) => {
+          if (file === lockPath) await pauseCleanup();
+          await unlink(file);
+        });
+      }
+      const writing = storage.mutate(mutation, () => true, mutationCommitted);
+      try {
+        await cleanup.promise;
+        expect(mutationCommitted).toHaveBeenCalledTimes(1);
+        expect(mutationCommitted).toHaveBeenCalledWith(expected);
+        expect(await storage.read()).toEqual(expected);
+        expect(nodeFs.existsSync(lockPath)).toBe(true);
+      } finally {
+        release.resolve();
+        await writing;
+      }
+      expect(await writing).toBe("applied");
+    }
+  );
 
   it.each(["generation", "publication", "narrowing", "retirement"] as const)(
     "a displaced history-lock holder cannot commit %s over its successor",
@@ -136,10 +198,11 @@ describe("inactive real cancellation storage", () => {
             ? { kind: "narrow", record: { ...original, scope: { kind: "summary", ...summary } } }
             : publication("obsolete-publisher");
       await assert.rejects(
-        storage.mutate(mutation, () => true),
+        storage.mutate(mutation, () => true, mutationCommitted),
         /no longer owned/
       );
       expect(displaced).toBe(true);
+      expect(mutationCommitted).not.toHaveBeenCalled();
       expect(await storage.read()).toEqual(successor);
       expect(await fs.readFile(generationPath, "utf8")).toBe("foreign-generation");
       expect(await fs.readFile(lockPath, "utf8")).toBe(`${process.pid}:foreign-holder`);
@@ -283,7 +346,7 @@ describe("inactive real cancellation storage", () => {
       await release.promise;
     });
     await entered.promise;
-    const stopping = storage.mutate(publication("locked"), () => true);
+    const stopping = storage.mutate(publication("locked"), () => true, mutationCommitted);
     // Queued behind Stop on the same real mutex, this callback observes its commit.
     const following = workspaceFileLocks.withLock(workspaceId, async () => {
       expect(await storage.read()).not.toBeNull();
@@ -312,7 +375,7 @@ describe("inactive real cancellation storage", () => {
     const obsolete = publication("obsolete");
     obsolete.publication.attempts = 2;
     obsolete.publication.predecessor = { nonce: null, generation: undefined };
-    const writing = storage.mutate(obsolete, () => true);
+    const writing = storage.mutate(obsolete, () => true, mutationCommitted);
     try {
       await attempted.promise;
       expect(await storage.read()).toBeNull();
@@ -339,7 +402,7 @@ describe("inactive real cancellation storage", () => {
       { kind: "retire", nonce: old.nonce },
       { kind: "retire", nonce: old.nonce, replacementWitness: { nonce: old.nonce } },
     ] satisfies CompactionCancellationMutation[]) {
-      expect(await storage.mutate(mutation, () => true)).toBe("superseded");
+      expect(await storage.mutate(mutation, () => true, mutationCommitted)).toBe("superseded");
       expect(await storage.read()).toEqual(expected);
     }
     await state.cancel();
@@ -363,18 +426,18 @@ describe("inactive real cancellation storage", () => {
       nonce: retained.nonce,
       replacementWitness: { nonce: retained.nonce },
     };
-    expect(await storage.mutate({ kind: "retire", nonce: retained.nonce }, () => true)).toBe(
-      "superseded"
-    );
+    expect(
+      await storage.mutate({ kind: "retire", nonce: retained.nonce }, () => true, mutationCommitted)
+    ).toBe("superseded");
     await assert.rejects(
-      storage.mutate(mutation, () => true),
+      storage.mutate(mutation, () => true, mutationCommitted),
       /not configured/
     );
     const refusing = new FileCompactionCancellationStorage(foreign, workspaceId, () =>
       Promise.resolve(false)
     );
     await assert.rejects(
-      refusing.mutate(mutation, () => true),
+      refusing.mutate(mutation, () => true, mutationCommitted),
       /not verified/
     );
     expect(await storage.read()).toEqual(retained);
@@ -391,10 +454,10 @@ describe("inactive real cancellation storage", () => {
         return true;
       }
     );
-    expect(await verifying.mutate(mutation, () => current)).toBe("superseded");
+    expect(await verifying.mutate(mutation, () => current, mutationCommitted)).toBe("superseded");
     expect(await storage.read()).toEqual(retained);
     // This injected authority exercises the seam only; real accepted-row proof belongs to H2b.
-    expect(await verifying.mutate(mutation, () => true)).toBe("applied");
+    expect(await verifying.mutate(mutation, () => true, mutationCommitted)).toBe("applied");
     expect(await storage.read()).toBeNull();
   });
 
@@ -420,11 +483,11 @@ describe("inactive real cancellation storage", () => {
       throw new Error("after generation commit");
     });
     await assert.rejects(
-      storage.mutate(mutation, () => true),
+      storage.mutate(mutation, () => true, mutationCommitted),
       /after generation commit/
     );
     mutation.publication.attempts++;
-    expect(await storage.mutate(mutation, () => true)).toBe("applied");
+    expect(await storage.mutate(mutation, () => true, mutationCommitted)).toBe("applied");
     expect((await storage.read())?.nonce).toBe("retry-me");
   });
 
@@ -450,7 +513,7 @@ describe("inactive real cancellation storage", () => {
           }
         );
       }
-      await assert.rejects(storage.mutate(mutation, () => true));
+      await assert.rejects(storage.mutate(mutation, () => true, mutationCommitted));
       await foreign.getContinuousCompactionJournal(workspaceId).advanceGeneration();
       const expected = await fs.readFile(
         path.join(sessionDir, CONTINUOUS_COMPACTION_GENERATION_FILE)
@@ -458,11 +521,11 @@ describe("inactive real cancellation storage", () => {
       mutation.publication.attempts++;
       if (stage === "unobserved") {
         await assert.rejects(
-          storage.mutate(mutation, () => true),
+          storage.mutate(mutation, () => true, mutationCommitted),
           /frontier was not captured/
         );
       } else {
-        expect(await storage.mutate(mutation, () => true)).toBe("superseded");
+        expect(await storage.mutate(mutation, () => true, mutationCommitted)).toBe("superseded");
       }
       expect(await storage.read()).toBeNull();
       expect(
@@ -539,7 +602,9 @@ describe("inactive real cancellation storage", () => {
       await advance(...args);
       current = false;
     });
-    expect(await storage.mutate(publication("stale"), () => current)).toBe("superseded");
+    expect(await storage.mutate(publication("stale"), () => current, mutationCommitted)).toBe(
+      "superseded"
+    );
     expect(await storage.read()).toBeNull();
     expect((await fs.readdir(sessionDir)).some((file) => file.includes(".continuous-"))).toBe(
       false

--- a/src/node/services/compactionCancellation.storage.test.ts
+++ b/src/node/services/compactionCancellation.storage.test.ts
@@ -2,12 +2,14 @@ import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:te
 import assert from "node:assert/strict";
 import * as fs from "node:fs/promises";
 import * as nodeFs from "node:fs";
+import callbackFs from "node:fs";
 import * as path from "node:path";
 import { createMuxMessage } from "@/common/types/message";
 import { CONTINUOUS_COMPACTION_GENERATION_FILE } from "@/constants/continuousCompaction";
 import { acquireProcessFileLock } from "@/node/utils/concurrency/fileLock";
 import { workspaceFileLocks } from "@/node/utils/concurrency/workspaceFileLocks";
 import { HistoryService } from "./historyService";
+import { HISTORY_APPEND_PROVENANCE_FILE } from "./historyAppendProvenance";
 import { createTestHistoryService } from "./testHistoryService";
 import { historyWriteLockPath, removeSessionDirUnderMemoryLocks } from "./workspaceRemoval";
 import {
@@ -52,6 +54,22 @@ const publication = (
   publication: { attempts: 1 },
 });
 
+function afterCompactionStaging(target: string, action: () => void) {
+  // write-file-atomic consumes CommonJS fs, so intercept its shared default export.
+  const rename = callbackFs.rename;
+  spyOn(callbackFs, "rename").mockImplementation(
+    Object.assign(
+      (...[source, destination, callback]: Parameters<typeof rename>) => {
+        rename(source, destination, (error) => {
+          if (!error && String(destination).startsWith(`${target}.continuous-`)) action();
+          callback(error);
+        });
+      },
+      { __promisify__: rename.__promisify__ }
+    )
+  );
+}
+
 describe("inactive real cancellation storage", () => {
   let h: Awaited<ReturnType<typeof createTestHistoryService>>;
   let storage: FileCompactionCancellationStorage;
@@ -78,6 +96,157 @@ describe("inactive real cancellation storage", () => {
     mock.restore();
     await h.cleanup();
   });
+
+  it.each(["generation", "publication", "narrowing", "retirement"] as const)(
+    "a displaced history-lock holder cannot commit %s over its successor",
+    async (phase) => {
+      await state.cancel();
+      const original = (await storage.read())!;
+      const successor = { ...record("foreign-successor"), retainUntilReplacement: true };
+      const generationPath = path.join(sessionDir, CONTINUOUS_COMPACTION_GENERATION_FILE);
+      const lockPath = historyWriteLockPath(h.config.rootDir, workspaceId);
+      let displaced = false;
+      const displace = () => {
+        displaced = true;
+        // Deterministically model lease reclamation while the first holder is
+        // suspended in I/O. The real ownership check must reject this new token.
+        nodeFs.writeFileSync(lockPath, `${process.pid}:foreign-holder`);
+        nodeFs.writeFileSync(storage.path, JSON.stringify(successor));
+        nodeFs.writeFileSync(generationPath, "foreign-generation");
+      };
+      if (phase === "retirement") {
+        const read = nodeFs.promises.readFile;
+        spyOn(nodeFs.promises, "readFile").mockImplementation((async (
+          ...args: Parameters<typeof read>
+        ) => {
+          const result = await read(...args);
+          if (args[0] === storage.path && !displaced) displace();
+          return result;
+        }) as typeof read);
+      } else {
+        const target = phase === "generation" ? generationPath : storage.path;
+        afterCompactionStaging(target, () => {
+          if (!displaced) displace();
+        });
+      }
+      const mutation: CompactionCancellationMutation =
+        phase === "retirement"
+          ? { kind: "retire", nonce: original.nonce }
+          : phase === "narrowing"
+            ? { kind: "narrow", record: { ...original, scope: { kind: "summary", ...summary } } }
+            : publication("obsolete-publisher");
+      await assert.rejects(
+        storage.mutate(mutation, () => true),
+        /no longer owned/
+      );
+      expect(displaced).toBe(true);
+      expect(await storage.read()).toEqual(successor);
+      expect(await fs.readFile(generationPath, "utf8")).toBe("foreign-generation");
+      expect(await fs.readFile(lockPath, "utf8")).toBe(`${process.pid}:foreign-holder`);
+    }
+  );
+
+  it.each([
+    "partial",
+    "archive",
+    "chat",
+    "truncate",
+    "pending receipt",
+    "final receipt",
+    "repair retirement",
+  ] as const)(
+    "a displaced repair cannot commit %s over successor recovery state",
+    async (phase) => {
+      const partialPath = path.join(sessionDir, "partial.json");
+      const archivePath = path.join(sessionDir, "chat-archive.jsonl");
+      const chatPath = path.join(sessionDir, "chat.jsonl");
+      const receiptPath = path.join(sessionDir, HISTORY_APPEND_PROVENANCE_FILE);
+      const generationPath = path.join(sessionDir, CONTINUOUS_COMPACTION_GENERATION_FILE);
+      const lockPath = historyWriteLockPath(h.config.rootDir, workspaceId);
+      const pending = createMuxMessage("old-summary", "assistant", "old", {
+        muxMetadata: { type: "compaction-summary", pendingFollowUp: followUp() },
+      });
+      const oldBytes = JSON.stringify(pending);
+      await fs.writeFile(storage.path, "{damaged cancellation");
+      await fs.writeFile(partialPath, oldBytes);
+      await fs.writeFile(archivePath, oldBytes + "\n");
+      await fs.writeFile(chatPath, oldBytes + "\n");
+      if (phase === "truncate") {
+        await fs.writeFile(`${archivePath}.truncate`, oldBytes + "\n");
+        await fs.writeFile(`${archivePath}.truncate.json`, "damaged truncate marker");
+      }
+      const successor = { ...record("foreign-repair-successor"), retainUntilReplacement: true };
+      const expected = new Map([
+        [storage.path, JSON.stringify(successor)],
+        [generationPath, "foreign-generation"],
+        [partialPath, JSON.stringify({ ...pending, id: "foreign-partial" })],
+        [archivePath, JSON.stringify({ ...pending, id: "foreign-archive" }) + "\n"],
+        [chatPath, JSON.stringify({ ...pending, id: "foreign-chat" }) + "\n"],
+        [receiptPath, "foreign-provenance-receipt"],
+      ]);
+      let displaced = false;
+      const displace = () => {
+        if (displaced) return;
+        displaced = true;
+        nodeFs.writeFileSync(lockPath, `${process.pid}:foreign-repair-holder`);
+        for (const [file, contents] of expected) nodeFs.writeFileSync(file, contents);
+      };
+      if (phase === "partial" || phase === "archive" || phase === "chat") {
+        afterCompactionStaging(
+          { partial: partialPath, archive: archivePath, chat: chatPath }[phase],
+          displace
+        );
+      } else if (phase === "truncate") {
+        const remove = fs.rm;
+        spyOn(fs, "rm").mockImplementation(async (file, options) => {
+          await remove(file, options);
+          if (file === archivePath) displace();
+        });
+      } else if (phase === "repair retirement") {
+        const rename = fs.rename;
+        spyOn(fs, "rename").mockImplementation(async (source, destination) => {
+          await rename(source, destination);
+          if (
+            destination === receiptPath &&
+            (JSON.parse(nodeFs.readFileSync(receiptPath, "utf8")) as { state?: unknown }).state ===
+              "stable"
+          )
+            displace();
+        });
+      } else {
+        const open = fs.open;
+        spyOn(fs, "open").mockImplementation(async (...args: Parameters<typeof open>) => {
+          const handle = await open(...args);
+          if (String(args[0]).startsWith(`${receiptPath}.`) && String(args[0]).endsWith(".tmp")) {
+            const close = handle.close.bind(handle);
+            spyOn(handle, "close").mockImplementation(async () => {
+              await close();
+              const receipt: unknown = JSON.parse(nodeFs.readFileSync(args[0], "utf8"));
+              const expectedState = phase === "pending receipt" ? "pending" : "stable";
+              if (
+                receipt &&
+                typeof receipt === "object" &&
+                "state" in receipt &&
+                receipt.state === expectedState
+              )
+                displace();
+            });
+          }
+          return handle;
+        });
+      }
+      const committed = mock(() => undefined);
+      await assert.rejects(
+        storage.repair(() => true, committed),
+        /no longer owned/
+      );
+      expect(displaced).toBe(true);
+      expect(committed).not.toHaveBeenCalled();
+      for (const [file, contents] of expected)
+        expect(await fs.readFile(file, "utf8")).toBe(contents);
+      expect(await fs.readFile(lockPath, "utf8")).toBe(`${process.pid}:foreign-repair-holder`);
+    }
+  );
 
   it("fresh reads distinguish absence, malformed bytes and I/O errors", async () => {
     expect(await storage.read()).toBeNull();
@@ -243,15 +412,13 @@ describe("inactive real cancellation storage", () => {
 
     const mutation = publication("retry-me");
     const advance = journal.advanceGenerationUnderHistoryLock.bind(journal);
-    spyOn(journal, "advanceGenerationUnderHistoryLock").mockImplementationOnce(
-      async (onCommitted) => {
-        await advance(onCommitted);
-        expect(mutation.publication.predecessor?.generation).toBe(
-          await journal.captureGenerationUnderHistoryLock()
-        );
-        throw new Error("after generation commit");
-      }
-    );
+    spyOn(journal, "advanceGenerationUnderHistoryLock").mockImplementationOnce(async (...args) => {
+      await advance(...args);
+      expect(mutation.publication.predecessor?.generation).toBe(
+        await journal.captureGenerationUnderHistoryLock()
+      );
+      throw new Error("after generation commit");
+    });
     await assert.rejects(
       storage.mutate(mutation, () => true),
       /after generation commit/
@@ -277,8 +444,8 @@ describe("inactive real cancellation storage", () => {
       } else {
         const advance = journal.advanceGenerationUnderHistoryLock.bind(journal);
         spyOn(journal, "advanceGenerationUnderHistoryLock").mockImplementationOnce(
-          async (committed) => {
-            await advance(committed);
+          async (...args) => {
+            await advance(...args);
             throw new Error("after advance");
           }
         );
@@ -368,12 +535,10 @@ describe("inactive real cancellation storage", () => {
     let current = true;
     const journal = h.historyService.getContinuousCompactionJournal(workspaceId);
     const advance = journal.advanceGenerationUnderHistoryLock.bind(journal);
-    spyOn(journal, "advanceGenerationUnderHistoryLock").mockImplementationOnce(
-      async (committed) => {
-        await advance(committed);
-        current = false;
-      }
-    );
+    spyOn(journal, "advanceGenerationUnderHistoryLock").mockImplementationOnce(async (...args) => {
+      await advance(...args);
+      current = false;
+    });
     expect(await storage.mutate(publication("stale"), () => current)).toBe("superseded");
     expect(await storage.read()).toBeNull();
     expect((await fs.readdir(sessionDir)).some((file) => file.includes(".continuous-"))).toBe(
@@ -559,8 +724,8 @@ describe("inactive real cancellation storage", () => {
     let current = true;
     const journal = h.historyService.getContinuousCompactionJournal(workspaceId);
     const advance = journal.advanceGenerationUnderHistoryLock.bind(journal);
-    spyOn(journal, "advanceGenerationUnderHistoryLock").mockImplementationOnce(async () => {
-      await advance();
+    spyOn(journal, "advanceGenerationUnderHistoryLock").mockImplementationOnce(async (...args) => {
+      await advance(...args);
       current = false;
     });
     expect(await storage.repair(() => current, committed)).toBeNull();

--- a/src/node/services/compactionCancellation.storage.test.ts
+++ b/src/node/services/compactionCancellation.storage.test.ts
@@ -122,7 +122,7 @@ describe("inactive real cancellation storage", () => {
           : phase === "retire"
             ? { kind: "retire", nonce: existing.nonce }
             : { kind: "narrow", record: narrowed };
-      const expected =
+      const expected: CompactionCancellationRecord | null =
         phase === "publish"
           ? { ...record("replacement"), retainUntilReplacement: true }
           : phase === "retire"

--- a/src/node/services/compactionCancellation.storage.test.ts
+++ b/src/node/services/compactionCancellation.storage.test.ts
@@ -5,6 +5,7 @@ import * as nodeFs from "node:fs";
 import callbackFs from "node:fs";
 import * as path from "node:path";
 import { createMuxMessage } from "@/common/types/message";
+import { SESSION_HISTORY_MAX_LINE_BYTES } from "@/common/constants/contextBudget";
 import { CONTINUOUS_COMPACTION_GENERATION_FILE } from "@/constants/continuousCompaction";
 import { acquireProcessFileLock } from "@/node/utils/concurrency/fileLock";
 import { workspaceFileLocks } from "@/node/utils/concurrency/workspaceFileLocks";
@@ -106,7 +107,11 @@ describe("inactive real cancellation storage", () => {
     async (phase) => {
       const narrowed: CompactionCancellationRecord = {
         ...record("existing"),
-        scope: { kind: "summary", ...summary },
+        scope: {
+          kind: "summary",
+          ...summary,
+          pendingFollowUp: { text: "Continue", providerOptions: { omitted: undefined } },
+        },
       };
       const existing = phase === "confirm" ? narrowed : record("existing");
       if (phase === "publish") existing.retainUntilReplacement = true;
@@ -122,7 +127,14 @@ describe("inactive real cancellation storage", () => {
           ? { ...record("replacement"), retainUntilReplacement: true }
           : phase === "retire"
             ? null
-            : narrowed;
+            : {
+                ...narrowed,
+                scope: {
+                  kind: "summary",
+                  ...summary,
+                  pendingFollowUp: { text: "Continue", providerOptions: {} },
+                },
+              };
       const lockPath = historyWriteLockPath(h.config.rootDir, workspaceId);
       const cleanup = Promise.withResolvers<void>();
       const release = Promise.withResolvers<void>();
@@ -148,7 +160,7 @@ describe("inactive real cancellation storage", () => {
       try {
         await cleanup.promise;
         expect(mutationCommitted).toHaveBeenCalledTimes(1);
-        expect(mutationCommitted).toHaveBeenCalledWith(expected);
+        assert.deepEqual(mutationCommitted.mock.calls[0]?.[0], expected);
         expect(await storage.read()).toEqual(expected);
         expect(nodeFs.existsSync(lockPath)).toBe(true);
       } finally {
@@ -156,6 +168,54 @@ describe("inactive real cancellation storage", () => {
         await writing;
       }
       expect(await writing).toBe("applied");
+    }
+  );
+
+  it.skipIf(process.platform === "win32").each(["publish", "narrow", "retire"] as const)(
+    "keeps %s debt after directory sync fails without losing the visible receipt",
+    async (phase) => {
+      await state.cancel();
+      const previous = (await storage.read())!;
+      const syncing = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const open = fs.open;
+      let fail = true;
+      spyOn(fs, "open").mockImplementation(async (...args: Parameters<typeof open>) => {
+        const handle = await open(...args);
+        if (args[0] === sessionDir && fail) {
+          fail = false;
+          spyOn(handle, "sync").mockImplementation(async () => {
+            syncing.resolve();
+            await release.promise;
+            throw new Error("directory sync failed");
+          });
+        }
+        return handle;
+      });
+      const writing =
+        phase === "publish"
+          ? state.cancel()
+          : phase === "narrow"
+            ? state.narrow(previous.nonce, summary)
+            : state.retire(previous.nonce);
+      try {
+        await Promise.race([
+          syncing.promise,
+          writing.then(() => assert.fail("mutation settled without syncing its directory")),
+        ]);
+        // Fresh disk bytes and the core's blocked read already agree before acknowledgment.
+        expect(await state.read()).toEqual(await storage.read());
+        expect(state.needsPersistence).toBe(true);
+        expect(nodeFs.existsSync(historyWriteLockPath(h.config.rootDir, workspaceId))).toBe(true);
+      } finally {
+        release.resolve();
+        await assert.rejects(writing, /directory sync failed/);
+      }
+      expect(state.needsPersistence).toBe(true);
+      const committed = await storage.read();
+      await state.retry();
+      expect(state.needsPersistence).toBe(false);
+      expect(await storage.read()).toEqual(committed);
     }
   );
 
@@ -206,6 +266,52 @@ describe("inactive real cancellation storage", () => {
       expect(await storage.read()).toEqual(successor);
       expect(await fs.readFile(generationPath, "utf8")).toBe("foreign-generation");
       expect(await fs.readFile(lockPath, "utf8")).toBe(`${process.pid}:foreign-holder`);
+    }
+  );
+
+  it.each(["newer", "oversized", "oversized newer"] as const)(
+    "preserves %s cancellation and recovery bytes through every refusal path",
+    async (kind) => {
+      const bytes =
+        " ".repeat(kind === "newer" ? 0 : SESSION_HISTORY_MAX_LINE_BYTES) +
+        JSON.stringify({ ...record("preserved"), version: kind === "oversized" ? 1 : 2 });
+      await fs.writeFile(storage.path, bytes);
+      await fs.writeFile(
+        path.join(sessionDir, "partial.json"),
+        JSON.stringify(
+          createMuxMessage("pending", "assistant", "summary", {
+            muxMetadata: { type: "compaction-summary", pendingFollowUp: followUp() },
+          })
+        )
+      );
+      const before = new Map(
+        await Promise.all(
+          (await fs.readdir(sessionDir)).map(
+            async (file) => [file, await fs.readFile(path.join(sessionDir, file))] as const
+          )
+        )
+      );
+      for (const operation of [
+        () => storage.read(),
+        () =>
+          storage.repair(
+            () => true,
+            () => mutationCommitted(null)
+          ),
+        () => state.readForReplacement(),
+        () => state.cancel(),
+      ]) {
+        await assert.rejects(
+          operation,
+          (error: unknown) =>
+            error instanceof Error && !(error instanceof MalformedCompactionCancellationError)
+        );
+        expect((await fs.readdir(sessionDir)).sort()).toEqual([...before.keys()].sort());
+        for (const [file, contents] of before)
+          expect(await fs.readFile(path.join(sessionDir, file))).toEqual(contents);
+      }
+      expect(state.repairRevision).toBe(0);
+      expect(mutationCommitted).not.toHaveBeenCalled();
     }
   );
 
@@ -418,6 +524,25 @@ describe("inactive real cancellation storage", () => {
     expect(await storage.read()).toBeNull();
   });
 
+  it("refuses a narrowing it could not read without replacing the current Stop", async () => {
+    await state.cancel();
+    const current = (await storage.read())!;
+    const scope = {
+      kind: "summary" as const,
+      ...summary,
+      pendingFollowUp: { text: "x".repeat(SESSION_HISTORY_MAX_LINE_BYTES) },
+    };
+    await assert.rejects(
+      storage.mutate(
+        { kind: "narrow", record: { ...current, scope } },
+        () => true,
+        mutationCommitted
+      )
+    );
+    expect(await storage.read()).toEqual(current);
+    expect(mutationCommitted).not.toHaveBeenCalled();
+  });
+
   it("requires an explicit in-lock verifier and rechecks local authority after verification", async () => {
     await state.cancel({ retainUntilReplacement: true });
     const retained = (await storage.read())!;
@@ -625,8 +750,14 @@ describe("inactive real cancellation storage", () => {
     expect(await storage.read()).not.toBeNull();
   });
 
-  it.each(["{broken", JSON.stringify({ ...record("bad"), retainUntilReplacement: "unknown" })])(
-    "repairs malformed cancellation while preserving raw privacy floors (%s)",
+  it.each([
+    "{broken",
+    JSON.stringify({ ...record("bad"), retainUntilReplacement: "unknown" }),
+    '{"version":1,"nonce":"duplicate","retainUntilReplacement":true,"retainUntilReplacement":false,"scope":{"kind":"unresolved"}}',
+    String.raw`{"version":1,"nonce":"escaped","retainUntilReplacement":true,"ret\u0061inUntilReplacement":false,"scope":{"kind":"unresolved"}}`,
+    '{"version":1,"nonce":"nested","scope":{"kind":"summary","id":"summary","pendingFollowUp":{"text":"old","text":"new"}}}',
+  ])(
+    "repairs malformed cancellation, syncs its directory, and preserves raw privacy floors (%s)",
     async (bytes) => {
       const summaryRow = createMuxMessage("summary", "assistant", "summary", {
         muxMetadata: { type: "compaction-summary", pendingFollowUp: followUp() },
@@ -645,8 +776,22 @@ describe("inactive real cancellation storage", () => {
       await fs.writeFile(storage.path, bytes);
       const journal = h.historyService.getContinuousCompactionJournal(workspaceId);
       const generation = await journal.captureGeneration();
+      let syncedRepair = false;
+      const open = fs.open;
+      spyOn(fs, "open").mockImplementation(async (...args: Parameters<typeof open>) => {
+        const handle = await open(...args);
+        if (args[0] === sessionDir) {
+          const sync = handle.sync.bind(handle);
+          spyOn(handle, "sync").mockImplementation(async () => {
+            await sync();
+            syncedRepair ||= state.repairRevision === 1;
+          });
+        }
+        return handle;
+      });
       expect(await state.read()).toBeNull();
       expect(state.repairRevision).toBe(1);
+      if (process.platform !== "win32") expect(syncedRepair).toBe(true);
       expect(await journal.captureGeneration()).not.toBe(generation);
       for (const file of ["chat-archive.jsonl", "chat.jsonl"]) {
         const repaired = await fs.readFile(path.join(sessionDir, file));

--- a/src/node/services/compactionCancellation.storage.test.ts
+++ b/src/node/services/compactionCancellation.storage.test.ts
@@ -1,0 +1,595 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs/promises";
+import * as nodeFs from "node:fs";
+import * as path from "node:path";
+import { createMuxMessage } from "@/common/types/message";
+import { CONTINUOUS_COMPACTION_GENERATION_FILE } from "@/constants/continuousCompaction";
+import { acquireProcessFileLock } from "@/node/utils/concurrency/fileLock";
+import { workspaceFileLocks } from "@/node/utils/concurrency/workspaceFileLocks";
+import { HistoryService } from "./historyService";
+import { createTestHistoryService } from "./testHistoryService";
+import { historyWriteLockPath, removeSessionDirUnderMemoryLocks } from "./workspaceRemoval";
+import {
+  CompactionCancellation,
+  FileCompactionCancellationStorage,
+  MalformedCompactionCancellationError,
+  type CompactionCancellationMutation,
+  type CompactionCancellationRecord,
+} from "./compactionCancellation";
+
+const workspaceId = "cancellation-storage";
+const followUp = (text = "Continue") => ({ text, model: "test:model", agentId: "exec" });
+const summary = { id: "summary", sequence: 1, pendingFollowUp: { text: "Continue" } };
+const record = (nonce: string): CompactionCancellationRecord => ({
+  version: 1,
+  nonce,
+  scope: { kind: "unresolved" },
+});
+const publication = (
+  nonce: string
+): Extract<CompactionCancellationMutation, { kind: "publish" }> => ({
+  kind: "publish",
+  record: record(nonce),
+  publication: { attempts: 1 },
+});
+
+describe("inactive real cancellation storage", () => {
+  let h: Awaited<ReturnType<typeof createTestHistoryService>>;
+  let storage: FileCompactionCancellationStorage;
+  let state: CompactionCancellation;
+  let foreign: HistoryService;
+  let sessionDir: string;
+
+  beforeEach(async () => {
+    h = await createTestHistoryService();
+    foreign = new HistoryService(h.config);
+    storage = new FileCompactionCancellationStorage(h.historyService, workspaceId);
+    state = new CompactionCancellation(storage);
+    sessionDir = path.dirname(storage.path);
+    expect(
+      (
+        await h.historyService.appendToHistory(
+          workspaceId,
+          createMuxMessage("user", "user", "Hello")
+        )
+      ).success
+    ).toBe(true);
+  });
+  afterEach(async () => {
+    mock.restore();
+    await h.cleanup();
+  });
+
+  it("fresh reads distinguish absence, malformed bytes and I/O errors", async () => {
+    expect(await storage.read()).toBeNull();
+    await state.cancel();
+    const first = (await state.read())!;
+    const other = new FileCompactionCancellationStorage(foreign, workspaceId);
+    expect(await other.read()).toEqual(first);
+    const loaded = (await other.read())!;
+    loaded.nonce = "changed locally";
+    expect(await other.read()).toEqual(first);
+    expect((await fs.stat(storage.path)).mode & 0o777).toBe(0o600);
+    await fs.writeFile(storage.path, "{private unfinished request");
+    await assert.rejects(storage.read(), MalformedCompactionCancellationError);
+    await fs.rm(storage.path);
+    await fs.mkdir(storage.path);
+    await assert.rejects(storage.read(), (error: unknown) => {
+      expect(error).not.toBeInstanceOf(MalformedCompactionCancellationError);
+      return (error as NodeJS.ErrnoException).code === "EISDIR";
+    });
+    await assert.rejects(
+      storage.repair(
+        () => true,
+        () => assert.fail("I/O is not repairable")
+      )
+    );
+    expect((await fs.stat(storage.path)).isDirectory()).toBe(true);
+  });
+
+  it("serializes with the shared in-process history mutex", async () => {
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const held = workspaceFileLocks.withLock(workspaceId, async () => {
+      entered.resolve();
+      await release.promise;
+    });
+    await entered.promise;
+    const stopping = storage.mutate(publication("locked"), () => true);
+    // Queued behind Stop on the same real mutex, this callback observes its commit.
+    const following = workspaceFileLocks.withLock(workspaceId, async () => {
+      expect(await storage.read()).not.toBeNull();
+    });
+    try {
+      expect(await storage.read()).toBeNull();
+    } finally {
+      release.resolve();
+    }
+    await Promise.all([held, stopping, following]);
+  });
+
+  it("waits on the exact cross-instance history file lock before observing a successor", async () => {
+    const lockPath = historyWriteLockPath(h.config.rootDir, workspaceId);
+    const lock = await acquireProcessFileLock({ lockPath, timeoutMs: 1000, label: "test holder" });
+    const attempted = Promise.withResolvers<void>();
+    const link = fs.link;
+    spyOn(fs, "link").mockImplementation(async (source, destination) => {
+      try {
+        return await link(source, destination);
+      } catch (error) {
+        if (destination === lockPath) attempted.resolve();
+        throw error;
+      }
+    });
+    const obsolete = publication("obsolete");
+    obsolete.publication.attempts = 2;
+    obsolete.publication.predecessor = { nonce: null, generation: undefined };
+    const writing = storage.mutate(obsolete, () => true);
+    try {
+      await attempted.promise;
+      expect(await storage.read()).toBeNull();
+      // A cooperating foreign owner publishes while retaining the actual file lock.
+      await fs.writeFile(storage.path, JSON.stringify(record("successor")));
+      await foreign.getContinuousCompactionJournal(workspaceId).advanceGenerationUnderHistoryLock();
+    } finally {
+      await lock[Symbol.asyncDispose]();
+    }
+    expect(await writing).toBe("superseded");
+    expect((await storage.read())?.nonce).toBe("successor");
+  });
+
+  it("protects foreign successor nonces from narrow, ordinary and witnessed retirement", async () => {
+    await state.cancel();
+    const old = (await state.read())!;
+    const successor = new CompactionCancellation(
+      new FileCompactionCancellationStorage(foreign, workspaceId)
+    );
+    await successor.cancel({ retainUntilReplacement: true });
+    const expected = await successor.read();
+    for (const mutation of [
+      { kind: "narrow", record: { ...old, scope: { kind: "summary", ...summary } } },
+      { kind: "retire", nonce: old.nonce },
+      { kind: "retire", nonce: old.nonce, replacementWitness: { nonce: old.nonce } },
+    ] satisfies CompactionCancellationMutation[]) {
+      expect(await storage.mutate(mutation, () => true)).toBe("superseded");
+      expect(await storage.read()).toEqual(expected);
+    }
+    await state.cancel();
+    expect((await storage.read())?.retainUntilReplacement).toBe(true);
+  });
+
+  it("narrows and retires only the exact current nonce", async () => {
+    await state.cancel();
+    const old = (await state.read())!;
+    await state.narrow(old.nonce, summary);
+    expect((await storage.read())?.scope).toEqual({ kind: "summary", ...summary });
+    expect(await state.retire(old.nonce)).toBe("applied");
+    expect(await storage.read()).toBeNull();
+  });
+
+  it("requires an explicit in-lock verifier and rechecks local authority after verification", async () => {
+    await state.cancel({ retainUntilReplacement: true });
+    const retained = (await storage.read())!;
+    const mutation: CompactionCancellationMutation = {
+      kind: "retire",
+      nonce: retained.nonce,
+      replacementWitness: { nonce: retained.nonce },
+    };
+    expect(await storage.mutate({ kind: "retire", nonce: retained.nonce }, () => true)).toBe(
+      "superseded"
+    );
+    await assert.rejects(
+      storage.mutate(mutation, () => true),
+      /not configured/
+    );
+    const refusing = new FileCompactionCancellationStorage(foreign, workspaceId, () =>
+      Promise.resolve(false)
+    );
+    await assert.rejects(
+      refusing.mutate(mutation, () => true),
+      /not verified/
+    );
+    expect(await storage.read()).toEqual(retained);
+    let current = true;
+    const verifying = new FileCompactionCancellationStorage(
+      foreign,
+      workspaceId,
+      async (witness) => {
+        expect(witness.nonce).toBe(retained.nonce);
+        expect(
+          await fs.readFile(historyWriteLockPath(h.config.rootDir, workspaceId), "utf8")
+        ).not.toBe("");
+        current = false;
+        return true;
+      }
+    );
+    expect(await verifying.mutate(mutation, () => current)).toBe("superseded");
+    expect(await storage.read()).toEqual(retained);
+    // This injected authority exercises the seam only; real accepted-row proof belongs to H2b.
+    expect(await verifying.mutate(mutation, () => true)).toBe("applied");
+    expect(await storage.read()).toBeNull();
+  });
+
+  it("records generation advancement before a later failure and retries its exact frontier", async () => {
+    await fs.mkdir(storage.path); // An unreadable predecessor whose rename will fail.
+    await assert.rejects(state.cancel());
+    const failed = (await state.read())!;
+    expect(failed.retainUntilReplacement).toBe(true);
+    const journal = h.historyService.getContinuousCompactionJournal(workspaceId);
+    expect(await journal.captureGeneration()).toBeDefined();
+    await fs.rm(storage.path, { recursive: true });
+    // The predecessor changed from unreadable to absent: this is not the recorded frontier.
+    expect(await state.retry()).toBe("superseded");
+    expect(await storage.read()).toBeNull();
+
+    const mutation = publication("retry-me");
+    const advance = journal.advanceGenerationUnderHistoryLock.bind(journal);
+    spyOn(journal, "advanceGenerationUnderHistoryLock").mockImplementationOnce(
+      async (onCommitted) => {
+        await advance(onCommitted);
+        expect(mutation.publication.predecessor?.generation).toBe(
+          await journal.captureGenerationUnderHistoryLock()
+        );
+        throw new Error("after generation commit");
+      }
+    );
+    await assert.rejects(
+      storage.mutate(mutation, () => true),
+      /after generation commit/
+    );
+    mutation.publication.attempts++;
+    expect(await storage.mutate(mutation, () => true)).toBe("applied");
+    expect((await storage.read())?.nonce).toBe("retry-me");
+  });
+
+  it.each(["unobserved", "admitted", "advanced"] as const)(
+    "a failed %s publication never adopts a foreign generation on retry",
+    async (stage) => {
+      const journal = h.historyService.getContinuousCompactionJournal(workspaceId);
+      const mutation = publication("stale");
+      if (stage === "unobserved") {
+        spyOn(journal, "captureGenerationUnderHistoryLock").mockRejectedValueOnce(
+          new Error("capture failed")
+        );
+      } else if (stage === "admitted") {
+        spyOn(journal, "advanceGenerationUnderHistoryLock").mockRejectedValueOnce(
+          new Error("advance failed")
+        );
+      } else {
+        const advance = journal.advanceGenerationUnderHistoryLock.bind(journal);
+        spyOn(journal, "advanceGenerationUnderHistoryLock").mockImplementationOnce(
+          async (committed) => {
+            await advance(committed);
+            throw new Error("after advance");
+          }
+        );
+      }
+      await assert.rejects(storage.mutate(mutation, () => true));
+      await foreign.getContinuousCompactionJournal(workspaceId).advanceGeneration();
+      const expected = await fs.readFile(
+        path.join(sessionDir, CONTINUOUS_COMPACTION_GENERATION_FILE)
+      );
+      mutation.publication.attempts++;
+      if (stage === "unobserved") {
+        await assert.rejects(
+          storage.mutate(mutation, () => true),
+          /frontier was not captured/
+        );
+      } else {
+        expect(await storage.mutate(mutation, () => true)).toBe("superseded");
+      }
+      expect(await storage.read()).toBeNull();
+      expect(
+        await fs.readFile(path.join(sessionDir, CONTINUOUS_COMPACTION_GENERATION_FILE))
+      ).toEqual(expected);
+    }
+  );
+
+  it("unobserved failures keep Stop debt blocking until a new explicit Stop captures a frontier", async () => {
+    spyOn(
+      h.historyService.getContinuousCompactionJournal(workspaceId),
+      "captureGenerationUnderHistoryLock"
+    ).mockRejectedValueOnce(new Error("generation read failed"));
+    await assert.rejects(state.cancel(), /generation read failed/);
+    const failed = (await state.read())!;
+    await foreign.getContinuousCompactionJournal(workspaceId).advanceGeneration();
+    await assert.rejects(state.retry(), /frontier was not captured/);
+    expect(state.needsPersistence).toBe(true);
+    expect(state.blocksRecovery).toBe(true);
+    expect(await state.read()).toEqual(failed);
+    expect(await storage.read()).toBeNull();
+    await assert.rejects(state.readForReplacement(), /frontier was not captured/);
+    expect(await state.cancel()).toBe("applied");
+    expect((await storage.read())?.nonce).not.toBe(failed.nonce);
+    expect(state.needsPersistence).toBe(false);
+  });
+
+  it("preserves the exact debt across failed unlink without deleting a later Stop", async () => {
+    await state.cancel();
+    const old = (await state.read())!;
+    const remove = nodeFs.rmSync;
+    let fail = true;
+    spyOn(nodeFs, "rmSync").mockImplementation((filePath, options) => {
+      if (filePath === storage.path && fail) {
+        fail = false;
+        throw new Error("unlink failed");
+      }
+      return remove(filePath, options);
+    });
+    await assert.rejects(state.retire(old.nonce), /unlink failed/);
+    expect(state.blocksRecovery).toBe(true);
+    expect(await storage.read()).toEqual(old);
+    const successor = new CompactionCancellation(
+      new FileCompactionCancellationStorage(foreign, workspaceId)
+    );
+    await successor.cancel();
+    expect(await state.retry()).toBe("superseded");
+    expect(await state.read()).toEqual(await successor.read());
+  });
+
+  it("retries a failed sidecar rename without losing its nonce or accepting a foreign frontier", async () => {
+    const rename = nodeFs.renameSync;
+    let fail = true;
+    spyOn(nodeFs, "renameSync").mockImplementation((source, destination) => {
+      if (destination === storage.path && fail) {
+        fail = false;
+        throw new Error("cancellation rename failed");
+      }
+      return rename(source, destination);
+    });
+    await assert.rejects(state.cancel(), /cancellation rename failed/);
+    const failed = (await state.read())!;
+    expect(state.blocksRecovery).toBe(true);
+    expect(await storage.read()).toBeNull();
+    expect(await state.retry()).toBe("applied");
+    expect(await storage.read()).toEqual(failed);
+  });
+
+  it("a locally superseded publication cannot rename its staged cancellation", async () => {
+    let current = true;
+    const journal = h.historyService.getContinuousCompactionJournal(workspaceId);
+    const advance = journal.advanceGenerationUnderHistoryLock.bind(journal);
+    spyOn(journal, "advanceGenerationUnderHistoryLock").mockImplementationOnce(
+      async (committed) => {
+        await advance(committed);
+        current = false;
+      }
+    );
+    expect(await storage.mutate(publication("stale"), () => current)).toBe("superseded");
+    expect(await storage.read()).toBeNull();
+    expect((await fs.readdir(sessionDir)).some((file) => file.includes(".continuous-"))).toBe(
+      false
+    );
+  });
+
+  it("Stop publishes even when real truncate recovery cannot read its marker", async () => {
+    await fs.mkdir(path.join(sessionDir, "chat-archive.jsonl.truncate.json"));
+    expect(
+      (
+        await h.historyService.appendToHistory(
+          workspaceId,
+          createMuxMessage("blocked", "user", "blocked")
+        )
+      ).success
+    ).toBe(false);
+    expect(await state.cancel()).toBe("applied");
+    expect(await storage.read()).not.toBeNull();
+  });
+
+  it.each(["{broken", JSON.stringify({ ...record("bad"), retainUntilReplacement: "unknown" })])(
+    "repairs malformed cancellation while preserving raw privacy floors (%s)",
+    async (bytes) => {
+      const summaryRow = createMuxMessage("summary", "assistant", "summary", {
+        muxMetadata: { type: "compaction-summary", pendingFollowUp: followUp() },
+      });
+      const rawFloor = Buffer.concat([
+        Buffer.from('{"metadata":{"contextBoundaryKind":"reset"},'),
+        Buffer.from([0xff]),
+        Buffer.from("\n"),
+      ]);
+      for (const file of ["chat-archive.jsonl", "chat.jsonl"]) {
+        await fs.writeFile(
+          path.join(sessionDir, file),
+          Buffer.concat([rawFloor, Buffer.from(JSON.stringify(summaryRow) + "\n")])
+        );
+      }
+      await fs.writeFile(storage.path, bytes);
+      const journal = h.historyService.getContinuousCompactionJournal(workspaceId);
+      const generation = await journal.captureGeneration();
+      expect(await state.read()).toBeNull();
+      expect(state.repairRevision).toBe(1);
+      expect(await journal.captureGeneration()).not.toBe(generation);
+      for (const file of ["chat-archive.jsonl", "chat.jsonl"]) {
+        const repaired = await fs.readFile(path.join(sessionDir, file));
+        expect(repaired.subarray(0, rawFloor.length)).toEqual(rawFloor);
+        expect(repaired.toString()).not.toContain('"pendingFollowUp"');
+      }
+      const history = await foreign.getHistoryFromLatestBoundary(workspaceId, 99);
+      assert(history.success);
+      expect(history.data.map((row) => row.id)).toEqual(["summary"]);
+    }
+  );
+
+  it("retains malformed cancellation across partial repair and neutralizes restored summaries on retry", async () => {
+    const summaryRow = createMuxMessage("restored", "assistant", "summary", {
+      muxMetadata: { type: "compaction-summary", pendingFollowUp: followUp() },
+    });
+    const archivePath = path.join(sessionDir, "chat-archive.jsonl");
+    expect((await h.historyService.writePartial(workspaceId, summaryRow)).success).toBe(true);
+    await fs.writeFile(`${archivePath}.truncate`, JSON.stringify(summaryRow) + "\n");
+    await fs.writeFile(`${archivePath}.truncate.json`, "malformed transaction");
+    await fs.writeFile(storage.path, "{bad cancellation");
+    const read = fs.readFile;
+    let fail = true;
+    spyOn(fs, "readFile").mockImplementation((async (...args: Parameters<typeof fs.readFile>) => {
+      if (args[0] === path.join(sessionDir, "chat.jsonl") && fail) {
+        fail = false;
+        throw new Error("active history read failed");
+      }
+      return read(...args);
+    }) as typeof fs.readFile);
+    await assert.rejects(state.read(), /active history read failed/);
+    expect(await fs.readFile(storage.path, "utf8")).toBe("{bad cancellation");
+    expect(await fs.readFile(archivePath, "utf8")).not.toContain('"pendingFollowUp"');
+    expect(state.repairRevision).toBe(0);
+    expect((await foreign.readPartial(workspaceId))?.metadata?.muxMetadata).toEqual({
+      type: "compaction-summary",
+    });
+    expect(await state.read()).toBeNull();
+    expect(state.repairRevision).toBe(1);
+    const history = await foreign.getLastMessages(workspaceId, 10);
+    assert(history.success);
+    expect(history.data[0]?.metadata?.muxMetadata).toEqual({ type: "compaction-summary" });
+  });
+
+  it("neutralizes the captured partial follow-up while preserving its recovery fields and eventual commit", async () => {
+    const partial = createMuxMessage("partial-summary", "assistant", "summary", {
+      historySequence: 1,
+      contextBoundaryKind: "reset",
+      muxMetadata: { type: "compaction-summary", pendingFollowUp: followUp() },
+    });
+    expect((await h.historyService.writePartial(workspaceId, partial)).success).toBe(true);
+    const before = (await foreign.readPartial(workspaceId))!;
+    await fs.writeFile(storage.path, "{broken cancellation");
+    expect(await state.read()).toBeNull();
+    expect(await foreign.readPartial(workspaceId)).toEqual({
+      ...before,
+      metadata: { ...before.metadata, muxMetadata: { type: "compaction-summary" } },
+    });
+    expect((await foreign.commitPartial(workspaceId)).success).toBe(true);
+    const history = await h.historyService.getLastMessages(workspaceId, 1);
+    assert(history.success);
+    expect(history.data[0]?.id).toBe(partial.id);
+    expect(history.data[0]?.metadata?.muxMetadata).toEqual({ type: "compaction-summary" });
+  });
+
+  it("a superseded partial repair leaves a queued foreign successor intact", async () => {
+    const old = createMuxMessage("old-partial", "assistant", "old", {
+      muxMetadata: { type: "compaction-summary", pendingFollowUp: followUp("old request") },
+    });
+    const successor = createMuxMessage("new-partial", "assistant", "new", {
+      muxMetadata: { type: "compaction-summary", pendingFollowUp: followUp("new request") },
+    });
+    expect((await h.historyService.writePartial(workspaceId, old)).success).toBe(true);
+    await fs.writeFile(storage.path, "{broken cancellation");
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const read = fs.readFile;
+    let held = false;
+    spyOn(fs, "readFile").mockImplementation((async (...args: Parameters<typeof fs.readFile>) => {
+      const result = await read(...args);
+      if (args[0] === path.join(sessionDir, "partial.json") && !held) {
+        held = true;
+        entered.resolve();
+        await release.promise;
+      }
+      return result;
+    }) as typeof fs.readFile);
+    let current = true;
+    const committed = mock(() => undefined);
+    const repairing = storage.repair(() => current, committed);
+    await entered.promise;
+    const writing = foreign.writePartial(workspaceId, successor);
+    current = false;
+    release.resolve();
+    expect(await repairing).toBeNull();
+    expect((await writing).success).toBe(true);
+    expect(await foreign.readPartial(workspaceId)).toMatchObject(successor);
+    expect(await fs.readFile(storage.path, "utf8")).toBe("{broken cancellation");
+    expect(committed).not.toHaveBeenCalled();
+  });
+
+  it.each(["JSON", "schema", "privacy", "I/O"])(
+    "retains cancellation on unsafe partial %s",
+    async (damage) => {
+      const partialPath = path.join(sessionDir, "partial.json");
+      const partial = createMuxMessage("partial", "assistant", "summary", {
+        muxMetadata: { type: "compaction-summary", pendingFollowUp: followUp() },
+      });
+      const contents =
+        damage === "JSON"
+          ? "{broken partial"
+          : damage === "schema"
+            ? JSON.stringify({ ...partial, parts: null })
+            : JSON.stringify(partial).replace(
+                '"metadata":',
+                '"metadata":{"contextBoundaryKind":"reset"},"metadata":'
+              );
+      if (damage === "I/O") await fs.mkdir(partialPath);
+      else await fs.writeFile(partialPath, contents);
+      await fs.writeFile(storage.path, "{broken cancellation");
+      await assert.rejects(state.read());
+      expect(await fs.readFile(storage.path, "utf8")).toBe("{broken cancellation");
+      expect(state.repairRevision).toBe(0);
+      if (damage !== "I/O") expect(await fs.readFile(partialPath, "utf8")).toBe(contents);
+    }
+  );
+
+  it("rereads valid successors under the repair lock and guards a repair superseded during I/O", async () => {
+    await fs.writeFile(storage.path, "{bad");
+    await assert.rejects(storage.read(), MalformedCompactionCancellationError);
+    const successor = new CompactionCancellation(
+      new FileCompactionCancellationStorage(foreign, workspaceId)
+    );
+    await successor.cancel({ retainUntilReplacement: true });
+    const committed = mock(() => undefined);
+    expect(await storage.repair(() => true, committed)).toEqual(await successor.read());
+    expect(committed).not.toHaveBeenCalled();
+
+    await fs.writeFile(storage.path, "{bad again");
+    let current = true;
+    const journal = h.historyService.getContinuousCompactionJournal(workspaceId);
+    const advance = journal.advanceGenerationUnderHistoryLock.bind(journal);
+    spyOn(journal, "advanceGenerationUnderHistoryLock").mockImplementationOnce(async () => {
+      await advance();
+      current = false;
+    });
+    expect(await storage.repair(() => current, committed)).toBeNull();
+    expect(await fs.readFile(storage.path, "utf8")).toBe("{bad again");
+    expect(committed).not.toHaveBeenCalled();
+  });
+
+  it.each(["damaged parts", "ambiguous reset"])(
+    "retains cancellation when clearing a %s summary would compromise repair safety",
+    async (damage) => {
+      const row = createMuxMessage("damaged", "assistant", "summary", {
+        muxMetadata: { type: "compaction-summary", pendingFollowUp: followUp() },
+      });
+      const raw =
+        damage === "damaged parts"
+          ? JSON.stringify({ ...row, parts: null })
+          : JSON.stringify(row).replace(
+              '"metadata":',
+              '"metadata":{"contextBoundaryKind":"reset"},"metadata":'
+            );
+      const chatPath = path.join(sessionDir, "chat.jsonl");
+      await fs.writeFile(chatPath, raw + "\n");
+      await fs.writeFile(storage.path, "{damaged cancellation");
+      await assert.rejects(state.read(), /Cannot safely neutralize/);
+      expect(await fs.readFile(chatPath, "utf8")).toBe(raw + "\n");
+      expect(await fs.readFile(storage.path, "utf8")).toBe("{damaged cancellation");
+      // Explicit intervention remains usable without dropping an unknown full-clear obligation.
+      expect(await state.readForReplacement()).toMatchObject({ retainUntilReplacement: true });
+    }
+  );
+
+  it("never resurrects a removed session through publication or repair", async () => {
+    await state.cancel();
+    await removeSessionDirUnderMemoryLocks({
+      rootDir: h.config.rootDir,
+      sessionDir,
+      workspaceId,
+      attemptId: "removal",
+    });
+    await assert.rejects(state.cancel(), /was removed/);
+    await assert.rejects(
+      storage.repair(
+        () => true,
+        () => assert.fail("removed")
+      ),
+      /was removed/
+    );
+    await assert.rejects(fs.stat(sessionDir), { code: "ENOENT" });
+  });
+});

--- a/src/node/services/compactionCancellation.test.ts
+++ b/src/node/services/compactionCancellation.test.ts
@@ -44,7 +44,7 @@ function harness() {
     repair: mock(
       (
         _isCurrent: () => boolean,
-        _onCommitted: () => void
+        _onCommitted: () => undefined
       ): Promise<CompactionCancellationRecord | null> => {
         return Promise.reject(new Error("Unexpected repair"));
       }

--- a/src/node/services/compactionCancellation.ts
+++ b/src/node/services/compactionCancellation.ts
@@ -134,7 +134,20 @@ export class FileCompactionCancellationStorage implements CompactionCancellation
   async read(): Promise<CompactionCancellationRecord | null> {
     let contents: string;
     try {
-      contents = await fs.readFile(this.path, "utf8");
+      const handle = await fs.open(this.path, "r");
+      try {
+        // Bound allocation even if the file grows; short reads do not imply EOF.
+        const buffer = Buffer.alloc(SESSION_HISTORY_MAX_LINE_BYTES + 1);
+        let count = 0;
+        while (count < buffer.length) {
+          const { bytesRead } = await handle.read(buffer, count, buffer.length - count, count);
+          if (bytesRead === 0) break;
+          count += bytesRead;
+        }
+        contents = buffer.toString("utf8", 0, count);
+      } finally {
+        await handle.close();
+      }
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
       throw error;

--- a/src/node/services/compactionCancellation.ts
+++ b/src/node/services/compactionCancellation.ts
@@ -4,8 +4,11 @@ import { promises as fs, rmSync } from "node:fs";
 import * as path from "node:path";
 import { z } from "zod";
 import { COMPACTION_CANCELLATION_FILE } from "@/constants/continuousCompaction";
+import { SESSION_HISTORY_MAX_LINE_BYTES } from "@/common/constants/contextBudget";
+import { isPlainObject } from "@/common/utils/isPlainObject";
 import type { HistoryService } from "./historyService";
 import { publishCompactionFile } from "./continuousCompactionJournal";
+import { hasAmbiguousResetKeys } from "./historyScanner";
 
 export interface CompactionCancellationSummary {
   id: string;
@@ -97,6 +100,18 @@ const CancellationRecordSchema = z.strictObject({
   ]),
 });
 
+function assertCancellationSize(contents: string): void {
+  if (Buffer.byteLength(contents, "utf8") > SESSION_HISTORY_MAX_LINE_BYTES)
+    throw new CompactionCancellationReadRefusedError("Cancellation record exceeds supported size");
+}
+
+function serializeCancellation(record: CompactionCancellationRecord) {
+  // JSON normalization must agree with both confirmation comparisons and commit receipts.
+  const contents = JSON.stringify(record);
+  assertCancellationSize(contents);
+  return { contents, record: CancellationRecordSchema.parse(JSON.parse(contents)) };
+}
+
 /** Inactive real adapter. H2b supplies accepted-row verification; H2c wires runtime consumers. */
 export class FileCompactionCancellationStorage implements CompactionCancellationStorage {
   readonly path: string;
@@ -124,9 +139,21 @@ export class FileCompactionCancellationStorage implements CompactionCancellation
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
       throw error;
     }
+    // The duplicate scanner's size ceiling must refuse inspection, never authorize repair.
+    assertCancellationSize(contents);
     try {
-      return CancellationRecordSchema.parse(JSON.parse(contents));
-    } catch {
+      const parsed: unknown = JSON.parse(contents);
+      if (
+        isPlainObject(parsed) &&
+        typeof parsed.version === "number" &&
+        Number.isInteger(parsed.version) &&
+        parsed.version > 1
+      )
+        throw new CompactionCancellationReadRefusedError("Unsupported cancellation record version");
+      if (hasAmbiguousResetKeys(contents)) throw new Error("Duplicate cancellation fields");
+      return CancellationRecordSchema.parse(parsed);
+    } catch (error) {
+      if (error instanceof CompactionCancellationReadRefusedError) throw error;
       // Do not include the bytes: pending requests can contain private user content.
       throw new MalformedCompactionCancellationError("Invalid compaction cancellation record");
     }
@@ -146,7 +173,8 @@ export class FileCompactionCancellationStorage implements CompactionCancellation
       )
         throw new Error("Cancellation frontier was not captured; a new Stop is required");
       const current = await this.read().catch((error: unknown) => {
-        if (mutation.kind !== "publish") throw error;
+        if (mutation.kind !== "publish" || error instanceof CompactionCancellationReadRefusedError)
+          throw error;
         // Explicit Stop may overwrite unreadable state, inheriting its unknown
         // full-clear obligation. Reads and automatic repair never gain this authority.
         return undefined;
@@ -167,6 +195,7 @@ export class FileCompactionCancellationStorage implements CompactionCancellation
         if (current === undefined || current?.retainUntilReplacement)
           mutation.record.retainUntilReplacement = true;
         if (!isCurrent()) return "superseded";
+        const { contents, record: committed } = serializeCancellation(mutation.record);
         // Record admission before advancing, and advancement at its commit point.
         // Unobserved failures remain blocking until a new explicit Stop captures a frontier.
         await journal.advanceGenerationUnderHistoryLock((advanced) => {
@@ -174,12 +203,12 @@ export class FileCompactionCancellationStorage implements CompactionCancellation
         }, checkLock);
         return (await publishCompactionFile(
           this.path,
-          JSON.stringify(mutation.record),
+          contents,
           isCurrent,
           () => {
-            frontier.nonce = mutation.record.nonce;
+            frontier.nonce = committed.nonce;
             // Install inherited retention before cleanup can admit a newer read.
-            onCommitted(mutation.record);
+            onCommitted(committed);
           },
           checkLock
         ))
@@ -190,8 +219,9 @@ export class FileCompactionCancellationStorage implements CompactionCancellation
       if (current?.nonce !== nonce) return "superseded";
       if (mutation.kind === "narrow") {
         if (current.retainUntilReplacement) return "superseded";
+        const { contents, record: committed } = serializeCancellation(mutation.record);
         if (current.scope.kind !== "unresolved") {
-          if (!isDeepStrictEqual(current, mutation.record)) return "superseded";
+          if (!isDeepStrictEqual(current, committed)) return "superseded";
           await checkLock();
           if (!isCurrent()) return "superseded";
           onCommitted(current);
@@ -199,9 +229,9 @@ export class FileCompactionCancellationStorage implements CompactionCancellation
         }
         return (await publishCompactionFile(
           this.path,
-          JSON.stringify(mutation.record),
+          contents,
           isCurrent,
-          () => onCommitted(mutation.record),
+          () => onCommitted(committed),
           checkLock
         ))
           ? "applied"

--- a/src/node/services/compactionCancellation.ts
+++ b/src/node/services/compactionCancellation.ts
@@ -74,10 +74,11 @@ export interface CompactionCancellationStorage {
    * Re-read under the lock; preserve newer valid records. Neutralize obsolete recovery
    * before removing malformed bytes, preserve privacy floors, and call onCommitted
    * synchronously when repair commits. Never repair an ordinary read/I/O failure.
+   * Returning undefined excludes async observers that could publish state too late.
    */
   repair(
     isCurrent: () => boolean,
-    onCommitted: () => void
+    onCommitted: () => undefined
   ): Promise<CompactionCancellationRecord | null>;
 }
 
@@ -208,7 +209,7 @@ export class FileCompactionCancellationStorage implements CompactionCancellation
 
   repair(
     isCurrent: () => boolean,
-    onCommitted: () => void
+    onCommitted: () => undefined
   ): Promise<CompactionCancellationRecord | null> {
     return this.history.withCompactionStorageLock(this.workspaceId, async () => {
       if (!isCurrent()) return null;

--- a/src/node/services/compactionCancellation.ts
+++ b/src/node/services/compactionCancellation.ts
@@ -136,7 +136,7 @@ export class FileCompactionCancellationStorage implements CompactionCancellation
     mutation: CompactionCancellationMutation,
     isCurrent: () => boolean
   ): Promise<CompactionCancellationMutationOutcome> {
-    return this.history.withCompactionStorageLock(this.workspaceId, async () => {
+    return this.history.withCompactionStorageLock(this.workspaceId, async (_dir, checkLock) => {
       if (!isCurrent()) return "superseded";
       if (
         mutation.kind === "publish" &&
@@ -170,14 +170,15 @@ export class FileCompactionCancellationStorage implements CompactionCancellation
         // Unobserved failures remain blocking until a new explicit Stop captures a frontier.
         await journal.advanceGenerationUnderHistoryLock((advanced) => {
           frontier.generation = advanced;
-        });
+        }, checkLock);
         return (await publishCompactionFile(
           this.path,
           JSON.stringify(mutation.record),
           isCurrent,
           () => {
             frontier.nonce = mutation.record.nonce;
-          }
+          },
+          checkLock
         ))
           ? "applied"
           : "superseded";
@@ -190,7 +191,13 @@ export class FileCompactionCancellationStorage implements CompactionCancellation
           return isCurrent() && isDeepStrictEqual(current, mutation.record)
             ? "applied"
             : "superseded";
-        return (await publishCompactionFile(this.path, JSON.stringify(mutation.record), isCurrent))
+        return (await publishCompactionFile(
+          this.path,
+          JSON.stringify(mutation.record),
+          isCurrent,
+          undefined,
+          checkLock
+        ))
           ? "applied"
           : "superseded";
       }
@@ -201,6 +208,7 @@ export class FileCompactionCancellationStorage implements CompactionCancellation
         if (witness.nonce !== nonce || !(await this.verifyReplacementUnderHistoryLock(witness)))
           throw new Error("Replacement witness was not verified");
       } else if (current.retainUntilReplacement) return "superseded";
+      await checkLock();
       if (!isCurrent()) return "superseded";
       rmSync(this.path, { force: true });
       return "applied";
@@ -211,7 +219,7 @@ export class FileCompactionCancellationStorage implements CompactionCancellation
     isCurrent: () => boolean,
     onCommitted: () => undefined
   ): Promise<CompactionCancellationRecord | null> {
-    return this.history.withCompactionStorageLock(this.workspaceId, async () => {
+    return this.history.withCompactionStorageLock(this.workspaceId, async (_dir, checkLock) => {
       if (!isCurrent()) return null;
       try {
         return await this.read();
@@ -221,15 +229,18 @@ export class FileCompactionCancellationStorage implements CompactionCancellation
       if (!isCurrent()) return null;
       await this.history
         .getContinuousCompactionJournal(this.workspaceId)
-        .advanceGenerationUnderHistoryLock();
+        .advanceGenerationUnderHistoryLock(undefined, checkLock);
       if (
         !(await this.history.neutralizeCompactionRecoveryUnderHistoryLock(
           this.workspaceId,
-          isCurrent
+          isCurrent,
+          checkLock
         )) ||
         !isCurrent()
       )
         return null;
+      await checkLock();
+      if (!isCurrent()) return null;
       // Keep malformed bytes until all obsolete recovery has been neutralized.
       // No await separates removal from the repair receipt or its final guard.
       rmSync(this.path, { force: true });

--- a/src/node/services/compactionCancellation.ts
+++ b/src/node/services/compactionCancellation.ts
@@ -1,5 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
+import { promises as fs, rmSync } from "node:fs";
+import * as path from "node:path";
+import { z } from "zod";
+import { COMPACTION_CANCELLATION_FILE } from "@/constants/continuousCompaction";
+import type { HistoryService } from "./historyService";
+import { publishCompactionFile } from "./continuousCompactionJournal";
 
 export interface CompactionCancellationSummary {
   id: string;
@@ -73,6 +79,163 @@ export interface CompactionCancellationStorage {
     isCurrent: () => boolean,
     onCommitted: () => void
   ): Promise<CompactionCancellationRecord | null>;
+}
+
+const CancellationRecordSchema = z.strictObject({
+  version: z.literal(1),
+  nonce: z.string().min(1),
+  retainUntilReplacement: z.boolean().optional(),
+  scope: z.discriminatedUnion("kind", [
+    z.strictObject({ kind: z.literal("unresolved") }),
+    z.strictObject({
+      kind: z.literal("summary"),
+      id: z.string().min(1),
+      sequence: z.number().int().nonnegative().optional(),
+      pendingFollowUp: z.record(z.string(), z.unknown()),
+    }),
+  ]),
+});
+
+/** Inactive real adapter. H2b supplies accepted-row verification; H2c wires runtime consumers. */
+export class FileCompactionCancellationStorage implements CompactionCancellationStorage {
+  readonly path: string;
+
+  constructor(
+    private readonly history: HistoryService,
+    private readonly workspaceId: string,
+    // This verifier runs under both history locks and must not re-enter them.
+    // No default authority: a caller-provided nonce alone cannot retire retention.
+    private readonly verifyReplacementUnderHistoryLock?: (
+      witness: CompactionCancellationReplacementWitness
+    ) => Promise<boolean>
+  ) {
+    this.path = path.join(
+      path.dirname(history.getContinuousCompactionJournal(workspaceId).path),
+      COMPACTION_CANCELLATION_FILE
+    );
+  }
+
+  async read(): Promise<CompactionCancellationRecord | null> {
+    let contents: string;
+    try {
+      contents = await fs.readFile(this.path, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw error;
+    }
+    try {
+      return CancellationRecordSchema.parse(JSON.parse(contents));
+    } catch {
+      // Do not include the bytes: pending requests can contain private user content.
+      throw new MalformedCompactionCancellationError("Invalid compaction cancellation record");
+    }
+  }
+
+  mutate(
+    mutation: CompactionCancellationMutation,
+    isCurrent: () => boolean
+  ): Promise<CompactionCancellationMutationOutcome> {
+    return this.history.withCompactionStorageLock(this.workspaceId, async () => {
+      if (!isCurrent()) return "superseded";
+      if (
+        mutation.kind === "publish" &&
+        mutation.publication.attempts > 1 &&
+        !mutation.publication.predecessor
+      )
+        throw new Error("Cancellation frontier was not captured; a new Stop is required");
+      const current = await this.read().catch((error: unknown) => {
+        if (mutation.kind !== "publish") throw error;
+        // Explicit Stop may overwrite unreadable state, inheriting its unknown
+        // full-clear obligation. Reads and automatic repair never gain this authority.
+        return undefined;
+      });
+      if (mutation.kind === "publish") {
+        const journal = this.history.getContinuousCompactionJournal(this.workspaceId);
+        const generation = await journal.captureGenerationUnderHistoryLock();
+        const nonce = current === undefined ? undefined : (current?.nonce ?? null);
+        const publication = mutation.publication;
+        if (
+          publication.attempts > 1 &&
+          (!publication.predecessor ||
+            publication.predecessor.nonce !== nonce ||
+            publication.predecessor.generation !== generation)
+        )
+          return "superseded";
+        const frontier = (publication.predecessor = { nonce, generation });
+        if (current === undefined || current?.retainUntilReplacement)
+          mutation.record.retainUntilReplacement = true;
+        if (!isCurrent()) return "superseded";
+        // Record admission before advancing, and advancement at its commit point.
+        // Unobserved failures remain blocking until a new explicit Stop captures a frontier.
+        await journal.advanceGenerationUnderHistoryLock((advanced) => {
+          frontier.generation = advanced;
+        });
+        return (await publishCompactionFile(
+          this.path,
+          JSON.stringify(mutation.record),
+          isCurrent,
+          () => {
+            frontier.nonce = mutation.record.nonce;
+          }
+        ))
+          ? "applied"
+          : "superseded";
+      }
+      const nonce = mutation.kind === "retire" ? mutation.nonce : mutation.record.nonce;
+      if (current?.nonce !== nonce) return "superseded";
+      if (mutation.kind === "narrow") {
+        if (current.retainUntilReplacement) return "superseded";
+        if (current.scope.kind !== "unresolved")
+          return isCurrent() && isDeepStrictEqual(current, mutation.record)
+            ? "applied"
+            : "superseded";
+        return (await publishCompactionFile(this.path, JSON.stringify(mutation.record), isCurrent))
+          ? "applied"
+          : "superseded";
+      }
+      const witness = mutation.replacementWitness;
+      if (witness) {
+        if (!this.verifyReplacementUnderHistoryLock)
+          throw new Error("Replacement witness verification is not configured");
+        if (witness.nonce !== nonce || !(await this.verifyReplacementUnderHistoryLock(witness)))
+          throw new Error("Replacement witness was not verified");
+      } else if (current.retainUntilReplacement) return "superseded";
+      if (!isCurrent()) return "superseded";
+      rmSync(this.path, { force: true });
+      return "applied";
+    });
+  }
+
+  repair(
+    isCurrent: () => boolean,
+    onCommitted: () => void
+  ): Promise<CompactionCancellationRecord | null> {
+    return this.history.withCompactionStorageLock(this.workspaceId, async () => {
+      if (!isCurrent()) return null;
+      try {
+        return await this.read();
+      } catch (error) {
+        if (!(error instanceof MalformedCompactionCancellationError)) throw error;
+      }
+      if (!isCurrent()) return null;
+      await this.history
+        .getContinuousCompactionJournal(this.workspaceId)
+        .advanceGenerationUnderHistoryLock();
+      if (
+        !(await this.history.neutralizeCompactionRecoveryUnderHistoryLock(
+          this.workspaceId,
+          isCurrent
+        )) ||
+        !isCurrent()
+      )
+        return null;
+      // Keep malformed bytes until all obsolete recovery has been neutralized.
+      // No await separates removal from the repair receipt or its final guard.
+      rmSync(this.path, { force: true });
+      onCommitted();
+      return null;
+    });
+  }
 }
 
 /**

--- a/src/node/services/compactionCancellation.ts
+++ b/src/node/services/compactionCancellation.ts
@@ -134,7 +134,8 @@ export class FileCompactionCancellationStorage implements CompactionCancellation
 
   mutate(
     mutation: CompactionCancellationMutation,
-    isCurrent: () => boolean
+    isCurrent: () => boolean,
+    onCommitted: (record: CompactionCancellationRecord | null) => undefined
   ): Promise<CompactionCancellationMutationOutcome> {
     return this.history.withCompactionStorageLock(this.workspaceId, async (_dir, checkLock) => {
       if (!isCurrent()) return "superseded";
@@ -177,6 +178,8 @@ export class FileCompactionCancellationStorage implements CompactionCancellation
           isCurrent,
           () => {
             frontier.nonce = mutation.record.nonce;
+            // Install inherited retention before cleanup can admit a newer read.
+            onCommitted(mutation.record);
           },
           checkLock
         ))
@@ -187,15 +190,18 @@ export class FileCompactionCancellationStorage implements CompactionCancellation
       if (current?.nonce !== nonce) return "superseded";
       if (mutation.kind === "narrow") {
         if (current.retainUntilReplacement) return "superseded";
-        if (current.scope.kind !== "unresolved")
-          return isCurrent() && isDeepStrictEqual(current, mutation.record)
-            ? "applied"
-            : "superseded";
+        if (current.scope.kind !== "unresolved") {
+          if (!isDeepStrictEqual(current, mutation.record)) return "superseded";
+          await checkLock();
+          if (!isCurrent()) return "superseded";
+          onCommitted(current);
+          return "applied";
+        }
         return (await publishCompactionFile(
           this.path,
           JSON.stringify(mutation.record),
           isCurrent,
-          undefined,
+          () => onCommitted(mutation.record),
           checkLock
         ))
           ? "applied"
@@ -211,6 +217,7 @@ export class FileCompactionCancellationStorage implements CompactionCancellation
       await checkLock();
       if (!isCurrent()) return "superseded";
       rmSync(this.path, { force: true });
+      onCommitted(null);
       return "applied";
     });
   }

--- a/src/node/services/continuousCompactionJournal.ts
+++ b/src/node/services/continuousCompactionJournal.ts
@@ -155,7 +155,7 @@ export class ContinuousCompactionJournalStore {
 
   /** Caller already holds the history lock; never re-enter the journal queue here. */
   async advanceGenerationUnderHistoryLock(
-    onCommitted?: (generation: string) => void
+    onCommitted?: (generation: string) => undefined
   ): Promise<void> {
     const generation = randomUUID();
     await publishCompactionFile(

--- a/src/node/services/continuousCompactionJournal.ts
+++ b/src/node/services/continuousCompactionJournal.ts
@@ -94,11 +94,14 @@ export async function publishCompactionFile(
   filePath: string,
   contents: string | Buffer,
   isCurrent: () => boolean,
-  onCommitted?: () => void
+  onCommitted?: () => void,
+  assertStillOwned?: () => Promise<void>
 ): Promise<boolean> {
   const stagedPath = `${filePath}.continuous-${randomUUID()}`;
   try {
     await writeFileAtomic(stagedPath, contents, { mode: 0o600 });
+    // Staging can outlive the lock lease; check ownership after that final I/O.
+    if (assertStillOwned) await assertStillOwned();
     if (!isCurrent()) return false;
     renameSync(stagedPath, filePath);
     try {
@@ -155,7 +158,8 @@ export class ContinuousCompactionJournalStore {
 
   /** Caller already holds the history lock; never re-enter the journal queue here. */
   async advanceGenerationUnderHistoryLock(
-    onCommitted?: (generation: string) => undefined
+    onCommitted?: (generation: string) => undefined,
+    assertStillOwned?: () => Promise<void>
   ): Promise<void> {
     const generation = randomUUID();
     await publishCompactionFile(
@@ -164,7 +168,8 @@ export class ContinuousCompactionJournalStore {
       () => true,
       // The cancellation retry must learn its exact frontier at rename, before
       // cleanup or lock release can fail or admit a foreign generation.
-      () => onCommitted?.(createHash("sha256").update(generation).digest("hex"))
+      () => onCommitted?.(createHash("sha256").update(generation).digest("hex")),
+      assertStillOwned
     );
   }
 

--- a/src/node/services/continuousCompactionJournal.ts
+++ b/src/node/services/continuousCompactionJournal.ts
@@ -154,11 +154,17 @@ export class ContinuousCompactionJournalStore {
   }
 
   /** Caller already holds the history lock; never re-enter the journal queue here. */
-  async advanceGenerationUnderHistoryLock(): Promise<void> {
-    await writeFileAtomic(
+  async advanceGenerationUnderHistoryLock(
+    onCommitted?: (generation: string) => void
+  ): Promise<void> {
+    const generation = randomUUID();
+    await publishCompactionFile(
       path.join(path.dirname(this.path), CONTINUOUS_COMPACTION_GENERATION_FILE),
-      randomUUID(),
-      { mode: 0o600 }
+      generation,
+      () => true,
+      // The cancellation retry must learn its exact frontier at rename, before
+      // cleanup or lock release can fail or admit a foreign generation.
+      () => onCommitted?.(createHash("sha256").update(generation).digest("hex"))
     );
   }
 

--- a/src/node/services/historyAppendProvenance.test.ts
+++ b/src/node/services/historyAppendProvenance.test.ts
@@ -424,13 +424,15 @@ if (!result.success) throw new Error(result.error);
   });
 
   test("an atomic rollover batch published before a rename error remains accepted once", async () => {
+    // write-file-atomic resolves symlinked temp roots before renaming an existing file.
+    const chatPath = await fs.realpath(store.chatPath);
     const rename = nodeFs.rename;
     let publishedRenames = 0;
     const failed = spyOn(nodeFs, "rename").mockImplementation(
       Object.assign(
         (...[source, target, callback]: Parameters<typeof nodeFs.rename>) => {
           rename(source, target, (error) => {
-            if (!error && target === store.chatPath) {
+            if (!error && target === chatPath) {
               publishedRenames++;
               callback(new Error("post-rename error"));
             } else callback(error);

--- a/src/node/services/historyAppendProvenance.ts
+++ b/src/node/services/historyAppendProvenance.ts
@@ -129,7 +129,10 @@ export class HistoryAppendProvenance {
     }
   }
 
-  private async publish(receipt: HistoryAppendReceipt): Promise<void> {
+  private async publish(
+    receipt: HistoryAppendReceipt,
+    assertStillOwned?: () => Promise<void>
+  ): Promise<void> {
     const bytes = Buffer.from(JSON.stringify(receipt));
     assert(
       bytes.length <= HISTORY_PROVENANCE_MAX_RECEIPT_BYTES,
@@ -145,6 +148,7 @@ export class HistoryAppendProvenance {
         await handle.close();
       }
       // Rename replaces a destination symlink rather than following it.
+      if (assertStillOwned) await assertStillOwned();
       await fs.rename(temporary, this.receiptPath);
       await this.syncDirectory();
     } finally {
@@ -188,7 +192,10 @@ export class HistoryAppendProvenance {
     return current.bytesRead;
   }
 
-  async runMutation<T>(operation: () => Promise<T>): Promise<T> {
+  async runMutation<T>(
+    operation: () => Promise<T>,
+    assertStillOwned?: () => Promise<void>
+  ): Promise<T> {
     assert(
       transactions.getStore()?.active !== true,
       "history provenance transactions must not nest"
@@ -199,10 +206,11 @@ export class HistoryAppendProvenance {
     const epoch = matched ? receipt.epoch : randomUUID();
     let tracking = true;
     try {
-      await this.publish({ version: 1, epoch, state: "pending", files: initial });
+      await this.publish({ version: 1, epoch, state: "pending", files: initial }, assertStillOwned);
     } catch (error) {
       // No mutation may begin while an old stable receipt remains trusted.
       // Deletion is the fallback; if that too fails, abort BEFORE the operation.
+      if (assertStillOwned) await assertStillOwned();
       await fs.rm(this.receiptPath, { force: true });
       await this.syncDirectory();
       tracking = false;
@@ -227,7 +235,10 @@ export class HistoryAppendProvenance {
           const files = await this.stamps();
           const stableEpoch =
             transaction.certified && sameStamps(files, transaction.expected) ? epoch : randomUUID();
-          await this.publish({ version: 1, epoch: stableEpoch, state: "stable", files });
+          await this.publish(
+            { version: 1, epoch: stableEpoch, state: "stable", files },
+            assertStillOwned
+          );
         } catch (error) {
           log.warn("Failed to finalize history append receipt", { error });
         }

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -352,15 +352,16 @@ export class HistoryService {
   /** Inactive sidecar seam: Stop must remain publishable when transcript recovery fails. */
   withCompactionStorageLock<T>(
     workspaceId: string,
-    operation: (sessionDir: string) => Promise<T>
+    operation: (sessionDir: string, assertStillOwned: () => Promise<void>) => Promise<T>
   ): Promise<T> {
     return this.fileLocks.withLock(workspaceId, () =>
-      this.withHistoryWriteFileLock(workspaceId, async () => {
+      this.withHistoryWriteFileLock(workspaceId, async (assertStillOwned) => {
         if (await isWorkspaceRemovalTombstoned(this.config.rootDir, workspaceId))
           throw new Error(`workspace ${workspaceId} was removed; refusing compaction mutation`);
         const sessionDir = this.getSessionDir(workspaceId);
+        await assertStillOwned();
         await ensurePrivateDir(sessionDir);
-        return operation(sessionDir);
+        return operation(sessionDir, assertStillOwned);
       })
     );
   }
@@ -368,13 +369,14 @@ export class HistoryService {
   /** Caller holds both history locks and has already fenced obsolete journal publication. */
   async neutralizeCompactionRecoveryUnderHistoryLock(
     workspaceId: string,
-    isCurrent: () => boolean
+    isCurrent: () => boolean,
+    assertStillOwned: () => Promise<void>
   ): Promise<boolean> {
     if (!isCurrent()) return false;
     return this.getAppendProvenance(workspaceId).runMutation(async () => {
       if (!isCurrent()) return false;
       invalidateHistoryAppendProvenance();
-      await this.recoverTruncateTransactionUnlocked(workspaceId);
+      await this.recoverTruncateTransactionUnlocked(workspaceId, assertStillOwned);
       const clearFollowUp = (row: MuxMessage): MuxMessage => {
         const metadata = row.metadata?.muxMetadata;
         if (!isCompactionSummaryMetadata(metadata) || metadata.pendingFollowUp === undefined)
@@ -403,7 +405,13 @@ export class HistoryService {
         const cleared = clearFollowUp(partial);
         if (
           cleared !== partial &&
-          !(await publishCompactionFile(partialPath, JSON.stringify(cleared), isCurrent))
+          !(await publishCompactionFile(
+            partialPath,
+            JSON.stringify(cleared),
+            isCurrent,
+            undefined,
+            assertStillOwned
+          ))
         )
           return false;
       }
@@ -435,10 +443,14 @@ export class HistoryService {
           changed ||= cleared !== row;
           return cleared;
         });
-        if (changed && !(await publishCompactionFile(filePath, contents, isCurrent))) return false;
+        if (
+          changed &&
+          !(await publishCompactionFile(filePath, contents, isCurrent, undefined, assertStillOwned))
+        )
+          return false;
       }
       return isCurrent();
-    });
+    }, assertStillOwned);
   }
 
   async getSubagentTranscript(
@@ -785,7 +797,10 @@ export class HistoryService {
     );
   }
 
-  private async recoverTruncateTransactionUnlocked(workspaceId: string): Promise<boolean> {
+  private async recoverTruncateTransactionUnlocked(
+    workspaceId: string,
+    assertStillOwned?: () => Promise<void>
+  ): Promise<boolean> {
     const archivePath = this.getChatArchivePath(workspaceId);
     const archiveTombstonePath = `${archivePath}.truncate`;
     const tombstoneExists = await fs.stat(archiveTombstonePath).then(
@@ -804,6 +819,7 @@ export class HistoryService {
         return false;
       }
       const archiveExists = (await this.readExistingFileBytes(archivePath)) !== null;
+      if (assertStillOwned) await assertStillOwned();
       if (archiveExists) {
         await fs.rm(archiveTombstonePath);
       } else {
@@ -814,6 +830,7 @@ export class HistoryService {
 
     const marker = this.parseTruncateTransaction(markerContents);
     if (!tombstoneExists) {
+      if (assertStillOwned) await assertStillOwned();
       await fs.rm(markerPath, { force: true });
       if (marker === null) {
         return false;
@@ -849,14 +866,19 @@ export class HistoryService {
           marker.rawHashes?.finalChatHash
         );
       if (committed) {
+        if (assertStillOwned) await assertStillOwned();
         await fs.rm(archiveTombstonePath);
+        if (assertStillOwned) await assertStillOwned();
         await fs.rm(markerPath, { force: true });
         return true;
       }
     }
 
+    if (assertStillOwned) await assertStillOwned();
     await fs.rm(archivePath, { force: true });
+    if (assertStillOwned) await assertStillOwned();
     await fs.rename(archiveTombstonePath, archivePath);
+    if (assertStillOwned) await assertStillOwned();
     await fs.rm(markerPath, { force: true });
     return false;
   }
@@ -2723,14 +2745,14 @@ export class HistoryService {
   /** Bare cross-process history file lock; see withCrossProcessWriteLock. */
   private async withHistoryWriteFileLock<T>(
     workspaceId: string,
-    operation: () => Promise<T>
+    operation: (assertStillOwned: () => Promise<void>) => Promise<T>
   ): Promise<T> {
     await using _lock = await acquireProcessFileLock({
       lockPath: historyWriteLockPath(this.config.rootDir, workspaceId),
       timeoutMs: HISTORY_WRITE_LOCK_TIMEOUT_MS,
       label: "history write lock",
     });
-    return await operation();
+    return await operation(() => _lock.assertStillOwned());
   }
 
   /**

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -349,6 +349,98 @@ export class HistoryService {
       : path.join(this.config.sessionsDir, workspaceId);
   }
 
+  /** Inactive sidecar seam: Stop must remain publishable when transcript recovery fails. */
+  withCompactionStorageLock<T>(
+    workspaceId: string,
+    operation: (sessionDir: string) => Promise<T>
+  ): Promise<T> {
+    return this.fileLocks.withLock(workspaceId, () =>
+      this.withHistoryWriteFileLock(workspaceId, async () => {
+        if (await isWorkspaceRemovalTombstoned(this.config.rootDir, workspaceId))
+          throw new Error(`workspace ${workspaceId} was removed; refusing compaction mutation`);
+        const sessionDir = this.getSessionDir(workspaceId);
+        await ensurePrivateDir(sessionDir);
+        return operation(sessionDir);
+      })
+    );
+  }
+
+  /** Caller holds both history locks and has already fenced obsolete journal publication. */
+  async neutralizeCompactionRecoveryUnderHistoryLock(
+    workspaceId: string,
+    isCurrent: () => boolean
+  ): Promise<boolean> {
+    if (!isCurrent()) return false;
+    return this.getAppendProvenance(workspaceId).runMutation(async () => {
+      if (!isCurrent()) return false;
+      invalidateHistoryAppendProvenance();
+      await this.recoverTruncateTransactionUnlocked(workspaceId);
+      const clearFollowUp = (row: MuxMessage): MuxMessage => {
+        const metadata = row.metadata?.muxMetadata;
+        if (!isCompactionSummaryMetadata(metadata) || metadata.pendingFollowUp === undefined)
+          return row;
+        const { pendingFollowUp: _followUp, ...rest } = metadata;
+        return { ...row, metadata: { ...row.metadata, muxMetadata: rest } };
+      };
+      // A partial summary can later be committed into history. Capture it under
+      // the same locks as partial writers and preserve its other recovery fields.
+      const partialPath = this.getPartialPath(workspaceId);
+      const partialBytes = await this.readExistingFileBytes(partialPath);
+      if (partialBytes !== null) {
+        const text = partialBytes.toString("utf8");
+        let partial: MuxMessage | null;
+        try {
+          partial = this.normalizeTranscriptMessage(JSON.parse(text));
+        } catch {
+          throw new Error("Cannot safely neutralize malformed partial summary");
+        }
+        if (
+          !isReadableHistoryMessage(partial) ||
+          !Buffer.from(text).equals(partialBytes) ||
+          (hasRawResetMarker(text) && hasAmbiguousResetKeys(text))
+        )
+          throw new Error("Cannot safely neutralize malformed partial summary");
+        const cleared = clearFollowUp(partial);
+        if (
+          cleared !== partial &&
+          !(await publishCompactionFile(partialPath, JSON.stringify(cleared), isCurrent))
+        )
+          return false;
+      }
+      // Repair every recoverable epoch, including summaries restored by truncate
+      // recovery. Raw rewrite helpers retain malformed/ambiguous privacy floors.
+      for (const filePath of [
+        this.getChatArchivePath(workspaceId),
+        this.getChatHistoryPath(workspaceId),
+      ]) {
+        if (!isCurrent()) return false;
+        const { rows } = await this.readHistoryForRewrite(filePath);
+        for (const row of rows) {
+          if (row.message) continue;
+          let damaged: MuxMessage | null;
+          try {
+            damaged = this.normalizeTranscriptMessage(JSON.parse(row.raw.toString("utf8")));
+          } catch {
+            continue;
+          }
+          const metadata = damaged?.metadata?.muxMetadata;
+          // Legacy recovery reads more permissively than rewrite. Keep the
+          // cancellation fence if clearing that intent could erase a raw floor.
+          if (isCompactionSummaryMetadata(metadata) && metadata.pendingFollowUp !== undefined)
+            throw new Error("Cannot safely neutralize malformed compaction summary");
+        }
+        let changed = false;
+        const contents = this.serializeHistoryRewrite(rows, workspaceId, (row) => {
+          const cleared = clearFollowUp(row);
+          changed ||= cleared !== row;
+          return cleared;
+        });
+        if (changed && !(await publishCompactionFile(filePath, contents, isCurrent))) return false;
+      }
+      return isCurrent();
+    });
+  }
+
   async getSubagentTranscript(
     input: { taskId: string; requestingWorkspaceId?: string | null },
     dependencies: SubagentTranscriptDependencies

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -361,7 +361,18 @@ export class HistoryService {
         const sessionDir = this.getSessionDir(workspaceId);
         await assertStillOwned();
         await ensurePrivateDir(sessionDir);
-        return operation(sessionDir, assertStillOwned);
+        const result = await operation(sessionDir, assertStillOwned);
+        // The receipt tracks visible bytes; success clears debt only after directory sync.
+        // Match append provenance's platform policy: Windows cannot sync directory handles.
+        if (process.platform !== "win32") {
+          const directory = await fs.open(sessionDir, "r");
+          try {
+            await directory.sync();
+          } finally {
+            await directory.close();
+          }
+        }
+        return result;
       })
     );
   }


### PR DESCRIPTION
Add the filesystem adapter for #4140's inactive cancellation core. Compare exact nonces and generation frontiers under local and shared history locks. Recheck lease ownership before every mutation so a displaced writer cannot publish, remove state, or repair history after takeover.

The adapter reports the exact JSON-normalized committed record, including inherited retention, synchronously before cleanup or lock release. Publication, narrowing, idempotent confirmation, and retirement all implement the parent's receipt contract. Directory sync completes before successful storage settlement; failure retains the visible receipt and persistence debt for retry. A later cleanup failure cannot undo that receipt or overwrite a newer accepted read.

Malformed cancellation repair fences publication and neutralizes authoritative recovery intent while preserving raw privacy floors. Duplicate-key detection reuses the existing scanner. Reads allocate and consume at most the existing size limit plus one byte through a descriptor that always closes. Future-version and oversized records explicitly refuse repair and replacement, preserving their bytes. Ordinary I/O failures remain visible. Retained cancellation can be retired only through an injected verifier for a durably accepted replacement; the adapter has no default witness authority.

This is the fixed top of phase stack #4140 → #4146. The adapter remains inactive, and both PRs will be queued together after current Codex approval, resolved findings, and passing CI.

Validation: 252 affected tests and full static checks pass. Eleven deterministic displaced-lease cases and four paused cleanup/lock-release cases fail against the respective unpatched implementations and pass with the fixes. Real HistoryService cases also cover short reads and bounded allocation, duplicate fields, future-version/oversize preservation, canonical receipts, and directory-sync failure/retry; all 77 parent core cases are included. Independent review approved the combined fixes. Nix formatting was skipped because Nix is unavailable.

---

_Generated with `xum` • Model: `unavailable` • Thinking: `unavailable` • Cost: `$unavailable`_

<!-- mux-attribution: model=unavailable thinking=unavailable costs=unavailable -->
