### PR TITLE
🤖 fix: fence stale compaction publications after history deletion

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -400,7 +400,8 @@ jobs:
         timeout-minutes: 10
       - name: Run tests
         if: matrix.os == 'linux'
-        run: xvfb-run -a make test-e2e
+        # Native focus and clipboard are shared by every Electron app on this display.
+        run: xvfb-run -a make test-e2e PLAYWRIGHT_ARGS="--workers=1"
         env:
           ELECTRON_DISABLE_SANDBOX: 1
       - name: Run tests

--- a/src/common/utils/messages/compactionBoundary.test.ts
+++ b/src/common/utils/messages/compactionBoundary.test.ts
@@ -146,26 +146,6 @@ describe("findLatestCompactionBoundaryIndex", () => {
 });
 
 describe("context boundary helpers", () => {
-  it("opts into reasoning eligibility without admitting rejected or reset rows", () => {
-    const reasoning = createMuxMessage("reasoning", "assistant", "");
-    reasoning.parts = [{ type: "reasoning", text: "Provider reasoning" }];
-    expect(hasProviderEligibleMessages([reasoning])).toBe(false);
-    expect(hasProviderEligibleMessages([reasoning], { preserveReasoningOnly: true })).toBe(true);
-    for (const metadata of [
-      { contextBudgetRejected: true },
-      { contextBoundaryKind: "reset" as const },
-    ]) {
-      expect(
-        hasProviderEligibleMessages([{ ...reasoning, metadata }], { preserveReasoningOnly: true })
-      ).toBe(false);
-    }
-    expect(
-      hasProviderEligibleMessages([createMuxMessage("empty", "assistant", "")], {
-        preserveReasoningOnly: true,
-      })
-    ).toBe(false);
-  });
-
   it("recognizes context reset boundaries as latest context boundary", () => {
     const messages = [
       createMuxMessage("u0", "user", "before"),

--- a/src/common/utils/messages/compactionBoundary.test.ts
+++ b/src/common/utils/messages/compactionBoundary.test.ts
@@ -146,6 +146,26 @@ describe("findLatestCompactionBoundaryIndex", () => {
 });
 
 describe("context boundary helpers", () => {
+  it("opts into reasoning eligibility without admitting rejected or reset rows", () => {
+    const reasoning = createMuxMessage("reasoning", "assistant", "");
+    reasoning.parts = [{ type: "reasoning", text: "Provider reasoning" }];
+    expect(hasProviderEligibleMessages([reasoning])).toBe(false);
+    expect(hasProviderEligibleMessages([reasoning], { preserveReasoningOnly: true })).toBe(true);
+    for (const metadata of [
+      { contextBudgetRejected: true },
+      { contextBoundaryKind: "reset" as const },
+    ]) {
+      expect(
+        hasProviderEligibleMessages([{ ...reasoning, metadata }], { preserveReasoningOnly: true })
+      ).toBe(false);
+    }
+    expect(
+      hasProviderEligibleMessages([createMuxMessage("empty", "assistant", "")], {
+        preserveReasoningOnly: true,
+      })
+    ).toBe(false);
+  });
+
   it("recognizes context reset boundaries as latest context boundary", () => {
     const messages = [
       createMuxMessage("u0", "user", "before"),

--- a/src/node/services/compactionPendingState.test.ts
+++ b/src/node/services/compactionPendingState.test.ts
@@ -434,6 +434,8 @@ describe("unactivated compaction pending-file protocol", () => {
         .getContinuousCompactionJournal(workspaceId)
         .captureGeneration();
       const b = await prepare("b");
+      const historyPath = path.join(h.config.sessionsDir, workspaceId, CHAT_FILE_NAME);
+      const beforeHeartbeat = await fs.readFile(historyPath);
       expect(
         (
           await h.historyService.appendToHistory(
@@ -446,10 +448,10 @@ describe("unactivated compaction pending-file protocol", () => {
           )
         ).success
       ).toBe(true);
-      // The ordered fixture supplies an already-completed deletion; the real adapter's
-      // exact-delete proof is tested separately. A later boundary cannot revoke that fact.
-      const deleted = await h.historyService.deleteMessage(workspaceId, "b");
-      expect(deleted.success).toBe(true);
+      // Model an already-completed exact rollback with real history bytes. Generic deletion
+      // advances the generation and would hide the same-generation boundary regression here;
+      // production activation owns the exact rollback transaction and its proof.
+      await fs.writeFile(historyPath, beforeHeartbeat);
       const foreign = new HistoryService(h.config);
       if (replacement === "unreadable-reset") boundaryOverride = { kind: "unreadable-reset" };
       if (replacement === "identified") {
@@ -471,7 +473,7 @@ describe("unactivated compaction pending-file protocol", () => {
       );
       const expected = replacement === "none" ? ["/legacy.ts"] : undefined;
       expect((await restart().load(() => true))?.attachments.readFiles).toEqual(expected);
-      expect(await store.rollback(b, () => deleted.success)).toBe(true);
+      expect(await store.rollback(b, () => true)).toBe(true);
       expect((await restart().load(() => true))?.attachments.readFiles).toEqual(expected);
     }
   );

--- a/src/node/services/historyScanner.ts
+++ b/src/node/services/historyScanner.ts
@@ -178,6 +178,19 @@ function classifyHistoryScanRow(text: string, probe: HistoryResetProbe): MuxMess
   }
 }
 
+/** Use the provider reader's probe when rewrites join previously separated unreadable rows. */
+export function hasUnreadableHistoryResetEvidence(rows: readonly Buffer[]): boolean {
+  const probe: HistoryResetProbe = { resetProbe: "", resetStage: 0, possibleReset: false };
+  for (let i = rows.length - 1; i >= 0; i--) {
+    const raw = rows[i].at(-1) === 10 ? rows[i].subarray(0, -1) : rows[i];
+    addHistoryResetProbe(probe, raw, true);
+    if (raw.length <= SESSION_HISTORY_MAX_LINE_BYTES)
+      classifyHistoryScanRow(raw.toString("utf8"), probe);
+    if (probe.possibleReset) return true;
+  }
+  return false;
+}
+
 function historyFileStamp(
   stat: { dev: number; ino: number; size: number; mtimeMs: number; ctimeMs: number } | undefined
 ): string {

--- a/src/node/services/historyScanner.ts
+++ b/src/node/services/historyScanner.ts
@@ -205,7 +205,8 @@ type ProviderHistoryStart =
 async function findProviderHistoryStart(
   handle: fs.FileHandle,
   fileSize: number,
-  skip: number
+  skip: number,
+  includeReadableResetFloor: boolean
 ): Promise<ProviderHistoryStart> {
   const probe: HistoryResetProbe = { resetProbe: "", resetStage: 0, possibleReset: false };
   let parts: Buffer[] = [];
@@ -234,7 +235,8 @@ async function findProviderHistoryStart(
     const durableBoundary = message !== null && isDurableContextBoundaryMarker(message);
     if (isManualHistoryReset(message, probe.possibleReset)) {
       // Retain readable reset markers, but never count them as skippable boundaries.
-      if (durableBoundary) return start;
+      // Deletion also needs readable malformed-role floors that provider requests exclude.
+      if (durableBoundary || (includeReadableResetFloor && message)) return start;
       // A fragmented marker may end several rows to the right of the key that
       // completed recognition. Never return any of that unreadable evidence.
       return unreadableRunEnd ?? rowEnd;
@@ -279,7 +281,8 @@ async function findProviderHistoryStart(
 async function readHistoryProjectionFromLatestBoundary<Row>(
   paths: Record<HistoryArtifact, string>,
   skip: number,
-  project: (value: unknown) => Row | null
+  project: (value: unknown) => Row | null,
+  includeReadableResetFloor = false
 ): Promise<Row[]> {
   assert(Number.isSafeInteger(skip) && skip >= 0, "provider boundary skip must be non-negative");
   const files = new Map<HistoryArtifact, { handle: fs.FileHandle; size: number; stamp: string }>();
@@ -303,7 +306,7 @@ async function readHistoryProjectionFromLatestBoundary<Row>(
     ): Promise<ProviderHistoryStart> => {
       const file = files.get(artifact);
       return file
-        ? findProviderHistoryStart(file.handle, file.size, skipCount)
+        ? findProviderHistoryStart(file.handle, file.size, skipCount, includeReadableResetFloor)
         : Promise.resolve({ kind: "exhausted", oldestBoundary: null, boundaryCount: 0 });
     };
     const readTail = async (artifact: HistoryArtifact, offset: number): Promise<Row[]> => {
@@ -361,10 +364,17 @@ async function readHistoryProjectionFromLatestBoundary<Row>(
 
 export function readProviderHistoryFromLatestBoundary(
   paths: Record<HistoryArtifact, string>,
-  skip: number
+  skip: number,
+  options?: {
+    /** Mutation classification needs the excluded floor itself; provider requests leave this off. */
+    includeReadableResetFloor?: boolean;
+  }
 ): Promise<MuxMessage[]> {
-  return readHistoryProjectionFromLatestBoundary(paths, skip, (value) =>
-    isReadableHistoryMessage(value) ? normalizeLegacyMuxMetadata(value) : null
+  return readHistoryProjectionFromLatestBoundary(
+    paths,
+    skip,
+    (value) => (isReadableHistoryMessage(value) ? normalizeLegacyMuxMetadata(value) : null),
+    options?.includeReadableResetFloor
   );
 }
 

--- a/src/node/services/historyService.test.ts
+++ b/src/node/services/historyService.test.ts
@@ -1212,6 +1212,78 @@ describe("HistoryService", () => {
     );
 
     it.each(
+      ["oversized", "ambiguous"].flatMap((variant) =>
+        [false, true].flatMap((keepTargetMessage) =>
+          ["protected", "readable", "archive"].map((targetKind) => ({
+            variant,
+            keepTargetMessage,
+            targetKind,
+          }))
+        )
+      )
+    )(
+      "truncation keeps protected active identity ($variant, $targetKind, keep=$keepTargetMessage)",
+      async ({ variant, keepTargetMessage, targetKind }) => {
+        const target = row("target");
+        const floor = {
+          ...createMuxMessage(
+            targetKind === "archive" ? "other-protected" : target.id,
+            "assistant",
+            "",
+            variant === "oversized" ? { contextBoundaryKind: CONTEXT_BOUNDARY_KINDS.RESET } : {}
+          ),
+          ...(variant === "oversized" && { padding: "x".repeat(SESSION_HISTORY_MAX_LINE_BYTES) }),
+        };
+        const placeholder = createMuxMessage(target.id, "assistant", "");
+        const fresh = row("fresh");
+        const archive = [row("archive-before"), target, row("archive-after")];
+        const activeTail = [...(targetKind === "readable" ? [placeholder] : []), fresh];
+        const { chatPath, archivePath, bytes } = await seedDeletionHistory(archive, [
+          floor,
+          ...activeTail,
+        ]);
+        // Preserve duplicate metadata keys as raw evidence; parsing alone loses the reset.
+        const floorLine = messageLine(ws, floor) + "\n";
+        const rawFloor = Buffer.from(
+          variant === "ambiguous"
+            ? floorLine.replace(
+                '"metadata":',
+                '"metadata":{"contextBoundaryKind":"reset"},"metadata":'
+              )
+            : floorLine
+        );
+        await fs.writeFile(chatPath, Buffer.concat([rawFloor, bytes(activeTail)]));
+        const beforeChat = await fs.readFile(chatPath);
+        const beforeArchive = await fs.readFile(archivePath);
+        const { store, receipt } = await capturePublication();
+        const result = await service.truncateAfterMessage(ws, target.id, { keepTargetMessage });
+
+        expect(result.success).toBe(targetKind !== "protected");
+        if (targetKind === "protected") {
+          expect(await fs.readFile(chatPath)).toEqual(beforeChat);
+          expect(await fs.readFile(archivePath)).toEqual(beforeArchive);
+          expect(await store.captureGeneration()).toBe(receipt.publicationGeneration);
+          expect(await store.read()).toEqual(receipt);
+        } else {
+          const retainedArchive =
+            targetKind === "archive" ? archive.slice(0, keepTargetMessage ? 2 : 1) : [];
+          const retainedActive =
+            targetKind === "readable" && keepTargetMessage ? [placeholder] : [];
+          expect(await fs.readFile(chatPath)).toEqual(
+            Buffer.concat([bytes(retainedArchive), rawFloor, bytes(retainedActive)])
+          );
+          if (targetKind === "archive") {
+            const archiveStat = await fs.stat(archivePath).catch((error: unknown) => error);
+            expect(archiveStat).toMatchObject({ code: "ENOENT" });
+          } else {
+            expect(await fs.readFile(archivePath)).toEqual(beforeArchive);
+          }
+          expect(await store.captureGeneration()).not.toBe(receipt.publicationGeneration);
+        }
+      }
+    );
+
+    it.each(
       ["single", "batch", "archive"].flatMap((method) => [0, 1].map((extra) => ({ method, extra })))
     )(
       "$method deletion counts JSON bytes without the LF at the reset limit (+$extra)",

--- a/src/node/services/historyService.test.ts
+++ b/src/node/services/historyService.test.ts
@@ -1112,6 +1112,106 @@ describe("HistoryService", () => {
     }
 
     it.each(
+      ["user", "system"].flatMap((role) =>
+        ["single", "batch", "archive"].flatMap((method) =>
+          [
+            { newerFloor: "none", tail: false },
+            { newerFloor: "none", tail: true },
+            { newerFloor: "boundary", tail: true },
+            { newerFloor: "raw reset", tail: true },
+          ].map((scenario) => ({ role, method, ...scenario }))
+        )
+      )
+    )(
+      "$method deletion fences a readable $role reset floor (newer: $newerFloor, tail: $tail)",
+      async ({ role, method, newerFloor, tail }) => {
+        assert(role === "user" || role === "system");
+        const floor: MuxMessage = { ...reset(), role };
+        const source = [row("old"), floor];
+        const suffix = [
+          ...(newerFloor === "boundary" ? [boundary()] : []),
+          ...(tail ? [row("fresh")] : []),
+        ];
+        const { chatPath, archivePath, bytes } = await seedDeletionHistory(
+          method === "archive" ? source : [],
+          [...(method === "archive" ? [] : source), ...suffix]
+        );
+        if (newerFloor === "raw reset") {
+          await fs.writeFile(
+            chatPath,
+            Buffer.concat([
+              bytes(method === "archive" ? [] : source),
+              Buffer.from('{"metadata":{"contextBoundaryKind":"reset"}\n'),
+              bytes(suffix),
+            ])
+          );
+        }
+        const before = await service.getHistoryFromLatestBoundary(ws);
+        assert(before.success);
+        expect(before.data.map((message) => message.id)).toEqual(
+          suffix.map((message) => message.id)
+        );
+        const { store, receipt } = await capturePublication();
+        const untouchedPath = method === "archive" ? chatPath : archivePath;
+        const untouched = await fs.readFile(untouchedPath);
+        const result =
+          method === "batch"
+            ? await service.deleteMessages(ws, [floor.id])
+            : await service.deleteMessage(ws, floor.id);
+        expect(result.success).toBe(true);
+        expect(await fs.readFile(untouchedPath)).toEqual(untouched);
+        const after = await service.getHistoryFromLatestBoundary(ws);
+        assert(after.success);
+        expect(after.data.map((message) => message.id)).toEqual([
+          ...(newerFloor === "none" ? ["old"] : []),
+          ...suffix.map((message) => message.id),
+        ]);
+        const changed = newerFloor === "none";
+        expect((await store.captureGeneration()) !== receipt.publicationGeneration).toBe(changed);
+        const foreign = new HistoryService(config).getContinuousCompactionJournal(ws);
+        expect(
+          (await foreign.recordFallbackPrefix(
+            receipt,
+            { modelString: "anthropic:next", prefix },
+            () => true
+          )) !== null
+        ).toBe(!changed);
+      }
+    );
+
+    it.each(
+      ["contiguous", "token-separated"].flatMap((variant) =>
+        [false, true].map((readableDuplicate) => ({ variant, readableDuplicate }))
+      )
+    )(
+      "single deletion preserves an active protected $variant reset ID shared with archive (readable duplicate: $readableDuplicate)",
+      async ({ variant, readableDuplicate }) => {
+        const floor = {
+          ...(variant === "contiguous" ? reset() : createMuxMessage("reset", "assistant", "")),
+          contextBoundaryKind: 0,
+          padding: "x".repeat(SESSION_HISTORY_MAX_LINE_BYTES),
+          candidate: "reset",
+        };
+        const placeholder = createMuxMessage(floor.id, "assistant", "");
+        const fresh = row("fresh");
+        const { chatPath, archivePath, bytes } = await seedDeletionHistory(
+          [row(floor.id)],
+          [floor, ...(readableDuplicate ? [placeholder] : []), fresh]
+        );
+        const beforeChat = await fs.readFile(chatPath);
+        const beforeArchive = await fs.readFile(archivePath);
+        const { store, receipt } = await capturePublication();
+        expect((await service.deleteMessage(ws, floor.id)).success).toBe(readableDuplicate);
+        expect(await fs.readFile(chatPath)).toEqual(
+          readableDuplicate ? bytes([floor, fresh]) : beforeChat
+        );
+        expect(await fs.readFile(archivePath)).toEqual(beforeArchive);
+        expect(await store.captureGeneration()).toBe(receipt.publicationGeneration);
+        expect(await store.read()).toEqual(receipt);
+      }
+    );
+
+    it.each(
       ["single", "batch", "archive"].flatMap((method) => [0, 1].map((extra) => ({ method, extra })))
     )(
       "$method deletion counts JSON bytes without the LF at the reset limit (+$extra)",

--- a/src/node/services/historyService.test.ts
+++ b/src/node/services/historyService.test.ts
@@ -1,6 +1,8 @@
 import * as path from "path";
 import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { CONTEXT_BOUNDARY_KINDS } from "@/common/constants/contextBoundary";
+import { SESSION_HISTORY_MAX_LINE_BYTES } from "@/common/constants/contextBudget";
+import { CONTINUOUS_COMPACTION_GENERATION_FILE } from "@/constants/continuousCompaction";
 import { HistoryService } from "./historyService";
 import type { Config } from "@/node/config";
 import { createTestHistoryService } from "./testHistoryService";
@@ -11,7 +13,9 @@ import { createMuxMessage, type MuxMessage } from "@/common/types/message";
 import assert from "node:assert";
 import { createHash } from "node:crypto";
 import * as fs from "fs/promises";
+import * as atomicWrite from "write-file-atomic";
 import * as fileLock from "@/node/utils/concurrency/fileLock";
+import { workspaceFileLocks } from "@/node/utils/concurrency/workspaceFileLocks";
 import {
   historyWriteLockPath,
   workspaceRemovalTombstonePath,
@@ -1075,7 +1079,337 @@ describe("HistoryService", () => {
       return { store, receipt };
     }
 
+    async function deleteErroredPlaceholder(messageId: string) {
+      const history = await service.getHistoryFromLatestBoundary(ws);
+      assert(history.success);
+      const message = history.data.find((entry) => entry.id === messageId);
+      assert(message);
+      assert(
+        (
+          await service.writePartial(ws, {
+            ...message,
+            parts: [],
+            metadata: { ...message.metadata, error: "stream failed" },
+          })
+        ).success
+      );
+      return service.commitPartial(ws, messageId);
+    }
+
+    async function seedDeletionHistory(archive: MuxMessage[], chat: MuxMessage[]) {
+      assert((await service.appendManyToHistory(ws, [...archive, ...chat])).success);
+      // Complete lazy rotation, then model legacy layouts where the archive
+      // still contributes provider context, or chat retains sealed duplicates.
+      assert((await service.getHistoryFromLatestBoundary(ws)).success);
+      const chatPath = path.join(config.sessionsDir, ws, "chat.jsonl");
+      const archivePath = path.join(config.sessionsDir, ws, "chat-archive.jsonl");
+      const bytes = (messages: MuxMessage[]) =>
+        Buffer.from(messages.map((message) => messageLine(ws, message) + "\n").join(""));
+      await fs.writeFile(chatPath, bytes(chat));
+      await fs.writeFile(archivePath, bytes(archive));
+      return { chatPath, archivePath, bytes };
+    }
+
+    it.each(
+      [
+        {
+          name: "empty placeholder",
+          archive: [],
+          chat: [createMuxMessage("target", "assistant", "")],
+          changed: false,
+        },
+        {
+          name: "display-only row",
+          archive: [],
+          chat: [{ ...display(), id: "target" }],
+          changed: false,
+        },
+        {
+          name: "sealed active row",
+          archive: [],
+          chat: [row("target"), boundary()],
+          changed: false,
+        },
+        {
+          name: "sealed active boundary",
+          archive: [],
+          chat: [{ ...reset(), id: "target" }, boundary()],
+          changed: false,
+        },
+        {
+          name: "sealed archive row",
+          archive: [row("target")],
+          chat: [boundary()],
+          changed: false,
+        },
+        {
+          name: "sealed archive boundary",
+          archive: [{ ...boundary(), id: "target" }],
+          chat: [reset()],
+          changed: false,
+        },
+        {
+          name: "active-first duplicate",
+          archive: [row("target")],
+          chat: [createMuxMessage("target", "assistant", ""), row("later")],
+          changed: false,
+        },
+        {
+          name: "duplicate active occurrences",
+          archive: [],
+          chat: [row("target"), boundary(), row("target"), row("later")],
+          changed: true,
+        },
+        {
+          name: "duplicate archive context",
+          archive: [row("target"), row("target")],
+          chat: [row("later")],
+          changed: true,
+        },
+        {
+          name: "archive duplicate sealed content",
+          archive: [row("target"), boundary(), createMuxMessage("target", "assistant", "")],
+          chat: [row("later")],
+          changed: false,
+        },
+        ...[reset(), reset(true), { ...boundary(), parts: [] }].map((message, index) => ({
+          name: `archive boundary ${index}`,
+          archive: [row("old"), { ...message, id: "target" }],
+          chat: [row("later")],
+          changed: true,
+        })),
+        {
+          name: "oversized reset evidence",
+          archive: [],
+          chat: [
+            row("old"),
+            { ...reset(), id: "target", padding: " ".repeat(SESSION_HISTORY_MAX_LINE_BYTES) },
+          ],
+          changed: false,
+          refused: true,
+        },
+      ].flatMap((testCase) =>
+        ["single", "batch"].map((method) => ({ refused: false, ...testCase, method }))
+      )
+    )(
+      "$method deletion classifies $name by removed occurrences",
+      async ({ archive, chat, changed, method, refused }) => {
+        const { chatPath, archivePath } = await seedDeletionHistory(
+          structuredClone(archive),
+          structuredClone(chat)
+        );
+        const beforeChat = await fs.readFile(chatPath);
+        const beforeArchive = await fs.readFile(archivePath);
+        const { store, receipt } = await capturePublication();
+        const inChat = chat.some((message) => message.id === "target");
+        const admitted = !refused && (method === "single" || inChat);
+        const advance = spyOn(store, "advanceGenerationUnderHistoryLock");
+        try {
+          const result =
+            method === "single"
+              ? await service.deleteMessage(ws, "target")
+              : await service.deleteMessages(ws, ["target"]);
+          expect(result).toMatchObject({ success: admitted });
+          expect(advance).toHaveBeenCalledTimes(admitted && changed ? 1 : 0);
+          if (!admitted) {
+            expect(await fs.readFile(chatPath)).toEqual(beforeChat);
+            expect(await fs.readFile(archivePath)).toEqual(beforeArchive);
+          } else {
+            // Active-first deletion must retain archive duplicates verbatim.
+            expect(await fs.readFile(inChat ? archivePath : chatPath)).toEqual(
+              inChat ? beforeArchive : beforeChat
+            );
+            const retained = await collectFullHistory(service, ws);
+            expect(retained.filter((message) => message.id === "target")).toHaveLength(
+              inChat ? archive.filter((message) => message.id === "target").length : 0
+            );
+          }
+          if (admitted && changed) {
+            expect(await store.captureGeneration()).not.toBe(receipt.publicationGeneration);
+            expect(await store.read()).toBeNull();
+          } else {
+            expect(await store.captureGeneration()).toBe(receipt.publicationGeneration);
+            expect(
+              await store.recordFallbackPrefix(
+                receipt,
+                { modelString: "anthropic:next", prefix },
+                () => true
+              )
+            ).not.toBeNull();
+          }
+        } finally {
+          advance.mockRestore();
+        }
+      }
+    );
+
+    it.each([
+      "single missing",
+      "batch missing",
+      "batch refused",
+      "duplicate batch IDs",
+      "partial placeholder",
+    ])("%s deletion leaves generation and unrelated history unchanged", async (method) => {
+      const { chatPath, archivePath } = await seedDeletionHistory(
+        [],
+        [row("target"), createMuxMessage("empty", "assistant", "")]
+      );
+      const before = await fs.readFile(chatPath);
+      const { store, receipt } = await capturePublication();
+      if (method === "duplicate batch IDs") {
+        expect(
+          await service.deleteMessages(ws, ["target", "target"]).catch((error: unknown) => error)
+        ).toBeInstanceOf(Error);
+      } else {
+        const result =
+          method === "partial placeholder"
+            ? await deleteErroredPlaceholder("empty")
+            : method === "single missing"
+              ? await service.deleteMessage(ws, "missing")
+              : await service.deleteMessages(
+                  ws,
+                  method === "batch refused" ? ["target", "missing"] : ["missing"]
+                );
+        expect(result.success).toBe(method === "partial placeholder");
+      }
+      if (method !== "partial placeholder") expect(await fs.readFile(chatPath)).toEqual(before);
+      expect(await fs.readFile(archivePath)).toEqual(Buffer.alloc(0));
+      expect(await store.captureGeneration()).toBe(receipt.publicationGeneration);
+      expect(await store.read()).toEqual(receipt);
+    });
+
+    it.each(
+      ["chat", "archive"].flatMap((artifact) =>
+        ["single", "batch"].flatMap((method) =>
+          [false, true].map((active) => ({ artifact, method, active }))
+        )
+      )
+    )(
+      "$method deletion preserves raw floors in $artifact (active cut: $active)",
+      async ({ artifact, method, active }) => {
+        const old = row("target");
+        const fresh = row(active ? "target" : "fresh");
+        const { chatPath, archivePath, bytes } = await seedDeletionHistory(
+          artifact === "archive" ? [old, fresh] : [],
+          artifact === "chat" ? [old, fresh] : [row("tail")]
+        );
+        const raw = Buffer.concat([
+          Buffer.from(' {\n"contextBoundaryKind"\n:\n"reset"\n'),
+          Buffer.from([0xff]),
+          Buffer.from("\n}\n"),
+        ]);
+        const targetPath = artifact === "chat" ? chatPath : archivePath;
+        await fs.writeFile(targetPath, Buffer.concat([bytes([old]), raw, bytes([fresh])]));
+        const { store, receipt } = await capturePublication();
+        const result =
+          method === "single"
+            ? await service.deleteMessage(ws, "target")
+            : await service.deleteMessages(ws, ["target"]);
+        const admitted = method === "single" || artifact === "chat";
+        expect(result.success).toBe(admitted);
+        expect(await fs.readFile(targetPath)).toEqual(
+          Buffer.concat([
+            ...(admitted ? [] : [bytes([old])]),
+            raw,
+            ...(admitted && active ? [] : [bytes([fresh])]),
+          ])
+        );
+        expect((await store.captureGeneration()) !== receipt.publicationGeneration).toBe(
+          admitted && active
+        );
+        const provider = await service.getHistoryFromLatestBoundary(ws);
+        assert(provider.success);
+        expect(provider.data.map((message) => message.id)).toEqual([
+          ...(admitted && active ? [] : [fresh.id]),
+          ...(artifact === "archive" ? ["tail"] : []),
+        ]);
+      }
+    );
+
+    it.each(
+      ["single", "batch", "archive", "partial"].flatMap((method) =>
+        ["generation", "history"].map((stage) => ({ method, stage }))
+      )
+    )(
+      "$method deletion handles a $stage write failure without changing history or counters",
+      async ({ method, stage }) => {
+        const target = method === "partial" ? reset() : row("target");
+        const { chatPath, archivePath } = await seedDeletionHistory(
+          method === "archive" ? [target] : [],
+          method === "archive" ? [] : [target]
+        );
+        const beforeChat = await fs.readFile(chatPath);
+        const beforeArchive = await fs.readFile(archivePath);
+        const { store, receipt } = await capturePublication();
+        const counters = service as unknown as { sequenceCounters: Map<string, number> };
+        const counter = counters.sequenceCounters.get(ws);
+        const failedPath =
+          stage === "generation"
+            ? path.join(config.sessionsDir, ws, CONTINUOUS_COMPACTION_GENERATION_FILE)
+            : method === "archive"
+              ? archivePath
+              : chatPath;
+        const atomic = atomicWrite.default;
+        const failure = spyOn(atomicWrite, "default").mockImplementation(
+          new Proxy(atomic, {
+            apply(target, _thisArg, args: Parameters<typeof atomic>) {
+              if (args[0] === failedPath) return Promise.reject(new Error("disk unavailable"));
+              return target(...args);
+            },
+          })
+        );
+        try {
+          const result =
+            method === "partial"
+              ? await deleteErroredPlaceholder(target.id)
+              : method === "batch"
+                ? await service.deleteMessages(ws, [target.id])
+                : await service.deleteMessage(ws, target.id);
+          expect(result.success).toBe(false);
+          expect(await fs.readFile(chatPath)).toEqual(beforeChat);
+          expect(await fs.readFile(archivePath)).toEqual(beforeArchive);
+          expect(counters.sequenceCounters.get(ws)).toBe(counter);
+          expect((await store.captureGeneration()) !== receipt.publicationGeneration).toBe(
+            stage === "history"
+          );
+          expect(await store.read()).toEqual(stage === "history" ? null : receipt);
+          if (method === "partial") expect(await service.readPartial(ws)).not.toBeNull();
+        } finally {
+          failure.mockRestore();
+        }
+      }
+    );
+
     const destructiveCases = [
+      {
+        name: "single provider-row deletion",
+        rows: [row("old"), row("tail")],
+        mutate: () => service.deleteMessage(ws, "old"),
+        expected: ["tail"],
+      },
+      {
+        name: "batch provider-row deletion",
+        rows: [row("old"), row("tail"), row("later")],
+        mutate: () => service.deleteMessages(ws, ["old", "tail"]),
+        expected: ["later"],
+      },
+      ...[
+        { name: "reset", message: reset() },
+        { name: "rollover", message: reset(true) },
+        { name: "empty compaction", message: { ...boundary(), parts: [] } },
+      ].flatMap(({ name, message }) =>
+        ["single", "batch", "partial"].map((method) => ({
+          name: `${method} deletion of ${name} boundary`,
+          rows: [row("old"), message],
+          mutate: () =>
+            method === "partial"
+              ? deleteErroredPlaceholder(message.id)
+              : method === "batch"
+                ? service.deleteMessages(ws, [message.id])
+                : service.deleteMessage(ws, message.id),
+          expected: ["old"],
+        }))
+      ),
       ...[false, true].flatMap((rollover) =>
         [false, true].map((batch) => ({
           name: `${rollover ? "rollover" : "reset"} ${batch ? "batch" : "single"}`,
@@ -1257,14 +1591,23 @@ describe("HistoryService", () => {
       }
     );
 
-    it("holds the history file lock from generation advancement through deletion", async () => {
-      assert((await service.appendToHistory(ws, row("old"))).success);
+    it.each(
+      ["clear", "single", "batch", "partial", "archive"].flatMap((method) =>
+        ["initial", "fallback", "boundary"].map((publication) => ({ method, publication }))
+      )
+    )("$method deletion fences foreign $publication", async (testCase) => {
+      const { method, publication } = testCase;
+      const target = method === "partial" ? reset() : row("old");
+      const { chatPath, archivePath } = await seedDeletionHistory(
+        method === "archive" ? [target] : [],
+        method === "archive" ? [] : [target]
+      );
       const store = service.getContinuousCompactionJournal(ws);
       // Exercise an existing durable generation too, rather than only legacy absence.
       await store.advanceGeneration();
       const { receipt } = await capturePublication();
-      await store.clear(receipt);
-      const historyPath = path.join(config.sessionsDir, ws, "chat.jsonl");
+      if (publication === "initial") await store.clear(receipt);
+      const historyPath = method === "archive" ? archivePath : chatPath;
       const before = await fs.readFile(historyPath, "utf8");
       const entered = Promise.withResolvers<void>();
       const release = Promise.withResolvers<void>();
@@ -1277,36 +1620,82 @@ describe("HistoryService", () => {
           await release.promise;
         }
       );
-      const clearing = service.clearHistory(ws);
-      const foreign = new HistoryService(config).getContinuousCompactionJournal(ws);
+      const deleting =
+        method === "clear"
+          ? service.clearHistory(ws)
+          : method === "partial"
+            ? deleteErroredPlaceholder(target.id)
+            : method === "batch"
+              ? service.deleteMessages(ws, [target.id])
+              : service.deleteMessage(ws, target.id);
+      const foreignHistory = new HistoryService(config);
+      const foreign = foreignHistory.getContinuousCompactionJournal(ws);
+      const publish = async (candidate: ContinuousCompactionJournal) => {
+        if (publication === "boundary")
+          return (
+            await foreignHistory.persistBoundaryWithTailCopies(
+              ws,
+              structuredClone(candidate.boundary),
+              [],
+              false,
+              () => true,
+              {
+                publication: { generation: candidate.publicationGeneration, journal: candidate },
+                onCommitted: () => undefined,
+              }
+            )
+          ).success;
+        return (
+          (publication === "fallback"
+            ? await foreign.recordFallbackPrefix(
+                candidate,
+                { modelString: "anthropic:next", prefix },
+                () => true
+              )
+            : await foreign.write(candidate, prefix, () => true)) !== null
+        );
+      };
       const capture = spyOn(foreign, "captureGenerationUnderHistoryLock");
       const acquire = fileLock.acquireProcessFileLock;
       const attempted = Promise.withResolvers<void>();
       let acquiring:
         | ReturnType<typeof spyOn<typeof fileLock, "acquireProcessFileLock">>
         | undefined;
-      let writing: ReturnType<typeof foreign.write> | undefined;
+      let writing: Promise<boolean> | undefined;
+      const queued = spyOn(workspaceFileLocks, "withLock");
       try {
         await entered.promise;
         acquiring = spyOn(fileLock, "acquireProcessFileLock").mockImplementation((options) => {
           attempted.resolve();
           return acquire(options);
         });
-        writing = foreign.write(receipt, prefix, () => true);
-        await attempted.promise;
+        writing = publish(receipt);
+        // Boundary writes first queue on the shared in-process mutex; journal
+        // publications go straight to the same cross-process history lock.
+        if (publication === "boundary") expect(queued).toHaveBeenCalled();
+        else await attempted.promise;
         expect(capture).not.toHaveBeenCalled();
         expect(await fs.readFile(historyPath, "utf8")).toBe(before);
         release.resolve();
-        expect((await clearing).success).toBe(true);
-        expect(await writing).toBeNull();
+        expect((await deleting).success).toBe(true);
+        expect(await writing).toBe(false);
         expect(await foreign.captureGeneration()).not.toBe(receipt.publicationGeneration);
         expect(await collectFullHistory(new HistoryService(config), ws)).toEqual([]);
+        expect(await foreign.read()).toBeNull();
+        const fresh = await foreign.write(
+          { ...receipt, publicationGeneration: await foreign.captureGeneration() },
+          prefix,
+          () => true
+        );
+        assert(fresh);
+        if (publication !== "initial") expect(await publish(fresh)).toBe(true);
       } finally {
         release.resolve();
-        await Promise.all([clearing, writing]);
+        await Promise.all([deleting, writing]);
         acquiring?.mockRestore();
         capture.mockRestore();
         advancing.mockRestore();
+        queued.mockRestore();
       }
     });
 

--- a/src/node/services/historyService.test.ts
+++ b/src/node/services/historyService.test.ts
@@ -1831,10 +1831,19 @@ describe("HistoryService", () => {
               ? archivePath
               : chatPath;
         const atomic = atomicWrite.default;
+        let injected = false;
         const failure = spyOn(atomicWrite, "default").mockImplementation(
           new Proxy(atomic, {
             apply(target, _thisArg, args: Parameters<typeof atomic>) {
-              if (args[0] === failedPath) return Promise.reject(new Error("disk unavailable"));
+              // Generation publication writes a staging sibling before renaming it into place.
+              const matches =
+                stage === "generation"
+                  ? typeof args[0] === "string" && args[0].startsWith(`${failedPath}.continuous-`)
+                  : args[0] === failedPath;
+              if (matches) {
+                injected = true;
+                return Promise.reject(new Error("disk unavailable"));
+              }
               return target(...args);
             },
           })
@@ -1846,6 +1855,7 @@ describe("HistoryService", () => {
               : method === "batch"
                 ? await service.deleteMessages(ws, [target.id])
                 : await service.deleteMessage(ws, target.id);
+          expect(injected).toBe(true);
           expect(result.success).toBe(false);
           expect(await fs.readFile(chatPath)).toEqual(beforeChat);
           expect(await fs.readFile(archivePath)).toEqual(beforeArchive);

--- a/src/node/services/historyService.test.ts
+++ b/src/node/services/historyService.test.ts
@@ -1326,6 +1326,122 @@ describe("HistoryService", () => {
       }
     );
 
+    it.each([
+      ...["single", "batch", "partial", "archive"].map((method) => ({ method, variant: "new" })),
+      ...[
+        "retained boundary",
+        "existing reset",
+        "retained separator",
+        "missing token",
+        "escaped junk",
+      ].map((variant) => ({ method: "single", variant })),
+    ])(
+      "$method deletion classifies joining malformed fragments ($variant)",
+      async ({ method, variant }) => {
+        const old = row("old");
+        const separator = createMuxMessage("separator", "assistant", "");
+        const fresh = row("fresh");
+        const retained =
+          variant === "retained separator" ? [createMuxMessage("retained", "assistant", "")] : [];
+        const suffix = variant === "retained boundary" ? [boundary()] : [];
+        const source = [old, separator, ...retained, fresh, ...suffix];
+        const { chatPath, archivePath, bytes } = await seedDeletionHistory(
+          method === "archive" ? source : [],
+          method === "archive" ? [] : source
+        );
+        const targetPath = method === "archive" ? archivePath : chatPath;
+        const left = Buffer.from(
+          variant === "existing reset"
+            ? '{"metadata":{"contextBoundaryKind":"reset"},broken\n'
+            : '{"metadata":{"contextBoundaryKind"\n'
+        );
+        const right =
+          variant === "escaped junk"
+            ? Buffer.concat([
+                Buffer.from("?junk"),
+                Buffer.from([0xff]),
+                Buffer.from(':"res\\u0065t"}}\n'),
+              ])
+            : Buffer.from(variant === "missing token" ? ':"other"}}\n' : ':"reset"}}\n');
+        const tail = Buffer.concat([bytes(retained), right, bytes([fresh, ...suffix])]);
+        await fs.writeFile(
+          targetPath,
+          Buffer.concat([bytes([old]), left, bytes([separator]), tail])
+        );
+        const before = await service.getHistoryFromLatestBoundary(ws);
+        assert(before.success);
+        expect(before.data.map((message) => message.id)).toEqual(
+          variant === "retained boundary"
+            ? ["sealed"]
+            : [
+                ...(variant === "existing reset" ? [] : ["old"]),
+                "separator",
+                ...retained.map((message) => message.id),
+                "fresh",
+              ]
+        );
+        const { store, receipt } = await capturePublication();
+        const result =
+          method === "partial"
+            ? await deleteErroredPlaceholder("separator")
+            : method === "batch"
+              ? await service.deleteMessages(ws, ["separator"])
+              : await service.deleteMessage(ws, "separator");
+        expect(result.success).toBe(true);
+        expect(await fs.readFile(targetPath)).toEqual(Buffer.concat([bytes([old]), left, tail]));
+        const after = await service.getHistoryFromLatestBoundary(ws);
+        assert(after.success);
+        const fenced = variant === "new" || variant === "escaped junk";
+        expect(after.data.map((message) => message.id)).toEqual(
+          variant === "retained boundary"
+            ? ["sealed"]
+            : [
+                ...(fenced || variant === "existing reset" ? [] : ["old"]),
+                ...retained.map((message) => message.id),
+                "fresh",
+              ]
+        );
+        expect((await store.captureGeneration()) !== receipt.publicationGeneration).toBe(fenced);
+        if (!fenced) {
+          expect(await store.read()).toEqual(receipt);
+          return;
+        }
+        const foreignHistory = new HistoryService(config);
+        const foreign = foreignHistory.getContinuousCompactionJournal(ws);
+        expect(
+          await foreign.recordFallbackPrefix(
+            receipt,
+            { modelString: "anthropic:next", prefix },
+            () => true
+          )
+        ).toBeNull();
+        expect(
+          (
+            await foreignHistory.persistBoundaryWithTailCopies(
+              ws,
+              structuredClone(receipt.boundary),
+              [],
+              false,
+              () => true,
+              {
+                publication: { generation: receipt.publicationGeneration, journal: receipt },
+                onCommitted: () => undefined,
+              }
+            )
+          ).success
+        ).toBe(false);
+        expect(await foreign.read()).toBeNull();
+        expect(await foreign.write(receipt, prefix, () => true)).toBeNull();
+        expect(
+          await foreign.write(
+            { ...receipt, publicationGeneration: await foreign.captureGeneration() },
+            prefix,
+            () => true
+          )
+        ).not.toBeNull();
+      }
+    );
+
     it.each(
       ["single", "batch", "archive", "partial"].flatMap((method) =>
         ["generation", "history"].map((stage) => ({ method, stage }))

--- a/src/node/services/historyService.test.ts
+++ b/src/node/services/historyService.test.ts
@@ -6,6 +6,7 @@ import { CONTINUOUS_COMPACTION_GENERATION_FILE } from "@/constants/continuousCom
 import { HistoryService } from "./historyService";
 import type { Config } from "@/node/config";
 import { createTestHistoryService } from "./testHistoryService";
+import { prepareProviderRequestMessages } from "./turnContextAssembler";
 import type { ContinuousCompactionJournal } from "@/common/orpc/schemas/continuousCompaction";
 import { createContextBudgetRejectedMessage } from "@/common/utils/messages/contextBudgetRejection";
 import { updateSubagentTranscriptArtifactsFile } from "./subagentTranscriptArtifacts";
@@ -1037,7 +1038,7 @@ describe("HistoryService", () => {
       return service.rejectContextBudgetRequest(ws, latest.data[0]);
     }
 
-    async function capturePublication() {
+    async function capturePublication(effectiveThinkingLevel: "off" | "high" = "off") {
       const store = service.getContinuousCompactionJournal(ws);
       const journal: ContinuousCompactionJournal = {
         version: 1,
@@ -1058,7 +1059,7 @@ describe("HistoryService", () => {
         preparation: {
           modelString: "anthropic:claude-sonnet-4-5",
           providerForMessages: "anthropic",
-          effectiveThinkingLevel: "off",
+          effectiveThinkingLevel,
           effectiveAgentId: "exec",
           toolNamesForSentinel: [],
         },
@@ -1111,6 +1112,153 @@ describe("HistoryService", () => {
     }
 
     it.each(
+      ["single", "batch", "archive"].flatMap((method) => [0, 1].map((extra) => ({ method, extra })))
+    )(
+      "$method deletion counts JSON bytes without the LF at the reset limit (+$extra)",
+      async ({ method, extra }) => {
+        const old = row("old");
+        const floor = { ...reset(), padding: "" };
+        const fresh = row("fresh");
+        const source = [old, floor, fresh];
+        const { chatPath, archivePath, bytes } = await seedDeletionHistory(
+          method === "archive" ? source : [],
+          method === "archive" ? [] : source
+        );
+        floor.padding = "x".repeat(
+          SESSION_HISTORY_MAX_LINE_BYTES + extra - Buffer.byteLength(messageLine(ws, floor))
+        );
+        expect(Buffer.byteLength(messageLine(ws, floor))).toBe(
+          SESSION_HISTORY_MAX_LINE_BYTES + extra
+        );
+        const targetPath = method === "archive" ? archivePath : chatPath;
+        const beforeBytes = bytes(source);
+        await fs.writeFile(targetPath, beforeBytes);
+        const before = await service.getHistoryFromLatestBoundary(ws);
+        assert(before.success);
+        expect(before.data.map((message) => message.id)).toEqual(
+          extra === 0 ? [floor.id, fresh.id] : [fresh.id]
+        );
+        const { store, receipt } = await capturePublication();
+        const result =
+          method === "batch"
+            ? await service.deleteMessages(ws, [floor.id])
+            : await service.deleteMessage(ws, floor.id);
+        expect(result.success).toBe(extra === 0);
+        expect(await fs.readFile(targetPath)).toEqual(
+          extra === 0 ? bytes([old, fresh]) : beforeBytes
+        );
+        const after = await service.getHistoryFromLatestBoundary(ws);
+        assert(after.success);
+        expect(after.data.map((message) => message.id)).toEqual(
+          extra === 0 ? [old.id, fresh.id] : [fresh.id]
+        );
+        expect((await store.captureGeneration()) !== receipt.publicationGeneration).toBe(
+          extra === 0
+        );
+      }
+    );
+
+    it.each(["single", "batch", "archive", "partial"])(
+      "%s deletion preserves oversized token-separated raw reset evidence",
+      async (method) => {
+        const floor = {
+          ...createMuxMessage("floor", "assistant", ""),
+          contextBoundaryKind: 0,
+          padding: "x".repeat(SESSION_HISTORY_MAX_LINE_BYTES),
+          candidate: "reset",
+        };
+        const placeholder =
+          method === "partial" ? [createMuxMessage("floor", "assistant", "")] : [];
+        const source = [row("old"), floor, ...placeholder, row("fresh")];
+        const { chatPath, archivePath } = await seedDeletionHistory(
+          method === "archive" ? source : [],
+          method === "archive" ? [] : source
+        );
+        const targetPath = method === "archive" ? archivePath : chatPath;
+        const beforeBytes = await fs.readFile(targetPath);
+        const before = await service.getHistoryFromLatestBoundary(ws);
+        assert(before.success);
+        expect(before.data.map((message) => message.id)).toEqual([
+          ...placeholder.map((message) => message.id),
+          "fresh",
+        ]);
+        const { store, receipt } = await capturePublication();
+        const result =
+          method === "partial"
+            ? await deleteErroredPlaceholder("floor")
+            : method === "batch"
+              ? await service.deleteMessages(ws, ["floor"])
+              : await service.deleteMessage(ws, "floor");
+        const after = await service.getHistoryFromLatestBoundary(ws);
+        assert(after.success);
+        expect(after.data.map((message) => message.id)).toEqual(["fresh"]);
+        expect(result.success).toBe(method === "partial");
+        expect(await fs.readFile(targetPath)).toEqual(
+          method === "partial"
+            ? Buffer.from(
+                beforeBytes.toString("utf8").replace(messageLine(ws, placeholder[0]) + "\n", "")
+              )
+            : beforeBytes
+        );
+        expect(await store.read()).toEqual(receipt);
+        expect(await store.captureGeneration()).toBe(receipt.publicationGeneration);
+      }
+    );
+
+    it.each(["single", "batch", "archive", "partial"])(
+      "%s deletion fences provider-preserved reasoning-only context",
+      async (method) => {
+        const reasoning: MuxMessage = {
+          ...createMuxMessage("reasoning", "assistant", ""),
+          parts: [{ type: "reasoning", text: "Preserved provider reasoning" }],
+        };
+        const placeholder =
+          method === "partial" ? [createMuxMessage("reasoning", "assistant", "")] : [];
+        const source = [row("old"), reasoning, ...placeholder, row("fresh")];
+        await seedDeletionHistory(
+          method === "archive" ? source : [],
+          method === "archive" ? [] : source
+        );
+        const before = await service.getHistoryFromLatestBoundary(ws);
+        assert(before.success);
+        expect(
+          prepareProviderRequestMessages(
+            before.data,
+            "anthropic",
+            "high"
+          ).providerRequestMessages.map((message) => message.id)
+        ).toEqual(["old", "reasoning", "fresh"]);
+        const { receipt } = await capturePublication("high");
+        if (method === "partial") {
+          assert(
+            (
+              await service.writePartial(ws, {
+                ...placeholder[0],
+                metadata: { ...placeholder[0].metadata, error: "stream failed" },
+              })
+            ).success
+          );
+        }
+        const result =
+          method === "partial"
+            ? await service.commitPartial(ws, "reasoning")
+            : method === "batch"
+              ? await service.deleteMessages(ws, ["reasoning"])
+              : await service.deleteMessage(ws, "reasoning");
+        expect(result.success).toBe(true);
+        const foreign = new HistoryService(config).getContinuousCompactionJournal(ws);
+        expect(
+          await foreign.recordFallbackPrefix(
+            receipt,
+            { modelString: "anthropic:next", prefix },
+            () => true
+          )
+        ).toBeNull();
+        expect(await foreign.captureGeneration()).not.toBe(receipt.publicationGeneration);
+      }
+    );
+
+    it.each(
       [
         {
           name: "empty placeholder",
@@ -1148,6 +1296,33 @@ describe("HistoryService", () => {
           chat: [reset()],
           changed: false,
         },
+        ...[false, true].map((archived) => {
+          const reasoning: MuxMessage = {
+            ...createMuxMessage("target", "assistant", ""),
+            parts: [{ type: "reasoning", text: "Sealed reasoning" }],
+          };
+          return {
+            name: `${archived ? "archive" : "active"} sealed reasoning`,
+            archive: archived ? [reasoning] : [],
+            chat: [...(archived ? [] : [reasoning]), boundary()],
+            changed: false,
+          };
+        }),
+        ...[
+          {
+            name: "ordinary oversized row",
+            padding: "x".repeat(SESSION_HISTORY_MAX_LINE_BYTES),
+            candidate: "ordinary",
+          },
+          { name: "readable reset-token payload", padding: "small", candidate: "reset" },
+        ].map(({ name, ...payload }) => ({
+          name,
+          archive: [],
+          chat: [
+            { ...createMuxMessage("target", "assistant", ""), contextBoundaryKind: 0, ...payload },
+          ],
+          changed: false,
+        })),
         {
           name: "active-first duplicate",
           archive: [row("target")],

--- a/src/node/services/historyService.test.ts
+++ b/src/node/services/historyService.test.ts
@@ -1258,6 +1258,96 @@ describe("HistoryService", () => {
       }
     );
 
+    it.each(
+      [
+        "single delete",
+        "batch delete",
+        "archive delete",
+        "active truncation",
+        "archive truncation",
+        "prefix truncation",
+        "rename",
+        "protected-only rename",
+        "clear",
+      ].flatMap((method) => ["chat", "archive"].map((artifact) => ({ method, artifact })))
+    )(
+      "$method accounts for a retained protected sequence in $artifact after restart",
+      async ({ method, artifact }) => {
+        const target = row("target");
+        const fresh = row("fresh");
+        const floor = {
+          ...createMuxMessage("floor", "assistant", ""),
+          contextBoundaryKind: 0,
+          padding: "x".repeat(SESSION_HISTORY_MAX_LINE_BYTES),
+          candidate: "reset",
+        };
+        const archivedTarget = method.startsWith("archive");
+        const protectedOnly = method === "protected-only rename";
+        const archive = [
+          ...(archivedTarget ? [target] : []),
+          ...(artifact === "archive" ? [floor] : []),
+        ];
+        const chat = [
+          ...(!protectedOnly && !archivedTarget ? [target] : []),
+          ...(artifact === "chat" ? [floor] : []),
+          ...(protectedOnly ? [] : [fresh]),
+        ];
+        const { chatPath, archivePath, bytes } = await seedDeletionHistory(archive, chat);
+        floor.metadata = { ...floor.metadata, historySequence: 100 };
+        await fs.writeFile(
+          artifact === "chat" ? chatPath : archivePath,
+          bytes(artifact === "chat" ? chat : archive)
+        );
+        const floorBytes = bytes([floor]);
+        const restarted = new HistoryService(config);
+        let nextWorkspace = ws;
+        const result =
+          method === "single delete" || method === "archive delete"
+            ? await restarted.deleteMessage(ws, target.id)
+            : method === "batch delete"
+              ? await restarted.deleteMessages(ws, [target.id])
+              : method === "active truncation" || method === "archive truncation"
+                ? await restarted.truncateAfterMessage(ws, target.id, { keepTargetMessage: true })
+                : method === "prefix truncation"
+                  ? await restarted.truncateHistory(ws, 0.1)
+                  : method === "clear"
+                    ? await restarted.clearHistory(ws)
+                    : await (async () => {
+                        nextWorkspace = `${ws}-renamed`;
+                        await fs.rename(
+                          path.dirname(chatPath),
+                          path.join(config.sessionsDir, nextWorkspace)
+                        );
+                        return restarted.migrateWorkspaceId(ws, nextWorkspace);
+                      })();
+        expect(result.success).toBe(true);
+        const retainedBytes = Buffer.concat(
+          await Promise.all(
+            ["chat.jsonl", "chat-archive.jsonl"].map((file) =>
+              fs
+                .readFile(path.join(config.sessionsDir, nextWorkspace, file))
+                .catch(() => Buffer.alloc(0))
+            )
+          )
+        );
+        expect(retainedBytes.includes(floorBytes)).toBe(method !== "clear");
+        // The rewrite must publish a counter consistent with retained bytes immediately;
+        // the append path's disk refresh must not be needed to repair its bookkeeping.
+        const counters = restarted as unknown as { sequenceCounters: Map<string, number> };
+        const cachedNext = counters.sequenceCounters.get(nextWorkspace);
+        const next = row("next");
+        expect((await restarted.appendToHistory(nextWorkspace, next)).success).toBe(true);
+        expect(next.metadata?.historySequence).toBe(method === "clear" ? 0 : 101);
+        const reloaded = new HistoryService(config);
+        const later = row("later");
+        expect((await reloaded.appendToHistory(nextWorkspace, later)).success).toBe(true);
+        expect(later.metadata?.historySequence).toBe(method === "clear" ? 1 : 102);
+        if (method !== "archive delete") {
+          expect(cachedNext).toBe(method === "clear" ? 0 : 101);
+        }
+      }
+    );
+
     it.each(["single", "batch", "archive", "partial"])(
       "%s deletion preserves oversized token-separated raw reset evidence",
       async (method) => {

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -3381,10 +3381,11 @@ export class HistoryService {
           }
 
           const filteredMessages = messages.filter((message) => !ids.has(message.id));
-          await writeFileAtomic(
-            this.getChatHistoryPath(workspaceId),
-            this.serializeHistoryRewrite(rows, workspaceId, (row) => (ids.has(row.id) ? null : row))
+          const historyEntries = this.serializeHistoryRewrite(rows, workspaceId, (row) =>
+            ids.has(row.id) ? null : row
           );
+          await this.fenceDeletedMessagesUnderHistoryLock(workspaceId, messages, ids);
+          await writeFileAtomic(this.getChatHistoryPath(workspaceId), historyEntries);
 
           const maxSeq = filteredMessages.reduce((max, message) => {
             const sequence = message.metadata?.historySequence;
@@ -3433,6 +3434,35 @@ export class HistoryService {
     );
   }
 
+  private async fenceDeletedMessagesUnderHistoryLock(
+    workspaceId: string,
+    messages: MuxMessage[],
+    deletedIds: ReadonlySet<string>,
+    newerMessageCount = 0
+  ): Promise<void> {
+    // Cleanup must retire foreign compactors only when the actual removed
+    // occurrences affect today's provider view, including an empty boundary.
+    // Use the raw-aware suffix so retained unreadable resets still seal old rows.
+    const providerMessages = await readProviderHistoryFromLatestBoundary(
+      {
+        chat: this.getChatHistoryPath(workspaceId),
+        archive: this.getChatArchivePath(workspaceId),
+      },
+      0
+    );
+    // Archive fallback excludes all newer chat rows. Matching IDs across files
+    // would conflate retained duplicates with occurrences this write removes.
+    const activeCount = Math.max(0, providerMessages.length - newerMessageCount);
+    const removed = messages
+      .slice(Math.max(0, messages.length - activeCount))
+      .filter((message) => deletedIds.has(message.id));
+    if (tailCutChangesProviderContext(removed)) {
+      // Call only after serialization admits the rewrite, immediately before
+      // its write. A later disk failure must not restore the old generation.
+      await this.getContinuousCompactionJournal(workspaceId).advanceGenerationUnderHistoryLock();
+    }
+  }
+
   private async deleteMessageUnderWriteLock(
     workspaceId: string,
     messageId: string
@@ -3458,12 +3488,16 @@ export class HistoryService {
 
         // Archived rows are strictly older than active rows, so deleting one
         // can never affect the sequence counter.
-        await writeFileAtomic(
-          this.getChatArchivePath(workspaceId),
-          this.serializeHistoryRewrite(archiveRows, workspaceId, (row) =>
-            row.id === messageId ? null : row
-          )
+        const archiveEntries = this.serializeHistoryRewrite(archiveRows, workspaceId, (row) =>
+          row.id === messageId ? null : row
         );
+        await this.fenceDeletedMessagesUnderHistoryLock(
+          workspaceId,
+          archiveMessages,
+          new Set([messageId]),
+          messages.length
+        );
+        await writeFileAtomic(this.getChatArchivePath(workspaceId), archiveEntries);
         return Ok(undefined);
       }
 
@@ -3472,6 +3506,7 @@ export class HistoryService {
         row.id === messageId ? null : row
       );
 
+      await this.fenceDeletedMessagesUnderHistoryLock(workspaceId, messages, new Set([messageId]));
       // Atomic write prevents corruption if app crashes mid-write
       await writeFileAtomic(historyPath, historyEntries);
 

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -19,6 +19,7 @@ import {
   type BoundedHistoryScanOptions,
 } from "./historyScanner";
 import { getRequestPreludeMessageIds } from "@/common/utils/messages/requestPrelude";
+import { isManualHistoryReset } from "@/common/utils/messages/contextWindows";
 import { createContextBudgetRejectedMessage } from "@/common/utils/messages/contextBudgetRejection";
 import * as path from "path";
 import { createHash, randomUUID } from "node:crypto";
@@ -99,6 +100,7 @@ interface HistoryTruncateTransaction extends HistoryTruncateHashes {
 interface HistoryRewriteRow {
   raw: Buffer;
   message: MuxMessage | undefined;
+  protectedMessageId?: string;
 }
 
 function splitHistoryLines(raw: Buffer): Buffer[] {
@@ -2663,20 +2665,21 @@ export class HistoryService {
       // Match the provider scanner's row budget without the JSONL delimiter.
       const content = line.at(-1) === 10 ? line.subarray(0, -1) : line;
       const text = content.toString("utf8");
-      return {
-        raw: line,
-        message: this.parseMessages(text, filePath, (value) =>
-          isReadableHistoryMessage(value) &&
-          !(hasRawResetMarker(text) && hasAmbiguousResetKeys(text)) &&
+      const parsed = this.parseMessages(text, filePath, (value) =>
+        isReadableHistoryMessage(value) ? normalizeLegacyMuxMetadata(value) : null
+      )[0];
+      const protectedReset =
+        parsed !== undefined &&
+        ((hasRawResetMarker(text) && hasAmbiguousResetKeys(text)) ||
           // Oversized rows use the provider scanner's token probe, even when
           // intervening bytes prevent a contiguous raw reset marker match.
-          !(
-            content.length > SESSION_HISTORY_MAX_LINE_BYTES &&
-            hasUnreadableHistoryResetEvidence([line])
-          )
-            ? normalizeLegacyMuxMetadata(value)
-            : null
-        )[0],
+          (content.length > SESSION_HISTORY_MAX_LINE_BYTES &&
+            hasUnreadableHistoryResetEvidence([line])));
+      return {
+        raw: line,
+        message: protectedReset ? undefined : parsed,
+        // Preserve identity for active-first lookup even when the raw floor cannot be rewritten.
+        protectedMessageId: protectedReset ? parsed?.id : undefined,
       };
     });
     return { rows, messages: rows.flatMap((row) => (row.message ? [row.message] : [])) };
@@ -3495,7 +3498,8 @@ export class HistoryService {
         chat: this.getChatHistoryPath(workspaceId),
         archive: this.getChatArchivePath(workspaceId),
       },
-      0
+      0,
+      { includeReadableResetFloor: true }
     );
     // Archive fallback excludes all newer chat rows. Matching IDs across files
     // would conflate retained duplicates with occurrences this write removes.
@@ -3506,6 +3510,7 @@ export class HistoryService {
       .filter((message) => deletedIds.has(message.id));
     if (
       tailCutChangesProviderContext(removed) ||
+      removed.some((message) => isManualHistoryReset(message)) ||
       deletionCreatesRawReset(rows, deletedIds, new Set(removed))
     ) {
       // Call only after serialization admits the rewrite, immediately before
@@ -3527,6 +3532,9 @@ export class HistoryService {
       const filteredMessages = messages.filter((msg) => msg.id !== messageId);
 
       if (filteredMessages.length === messages.length) {
+        if (rows.some((row) => row.protectedMessageId === messageId)) {
+          return Err(`Message with ID ${messageId} is protected reset evidence in active history`);
+        }
         // Not in the active epoch — the row may live in the sealed archive
         // (rare: cleanup paths almost always target recent rows).
         const { rows: archiveRows, messages: archiveMessages } = await this.readHistoryForRewrite(

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -3653,6 +3653,12 @@ export class HistoryService {
           const keepTargetMessage = options?.keepTargetMessage === true;
 
           if (messageIndex === -1) {
+            // A protected active target must not redirect an edit/fork to an older duplicate.
+            if (rows.some((row) => row.protectedMessage?.id === messageId)) {
+              return Err(
+                `Message with ID ${messageId} is protected reset evidence in active history`
+              );
+            }
             // Editing/forking from a pre-boundary message: the target lives in the
             // sealed archive. Everything after the cut (the archive tail AND the
             // entire active epoch) is discarded, so collapse the remainder back

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -7,6 +7,7 @@ import { SESSION_HISTORY_MAX_SCAN_BYTES } from "@/common/constants/contextBudget
 import {
   hasRawResetMarker,
   hasAmbiguousResetKeys,
+  hasUnreadableHistoryResetEvidence,
   isReadableHistoryMessage,
   scanHistoryFilesBounded,
   readProviderHistoryFromLatestBoundary,
@@ -131,6 +132,41 @@ function tailCutChangesProviderContext(removedMessages: MuxMessage[]): boolean {
       preserveReasoningOnly: true,
     })
   );
+}
+
+function deletionCreatesRawReset(
+  rows: readonly HistoryRewriteRow[],
+  deletedIds: ReadonlySet<string>,
+  activeRemoved: ReadonlySet<MuxMessage>
+): boolean {
+  let originalRun: Buffer[] = [];
+  let joinedRun: Buffer[] = [];
+  let existingReset = false;
+  let removedActive = false;
+  const createdReset = () =>
+    removedActive &&
+    !existingReset &&
+    !hasUnreadableHistoryResetEvidence(originalRun) &&
+    hasUnreadableHistoryResetEvidence(joinedRun);
+  // Readable rows break the raw reset probe, even when provider-ineligible.
+  // Removing such a separator can seal captured context without removing it.
+  for (const row of rows) {
+    if (!row.message) {
+      originalRun.push(row.raw);
+      joinedRun.push(row.raw);
+    } else if (deletedIds.has(row.message.id)) {
+      existingReset ||= hasUnreadableHistoryResetEvidence(originalRun);
+      originalRun = [];
+      removedActive ||= activeRemoved.has(row.message);
+    } else {
+      if (createdReset()) return true;
+      originalRun = [];
+      joinedRun = [];
+      existingReset = false;
+      removedActive = false;
+    }
+  }
+  return createdReset();
 }
 
 function stripContextUsage(message: MuxMessage): MuxMessage {
@@ -3384,7 +3420,7 @@ export class HistoryService {
           const historyEntries = this.serializeHistoryRewrite(rows, workspaceId, (row) =>
             ids.has(row.id) ? null : row
           );
-          await this.fenceDeletedMessagesUnderHistoryLock(workspaceId, messages, ids);
+          await this.fenceDeletedMessagesUnderHistoryLock(workspaceId, rows, ids);
           await writeFileAtomic(this.getChatHistoryPath(workspaceId), historyEntries);
 
           const maxSeq = filteredMessages.reduce((max, message) => {
@@ -3436,7 +3472,7 @@ export class HistoryService {
 
   private async fenceDeletedMessagesUnderHistoryLock(
     workspaceId: string,
-    messages: MuxMessage[],
+    rows: HistoryRewriteRow[],
     deletedIds: ReadonlySet<string>,
     newerMessageCount = 0
   ): Promise<void> {
@@ -3453,10 +3489,14 @@ export class HistoryService {
     // Archive fallback excludes all newer chat rows. Matching IDs across files
     // would conflate retained duplicates with occurrences this write removes.
     const activeCount = Math.max(0, providerMessages.length - newerMessageCount);
+    const messages = rows.flatMap((row) => (row.message ? [row.message] : []));
     const removed = messages
       .slice(Math.max(0, messages.length - activeCount))
       .filter((message) => deletedIds.has(message.id));
-    if (tailCutChangesProviderContext(removed)) {
+    if (
+      tailCutChangesProviderContext(removed) ||
+      deletionCreatesRawReset(rows, deletedIds, new Set(removed))
+    ) {
       // Call only after serialization admits the rewrite, immediately before
       // its write. A later disk failure must not restore the old generation.
       await this.getContinuousCompactionJournal(workspaceId).advanceGenerationUnderHistoryLock();
@@ -3493,7 +3533,7 @@ export class HistoryService {
         );
         await this.fenceDeletedMessagesUnderHistoryLock(
           workspaceId,
-          archiveMessages,
+          archiveRows,
           new Set([messageId]),
           messages.length
         );
@@ -3506,7 +3546,7 @@ export class HistoryService {
         row.id === messageId ? null : row
       );
 
-      await this.fenceDeletedMessagesUnderHistoryLock(workspaceId, messages, new Set([messageId]));
+      await this.fenceDeletedMessagesUnderHistoryLock(workspaceId, rows, new Set([messageId]));
       // Atomic write prevents corruption if app crashes mid-write
       await writeFileAtomic(historyPath, historyEntries);
 

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -100,7 +100,7 @@ interface HistoryTruncateTransaction extends HistoryTruncateHashes {
 interface HistoryRewriteRow {
   raw: Buffer;
   message: MuxMessage | undefined;
-  protectedMessageId?: string;
+  protectedMessage?: MuxMessage;
 }
 
 function splitHistoryLines(raw: Buffer): Buffer[] {
@@ -2678,11 +2678,21 @@ export class HistoryService {
       return {
         raw: line,
         message: protectedReset ? undefined : parsed,
-        // Preserve identity for active-first lookup even when the raw floor cannot be rewritten.
-        protectedMessageId: protectedReset ? parsed?.id : undefined,
+        // Keep identity and sequence accounting even when the raw floor cannot be rewritten.
+        protectedMessage: protectedReset ? parsed : undefined,
       };
     });
     return { rows, messages: rows.flatMap((row) => (row.message ? [row.message] : [])) };
+  }
+
+  private getProtectedRewriteMaxSequence(rows: readonly HistoryRewriteRow[]): number {
+    // These parsed rows survive every partial rewrite as raw bytes, even beyond a cut.
+    // Their sequences remain occupied regardless of whether they are transformable.
+    return (
+      this.getNewestHistorySequence(
+        rows.flatMap((row) => (row.protectedMessage ? [row.protectedMessage] : []))
+      ) ?? -1
+    );
   }
 
   private serializeHistoryRewrite(
@@ -3452,7 +3462,7 @@ export class HistoryService {
               return max;
             }
             return sequence > max ? sequence : max;
-          }, -1);
+          }, this.getProtectedRewriteMaxSequence(rows));
           const archiveMaxSeq = await this.getArchiveTailMaxSequence(workspaceId);
           const nextSeq = Math.max(maxSeq, archiveMaxSeq) + 1;
           assert(
@@ -3532,7 +3542,7 @@ export class HistoryService {
       const filteredMessages = messages.filter((msg) => msg.id !== messageId);
 
       if (filteredMessages.length === messages.length) {
-        if (rows.some((row) => row.protectedMessageId === messageId)) {
+        if (rows.some((row) => row.protectedMessage?.id === messageId)) {
           return Err(`Message with ID ${messageId} is protected reset evidence in active history`);
         }
         // Not in the active epoch — the row may live in the sealed archive
@@ -3590,7 +3600,7 @@ export class HistoryService {
         }
 
         return seq > max ? seq : max;
-      }, -1);
+      }, this.getProtectedRewriteMaxSequence(rows));
       // Sealed archive rows keep their sequences across active-file deletes.
       // Without this floor, deleting the last sequenced active row in a fresh
       // process would cache a counter below archived rows and reuse their
@@ -3703,7 +3713,7 @@ export class HistoryService {
             }
 
             return seq > max ? seq : max;
-          }, -1);
+          }, this.getProtectedRewriteMaxSequence(rows));
           // Sealed archive rows keep their sequences across an active-epoch
           // truncation. When the truncation empties the active file, floor the
           // counter with the archive max so new appends can never reuse archived
@@ -3776,6 +3786,10 @@ export class HistoryService {
 
       // Update sequence counter to continue from where we truncated.
       // Self-healing read path: skip malformed persisted historySequence values.
+      const protectedMaxSeq = this.getProtectedRewriteMaxSequence([
+        ...archiveRows,
+        ...activeEpochRows,
+      ]);
       const maxTruncatedSeq = truncatedMessages.reduce((max, msg) => {
         const seq = msg.metadata?.historySequence;
         if (seq === undefined) {
@@ -3795,7 +3809,7 @@ export class HistoryService {
         }
 
         return seq > max ? seq : max;
-      }, -1);
+      }, protectedMaxSeq);
       const nextSeq = maxTruncatedSeq + 1;
       assert(
         isNonNegativeInteger(nextSeq),
@@ -4025,6 +4039,10 @@ export class HistoryService {
 
           // Update sequence counter to continue from where we are.
           // Self-healing read path: skip malformed persisted historySequence values.
+          const protectedMaxSeq = this.getProtectedRewriteMaxSequence([
+            ...archiveRows,
+            ...chatRows,
+          ]);
           const maxRemainingSeq = remainingMessages.reduce((max, msg) => {
             const seq = msg.metadata?.historySequence;
             if (seq === undefined) {
@@ -4044,7 +4062,7 @@ export class HistoryService {
             }
 
             return seq > max ? seq : max;
-          }, -1);
+          }, protectedMaxSeq);
           const nextSeq = maxRemainingSeq + 1;
           assert(
             isNonNegativeInteger(nextSeq),
@@ -4112,12 +4130,15 @@ export class HistoryService {
           const { rows, messages } = await this.readHistoryForRewrite(
             this.getChatHistoryPath(newWorkspaceId)
           );
+          const oldCounter = Math.max(
+            this.sequenceCounters.get(oldWorkspaceId) ?? 0,
+            this.getProtectedRewriteMaxSequence([...archiveRows, ...rows]) + 1
+          );
           if (messages.length === 0) {
             // No active messages to migrate, just transfer the sequence counter.
             // Floor it with the archive max: an archive-only session (active file
             // deleted/truncated) renamed in a fresh process has no cached counter,
             // and seeding 0 would reuse archived historySequence values.
-            const oldCounter = this.sequenceCounters.get(oldWorkspaceId) ?? 0;
             const archiveFloor = (await this.getArchiveTailMaxSequence(newWorkspaceId)) + 1;
             this.sequenceCounters.set(newWorkspaceId, Math.max(oldCounter, archiveFloor));
             this.sequenceCounters.delete(oldWorkspaceId);
@@ -4132,7 +4153,6 @@ export class HistoryService {
           await writeFileAtomic(newHistoryPath, historyEntries);
 
           // Transfer sequence counter to new workspace ID
-          const oldCounter = this.sequenceCounters.get(oldWorkspaceId) ?? 0;
           this.sequenceCounters.set(newWorkspaceId, oldCounter);
           this.sequenceCounters.delete(oldWorkspaceId);
 

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -3,7 +3,10 @@ import {
   HISTORY_PROVENANCE_MAX_RECEIPT_BYTES,
   invalidateHistoryAppendProvenance,
 } from "./historyAppendProvenance";
-import { SESSION_HISTORY_MAX_SCAN_BYTES } from "@/common/constants/contextBudget";
+import {
+  SESSION_HISTORY_MAX_SCAN_BYTES,
+  SESSION_HISTORY_MAX_LINE_BYTES,
+} from "@/common/constants/contextBudget";
 import {
   hasRawResetMarker,
   hasAmbiguousResetKeys,
@@ -2657,12 +2660,20 @@ export class HistoryService {
   }> {
     const raw = (await this.readExistingFileBytes(filePath)) ?? Buffer.alloc(0);
     const rows = splitHistoryLines(raw).map((line) => {
-      const text = line.toString("utf8");
+      // Match the provider scanner's row budget without the JSONL delimiter.
+      const content = line.at(-1) === 10 ? line.subarray(0, -1) : line;
+      const text = content.toString("utf8");
       return {
         raw: line,
         message: this.parseMessages(text, filePath, (value) =>
           isReadableHistoryMessage(value) &&
-          !(hasRawResetMarker(text) && hasAmbiguousResetKeys(text))
+          !(hasRawResetMarker(text) && hasAmbiguousResetKeys(text)) &&
+          // Oversized rows use the provider scanner's token probe, even when
+          // intervening bytes prevent a contiguous raw reset marker match.
+          !(
+            content.length > SESSION_HISTORY_MAX_LINE_BYTES &&
+            hasUnreadableHistoryResetEvidence([line])
+          )
             ? normalizeLegacyMuxMetadata(value)
             : null
         )[0],


### PR DESCRIPTION
Deleting current provider rows or their boundary can leave a foreign compactor's captured generation valid, allowing stale initial, fallback, or boundary publication after cleanup. This change fences the removed occurrences before rewriting history, using the provider scanner's raw-aware suffix rules.

It covers single deletion, batch deletion, archive fallback, and the private deletion used by commitPartial. Deleting a readable separator can join malformed fragments into new reset evidence; the shared scanner probe detects that change while preserving the raw bytes. Readable user/system reset floors participate in deletion classification without changing provider reads. Oversized reset evidence stays raw, and protected active identities prevent deletion or truncation from falling back to an archived duplicate. Exact-limit valid rows remain addressable because the size check excludes the trailing LF. Retained boundaries and separators, existing reset evidence, incomplete tokens, and ineffective cuts preserve generation. A later history-write failure retains the conservative fence.

Protected parsed rows retain identity and sequence metadata separately from transformable rows. Partial rewrites and rename keep their cached counter above retained protected sequences. Seven counter regressions were reproduced; actual sequence reuse was not reproduced because ordinary appends already refresh durable history. Reasoning-only deletions inherit the conservative provider-context classification from merged #4135. The pending-state prerequisite #4138 has also merged; this PR is the remaining deletion layer. Runtime activation is separate.

Validation: 518 affected tests and full static checks pass on the main-integrated candidate. Coverage includes raw-fragment joining, malformed-role reset floors, protected active/archive duplicate IDs, exact-limit and oversized rows, sequence accounting, real provider history, and stale initial/fallback/boundary publication. The exact-rollback fixture restores captured history bytes so its unchanged-generation assertions remain meaningful after generic deletion gains fencing.

Edit/fork truncation now refuses a protected active target before archive fallback when no readable active match exists. Four regressions reproduced destructive fallback to an archived duplicate; twelve cases cover oversized and ambiguous reset rows in both keep/remove modes. Refusal preserves both files byte-for-byte, generation, and the publication journal. Readable active duplicates retain precedence, while unrelated protected IDs still allow legitimate archive truncation. The correction reuses existing identity metadata and the single-deletion guard; independent review approved it.

The queued-base CI failure was isolated to four fault-injection cases after #4146 changed generation publication to write a staging sibling and then rename it. The fixture now matches that exact generation artifact's staging prefix, keeps history-stage matching exact, and asserts that injection fired. All four regressions, all eight write-failure controls, and the 349-test history suite pass on the previously failing merge-group base. Production behavior is unchanged by this integration correction. Nix formatting was skipped because Nix is unavailable.

Linux E2E also now runs with one worker because all Electron workers share one Xvfb display and clipboard. On the exact failing queue candidate, native probes reproduced three clipboard denials in four competing-window runs: two lost focus before validation, and one during the awaited isolated-world activation check. Focusing the parent before clicking a self-closing auth popup reproduced the same closed-target error on attempt nine; authentication completed, the remote stayed connected, and the local renderer and projects remained intact. Security checks and all original tests remain unchanged.

The unmodified remote-connection file passes all three tests with one Linux worker (34.9 seconds); 30 focused popup controls also pass. Reproduction used Linux arm64 with pinned Electron 40.9.3, Playwright 1.57.0, and Bun 1.3.5; the failing CI runner was x64. Full static checks and both workflow linters pass for the final CI-only correction. The worker-count repair was verified at b82705b1f by the full Linux x64 CI suite: 55 tests passed and 21 skipped using one worker, including all remote-connection tests. Measured test execution took 8.5 minutes; the complete job took 9m56s including setup and build ([CI result](https://github.com/coder/xum/actions/runs/34279578520/job/102240858941)). Serial execution trades some throughput for stable native focus without reducing coverage.

Regression risk is in classifying which removed occurrences affect provider context while preserving malformed privacy floors and occupied sequences. Tests cover retained-floor controls, duplicate IDs, restart, and generation/history-write failure ordering using real HistoryService storage.

---

_Generated with `xum` • Model: `unavailable` • Thinking: `unavailable` • Cost: `$unavailable`_

<!-- mux-attribution: model=unavailable thinking=unavailable costs=unavailable -->
