### PR TITLE
🤖 fix: prevent message edits from hanging during active streams

### DIFF
--- a/src/node/services/agentSession.tokenBudget.test.ts
+++ b/src/node/services/agentSession.tokenBudget.test.ts
@@ -1279,6 +1279,32 @@ describe("AgentSession token-budget lifecycle", () => {
     estimate: 127_000,
     hardCeiling: 119_808,
   };
+  test("an edited request can recover its own pre-handle budget overflow", async () => {
+    const h = await setup({ failure: (attempt) => (attempt === 1 ? exceeded : undefined) });
+    await seedHistory(h, 20_000);
+    await h.historyService.appendToHistory(
+      workspaceId,
+      createMuxMessage("edit-target", "user", "Original request")
+    );
+
+    expect(
+      (
+        await h.session.sendMessage("Edited request", {
+          ...options,
+          editMessageId: "edit-target",
+        })
+      ).success
+    ).toBe(true);
+    const retry = await h.secondRequest.promise;
+    expect(h.requests).toHaveLength(2);
+    const active = sliceMessagesForProviderFromLatestContextBoundary(retry.messages);
+    expect(
+      active.filter((row) => row.role === "user" && !row.metadata?.synthetic).map(text)
+    ).toEqual(["Edited request"]);
+    expect(active.some((row) => row.id === "old-answer")).toBe(false);
+    expect(rolloverRows(await allRows(h))).toHaveLength(1);
+  });
+
   test.each(
     (["file", "skill", "deduped-skill", "family"] as const).flatMap((kind) =>
       [false, true].flatMap((asyncFailure) =>

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -914,8 +914,6 @@ export class AgentSession {
         error: getErrorMessage(error),
       }),
   });
-  // When true, stream-end skips auto-flushing queued messages so an edit can truncate first.
-  private deferQueuedFlushUntilAfterEdit = false;
   // Provider-executed tools (for example native web_search/web_fetch) complete inside one
   // provider response, so the SDK's between-step stopWhen hook cannot preempt after them.
   // Track known siblings and reserve soft interruption for that native-only boundary.
@@ -3734,11 +3732,12 @@ export class AgentSession {
         return refuseBeforeAcceptance(
           createUnknownSendMessageError(CONTEXT_MUTATION_SEND_BLOCKED_MESSAGE)
         );
+      // Reserve before interrupting: terminal policy can otherwise start queued work
+      // while stopStream settles, leaving this edit waiting on the wrong turn.
+      attempt.editReservation = this.coordinator.reserve("edit");
       this.continuousCompactor.reset("edit");
-      // Ensure no in-flight completion code can append after we truncate.
-      if (this.isBusy()) {
-        let preemptedPreparing = false;
-
+      // Ignore our own reservation when deciding whether a turn needs to settle.
+      if (this.coordinator.phase !== "idle") {
         // If a turn is still PREPARING/STREAMING, interrupt aggressively — history is about to be
         // truncated.
         //
@@ -3761,32 +3760,18 @@ export class AgentSession {
 
         // Editing owns history before its replacement reaches PREPARING. The coordinator
         // invalidates startup synchronously so late completion cannot write across truncation.
-        preemptedPreparing = this.coordinator.preemptPreparation();
+        if (!this.coordinator.preemptPreparation()) {
+          await this.waitForIdle();
+        }
 
-        // Tell stream-end to skip sendQueuedMessages() so the edit truncates first.
-        this.deferQueuedFlushUntilAfterEdit = true;
-        try {
-          if (!preemptedPreparing) {
-            await this.waitForIdle();
-          }
-
-          // Workspace teardown does not await in-flight async work; bail out if the session was
-          // disposed while waiting for completion cleanup.
-          if (this.coordinator.disposed) {
-            return Ok(undefined);
-          }
-        } finally {
-          this.deferQueuedFlushUntilAfterEdit = false;
+        // Teardown may have started while completion cleanup was settling.
+        if (this.coordinator.disposed) {
+          return Ok(undefined);
         }
       }
 
-      // r40: same admission gate as the acceptance path below — the edit is
-      // about to truncate and rewrite history while a context-discarding
-      // mutation may sit between its busy check and its mutation. Checked in
-      // the same synchronous block that arms the edit reservation (which
-      // claims busy-ness), so whichever side runs first is observed by the
-      // other. The epoch probe (r41) also refuses edits whose target rows a
-      // completed mutation already discarded.
+      // Recheck admission after settlement: a context mutation may have already
+      // claimed admission or discarded the target before we reserved the edit.
       if (this.coordinator.admissionBlocked || isAdmissionStale()) {
         return refuseBeforeAcceptance(
           createUnknownSendMessageError(CONTEXT_MUTATION_SEND_BLOCKED_MESSAGE)
@@ -3798,11 +3783,7 @@ export class AgentSession {
         );
       }
 
-      // Idle (or preempted to idle) now: hold busy-ness from here until the
-      // turn phase takes over, so concurrent sends queue instead of racing the
-      // truncate + summary + append sequence below.
       attempt.expectedTurn = this.coordinator.turnId;
-      attempt.editReservation ??= this.coordinator.reserve("edit");
 
       // The edit is about to truncate and rewrite history. Any queued content from
       // the previous turn was written in the old context — return it to the input
@@ -5122,7 +5103,9 @@ export class AgentSession {
   /** Emergency retries reuse the accepted user row; never rerun a completed tool to recover context. */
   private async rolloverAfterBudgetFailure(
     model: string,
-    estimate?: number
+    estimate?: number,
+    // An edited startup may recover its own request without admitting competing turns.
+    editReservation?: PreparationAttempt["editReservation"]
   ): Promise<
     Result<
       { snapshot: RequestAssemblySnapshot; request: PreparedStreamMessage } | undefined,
@@ -5139,7 +5122,7 @@ export class AgentSession {
       context.contextBudgetRetried ||
       this.compactionMonitor.getThreshold() >= 1 ||
       this.coordinator.admissionBlocked ||
-      this.deferQueuedFlushUntilAfterEdit ||
+      this.coordinator.editBlocked(editReservation?.id) ||
       this.coordinator.disposed ||
       this.coordinator.closing
     )
@@ -5288,7 +5271,7 @@ export class AgentSession {
         this.activeStreamContext !== context ||
         this.contextBudgetGeneration !== generation ||
         this.coordinator.admissionBlocked ||
-        this.deferQueuedFlushUntilAfterEdit ||
+        this.coordinator.editBlocked(editReservation?.id) ||
         this.coordinator.disposed ||
         this.coordinator.closing
       )
@@ -6220,7 +6203,7 @@ export class AgentSession {
     if (
       this.midStreamCompactionPending ||
       this.continuousCompactor.isApplying() ||
-      this.deferQueuedFlushUntilAfterEdit
+      this.coordinator.editBlocked()
     )
       return;
     try {
@@ -7000,7 +6983,8 @@ export class AgentSession {
         ) {
           const rolled = await this.rolloverAfterBudgetFailure(
             streamResult.error.model,
-            streamResult.error.estimate
+            streamResult.error.estimate,
+            preparation?.editReservation
           );
           await using _rolloverRequest = rolled.success ? rolled.data?.request : undefined;
           if (
@@ -8084,7 +8068,7 @@ export class AgentSession {
       const hadQueuedMessages = this.hasPendingManualFollowUp();
       const continuousApplyPending =
         this.midStreamCompactionPending || this.continuousCompactor.isApplying();
-      if (this.deferQueuedFlushUntilAfterEdit || continuousApplyPending) {
+      if (this.coordinator.editBlocked() || continuousApplyPending) {
         this.queuedProviderToolEndAbortInFlight = false;
         // Clear the queued-message signal while the edit flow owns the next dispatch.
         this.backgroundProcessManager.setMessageQueued(this.workspaceId, false);
@@ -8096,7 +8080,7 @@ export class AgentSession {
 
       if (
         !handled &&
-        !this.deferQueuedFlushUntilAfterEdit &&
+        !this.coordinator.editBlocked() &&
         !continuousApplyPending &&
         !hadQueuedMessages
       ) {
@@ -9010,9 +8994,7 @@ export class AgentSession {
 
     // Physical check: withdrawn entries must still drain so their onCanceled fires.
     const shouldDispatch =
-      abortReason !== "user" &&
-      !this.deferQueuedFlushUntilAfterEdit &&
-      !this.messageQueue.isEmpty();
+      abortReason !== "user" && !this.coordinator.editBlocked() && !this.messageQueue.isEmpty();
     this.queuedProviderToolEndAbortInFlight = false;
 
     if (!shouldDispatch) {
@@ -9117,11 +9099,7 @@ export class AgentSession {
    * failed-startup drains elsewhere in this file.
    */
   drainQueuedMessagesIfIdle(): void {
-    if (
-      this.hasActiveOrPendingTurnWork() ||
-      this.deferQueuedFlushUntilAfterEdit ||
-      this.messageQueue.isEmpty()
-    ) {
+    if (this.hasActiveOrPendingTurnWork() || this.messageQueue.isEmpty()) {
       return;
     }
     this.sendQueuedMessages("idle");
@@ -9134,7 +9112,7 @@ export class AgentSession {
   sendQueuedMessages(trigger: QueueDrainTrigger = "terminal"): void {
     if (
       this.coordinator.closing ||
-      this.deferQueuedFlushUntilAfterEdit ||
+      this.coordinator.editBlocked() ||
       this.midStreamCompactionPending
     )
       return;

--- a/src/node/services/agentSession.turnCompletion.test.ts
+++ b/src/node/services/agentSession.turnCompletion.test.ts
@@ -413,6 +413,98 @@ describe("AgentSession turn completion", () => {
     }
   );
 
+  test.each(["completed", "aborted"] as const)(
+    "edit reserves the next turn before interruption finishes (%s)",
+    async (status) => {
+      const completion = Promise.withResolvers<TurnCompletion>();
+      const stopEntered = Promise.withResolvers<void>();
+      const stopReleased = Promise.withResolvers<void>();
+      const replacementStarted = Promise.withResolvers<void>();
+      const emitter = new EventEmitter();
+      const streamMessage = mock(() => {
+        const messageId = `assistant-${streamMessage.mock.calls.length}`;
+        start(emitter, messageId);
+        if (streamMessage.mock.calls.length > 1) replacementStarted.resolve();
+        return Promise.resolve(
+          Ok({
+            messageId,
+            completion:
+              streamMessage.mock.calls.length === 1
+                ? completion.promise
+                : createStartedTurnHandle(h.session.closingSignal).completion,
+          })
+        );
+      });
+      const h = await createAgentSessionHarness({
+        workspaceId,
+        aiEmitter: emitter,
+        captureEvents: true,
+        aiServiceOverrides: {
+          streamMessage,
+          stopStream: mock(async () => {
+            stopEntered.resolve();
+            await stopReleased.promise;
+            return Ok(undefined);
+          }),
+        },
+      });
+      const consumer = observePolicy(h.session);
+      const outcome: TurnCompletion =
+        status === "completed"
+          ? { status, streamEnd: end() }
+          : { status, abortReason: "user", streamAbort: abort() };
+      let edit: ReturnType<AgentSession["sendMessage"]> | undefined;
+      try {
+        await h.session.sendMessage("original", sendOptions);
+        const firstPolicy = policyPromise(consumer);
+        const history = await h.historyService.getHistoryFromLatestBoundary(workspaceId);
+        if (!history.success) throw new Error(history.error);
+        const userId = history.data.find((message) => message.role === "user")!.id;
+        h.session.queueMessage("queued follow-up", {
+          ...sendOptions,
+          queueDispatchMode: "turn-end",
+        });
+        edit = h.session.sendMessage("edited", { ...sendOptions, editMessageId: userId });
+        await stopEntered.promise;
+
+        // The engine can finish naturally while stopStream is still settling. Its policy
+        // must not hand the turn to queued work that the edit would then wait on.
+        emitter.emit(
+          status === "completed" ? "stream-end" : "stream-abort",
+          status === "completed" ? end() : abort()
+        );
+        completion.resolve(outcome);
+        await firstPolicy;
+        expect(streamMessage).toHaveBeenCalledTimes(1);
+        expect(internal(h.session).coordinator.phase).toBe("idle");
+        expect(h.session.isBusy()).toBe(true);
+
+        stopReleased.resolve();
+        expect((await edit).success).toBe(true);
+        await replacementStarted.promise;
+        expect(streamMessage).toHaveBeenCalledTimes(2);
+        expect(h.session.hasQueuedMessages()).toBe(false);
+        expect(h.events.filter((event) => event.type === "restore-to-input")).toMatchObject([
+          { text: "queued follow-up" },
+        ]);
+        const editedHistory = await h.historyService.getHistoryFromLatestBoundary(workspaceId);
+        if (!editedHistory.success) throw new Error(editedHistory.error);
+        expect(
+          editedHistory.data
+            .filter((message) => message.role === "user")
+            .map((message) => message.parts)
+        ).toMatchObject([[{ type: "text", text: "edited" }]]);
+      } finally {
+        h.session.beginDispose();
+        completion.resolve(outcome);
+        stopReleased.resolve();
+        await edit;
+        await h.session.dispose();
+        await h.cleanup();
+      }
+    }
+  );
+
   test.each(["user", "system"] as const)(
     "startup %s cancellation handle does not duplicate its delayed notification",
     async (reason) => {

--- a/tests/ipc/streaming/queuedMessages.completing.test.ts
+++ b/tests/ipc/streaming/queuedMessages.completing.test.ts
@@ -644,21 +644,24 @@ describe("Queued messages during stream completion", () => {
       }
       expect(queuedEvent.queuedMessages).toEqual([queuedText]);
 
+      const editWaiting = createDeferred<void>();
+      const waitForIdle = session.waitForIdle.bind(session);
+      const waitForIdleSpy = jest.spyOn(session, "waitForIdle").mockImplementationOnce((signal) => {
+        editWaiting.resolve();
+        return waitForIdle(signal);
+      });
+
       const editedText = "Edited message";
       const editSendPromise = sendMessageWithModel(env, workspaceId, editedText, HAIKU_MODEL, {
         editMessageId: firstUserMessageId,
       });
 
-      // Ensure the edit armed the defer latch before allowing stream-end cleanup to continue.
-      // Without this, the test can race stream-end and release the completion gate too early.
-      const armedDeferLatch = await waitFor(() => {
-        return Boolean(
-          (session as unknown as { deferQueuedFlushUntilAfterEdit?: boolean })
-            .deferQueuedFlushUntilAfterEdit
-        );
-      }, 5000);
-      if (!armedDeferLatch) {
-        throw new Error("Edit never armed deferQueuedFlushUntilAfterEdit latch");
+      // Join the actual edit wait before releasing completion, rather than polling
+      // a private latch that duplicates the reservation owning this operation.
+      try {
+        await editWaiting.promise;
+      } finally {
+        waitForIdleSpy.mockRestore();
       }
 
       releaseCompletion.resolve();


### PR DESCRIPTION
## Summary

Fix message edits hanging during an active stream by reserving the edit before awaiting interruption. Terminal policy can no longer dispatch a queued successor while `stopStream` settles, leaving the edit waiting on the wrong turn.

## Implementation

- Use the existing owned edit reservation for the entire interruption → truncation → replacement-startup path.
- Remove the separate queue-deferral flag and its try/finally synchronization; preserve completion cleanup, startup preemption, and admission guards.
- Allow the edited startup's own emergency context-budget recovery through its reservation without admitting competing turns.

## Validation

- Deterministic completion/abort races failed before the fix and pass afterward: the edit retains ownership, restores queued input, and persists only the edited user turn.
- Added a regression for emergency budget recovery during edited startup.
- After rebasing onto current main, all 667 agent-session/coordinator tests passed (~11s).
- All 6 stream-completion IPC tests pass under Node 22 (~6s); replaced the old private-flag polling with an explicit edit-wait barrier.
- `make static-check` passes locally.

## Subtractive ledger

Production: **26 lines added, 48 removed; net −22**. Removed duplicate edit-deferral state, its synchronization, and a redundant queue-drain guard. Existing reservation ownership and cleanup now enforce the same safety boundary across the whole operation. No unrelated offsets.

## Risks

This changes edit exclusion timing across stream completion, queue dispatch, and compaction. Existing completion/admission/queue tests remain green, and owned budget-recovery coverage protects the edited request from blocking itself.

---

_Generated with `xum` • Model: `openai:gpt-6-astra` • Thinking: `xhigh` • Cost: `$3.79`_

<!-- mux-attribution: model=openai:gpt-6-astra thinking=xhigh costs=3.79 -->
