### PR TITLE
🤖 fix: roll back a turn when shutdown lands in its pre-acceptance awaits

### DIFF
--- a/src/node/services/agentSession.scopedLifetimes.test.ts
+++ b/src/node/services/agentSession.scopedLifetimes.test.ts
@@ -166,8 +166,9 @@ describe("AgentSession scoped turn lifetimes", () => {
       release.resolve();
       await Promise.all([send, closing]);
       expect(spyOn(h.aiService, "streamMessage")).not.toHaveBeenCalled();
+      // The joined append is then rolled back: the refused turn leaves no row for startup recovery.
       const history = await h.historyService.getHistoryFromLatestBoundary(workspaceId);
-      expect(history.success && history.data.some((message) => message.role === "user")).toBe(true);
+      expect(history).toEqual(Ok([]));
     } finally {
       release.resolve();
       await send;

--- a/src/node/services/agentSession.startupAutoRetry.test.ts
+++ b/src/node/services/agentSession.startupAutoRetry.test.ts
@@ -328,6 +328,66 @@ describe("AgentSession startup auto-retry recovery", () => {
     }
   );
 
+  test.each(["materialize", "append"] as const)(
+    "beginShutdown inside an edit's %s await keeps the replacement row after truncation",
+    async (window) => {
+      const workspaceId = `startup-retry-shutdown-edit-${window}`;
+      const streamMessage = mock(() =>
+        Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal, "assistant-1")))
+      );
+      const { session, historyService, cleanup } = await createSessionBundle(workspaceId, {
+        streamMessage: streamMessage as unknown as AgentSessionAIService["streamMessage"],
+      });
+      cleanups.push(cleanup);
+      for (const [id, role, text] of [
+        ["u0", "user", "first turn"],
+        ["a0", "assistant", "first answer"],
+        ["u1", "user", "original wording"],
+        ["a1", "assistant", "answer to the original"],
+      ] as const) {
+        const row = createMuxMessage(id, role, text, { timestamp: Date.now() });
+        expect((await historyService.appendToHistory(workspaceId, row)).success).toBe(true);
+      }
+
+      // The edit has already truncated u1 and a1 when shutdown lands; only the replacement row
+      // records the user's input now, so it must survive instead of being rolled back.
+      if (window === "materialize") {
+        const internals = session as unknown as {
+          materializeAgentSkillSnapshots: (...args: unknown[]) => Promise<MuxMessage[]>;
+        };
+        const materialize = internals.materializeAgentSkillSnapshots.bind(session);
+        internals.materializeAgentSkillSnapshots = async (...args: unknown[]) => {
+          const snapshots = await materialize(...args);
+          session.beginShutdown();
+          return snapshots;
+        };
+      } else {
+        const append = historyService.appendToHistory.bind(historyService);
+        spyOn(historyService, "appendToHistory").mockImplementation(async (id, message) => {
+          const result = await append(id, message);
+          session.beginShutdown();
+          return result;
+        });
+      }
+
+      const sendResult = await session.sendMessage("edited wording", {
+        model: "anthropic:claude-sonnet-4-5",
+        agentId: "exec",
+        editMessageId: "u1",
+      });
+      expect(sendResult.success).toBe(false);
+      expect(streamMessage).not.toHaveBeenCalled();
+      const history = await historyService.getHistoryFromLatestBoundary(workspaceId);
+      expect(history.success ? history.data : ["unexpected"]).toMatchObject([
+        { id: "u0" },
+        { id: "a0" },
+        { role: "user", parts: [{ type: "text", text: "edited wording" }] },
+      ]);
+
+      await session.dispose();
+    }
+  );
+
   test("beginShutdown during pre-stream awaits stops the stream before the provider", async () => {
     const workspaceId = "startup-retry-shutdown-mid-prepare";
     const streamMessage = mock(() =>

--- a/src/node/services/agentSession.startupAutoRetry.test.ts
+++ b/src/node/services/agentSession.startupAutoRetry.test.ts
@@ -16,7 +16,11 @@ import type { HistoryService } from "./historyService";
 import type { Config } from "@/node/config";
 import type { InitStateManager } from "./initStateManager";
 import type { WorkspaceChatMessage, SendMessageOptions } from "@/common/orpc/types";
-import { createMuxMessage, pickStartupRetrySendOptions } from "@/common/types/message";
+import {
+  createMuxMessage,
+  pickStartupRetrySendOptions,
+  type MuxMessage,
+} from "@/common/types/message";
 import { DEFAULT_RUNTIME_CONFIG } from "@/common/constants/workspace";
 import type { WorkspaceMetadata } from "@/common/types/workspace";
 import { Ok } from "@/common/types/result";
@@ -268,6 +272,61 @@ describe("AgentSession startup auto-retry recovery", () => {
 
     await session.dispose();
   });
+
+  test.each(["materialize", "append"] as const)(
+    "beginShutdown inside the %s await rolls the unaccepted turn back instead of leaving a row",
+    async (window) => {
+      const workspaceId = `startup-retry-shutdown-mid-${window}`;
+      const streamMessage = mock(() =>
+        Promise.resolve(Ok(createStartedTurnHandle(session.closingSignal, "assistant-1")))
+      );
+      const { session, historyService, cleanup } = await createSessionBundle(workspaceId, {
+        streamMessage: streamMessage as unknown as AgentSessionAIService["streamMessage"],
+      });
+      cleanups.push(cleanup);
+      const seeded = [
+        createMuxMessage("user-0", "user", "earlier turn", { timestamp: Date.now() }),
+        createMuxMessage("assistant-0", "assistant", "earlier answer", { timestamp: Date.now() }),
+      ];
+      for (const row of seeded) {
+        expect((await historyService.appendToHistory(workspaceId, row)).success).toBe(true);
+      }
+
+      // Shutdown lands after the pre-persist latch check passed, inside a later pre-acceptance
+      // await: snapshot materialization, or the user row's own append (already durable then).
+      if (window === "materialize") {
+        const internals = session as unknown as {
+          materializeAgentSkillSnapshots: (...args: unknown[]) => Promise<MuxMessage[]>;
+        };
+        const materialize = internals.materializeAgentSkillSnapshots.bind(session);
+        internals.materializeAgentSkillSnapshots = async (...args: unknown[]) => {
+          const snapshots = await materialize(...args);
+          session.beginShutdown();
+          return snapshots;
+        };
+      } else {
+        const append = historyService.appendToHistory.bind(historyService);
+        spyOn(historyService, "appendToHistory").mockImplementation(async (id, message) => {
+          const result = await append(id, message);
+          session.beginShutdown();
+          return result;
+        });
+      }
+
+      const sendResult = await session.sendMessage("hello", {
+        model: "anthropic:claude-sonnet-4-5",
+        agentId: "exec",
+      });
+      expect(sendResult.success).toBe(false);
+      expect(streamMessage).not.toHaveBeenCalled();
+      const history = await historyService.getHistoryFromLatestBoundary(workspaceId);
+      expect(history.success ? history.data.map((row) => row.id) : ["unexpected"]).toEqual(
+        seeded.map((row) => row.id)
+      );
+
+      await session.dispose();
+    }
+  );
 
   test("beginShutdown during pre-stream awaits stops the stream before the provider", async () => {
     const workspaceId = "startup-retry-shutdown-mid-prepare";

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -4422,6 +4422,14 @@ export class AgentSession {
         )
       );
     }
+    // The shutdown latch was checked before the snapshot materialization and history I/O above,
+    // and isCurrentTurn stays true while merely closing. Refuse while the rows are still
+    // rollback-eligible: retained, they read as a dispatched turn to the next startup.
+    if (this.coordinator.closing) {
+      return refuseBeforeAcceptance(
+        createUnknownSendMessageError(SESSION_SHUTDOWN_SEND_BLOCKED_MESSAGE)
+      );
+    }
 
     if (contextRollover) {
       // Branch summaries must remain discoverable if the append/rollback failed. Only

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -3427,6 +3427,12 @@ export class AgentSession {
       internal?.admissionStale?.() === true ||
       !this.coordinator.isCurrentTurn(attempt.owner ?? attempt.expectedTurn) ||
       this.coordinator.editBlocked(attempt.editReservation?.id);
+    // An edit's truncation is irreversible: past it, only the replacement row records the user's
+    // input, so shutdown must let that row land (the PREPARING gate then refuses with rows
+    // retained and startup recovery resumes the edit) rather than lose both versions.
+    let editTailTruncated = false;
+    const shutdownRefusesBeforePersist = (): boolean =>
+      this.coordinator.closing && !editTailTruncated;
 
     const cancelSignal = internal?.cancelSignal;
     const persistedCancelableMessageIds: string[] = [];
@@ -3837,6 +3843,7 @@ export class AgentSession {
           return Err(createUnknownSendMessageError(truncateResult.error));
         }
       } else {
+        editTailTruncated = true;
         // RLM mode: summarize the truncated tail into a durable labeled row
         // BEFORE the edited user message is appended and this turn's request is
         // built (log purity by construction). Best-effort with a hard deadline —
@@ -4171,7 +4178,7 @@ export class AgentSession {
     }
     // Still pre-persist: a row appended now would read as a dispatched turn on the next startup
     // while streamWithHistory's own latch check keeps its stream from ever running.
-    if (this.coordinator.closing) {
+    if (shutdownRefusesBeforePersist()) {
       return refuseBeforeAcceptance(
         createUnknownSendMessageError(SESSION_SHUTDOWN_SEND_BLOCKED_MESSAGE)
       );
@@ -4285,7 +4292,11 @@ export class AgentSession {
           [...contextBudgetPrefix, ...requestPrelude]
         );
         if (await cancelBeforeAcceptance()) return Ok(undefined);
-        if (isAdmissionStale() || this.coordinator.admissionBlocked || this.coordinator.closing) {
+        if (
+          isAdmissionStale() ||
+          this.coordinator.admissionBlocked ||
+          shutdownRefusesBeforePersist()
+        ) {
           return Err(createUnknownSendMessageError(CONTEXT_MUTATION_SEND_BLOCKED_MESSAGE));
         }
         if (!freshBudget.success) return await rejectBudgetSend(freshBudget.error);
@@ -4331,7 +4342,11 @@ export class AgentSession {
           await this.applyContextResetSideEffects();
         }
         if (await cancelBeforeAcceptance()) return Ok(undefined);
-        if (isAdmissionStale() || this.coordinator.admissionBlocked || this.coordinator.closing) {
+        if (
+          isAdmissionStale() ||
+          this.coordinator.admissionBlocked ||
+          shutdownRefusesBeforePersist()
+        ) {
           return Err(createUnknownSendMessageError(CONTEXT_MUTATION_SEND_BLOCKED_MESSAGE));
         }
         // Ordinary sends stay append-only; only coupled snapshots/boundaries need an atomic batch.
@@ -4425,7 +4440,7 @@ export class AgentSession {
     // The shutdown latch was checked before the snapshot materialization and history I/O above,
     // and isCurrentTurn stays true while merely closing. Refuse while the rows are still
     // rollback-eligible: retained, they read as a dispatched turn to the next startup.
-    if (this.coordinator.closing) {
+    if (shutdownRefusesBeforePersist()) {
       return refuseBeforeAcceptance(
         createUnknownSendMessageError(SESSION_SHUTDOWN_SEND_BLOCKED_MESSAGE)
       );


### PR DESCRIPTION
## Summary

`AgentSession.sendMessage` checked the shutdown latch once, before awaiting snapshot materialization and the turn's history appends. A shutdown that began inside those awaits left the appended rows durable while the turn was still refused, so the next startup read the answer-less user row as an interrupted turn and auto-retried it. The latch is now re-checked at the rollback horizon, where the rows are still rollback-eligible, and the refusal goes through the existing rollback path. Edits are the one exception: once their truncation has happened, shutdown lets the replacement row land instead of losing both versions of the input.

Fixes #4073

## Background

Codex flagged this on #4058 (round 23, P2). The pre-persist gate added there refuses shutdown before any row lands, but everything after it (`materializeAgentSkillSnapshots`, `materializeMcpPromptSnapshots`, the snapshot/user-row appends) is awaited with no further latch check. `isCurrentTurn` stays true while the coordinator is merely closing, so the existing rollback-horizon checkpoint did not observe the shutdown either; `coordinator.prepare()` later rejected the turn with `closing`, returning `Err` to the caller with the row already durable.

## Implementation

- One new check at the rollback horizon (after the caller-probe staleness checkpoint, before `markRowsDurable()`) that refuses through `refuseBeforeAcceptance`, the same helper the pre-persist gate uses: it rolls back this attempt's rows and marks them durable only if the rollback verifiably failed. Covering the horizon rather than only the two materialize awaits closes the append-I/O windows too, and every path (ordinary, pre-turn batch, on-send compaction row, token-budget batch) funnels through it.
- Edits: `truncateAfterMessage` runs before any of these checks and is irreversible. Every pre-persist shutdown refusal an edit can reach afterwards (the pre-persist gate, the two token-budget checks before the batch append, and the new horizon check) now goes through `shutdownRefusesBeforePersist()`, which stays false once the truncation succeeded. The replacement row lands, the PREPARING gate refuses the turn with the row retained, and startup recovery resumes the edit. Before truncation, and for the missing-target no-op truncation, shutdown still refuses as before.
- The `scopedLifetimes` join test previously pinned the retained row after a shutdown landing inside an ordinary send's append; its join assertions are unchanged and it now asserts the rolled-back outcome.

## Validation

- New `startupAutoRetry` cases run shutdown inside the stubbed `materializeAgentSkillSnapshots` await and inside the user row's own append (row durable, then removed). Both were red on `origin/main` at the history assertion (refusal returned, one extra durable row) and are green with the fix; seeded earlier rows survive the rollback.
- Edit cases: the same two windows with `editMessageId` keep `[u0, a0, replacement]` and start no provider; both fail when the truncation flag is not set.
- All 34 `agentSession*.test.ts` suites and `make static-check` pass locally.

## Risks

Low and confined to shutdown ordering. The checks only fire when `beginShutdown()` has already run, and the turn was already going to be refused at the PREPARING gate; the change is that ordinary sends roll their rows back instead of retaining them, while post-truncation edits proceed to persist their replacement instead of refusing (previously the pre-persist gate could refuse a truncated edit and leave neither version). The emergency rollover path (`rolloverAfterBudgetFailure`) is separate and untouched.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=0.00 -->
