### PR TITLE
🤖 fix: bound the origin fetch during worktree workspace creation

### DIFF
--- a/src/constants/terminationTimeouts.ts
+++ b/src/constants/terminationTimeouts.ts
@@ -4,6 +4,13 @@ export const TASK_TERMINATION_WORKSPACE_REMOVE_TIMEOUT_MS = 2 * 60 * 1000;
 export const WORKTREE_DELETE_GIT_TIMEOUT_MS = 60 * 1000;
 
 /**
+ * Bounds the best-effort `git fetch origin <trunk>` before a local worktree is added. A Git
+ * credential helper (for example Coder's askpass waiting on missing external auth) can block the
+ * fetch indefinitely; after this deadline creation continues from the local trunk.
+ */
+export const WORKTREE_CREATE_FETCH_TIMEOUT_MS = 15 * 1000;
+
+/**
  * Bounds backup Git calls that can hang on a blackholed remote, while leaving room for a
  * slow initial clone.
  */

--- a/src/node/worktree/WorktreeManager.test.ts
+++ b/src/node/worktree/WorktreeManager.test.ts
@@ -32,6 +32,7 @@ async function createWorktreeManagerFixture(options?: {
   existingBranchName?: string;
   currentBranchName?: string;
   tempDirPrefix?: string;
+  fetchTimeoutMs?: number;
 }) {
   const rootDir = await fsPromises.realpath(
     await fsPromises.mkdtemp(
@@ -56,10 +57,80 @@ async function createWorktreeManagerFixture(options?: {
   return {
     rootDir,
     projectPath,
-    manager: new WorktreeManager(srcBaseDir),
+    manager: new WorktreeManager(
+      srcBaseDir,
+      options?.fetchTimeoutMs === undefined ? undefined : { fetchTimeoutMs: options.fetchTimeoutMs }
+    ),
     initLogger: createNullInitLogger(),
     cleanup: () => fsPromises.rm(rootDir, { recursive: true, force: true }),
   };
+}
+
+/**
+ * Point origin at an upload-pack shim that never answers and leaves a background child holding
+ * the inherited stdio pipes, like a credential helper blocked on external authentication.
+ */
+async function installStalledOriginFetch(fixture: { rootDir: string; projectPath: string }) {
+  const pidFile = path.join(fixture.rootDir, "stall-pids");
+  const shim = path.join(fixture.rootDir, "stalled-upload-pack.sh");
+  await fsPromises.writeFile(
+    shim,
+    `#!/bin/sh\nsleep 600 &\nprintf '%s\\n%s\\n' "$$" "$!" > "${pidFile}"\nwait\n`,
+    "utf-8"
+  );
+  await fsPromises.chmod(shim, 0o755);
+  execFileSync("git", ["remote", "add", "origin", "."], {
+    cwd: fixture.projectPath,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["config", "remote.origin.uploadpack", shim], {
+    cwd: fixture.projectPath,
+    stdio: "ignore",
+  });
+
+  return {
+    async waitForPids(): Promise<number[]> {
+      const deadline = Date.now() + 5_000;
+      while (Date.now() < deadline) {
+        const lines = await fsPromises.readFile(pidFile, "utf-8").then(
+          (content) => content.trim().split("\n"),
+          () => []
+        );
+        if (lines.length === 2) return lines.map(Number);
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+      throw new Error("stalled upload-pack shim did not start");
+    },
+  };
+}
+
+async function isProcessGone(pid: number): Promise<boolean> {
+  try {
+    process.kill(pid, 0);
+  } catch {
+    return true;
+  }
+  // A killed orphan that PID 1 has not reaped yet still answers signal 0.
+  return fsPromises.readFile(`/proc/${pid}/stat`, "utf-8").then(
+    (stat) => stat.slice(stat.lastIndexOf(")") + 2).startsWith("Z"),
+    () => false
+  );
+}
+
+async function waitForProcessesToExit(pids: number[]): Promise<boolean> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const gone = await Promise.all(pids.map(isProcessGone));
+    if (gone.every(Boolean)) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return false;
+}
+
+function gitRevParseHead(cwd: string): string {
+  return execFileSync("git", ["rev-parse", "HEAD"], { cwd, stdio: ["ignore", "pipe", "ignore"] })
+    .toString()
+    .trim();
 }
 
 describe("WorktreeManager constructor", () => {
@@ -235,6 +306,116 @@ describe("WorktreeManager.createWorkspace", () => {
       } else {
         process.env.XUM_DISABLE_PROJECT_AUTOMATION = previous;
       }
+      await fixture.cleanup();
+    }
+  }, 20_000);
+
+  it("bounds a stalled origin fetch, kills its process tree, and falls back to the local trunk", async () => {
+    const fixture = await createWorktreeManagerFixture({ fetchTimeoutMs: 1_000 });
+
+    try {
+      const stall = await installStalledOriginFetch(fixture);
+      const stderrLines: string[] = [];
+
+      const result = await fixture.manager.createWorkspace({
+        projectPath: fixture.projectPath,
+        branchName: "feature-stalled-fetch",
+        trunkBranch: "main",
+        trusted: true,
+        initLogger: {
+          ...fixture.initLogger,
+          logStderr: (line) => stderrLines.push(line),
+        },
+      });
+
+      expect(result.success).toBe(true);
+      if (!result.success || !result.workspacePath) {
+        throw new Error("Expected createWorkspace to fall back to the local trunk");
+      }
+      expect(stderrLines.some((line) => line.includes("did not finish within"))).toBe(true);
+      expect(gitRevParseHead(result.workspacePath)).toBe(gitRevParseHead(fixture.projectPath));
+
+      const pids = await stall.waitForPids();
+      expect(await waitForProcessesToExit(pids)).toBe(true);
+    } finally {
+      await fixture.cleanup();
+    }
+  }, 20_000);
+
+  it("keeps caller cancellation a cancellation while the origin fetch stalls", async () => {
+    const fixture = await createWorktreeManagerFixture({ fetchTimeoutMs: 30_000 });
+
+    try {
+      const stall = await installStalledOriginFetch(fixture);
+      const controller = new AbortController();
+      const stderrLines: string[] = [];
+      const workspacePath = fixture.manager.getWorkspacePath(
+        fixture.projectPath,
+        "feature-cancelled-fetch"
+      );
+
+      const pending = fixture.manager.createWorkspace({
+        projectPath: fixture.projectPath,
+        branchName: "feature-cancelled-fetch",
+        trunkBranch: "main",
+        trusted: true,
+        abortSignal: controller.signal,
+        initLogger: {
+          ...fixture.initLogger,
+          logStderr: (line) => stderrLines.push(line),
+        },
+      });
+      const pids = await stall.waitForPids();
+      controller.abort();
+      const result = await pending;
+
+      expect(result.success).toBe(false);
+      expect(stderrLines).toEqual([]);
+      const workspaceExists = await fsPromises.access(workspacePath).then(
+        () => true,
+        () => false
+      );
+      expect(workspaceExists).toBe(false);
+      expect(await waitForProcessesToExit(pids)).toBe(true);
+    } finally {
+      await fixture.cleanup();
+    }
+  }, 20_000);
+
+  it("bases new branches on the freshly fetched origin trunk", async () => {
+    const fixture = await createWorktreeManagerFixture();
+
+    try {
+      const remotePath = path.join(fixture.rootDir, "remote");
+      execFileSync("git", ["clone", "--quiet", fixture.projectPath, remotePath], {
+        stdio: "ignore",
+      });
+      execSync(
+        'git config user.email "test@example.com" && git config user.name "test" && ' +
+          'git config commit.gpgsign false && git commit --allow-empty -m "remote-only"',
+        { cwd: remotePath, stdio: "ignore" }
+      );
+      execFileSync("git", ["remote", "add", "origin", remotePath], {
+        cwd: fixture.projectPath,
+        stdio: "ignore",
+      });
+      const remoteHead = gitRevParseHead(remotePath);
+      expect(remoteHead).not.toBe(gitRevParseHead(fixture.projectPath));
+
+      const result = await fixture.manager.createWorkspace({
+        projectPath: fixture.projectPath,
+        branchName: "feature-fresh-origin",
+        trunkBranch: "main",
+        trusted: true,
+        initLogger: fixture.initLogger,
+      });
+
+      expect(result.success).toBe(true);
+      if (!result.success || !result.workspacePath) {
+        throw new Error("Expected createWorkspace to return a workspace path");
+      }
+      expect(gitRevParseHead(result.workspacePath)).toBe(remoteHead);
+    } finally {
       await fixture.cleanup();
     }
   }, 20_000);

--- a/src/node/worktree/WorktreeManager.ts
+++ b/src/node/worktree/WorktreeManager.ts
@@ -20,7 +20,10 @@ import {
   gitNoRepoAutomationEnv,
   gitNoRepoAutomationEnvForLocalRepo,
 } from "@/node/utils/gitNoHooksEnv";
-import { WORKTREE_DELETE_GIT_TIMEOUT_MS } from "@/constants/terminationTimeouts";
+import {
+  WORKTREE_CREATE_FETCH_TIMEOUT_MS,
+  WORKTREE_DELETE_GIT_TIMEOUT_MS,
+} from "@/constants/terminationTimeouts";
 import { syncLocalGitSubmodules } from "@/node/runtime/submoduleSync";
 import { syncXumignoreFiles } from "./xumignore";
 
@@ -35,10 +38,12 @@ const MISSING_WORKTREE_ERROR_PATTERNS = ["not a working tree", "does not exist",
 
 export class WorktreeManager {
   private readonly srcBaseDir: string;
+  private readonly fetchTimeoutMs: number;
 
-  constructor(srcBaseDir: string) {
+  constructor(srcBaseDir: string, options?: { fetchTimeoutMs?: number }) {
     // Expand tilde to actual home directory path for local file system operations
     this.srcBaseDir = expandTilde(srcBaseDir);
+    this.fetchTimeoutMs = options?.fetchTimeoutMs ?? WORKTREE_CREATE_FETCH_TIMEOUT_MS;
   }
 
   getWorkspacePath(projectPath: string, workspaceName: string): string {
@@ -294,21 +299,39 @@ export class WorktreeManager {
     initLogger: InitLogger,
     noHooksEnv: GitExecOptions
   ): Promise<boolean> {
+    // A credential helper such as Coder's askpass can block the fetch indefinitely while it waits
+    // for external authentication, and even a killed fetch leaves helpers holding the stdio pipes.
+    // Bound the fetch separately from caller cancellation so a deadline falls back to the local
+    // trunk while an explicit abort still cancels creation.
+    const deadline = AbortSignal.timeout(this.fetchTimeoutMs);
+    const callerSignal = noHooksEnv?.signal;
     try {
       initLogger.logStep(`Fetching latest from origin/${trunkBranch}...`);
 
-      using fetchProc = execFileAsync(
-        "git",
-        ["-C", projectPath, "fetch", "origin", trunkBranch],
-        noHooksEnv
-      );
+      using fetchProc = execFileAsync("git", ["-C", projectPath, "fetch", "origin", trunkBranch], {
+        ...noHooksEnv,
+        signal: callerSignal ? AbortSignal.any([callerSignal, deadline]) : deadline,
+        killTreeOnTermination: true,
+      });
       await fetchProc.result;
 
       initLogger.logStep("Fetched latest from origin");
       return true;
     } catch (error) {
-      if (isAbortError(error, noHooksEnv?.signal)) {
+      if (isAbortError(error, callerSignal)) {
         throw error;
+      }
+      if (deadline.aborted) {
+        const seconds = Math.round(this.fetchTimeoutMs / 1000);
+        initLogger.logStderr(
+          `Note: Fetch from origin did not finish within ${seconds}s (Git may be waiting on a credential helper or external authentication); using local branch state`
+        );
+        log.warn("Worktree creation fetch timed out; using local trunk", {
+          projectPath,
+          trunkBranch,
+          timeoutMs: this.fetchTimeoutMs,
+        });
+        return false;
       }
       const errorMsg = getErrorMessage(error);
       // Branch doesn't exist on origin (common for subagent local-only branches)


### PR DESCRIPTION
## Summary

Bound the best-effort `git fetch origin <trunk>` that runs before a local worktree is added, so workspace creation can no longer hang forever when a Git credential helper (Coder's askpass waiting on missing or expired GitHub external auth) blocks the fetch. After 15 s the fetch process tree is killed, creation continues from the local trunk with a diagnostic init-log note, and an explicit cancellation still cancels creation instead of falling back.

Fixes #4122

## Background

`WorktreeManager.createWorkspace` awaited `fetchOriginTrunk` with no deadline. Inside a Coder workspace with an HTTPS GitHub origin and no valid external auth, Coder's askpass helper waits indefinitely, so the whole creation request stayed pending: nothing appeared in the sidebar, no error was shown, and fetch processes were observed waiting on askpass for 40+ minutes. Killing only the `git fetch` leader is not enough either: the helper descendants inherit the subprocess stdio pipes, so Node's `close` event never fires and the awaiting promise still never settles (this also meant cancelling the creation hung today).

## Implementation

- `WORKTREE_CREATE_FETCH_TIMEOUT_MS = 15 s` (new constant in `src/constants/terminationTimeouts.ts`). `WorktreeManager` takes an optional `{ fetchTimeoutMs }` so tests can shorten it; runtime callers are unchanged.
- `fetchOriginTrunk` runs the fetch with `AbortSignal.any([callerSignal, AbortSignal.timeout(fetchTimeoutMs)])` and the existing `killTreeOnTermination: true` option of `execFileAsync` (detached process group + SIGKILL of the group on Unix, `taskkill /T` on Windows, stdio pipes destroyed so `close` fires).
- Catch order: caller abort is rethrown first (cancellation stays a cancellation and no worktree is added); a fired deadline logs `Note: Fetch from origin did not finish within 15s (Git may be waiting on a credential helper or external authentication); using local branch state` plus a `log.warn`, then returns `false` so the existing local-trunk fallback runs; other fetch failures keep their current handling.
- `SSHRuntime.fetchOriginTrunk` already bounds its remote fetch (120 s exec timeout) and is untouched.

## Validation

- Red-green: on unfixed `main` both new stall tests hang until the 20 s test timeout. With the deadline but `killTreeOnTermination: false` they still hang, proving the tests guard process-tree termination and not just the timeout. With the full fix all 21 tests in `WorktreeManager.test.ts` pass.
- The stall fixture points `origin` at a `remote.origin.uploadpack` shim that spawns `sleep 600 &` (inherits the stdio pipes) and `wait`s; tests assert the fallback result, the diagnostic note, that the new branch is based on the local trunk, and that both shim PIDs are gone (zombies awaiting reap count as gone).
- Cancellation test: aborting while the shim stalls returns `success: false`, logs no fallback note, leaves no workspace directory, and kills the shim tree.
- Fresh-origin test: with a reachable origin holding a newer commit, the new workspace HEAD equals `origin/main`.
- Remote dogfood UAT (Coder Agents, real UI, head `17fbae3549`): a project whose origin needs credentials and whose credential helper never answers created its workspace in 15.10 s and 15.13 s with the diagnostic note visible in the init log; the creation fetch's process group (git, helper, and its `sleep`) was gone within a second of the deadline with no manual cleanup; a healthy origin with a newer commit created the branch on the fresh `origin/main` (96 ms); a genuine creation failure (ref lock permission denied) surfaced as a visible error.
- UAT observations outside this change (no code changed for them, none shown to be regressions): deleting the pending draft row in the UI during the stalled fetch does not abort the backend creation, because the create request has not returned a workspace id yet (explicit `AbortSignal` cancellation is covered by the unit test); the background git-status fetch is a separate app-owned fetch path that also stalls on the same credential helper and is not bounded by this PR; stopping the server during the 15 s window orphans the detached fetch group, which is inherent to `killTreeOnTermination`.

## Risks

Low and scoped to local worktree creation. Behavior change: a fetch that legitimately takes longer than 15 s (very slow network, huge delta) now falls back to the local trunk with a visible note instead of waiting; the background git-status fetch keeps `origin/<trunk>` fresh in normal use, and creation already fell back when the fetch failed. The fetch now runs in its own process group on Unix (required for group kill), which is the same mode other bounded git calls in the repo use.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$26.89`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=26.89 -->
