### PR TITLE
🤖 fix: preserve Codex OAuth prompt cache routing

### DIFF
--- a/scripts/check_codex_comments_test.py
+++ b/scripts/check_codex_comments_test.py
@@ -141,16 +141,20 @@ else:
                         cache=data if cached else None,
                     )
 
-    def test_auto_triggered_security_heading_does_not_hide_findings(self):
-        header = "### 🛡️ Codex Security Review · _Automatically triggered_\n\n"
+    def test_security_headings_do_not_hide_findings(self):
         clean = FIXTURES["security_no_findings"]["body"]
-        for body, expected in (
-            (clean, 0),
-            (clean + "\n\n[P1] A security issue still needs fixing.", 1),
-            ("Security review completed. Found a P1 credential disclosure.", 1),
+        for header in (
+            "### 🛡️ Codex Security Review\n\n",
+            "### 🛡️ Codex Security Review · _Automatically triggered_\n\n",
         ):
-            with self.subTest(body=body):
-                self.assert_gate(expected, snapshot([comment(header + body)]))
+            for body, expected in (
+                (clean, 0),
+                (clean + "\n\n[P1] A security issue still needs fixing.", 1),
+                ("Security review completed. Found a P1 credential disclosure.", 1),
+                (header + clean, 1),
+            ):
+                with self.subTest(header=header, body=body):
+                    self.assert_gate(expected, snapshot([comment(header + body)]))
 
     def test_summary_completion_requires_metadata_and_every_review_row(self):
         completed = FIXTURES["summary"]["body"]

--- a/scripts/lib/codex_comments.jq
+++ b/scripts/lib/codex_comments.jq
@@ -4,7 +4,7 @@
 # Strip only the observed help text: a heading alone must not hide a finding
 # added inside the details section, or a second section appended after it.
 def codex_without_help:
-  ltrimstr("### 🛡️ Codex Security Review · _Automatically triggered_\n\n")
+  sub("^### 🛡️ Codex Security Review( · _Automatically triggered_)?\n\n"; "")
   | rtrimstr("\n\n<details> <summary>ℹ️ About Codex in GitHub</summary>\n<br/>\n\n"
     + "[Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you\n"
     + "- Open a pull request for review\n- Mark a draft as ready\n- Comment \"@codex review\" or \"@codex security review\".\n\n"

--- a/src/node/services/providerModelFactory.test.ts
+++ b/src/node/services/providerModelFactory.test.ts
@@ -1189,8 +1189,12 @@ describe("ProviderModelFactory GitHub Copilot", () => {
         expect(headers.get("content-type")).toBe("application/json");
         expect(headers.get("session-id")).toBeNull();
 
-        for (const sessionId of [undefined, "explicit-session"]) {
-          const promptCacheKey = "mux-v1-project-scope";
+        for (const [promptCacheKey, sessionId, expectedSessionId] of [
+          ["mux-v1-project-scope", undefined, "mux-v1-project-scope"],
+          ["mux-v1-日本語-scope", undefined, "mux-v1-%E6%97%A5%E6%9C%AC%E8%AA%9E-scope"],
+          ["mux-v1-project\nscope", undefined, "mux-v1-project%0Ascope"],
+          ["mux-v1-project-scope", "explicit-session", "explicit-session"],
+        ] as const) {
           const cacheHeaders = new Headers(request.headers);
           if (sessionId) cacheHeaders.set("session-id", sessionId);
           for (let turn = 0; turn < 2; turn++) {
@@ -1205,9 +1209,7 @@ describe("ProviderModelFactory GitHub Copilot", () => {
             });
             const outgoing = requests.at(-1);
             expect(outgoing?.input).toBe(CODEX_ENDPOINT);
-            expect(new Headers(outgoing?.init?.headers).get("session-id")).toBe(
-              sessionId ?? promptCacheKey
-            );
+            expect(new Headers(outgoing?.init?.headers).get("session-id")).toBe(expectedSessionId);
           }
         }
       } finally {

--- a/src/node/services/providerModelFactory.test.ts
+++ b/src/node/services/providerModelFactory.test.ts
@@ -1193,6 +1193,7 @@ describe("ProviderModelFactory GitHub Copilot", () => {
           ["mux-v1-project-scope", undefined, "mux-v1-project-scope"],
           ["mux-v1-日本語-scope", undefined, "mux-v1-%E6%97%A5%E6%9C%AC%E8%AA%9E-scope"],
           ["mux-v1-project\nscope", undefined, "mux-v1-project%0Ascope"],
+          ["mux-v1-\ud800-scope", undefined, "mux-v1-%EF%BF%BD-scope"],
           ["mux-v1-project-scope", "explicit-session", "explicit-session"],
         ] as const) {
           const cacheHeaders = new Headers(request.headers);
@@ -1205,10 +1206,14 @@ describe("ProviderModelFactory GitHub Copilot", () => {
                 model: "gpt-5.3-codex",
                 input: [{ role: "user", content: `Turn ${turn}` }],
                 prompt_cache_key: promptCacheKey,
+                store: true,
+                truncation: "auto",
               }),
             });
             const outgoing = requests.at(-1);
             expect(outgoing?.input).toBe(CODEX_ENDPOINT);
+            expect(JSON.parse(outgoing?.init?.body as string)).toMatchObject({ store: false });
+            expect(JSON.parse(outgoing?.init?.body as string)).not.toHaveProperty("truncation");
             expect(new Headers(outgoing?.init?.headers).get("session-id")).toBe(expectedSessionId);
           }
         }

--- a/src/node/services/providerModelFactory.test.ts
+++ b/src/node/services/providerModelFactory.test.ts
@@ -1187,6 +1187,29 @@ describe("ProviderModelFactory GitHub Copilot", () => {
         expect(headers.get("authorization")).toBe("Bearer test-access-token");
         expect(headers.get("chatgpt-account-id")).toBe("test-account-id");
         expect(headers.get("content-type")).toBe("application/json");
+        expect(headers.get("session-id")).toBeNull();
+
+        for (const sessionId of [undefined, "explicit-session"]) {
+          const promptCacheKey = "mux-v1-project-scope";
+          const cacheHeaders = new Headers(request.headers);
+          if (sessionId) cacheHeaders.set("session-id", sessionId);
+          for (let turn = 0; turn < 2; turn++) {
+            await capturedFetch(request.url, {
+              method: "POST",
+              headers: cacheHeaders,
+              body: JSON.stringify({
+                model: "gpt-5.3-codex",
+                input: [{ role: "user", content: `Turn ${turn}` }],
+                prompt_cache_key: promptCacheKey,
+              }),
+            });
+            const outgoing = requests.at(-1);
+            expect(outgoing?.input).toBe(CODEX_ENDPOINT);
+            expect(new Headers(outgoing?.init?.headers).get("session-id")).toBe(
+              sessionId ?? promptCacheKey
+            );
+          }
+        }
       } finally {
         PROVIDER_REGISTRY.openai = originalOpenAIRegistry;
       }

--- a/src/node/services/providerModelFactory.ts
+++ b/src/node/services/providerModelFactory.ts
@@ -1738,7 +1738,8 @@ export class ProviderModelFactory {
                       typeof promptCacheKey === "string" &&
                       promptCacheKey.length > 0
                     ) {
-                      headers.set("session-id", promptCacheKey);
+                      // Project names may contain Unicode or control characters invalid in headers.
+                      headers.set("session-id", encodeURIComponent(promptCacheKey));
                     }
                     nextInit = {
                       ...init,

--- a/src/node/services/providerModelFactory.ts
+++ b/src/node/services/providerModelFactory.ts
@@ -1728,6 +1728,18 @@ export class ProviderModelFactory {
                   try {
                     const headers = new Headers(init?.headers);
                     headers.delete("content-length");
+                    // Codex derives its cache routing key from session-id, not the body key.
+                    // Reuse Xum's stable scope so successive OAuth turns reach the same cache.
+                    const { prompt_cache_key: promptCacheKey } = JSON.parse(body) as {
+                      prompt_cache_key?: unknown;
+                    };
+                    if (
+                      !headers.has("session-id") &&
+                      typeof promptCacheKey === "string" &&
+                      promptCacheKey.length > 0
+                    ) {
+                      headers.set("session-id", promptCacheKey);
+                    }
                     nextInit = {
                       ...init,
                       headers,

--- a/src/node/services/providerModelFactory.ts
+++ b/src/node/services/providerModelFactory.ts
@@ -1738,8 +1738,11 @@ export class ProviderModelFactory {
                       typeof promptCacheKey === "string" &&
                       promptCacheKey.length > 0
                     ) {
-                      // Project names may contain Unicode or control characters invalid in headers.
-                      headers.set("session-id", encodeURIComponent(promptCacheKey));
+                      // UTF-8 replaces lone surrogates before encoding project names for HTTP headers.
+                      headers.set(
+                        "session-id",
+                        encodeURIComponent(Buffer.from(promptCacheKey).toString())
+                      );
                     }
                     nextInit = {
                       ...init,


### PR DESCRIPTION
## Summary
Forward a header-safe encoding of Xum's existing stable `prompt_cache_key` as a missing `session-id` for **Codex OAuth Responses requests**. The tested Codex backend uses this header for cache routing; keeping only the body key caused repeated misses.

- Preserve an explicitly supplied session header and leave callers without a nonempty string cache key unchanged.
- Reuse the existing project/workspace cache scope; Replace malformed UTF-16 via UTF-8, then URI-encode it so Unicode/control characters in project names cannot make `Headers.set()` reject the request. No new IDs, persistence, or thread/turn-state headers.
- Add fetch-boundary coverage for keyless callers, stable routing across turns, Unicode/control characters, lone surrogates, normalization invariants, and explicit-header precedence.
- **Scope:** OAuth routing/tests plus the explicitly authorized Codex CI parser fix. No gateway cache-write accounting changes.

## Evidence
A controlled diagnostic on `289277eb7` sent 14 byte-identical 6,177-token Astra OAuth bodies. In-phase completion-to-next-request gaps were ~14s (phase boundaries ~30–35s):

| Added headers | Raw cached input |
|---|---:|
| None, including after a warmed request | 0 on all three requests |
| Stable session + thread | 0 cold, then 6,016 twice |
| **Stable session only** | **6,016 twice (97.4%)** |
| Thread only | 0 twice |
| Client-request only | 0 |
| Existing non-UUID `mux-v1-…` scope as session | 0 cold → 6,016 |

The returned cache key followed `session-id` even when it differed from the body key. This is a reversible header-only result, not an inference from absent headers or changing response keys alone.

The initial header-forwarding patch was then dogfooded using **dev-server-sandbox + agent-browser**, a no-tools synthetic project, and existing unexpired OAuth credentials. Normalized instructions/tools/cache key stayed identical; every turn preserved the input prefix and appended two items. Baseline chat turns had 0 cache reads. The patched path went cold → **1,664/1,857 cached tokens (89.6%)**, visible in Stats.

<details>
<summary>Sanitized sandbox screenshots and recording</summary>

Before:
![Baseline OAuth turns: no Cache Read row](https://github.com/user-attachments/assets/5fe9b50b-143a-4ba5-b5b2-5a518d41e91a)

After:
![Patched OAuth path: Cache Read appears](https://github.com/user-attachments/assets/d001c69d-1e35-43fe-81e8-768a0e921d2d)

https://github.com/user-attachments/assets/54dba7c8-d4de-4b5e-a70a-f6b292c4978b

</details>

## Validation
- Fresh after rebasing onto `50b357e67`: **353 targeted tests passed** (`providerModelFactory.test.ts`, `providerOptions.test.ts`), ~1s.
- Fresh **`make static-check` passed**: both TypeScript projects, ESLint, formatting, generated-source/docs checks.
- During diagnosis, the core regression was red without the implementation; the broader five-file suite passed **438 tests** with it.
- Reused the recorded live evidence rather than spending more OAuth quota: the provider factory, its tests, and provider options were unchanged between the diagnostic base and current main before applying the header-forwarding patch. The final URI-encoding follow-up leaves these ASCII scopes unchanged; Unicode/control-character and lone-surrogate cases were reproduced red at the fetch boundary and are now green. Tests also retain store=false and truncation stripping for these cases.
- Credential copies and private request bodies were deleted; sandbox/browser stopped. Only source/tests are committed; no credentials or diagnostic logs.

## Codex CI parser fix

The user authorized including the narrow CI fix here to unblock the merge. Accept both observed security-review headings (plain and automatically triggered), strip only one heading, and leave the existing exact clean-verdict matching intact. Findings, appended findings, repeated headings, unknown metadata, and incomplete summaries remain blocking; informational metadata still does not count as approval.

- Real PR dogfood: before the fix, four clean security verdicts were reported as unresolved despite **zero unresolved threads**. After the fix, `./scripts/check_codex_comments.sh 4159` passes with zero blocking comments.
- The new plain-heading case was red before the fix; all **12 offline shell-gate regression tests passed** (~149s), including pagination/cache/author/approval safety cases.
- **353 OAuth tests** and **`make static-check`** passed again on the completed change.

<details>
<summary>Recorded terminal verification</summary>

![Live comments gate and fail-closed heading regression pass](https://github.com/user-attachments/assets/9c9928b4-e60f-4dc4-99a6-55a0d1a8a9c1)

Accelerated terminal replay (idle delays removed):

https://github.com/user-attachments/assets/5394fa61-fd1d-4126-8c6c-9481ae2e05bd

</details>

## Limits / review focus
This evidence covers one account and Astra over Codex HTTP, not every model/account or a public OpenAI API contract. It does not prove a regression introduced by a particular update; released v0.28.4 has the same omission. Cold-start misses, prefix churn, eviction, and callers without a stable cache scope remain possible. Project-wide scope reuse retains Xum's existing policy; explicit session IDs remain authoritative.

Official Codex `rust-v0.153.4` also sends session/thread/client-request headers on **HTTP** ([source](https://github.com/openai/codex/blob/042fb41b7c813ac7999105e886b2b7aa715b5081/codex-rs/codex-api/src/endpoint/responses.rs#L120-L123)); the controlled isolation above shows that thread/client-request headers are unnecessary for this fix. Server-issued `x-codex-turn-state` is deliberately not replayed across turns.

Merge queue only after all required CI and final review gates pass; no deployment changes.

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-6-astra` • Thinking: `off` • Cost: `$108.19`_

<!-- mux-attribution: model=openai:gpt-6-astra thinking=off costs=108.19 -->




