### PR TITLE
🤖 fix: acquire the event lock before the task-tree lock in task_send_message

### DIFF
--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -3730,6 +3730,90 @@ describe("TaskService", () => {
     expect(findWorkspaceInConfig(config, oldParentId)).toBeDefined();
   });
 
+  test("reported-task cleanup and task_send_message never deadlock on the event and task-tree locks", async () => {
+    const config = await createTestConfig(rootDir);
+    const projectPath = path.join(rootDir, "repo");
+    const parentWorkspaceId = "parent-cleanup-send-lock-order";
+    const childTaskId = "child-cleanup-send-lock-order";
+
+    await saveWorkspaces(
+      config,
+      projectPath,
+      [
+        projectWorkspace(projectPath, "parent", parentWorkspaceId),
+        projectWorkspace(projectPath, "child", childTaskId, {
+          parentWorkspaceId,
+          agentId: "explore",
+          agentType: "explore",
+          taskStatus: "reported",
+          reportedAt: "2026-08-10T00:00:00.000Z",
+          taskModelString: "openai:gpt-5.2",
+          workflowTask: { runId: "wfr_cleanup_send_lock_order", stepId: "explore" },
+        }),
+      ],
+      testTaskSettings()
+    );
+
+    // Mirror WorkspaceService.remove(): confirm and delete under the task-tree lifecycle lock.
+    // Hold the call open between cleanup taking the child's event lock and remove() taking the
+    // tree lock, so the send can be parked on its own lock acquisition inside that window.
+    let releaseRemove!: () => void;
+    const removeGate = new Promise<void>((resolve) => {
+      releaseRemove = resolve;
+    });
+    let removeEntered!: () => void;
+    const removeStarted = new Promise<void>((resolve) => {
+      removeEntered = resolve;
+    });
+    const remove = mock(
+      async (
+        workspaceId: string,
+        _force?: boolean,
+        options?: { beforeRemove?: () => Promise<boolean> }
+      ): Promise<Result<void>> => {
+        removeEntered();
+        await removeGate;
+        return await taskService.withTaskTreeLifecycleLock(workspaceId, async () => {
+          if (options?.beforeRemove != null && !(await options.beforeRemove())) {
+            return Ok(undefined);
+          }
+          await removeWorkspaceFromTestConfig(config, workspaceId);
+          return Ok(undefined);
+        });
+      }
+    );
+    const { workspaceService } = createWorkspaceServiceMocks({ remove });
+    const { taskService } = createTaskServiceHarness(config, { workspaceService });
+    const internals = taskService as unknown as {
+      requestReportedTaskCleanupRecheck: (workspaceId: string) => Promise<void>;
+    };
+
+    const cleanup = internals.requestReportedTaskCleanupRecheck(childTaskId);
+    await removeStarted;
+    const send = taskService.sendMessageToDescendantAgentTask(
+      parentWorkspaceId,
+      childTaskId,
+      "steer the reported child",
+      "tool-end"
+    );
+    // One macrotask turn: the send's pre-lock section is microtask-only, so by now it is parked
+    // on its first lock acquisition while cleanup still holds the child's event lock.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    releaseRemove();
+
+    let deadlockTimer: ReturnType<typeof setTimeout> | undefined;
+    const outcome = await Promise.race([
+      Promise.all([cleanup, send]).then(() => "settled" as const),
+      new Promise<"deadlocked">((resolve) => {
+        deadlockTimer = setTimeout(() => resolve("deadlocked"), 5_000);
+      }),
+    ]);
+    clearTimeout(deadlockTimer);
+    expect(outcome).toBe("settled");
+    expect(await send).toEqual(Err({ code: "not_found" }));
+    expect(findWorkspaceInConfig(config, childTaskId)).toBeUndefined();
+  }, 10_000);
+
   test("bare compaction stream-end resumes the pre-compaction parent identity", async () => {
     const config = await createTestConfig(rootDir);
     const projectPath = path.join(rootDir, "repo");

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -1195,7 +1195,9 @@ function buildWorkflowTimeoutFinalizationPrompt(
 
 export class TaskService implements AgentTaskIntegration {
   // Serialize stream-end processing per workspace to avoid races when
-  // finalizing reported tasks and cleanup state transitions.
+  // finalizing reported tasks and cleanup state transitions. Lock order: acquired BEFORE the
+  // task-tree lifecycle lock. Stream-end finalization and cleanup rechecks hold this lock while
+  // remove() takes the tree lock, so any path needing both nests event -> task-tree.
   private readonly workspaceEventLocks = new MutexMap<string>();
   // Separate parent-scoped lock for deferred best-of fallback/finalization. This path can run
   // concurrently from multiple child stream-end handlers for the same parent, and it must remain
@@ -4552,8 +4554,10 @@ export class TaskService implements AgentTaskIntegration {
       return Ok(queuedUpdateResult.data);
     }
 
-    return this.withTaskTreeLifecycleLock(taskId, async () =>
-      this.workspaceEventLocks.withLock(taskId, async () => {
+    // Event lock first, then the task-tree lock: the order every path holding both follows (see
+    // workspaceEventLocks). The reverse nesting deadlocked against reported-task cleanup.
+    return this.workspaceEventLocks.withLock(taskId, async () =>
+      this.withTaskTreeLifecycleLock(taskId, async () => {
         const cfg = this.config.loadConfigOrDefault();
         const entry = findWorkspaceEntry(cfg, taskId);
         if (!entry) {
@@ -13715,8 +13719,8 @@ export class TaskService implements AgentTaskIntegration {
       // holds: reactivation, re-parenting, and task_stop all mutate under that lock, so a task
       // confirmed eligible there cannot change underneath the removal. remove() is the only lock
       // acquisition on this path: runtime callers reach it under the workspace event lock
-      // (stream-end finalization, cleanup rechecks), nesting event -> task-tree, the inverse of
-      // the send path's task-tree -> event. That nesting predates the live recheck.
+      // (stream-end finalization, cleanup rechecks), nesting event -> task-tree, the order every
+      // path holding both locks follows (see workspaceEventLocks).
       let confirmed: { ok: true; parentWorkspaceId: string } | undefined;
       const removeResult = await this.workspaceService.remove(targetWorkspaceId, true, {
         beforeRemove: async () => {

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -13718,7 +13718,7 @@ export class TaskService implements AgentTaskIntegration {
       // Deletion is decided on live state inside the task-tree lifecycle lock that remove()
       // holds: reactivation, re-parenting, and task_stop all mutate under that lock, so a task
       // confirmed eligible there cannot change underneath the removal. remove() is the only lock
-      // acquisition on this path: runtime callers reach it under the workspace event lock
+      // acquisition on this path; callers that already hold a lock hold the workspace event lock
       // (stream-end finalization, cleanup rechecks), nesting event -> task-tree, the order every
       // path holding both locks follows (see workspaceEventLocks).
       let confirmed: { ok: true; parentWorkspaceId: string } | undefined;


### PR DESCRIPTION
## Summary

`task_send_message` to a descendant task nested the task-tree lifecycle lock outside the workspace event lock, while reported-task cleanup nests them the other way (event lock held, then `WorkspaceService.remove()` takes the tree lock). When a send to a task interleaved with that task's cleanup, each side waited on the other's lock forever. The send path now acquires the event lock first, so every path that holds both locks uses one order, and a deterministic regression test pins the interleaving.

Fixes #4072

## Background

Surfaced by Codex on #4058, which added the live recheck inside `remove()` and documented the inversion without changing it; the ordering predates that PR.

## Implementation

- `dispatchTrustedDescendantMessage` now nests `workspaceEventLocks.withLock(taskId, () => withTaskTreeLifecycleLock(taskId, ...))`. The joint critical section is unchanged (both locks are still held for the whole body); only the acquisition order flips.
- This direction was chosen over deferring `remove()` out of the event-locked section because the event lock is the outermost lock everywhere else it appears: the stream-end, stream-abort and error listeners take it first, and cleanup rechecks, hard-timeout termination and workspace-turn finalization all nest inside it. Moving cleanup would have meant moving every tree-lock acquisition out from under `handleStreamEnd`.
- The `workspaceEventLocks` declaration now documents the order (event lock before task-tree lock) and the cleanup comment no longer describes an inversion.

## Validation

- New test `reported-task cleanup and task_send_message never deadlock on the event and task-tree locks`: drives the real `requestReportedTaskCleanupRecheck` on a reported workflow-owned child, parks a `sendMessageToDescendantAgentTask` on its lock acquisition inside the window before the (lock-mirroring) `remove()` takes the tree lock, then lets removal proceed. Red on the previous nesting (`Expected "settled", Received "deadlocked"`), green after the swap; whole `taskService.test.ts` 490/490.
- Remote dogfood UAT at this SHA (Bun 1.3.5) reproduced the same red/green and full-suite results, and a real-model smoke confirmed `task_send_message` to a reported child reactivates it, to a live child queues, and stop-then-send reactivates, with no hang. The exact cleanup/send overlap window is covered by the deterministic test only; it is not observable by hand.

## Risks

Low. The send path holds the same two locks over the same body; only which one it waits for first changes. Other tree-lock holders (create, stop, retitle, remove, archive, unarchive) never take the event lock, so the new order adds no wait edge.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$36.01`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=36.01 -->
