### PR TITLE
🤖 fix: serialize best-of report publication with grouped finalization

### DIFF
--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -12,6 +12,7 @@ import {
 } from "@/constants/terminationTimeouts";
 import { Config, type ProjectsConfig, type Workspace as WorkspaceConfigEntry } from "@/node/config";
 import { HistoryService } from "@/node/services/historyService";
+import type { MutexMap } from "@/node/utils/concurrency/mutexMap";
 import * as subagentGitPatchArtifacts from "@/node/services/subagentGitPatchArtifacts";
 import {
   getSubagentGitPatchMboxPath,
@@ -16827,6 +16828,113 @@ describe("TaskService", () => {
     expect(remainingTaskIds).toContain(childTwoId);
   });
 
+  test("best-of finalization never ships a report a resumed sibling is replacing", async () => {
+    const parentId = "parent-best-of-resumed-sibling";
+    const childOneId = "child-best-of-resumed-sibling-1";
+    const childTwoId = "child-best-of-resumed-sibling-2";
+    const bestOf = { groupId: "best-of-resumed-sibling", index: 0, total: 2 } as const;
+
+    const { config, historyService, partialService, taskService } =
+      await createBestOfTaskServiceTestHarness({
+        parentId,
+        children: [
+          {
+            id: childOneId,
+            name: "agent_explore_child_1",
+            taskStatus: "running",
+            bestOf,
+          },
+          {
+            // Reported once, then its re-run was stopped: the user resume below replaces its report.
+            id: childTwoId,
+            name: "agent_explore_child_2",
+            taskStatus: "interrupted",
+            bestOf: { ...bestOf, index: 1 },
+          },
+        ],
+      });
+
+    await writePendingBestOfParentPartial({
+      partialService,
+      parentId,
+      messageId: "assistant-parent-best-of-resumed-sibling",
+      toolCallId: "task-best-of-resumed-sibling-call",
+      title: "Best of 2",
+      n: 2,
+      timestamp: Date.now(),
+    });
+    await upsertTestSubagentReports({
+      config,
+      parentId,
+      reports: [
+        {
+          childTaskId: childTwoId,
+          reportMarkdown: "Report from child two (pre-continuation)",
+          title: "Option two (stale)",
+        },
+      ],
+    });
+
+    // Barrier at the commit of child one's grouped output: its assembly has already read child
+    // two's old artifact. Resume child two and let its replacement report race the commit. The
+    // replacement is started, not awaited (awaiting it under the assembly's lock would deadlock);
+    // the barrier lifts once child two asks for the group lock, so it has run as far as the lock
+    // lets it: blocked before publishing, or, were publication unserialized, already published
+    // and queueing for delivery.
+    const groupLocks = (taskService as unknown as { deferredBestOfLocks: MutexMap<string> })
+      .deferredBestOfLocks;
+    const withGroupLock = groupLocks.withLock.bind(groupLocks);
+    let onGroupLockRequested: (() => void) | undefined;
+    spyOn(groupLocks, "withLock").mockImplementation(((
+      key: string,
+      operation: () => Promise<unknown>
+    ) => {
+      if (key === parentId) onGroupLockRequested?.();
+      return withGroupLock(key, operation);
+    }) as typeof groupLocks.withLock);
+    const updatePartial = historyService.updatePartialIfMessageIdMatches.bind(historyService);
+    let replacementReport: Promise<void> | undefined;
+    spyOn(historyService, "updatePartialIfMessageIdMatches").mockImplementationOnce(
+      async (workspaceId, messageId, updater) => {
+        expect(await taskService.markInterruptedTaskRunning(childTwoId)).toBe(true);
+        const groupLockRequested = new Promise<void>((resolve) => {
+          onGroupLockRequested = resolve;
+        });
+        replacementReport = finalizeReportedChildTaskForTest({
+          historyService,
+          partialService,
+          taskService,
+          childId: childTwoId,
+          reportMarkdown: "Report from child two (continuation)",
+          title: "Option two",
+        });
+        await groupLockRequested;
+        return updatePartial(workspaceId, messageId, updater);
+      }
+    );
+
+    await finalizeReportedChildTaskForTest({
+      historyService,
+      partialService,
+      taskService,
+      childId: childOneId,
+      reportMarkdown: "Report from child one",
+      title: "Option one",
+    });
+    expect(replacementReport).toBeDefined();
+    await replacementReport;
+    await flushTerminalAttentionDrains(taskService);
+
+    const toolPart = getTaskToolPart(await partialService.readPartial(parentId));
+    expect(toolPart?.state).toBe("output-available");
+    const serializedOutput = JSON.stringify(toolPart?.output);
+    expect(serializedOutput).toContain("Report from child one");
+    expect(serializedOutput).toContain("Report from child two (continuation)");
+    expect(serializedOutput).not.toContain("pre-continuation");
+    const parentHistory = await collectFullHistory(historyService, parentId);
+    expect(JSON.stringify(parentHistory)).not.toContain("pre-continuation");
+  });
+
   test("agent_report recovers a pending legacy variants task call", async () => {
     const parentId = "parent-legacy-variants";
     const childOneId = "child-legacy-variant-1";
@@ -17050,9 +17158,11 @@ describe("TaskService", () => {
             bestOf,
           },
           {
+            // Already reported (artifact seeded below) and then stopped; its late stream-end
+            // below re-delivers the same report.
             id: childTwoId,
             name: "agent_explore_child_2",
-            taskStatus: "running",
+            taskStatus: "interrupted",
             bestOf: { ...bestOf, index: 1 },
           },
         ],

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -12512,123 +12512,31 @@ export class TaskService implements AgentTaskIntegration {
       };
     }
 
-    // Notify clients immediately even if we can't delete the workspace yet.
-    await this.editWorkspaceEntry(
-      childWorkspaceId,
-      (ws) => {
-        ws.taskStatus = "reported";
-        ws.reportedAt = getIsoNow();
-        // Successful completion resets the persisted recovery circuit breaker.
-        delete ws.taskRecoveryAttempts;
-      },
-      { allowMissing: true }
-    );
-    // Drop queued incremental updates synchronously with the terminal commit: while they sit at
-    // the parent's queue head as tool-end entries, the parent's stream stops at its next step
-    // boundary for them, and a dispatch refused as superseded cannot restore that cut turn.
-    // skipCancelCallbacks: a parent running as a delegated workspace turn queues each report with
-    // continuation-failure callbacks; superseding the report must not interrupt that live turn.
-    const progressParentWorkspaceId = latestEntryBeforeReport?.workspace.parentWorkspaceId;
-    if (progressParentWorkspaceId) {
-      const queuedProgressRemoval = this.workspaceService.removeQueuedMessagesByDedupeKeyPrefix(
-        progressParentWorkspaceId,
-        agentReportProgressDedupePrefix(childWorkspaceId),
-        { cancelReason: AGENT_REPORT_PROGRESS_SUPERSEDED_REASON, skipCancelCallbacks: true }
-      );
-      if (!queuedProgressRemoval.success) {
-        log.warn("Failed to remove queued incremental sub-agent reports", {
-          parentWorkspaceId: progressParentWorkspaceId,
-          childWorkspaceId,
-          error: queuedProgressRemoval.error,
-        });
-      }
-    }
-    eventSpine.emit("task.reported", { workspaceId: childWorkspaceId, taskId: childWorkspaceId });
-
-    await this.emitWorkspaceMetadata(childWorkspaceId);
-
-    // NOTE: Stream continues — we intentionally do NOT abort it.
-    // Deterministic termination is enforced by StreamManager stopWhen logic that
-    // waits for an agent_report tool result where output.success === true at the
-    // step boundary (preserving usage accounting). recordSessionUsage runs when
-    // the stream ends naturally.
-
-    const cfgAfterReport = this.config.loadConfigOrDefault();
-    const latestChildEntry = findWorkspaceEntry(cfgAfterReport, childWorkspaceId) ?? childEntry;
-    const parentWorkspaceId = latestChildEntry?.workspace.parentWorkspaceId;
-    if (!parentWorkspaceId) {
-      const reason = latestChildEntry
-        ? "missing parentWorkspaceId"
-        : "workspace not found in config";
-      log.debug("Ignoring agent_report: workspace is not an agent task", {
+    // A best-of sibling's status flip and artifact write must not interleave with the grouped
+    // assembly that runs under this lock (deliverReportToParent, startup recovery): an assembly
+    // that read the old artifact of a sibling already marked reported would finalize the parent
+    // on the report this publication is replacing.
+    const bestOfParentWorkspaceId =
+      latestEntryBeforeReport != null &&
+      (this.getEffectiveTaskGroup(childWorkspaceId, latestEntryBeforeReport.workspace)?.total ??
+        1) > 1
+        ? latestEntryBeforeReport.workspace.parentWorkspaceId
+        : undefined;
+    const publish = () =>
+      this.publishAgentTaskReport(
         childWorkspaceId,
-        reason,
-      });
-      // Best-effort: resolve any foreground waiters even if we can't deliver to a parent.
-      this.resolveWaiters(childWorkspaceId, reportArgs);
-      void this.maybeStartQueuedTasks();
+        childEntry,
+        latestEntryBeforeReport,
+        reportArgs
+      );
+    const published =
+      bestOfParentWorkspaceId != null
+        ? await this.deferredBestOfLocks.withLock(bestOfParentWorkspaceId, publish)
+        : await publish();
+    if (!published) {
       return { finalized: true };
     }
-
-    const reportTitle = coerceNonEmptyString(reportArgs.title);
-    this.timelineRecorder.record(parentWorkspaceId, {
-      kind: "task.reported",
-      // Background reports are also injected into parent history, which the timeline maps; keying
-      // both on the task keeps one row per report.
-      source: { system: "task", key: subagentReportSourceKey(childWorkspaceId) },
-      status: "completed",
-      anchor: { taskId: childWorkspaceId, childWorkspaceId },
-      data: {
-        ...(reportTitle ? { title: reportTitle } : {}),
-        digest: reportArgs.reportMarkdown,
-      },
-    });
-
-    const isWorkflowOwnedChildReport = latestChildEntry?.workspace.workflowTask != null;
-
-    const indexAfterReport = this.buildAgentTaskIndex(cfgAfterReport);
-    const ancestorWorkspaceIds = this.listAncestorWorkspaceIdsUsingParentById(
-      indexAfterReport.parentById,
-      childWorkspaceId
-    );
-    const workflowOwnedAncestorWorkspaceIds = ancestorWorkspaceIds.filter(
-      (ancestorWorkspaceId) =>
-        this.getWorkflowOwnedDescendantAgentTaskUsingIndex(
-          indexAfterReport,
-          ancestorWorkspaceId,
-          childWorkspaceId
-        ) === true
-    );
-
-    // Persist the completed report in the session dirs of all ancestors so `task_await` can
-    // retrieve it after cleanup/restart (even if the task workspace itself is deleted).
-    const persistedAtMs = Date.now();
-    for (const ancestorWorkspaceId of ancestorWorkspaceIds) {
-      try {
-        const ancestorSessionDir = path.join(this.config.sessionsDir, ancestorWorkspaceId);
-        await upsertSubagentReportArtifact({
-          workspaceId: ancestorWorkspaceId,
-          workspaceSessionDir: ancestorSessionDir,
-          childTaskId: childWorkspaceId,
-          parentWorkspaceId,
-          ancestorWorkspaceIds,
-          workflowOwnedAncestorWorkspaceIds,
-          reportMarkdown: reportArgs.reportMarkdown,
-          model: latestChildEntry?.workspace.taskModelString,
-          thinkingLevel: latestChildEntry?.workspace.taskThinkingLevel,
-          title: reportArgs.title,
-          planFilePath: reportArgs.planFilePath,
-          structuredOutput: reportArgs.structuredOutput,
-          nowMs: persistedAtMs,
-        });
-      } catch (error: unknown) {
-        log.error("Failed to persist subagent report artifact", {
-          workspaceId: ancestorWorkspaceId,
-          childTaskId: childWorkspaceId,
-          error,
-        });
-      }
-    }
+    const { parentWorkspaceId, latestChildEntry, isWorkflowOwnedChildReport } = published;
 
     // Goal attribution is informational; if it throws (permissions failure,
     // disk-full, corrupted extensionMetadata.json in pushSnapshot), execution
@@ -12744,6 +12652,149 @@ export class TaskService implements AgentTaskIntegration {
     });
 
     return { finalized: true };
+  }
+
+  /**
+   * Marks the child reported and persists its report artifact in every ancestor session dir.
+   * Returns null when the child is not an agent task (no parent to deliver to).
+   */
+  private async publishAgentTaskReport(
+    childWorkspaceId: string,
+    childEntry: { projectPath: string; workspace: WorkspaceConfigEntry } | null | undefined,
+    latestEntryBeforeReport:
+      | { projectPath: string; workspace: WorkspaceConfigEntry }
+      | null
+      | undefined,
+    reportArgs: {
+      reportMarkdown: string;
+      title?: string;
+      structuredOutput?: unknown;
+      planFilePath?: string;
+    }
+  ): Promise<{
+    parentWorkspaceId: string;
+    latestChildEntry: { projectPath: string; workspace: WorkspaceConfigEntry } | null | undefined;
+    isWorkflowOwnedChildReport: boolean;
+  } | null> {
+    // Notify clients immediately even if we can't delete the workspace yet.
+    await this.editWorkspaceEntry(
+      childWorkspaceId,
+      (ws) => {
+        ws.taskStatus = "reported";
+        ws.reportedAt = getIsoNow();
+        // Successful completion resets the persisted recovery circuit breaker.
+        delete ws.taskRecoveryAttempts;
+      },
+      { allowMissing: true }
+    );
+    // Drop queued incremental updates synchronously with the terminal commit: while they sit at
+    // the parent's queue head as tool-end entries, the parent's stream stops at its next step
+    // boundary for them, and a dispatch refused as superseded cannot restore that cut turn.
+    // skipCancelCallbacks: a parent running as a delegated workspace turn queues each report with
+    // continuation-failure callbacks; superseding the report must not interrupt that live turn.
+    const progressParentWorkspaceId = latestEntryBeforeReport?.workspace.parentWorkspaceId;
+    if (progressParentWorkspaceId) {
+      const queuedProgressRemoval = this.workspaceService.removeQueuedMessagesByDedupeKeyPrefix(
+        progressParentWorkspaceId,
+        agentReportProgressDedupePrefix(childWorkspaceId),
+        { cancelReason: AGENT_REPORT_PROGRESS_SUPERSEDED_REASON, skipCancelCallbacks: true }
+      );
+      if (!queuedProgressRemoval.success) {
+        log.warn("Failed to remove queued incremental sub-agent reports", {
+          parentWorkspaceId: progressParentWorkspaceId,
+          childWorkspaceId,
+          error: queuedProgressRemoval.error,
+        });
+      }
+    }
+    eventSpine.emit("task.reported", { workspaceId: childWorkspaceId, taskId: childWorkspaceId });
+
+    await this.emitWorkspaceMetadata(childWorkspaceId);
+
+    // NOTE: Stream continues — we intentionally do NOT abort it.
+    // Deterministic termination is enforced by StreamManager stopWhen logic that
+    // waits for an agent_report tool result where output.success === true at the
+    // step boundary (preserving usage accounting). recordSessionUsage runs when
+    // the stream ends naturally.
+
+    const cfgAfterReport = this.config.loadConfigOrDefault();
+    const latestChildEntry = findWorkspaceEntry(cfgAfterReport, childWorkspaceId) ?? childEntry;
+    const parentWorkspaceId = latestChildEntry?.workspace.parentWorkspaceId;
+    if (!parentWorkspaceId) {
+      const reason = latestChildEntry
+        ? "missing parentWorkspaceId"
+        : "workspace not found in config";
+      log.debug("Ignoring agent_report: workspace is not an agent task", {
+        childWorkspaceId,
+        reason,
+      });
+      // Best-effort: resolve any foreground waiters even if we can't deliver to a parent.
+      this.resolveWaiters(childWorkspaceId, reportArgs);
+      void this.maybeStartQueuedTasks();
+      return null;
+    }
+
+    const reportTitle = coerceNonEmptyString(reportArgs.title);
+    this.timelineRecorder.record(parentWorkspaceId, {
+      kind: "task.reported",
+      // Background reports are also injected into parent history, which the timeline maps; keying
+      // both on the task keeps one row per report.
+      source: { system: "task", key: subagentReportSourceKey(childWorkspaceId) },
+      status: "completed",
+      anchor: { taskId: childWorkspaceId, childWorkspaceId },
+      data: {
+        ...(reportTitle ? { title: reportTitle } : {}),
+        digest: reportArgs.reportMarkdown,
+      },
+    });
+
+    const isWorkflowOwnedChildReport = latestChildEntry?.workspace.workflowTask != null;
+
+    const indexAfterReport = this.buildAgentTaskIndex(cfgAfterReport);
+    const ancestorWorkspaceIds = this.listAncestorWorkspaceIdsUsingParentById(
+      indexAfterReport.parentById,
+      childWorkspaceId
+    );
+    const workflowOwnedAncestorWorkspaceIds = ancestorWorkspaceIds.filter(
+      (ancestorWorkspaceId) =>
+        this.getWorkflowOwnedDescendantAgentTaskUsingIndex(
+          indexAfterReport,
+          ancestorWorkspaceId,
+          childWorkspaceId
+        ) === true
+    );
+
+    // Persist the completed report in the session dirs of all ancestors so `task_await` can
+    // retrieve it after cleanup/restart (even if the task workspace itself is deleted).
+    const persistedAtMs = Date.now();
+    for (const ancestorWorkspaceId of ancestorWorkspaceIds) {
+      try {
+        const ancestorSessionDir = path.join(this.config.sessionsDir, ancestorWorkspaceId);
+        await upsertSubagentReportArtifact({
+          workspaceId: ancestorWorkspaceId,
+          workspaceSessionDir: ancestorSessionDir,
+          childTaskId: childWorkspaceId,
+          parentWorkspaceId,
+          ancestorWorkspaceIds,
+          workflowOwnedAncestorWorkspaceIds,
+          reportMarkdown: reportArgs.reportMarkdown,
+          model: latestChildEntry?.workspace.taskModelString,
+          thinkingLevel: latestChildEntry?.workspace.taskThinkingLevel,
+          title: reportArgs.title,
+          planFilePath: reportArgs.planFilePath,
+          structuredOutput: reportArgs.structuredOutput,
+          nowMs: persistedAtMs,
+        });
+      } catch (error: unknown) {
+        log.error("Failed to persist subagent report artifact", {
+          workspaceId: ancestorWorkspaceId,
+          childTaskId: childWorkspaceId,
+          error,
+        });
+      }
+    }
+
+    return { parentWorkspaceId, latestChildEntry, isWorkflowOwnedChildReport };
   }
 
   private enforceCompletedReportCacheLimit(): void {
@@ -13065,17 +13116,48 @@ export class TaskService implements AgentTaskIntegration {
   }
 
   /**
-   * A reported sibling that a client reawakened (workspace-turn continuation) or that is streaming
-   * still owns its previous report artifact. Finalizing the parent on that artifact would freeze the
-   * grouped result on a report the child is replacing, so its group waits for the new report.
+   * A reported sibling that a client reawakened (workspace-turn continuation), that a resume put
+   * back to running (its re-run may be between streams or past stream-end but before its
+   * publication), or that is streaming still owns its previous report artifact. Finalizing the
+   * parent on that artifact would freeze the grouped result on a report the child is replacing,
+   * so its group waits for the new report.
    */
   private isBestOfSiblingExecutingAgain(sibling: {
     taskId: string;
+    taskStatus?: WorkspaceConfigEntry["taskStatus"];
     taskExecutionStatus?: WorkspaceConfigEntry["taskExecutionStatus"];
   }): boolean {
     return (
+      sibling.taskStatus === "running" ||
+      sibling.taskStatus === "awaiting_report" ||
       isActiveWorkspaceTurnTaskStatus(sibling.taskExecutionStatus) ||
       this.aiService.isStreaming(sibling.taskId)
+    );
+  }
+
+  /**
+   * Synchronous so the partial-commit transform can re-run it with no await between the check and
+   * the write: every sibling the grouped output was assembled from must still be the group and
+   * none may be executing again.
+   */
+  private areBestOfSiblingsStillSettled(params: {
+    parentWorkspaceId: string;
+    groupId: string;
+    assembledTaskIds: readonly string[];
+    reportingTaskId?: string;
+  }): boolean {
+    const liveSiblings = this.listBestOfSiblingTasks({
+      parentWorkspaceId: params.parentWorkspaceId,
+      groupId: params.groupId,
+    });
+    return (
+      liveSiblings.length === params.assembledTaskIds.length &&
+      liveSiblings.every(
+        (sibling, index) =>
+          sibling.taskId === params.assembledTaskIds[index] &&
+          (sibling.taskId === params.reportingTaskId ||
+            !this.isBestOfSiblingExecutingAgain(sibling))
+      )
     );
   }
 
@@ -13147,23 +13229,23 @@ export class TaskService implements AgentTaskIntegration {
 
     // The artifact reads above awaited disk I/O, during which a client can reawaken a sibling
     // whose old report is already in `reports`; re-read live state once more before handing out.
-    const liveSiblings = this.listBestOfSiblingTasks({
-      parentWorkspaceId: params.parentWorkspaceId,
-      groupId: params.groupId,
-    });
+    // The commit transform repeats this check so a resume landing after this point cannot slip
+    // between it and the partial write either.
+    const taskIds = siblings.map((sibling) => sibling.taskId);
     if (
-      liveSiblings.length !== siblings.length ||
-      liveSiblings.some(
-        (sibling) =>
-          sibling.taskId !== params.reportingTaskId && this.isBestOfSiblingExecutingAgain(sibling)
-      )
+      !this.areBestOfSiblingsStillSettled({
+        parentWorkspaceId: params.parentWorkspaceId,
+        groupId: params.groupId,
+        assembledTaskIds: taskIds,
+        reportingTaskId: params.reportingTaskId,
+      })
     ) {
       return null;
     }
 
     const output = {
       status: "completed" as const,
-      taskIds: siblings.map((sibling) => sibling.taskId),
+      taskIds,
       reports,
     };
     const parsed = TaskToolResultSchema.safeParse(output);
@@ -13244,8 +13326,6 @@ export class TaskService implements AgentTaskIntegration {
       return (
         sibling.taskStatus === "queued" ||
         sibling.taskStatus === "starting" ||
-        sibling.taskStatus === "running" ||
-        sibling.taskStatus === "awaiting_report" ||
         this.isBestOfSiblingExecutingAgain(sibling)
       );
     });
@@ -13504,25 +13584,27 @@ export class TaskService implements AgentTaskIntegration {
     }
 
     let finalizedOutput: z.infer<typeof TaskToolResultSchema> = parsedOutput.data;
+    let areGroupSiblingsStillSettled: (() => boolean) | undefined;
     if (parsedInput.groupCount > 1) {
+      const bestOf =
+        childEntry?.workspace.bestOf ?? this.config.getLegacyTaskVariantGroup(childWorkspaceId);
+      if (!bestOf) {
+        return { kind: "failed" };
+      }
+
       const hasGroupedCompletedOutput =
         Array.isArray(parsedOutput.data.taskIds) &&
         "reports" in parsedOutput.data &&
         Array.isArray(parsedOutput.data.reports);
-      if (hasGroupedCompletedOutput) {
-        finalizedOutput = parsedOutput.data;
-      } else {
-        const bestOf =
-          childEntry?.workspace.bestOf ?? this.config.getLegacyTaskVariantGroup(childWorkspaceId);
-        if (!bestOf) {
-          return { kind: "failed" };
-        }
-
+      // A caller-assembled grouped output (deferred delivery) names no reporting sibling, so
+      // every sibling must be settled at commit time.
+      const reportingTaskId = hasGroupedCompletedOutput ? undefined : childWorkspaceId;
+      if (!hasGroupedCompletedOutput) {
         const groupedOutput = await this.buildBestOfCompletedTaskToolOutput({
           parentWorkspaceId: workspaceId,
           groupId: bestOf.groupId,
           total: bestOf.total,
-          reportingTaskId: childWorkspaceId,
+          reportingTaskId,
         });
         if (!groupedOutput) {
           return { kind: "not_ready" };
@@ -13530,17 +13612,32 @@ export class TaskService implements AgentTaskIntegration {
 
         finalizedOutput = groupedOutput;
       }
+      const assembledTaskIds = finalizedOutput.taskIds ?? [];
+      areGroupSiblingsStillSettled = () =>
+        this.areBestOfSiblingsStillSettled({
+          parentWorkspaceId: workspaceId,
+          groupId: bestOf.groupId,
+          assembledTaskIds,
+          reportingTaskId,
+        });
     }
 
     // The grouped output above was assembled from disk reads that a parent turn can overtake:
     // its commitPartial moves this partial into history and its stream writes a fresh one under a
     // new message id. Apply the finalization only while the partial is still this message with
-    // this call pending, and never under a stream that has already started.
+    // this call pending, and never under a stream that has already started. A sibling resumed
+    // during those reads is about to replace the artifact already assembled here; the transform
+    // runs with no await before the write, so this is the last point that can still see it.
+    let groupSiblingResumed = false;
     const writeResult = await this.historyService.updatePartialIfMessageIdMatches(
       workspaceId,
       partial.id,
       (current) => {
         if (this.aiService.isStreaming(workspaceId)) return null;
+        if (areGroupSiblingsStillSettled != null && !areGroupSiblingsStillSettled()) {
+          groupSiblingResumed = true;
+          return null;
+        }
         const stillPending = current.parts.some(
           (part) =>
             isDynamicToolPart(part) &&
@@ -13569,6 +13666,9 @@ export class TaskService implements AgentTaskIntegration {
       return { kind: "failed" };
     }
     if (!writeResult.data) {
+      if (groupSiblingResumed) {
+        return { kind: "not_ready" };
+      }
       log.debug("tryFinalizePendingTaskToolCallInPartial: partial superseded before finalization", {
         workspaceId,
         messageId: partial.id,


### PR DESCRIPTION
## Summary

Best-of grouped finalization could commit the parent's task tool output on a sibling report artifact that the sibling was already replacing. Publication of a best-of child's report now runs under the same per-parent lock as the grouped assembly, a resumed sibling counts as executing again, and the partial commit re-checks the siblings synchronously right before the write.

## Background

Fixes #4074 (Codex round 23 P1 on #4058). `buildBestOfCompletedTaskToolOutput` read every sibling's report artifact, then re-sampled only current activity (`isBestOfSiblingExecutingAgain`: active workspace-turn status or streaming) before handing the grouped output to the partial commit. Two windows let a stale artifact through:

- A sibling's continuation that started after its artifact was read and finished before the re-check was idle again at the re-check, so the assembly finalized on the old artifact already in `reports`.
- `finalizeAgentTaskReport` flipped the child to `reported` before writing its artifact, both outside `deferredBestOfLocks`. An assembly that ran between the flip and the write saw a reported, idle sibling with its old artifact.

In both cases the sibling's later delivery found the grouped output already finalized, so its replacement report was dropped from the tool result.

## Implementation

- `finalizeAgentTaskReport` moves the status flip plus artifact writes into `publishAgentTaskReport` and, for best-of children, runs it under `deferredBestOfLocks(parent)`, the lock the assembly already holds. The lock is released before `deliverReportToParent` re-acquires it, so the critical section stays the publication only.
- `isBestOfSiblingExecutingAgain` also treats `taskStatus` `running` / `awaiting_report` as executing again: a resumed sibling (for example `markInterruptedTaskRunning`) has no workspace-turn mirror and is not streaming between its stream end and its publication. `shouldDeferBestOfFallback` now relies on the shared predicate instead of repeating those statuses.
- `areBestOfSiblingsStillSettled` is a synchronous check (sibling identities plus executing-again) used by the assembly's live re-check and again inside the `updatePartialIfMessageIdMatches` transform, where no await separates the check from the write. When it fails there, `tryFinalizePendingTaskToolCallInPartial` returns `not_ready` so the reporting sibling defers rather than appending a synthetic fallback; the resumed sibling's own report finalizes the group.

## Validation

- New test `best-of finalization never ships a report a resumed sibling is replacing`: a barrier on the parent's partial commit resumes the already-reported sibling and drives its replacement report through the production stream-end path while the first sibling's assembly is mid-commit; the barrier lifts when the sibling requests the group lock. Red on main (grouped output carried the pre-continuation report); green with the fix.
- Inverted toggles over the whole `taskService.test.ts` file: removing the publication lock, the status-aware predicate, or the commit-time re-check each turns the new test red again.
- `grouped partial finalization exposes each terminal report exactly once` seeded a `running` sibling with an on-disk artifact, which is now by definition a sibling whose report is being replaced; its fixture models the settled state (`interrupted` with the artifact) so its exactly-once assertion still holds.

- Remote dogfood UAT on this SHA (real models, raw `chat.jsonl` verified): a foreground best-of candidate stopped while working and resumed lands its newest report in the finalized group with one report per candidate; single task, background terminal wake, and `task_stop` behave as before. A user Stop on the parent commits its partial into history (`cleanupAbortedStream`), so the `partial.json` recovery path this PR hardens is not reachable from the UI and is covered by the tests above.


## Risks

Moderate, scoped to best-of report delivery. The new lock hold in `finalizeAgentTaskReport` covers config edits, metadata emission, and artifact writes; it acquires `deferredBestOfLocks(parent)` before `workspaceFileLocks(parent)`, the same order the assembly uses, and is released before delivery re-acquires it. A best-of sibling with a stale artifact whose status is `running` or `awaiting_report` now defers grouped finalization until it reports again, where it previously finalized on the stale artifact.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=0.00 -->


