### PR TITLE
🤖 feat: review plugin updates in place instead of uninstall/reinstall

### DIFF
--- a/src/browser/features/Settings/Sections/PluginsSettingsSection.stories.tsx
+++ b/src/browser/features/Settings/Sections/PluginsSettingsSection.stories.tsx
@@ -421,6 +421,38 @@ export const AddPluginConsentPreviewPhoneViewport: Story = {
   },
 };
 
+const UPDATE_REVIEW_OPTIONS: MockORPCClientOptions = {
+  agentPlugins: {
+    items: [MANAGED_ITEM],
+    updateChecks: [
+      {
+        name: "grill",
+        status: "update-available",
+        remoteSha: "d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3",
+      },
+    ],
+    updateReview: {
+      name: "grill",
+      fromSha: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+      toSha: "d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3",
+      version: "1.3.0",
+      changes: [
+        {
+          summary: "changes the model-visible advertisement of skill 'grilling'",
+          before: "Grill the user about a plan or decision.",
+          after:
+            "Grill the user relentlessly about a plan, decision, or idea. Use when the user wants to stress-test their thinking.",
+        },
+        {
+          summary: "adds MCP server 'planner'",
+          after: "node ~/.mux/plugins/grill/server.js --port 0",
+        },
+      ],
+      warnings: [],
+    },
+  },
+};
+
 /**
  * Update → inline capability review. The pending update rewords a skill's
  * model-visible description and adds an MCP server, so Update opens the
@@ -429,39 +461,7 @@ export const AddPluginConsentPreviewPhoneViewport: Story = {
  */
 export const UpdateRequiresReview: Story = {
   render: () => (
-    <PluginsSectionStoryShell
-      options={{
-        agentPlugins: {
-          items: [MANAGED_ITEM],
-          updateChecks: [
-            {
-              name: "grill",
-              status: "update-available",
-              remoteSha: "d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3",
-            },
-          ],
-          updateReview: {
-            name: "grill",
-            fromSha: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
-            toSha: "d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3",
-            version: "1.3.0",
-            changes: [
-              {
-                summary: "changes the model-visible advertisement of skill 'grilling'",
-                before: "Grill the user about a plan or decision.",
-                after:
-                  "Grill the user relentlessly about a plan, decision, or idea. Use when the user wants to stress-test their thinking.",
-              },
-              {
-                summary: "adds MCP server 'planner'",
-                after: "node ~/.mux/plugins/grill/server.js --port 0",
-              },
-            ],
-            warnings: [],
-          },
-        },
-      }}
-    >
+    <PluginsSectionStoryShell options={UPDATE_REVIEW_OPTIONS}>
       <PluginsSettingsSection />
     </PluginsSectionStoryShell>
   ),
@@ -474,5 +474,43 @@ export const UpdateRequiresReview: Story = {
     await canvas.findByText("Grill the user about a plan or decision.");
     await canvas.findByText(/adds MCP server 'planner'/);
     await canvas.findByRole("button", { name: /Apply update/ });
+  },
+};
+
+/**
+ * Update review at phone width: long capability summaries, before/after
+ * values, and MCP command lines must wrap inside the card instead of
+ * overflowing its right edge.
+ */
+export const UpdateRequiresReviewPhoneViewport: Story = {
+  globals: {
+    viewport: { value: "mobile1", isRotated: false },
+  },
+  parameters: {
+    layout: "fullscreen",
+    pixel: {
+      matrix: { themes: ["dark"], viewports: ["phone"] },
+    },
+  },
+  render: () => (
+    <PluginsSectionStoryShell options={UPDATE_REVIEW_OPTIONS}>
+      {/* Fixed phone width so the play's overflow assertion holds in the CI
+          test-runner too, which ignores viewport globals (AGENTS.md). */}
+      <div style={{ width: 390 }}>
+        <PluginsSettingsSection />
+      </div>
+    </PluginsSectionStoryShell>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole("button", { name: /^Update$/ }));
+    const applyButton = await canvas.findByRole("button", { name: /Apply update/ });
+    const card = applyButton.closest("div[class*='rounded-md']");
+    if (!(card instanceof HTMLElement)) {
+      throw new Error("Update review card not found");
+    }
+    if (card.scrollWidth > card.clientWidth + 1) {
+      throw new Error("Update review overflows its card at phone width");
+    }
   },
 };

--- a/src/browser/features/Settings/Sections/PluginsSettingsSection.stories.tsx
+++ b/src/browser/features/Settings/Sections/PluginsSettingsSection.stories.tsx
@@ -420,3 +420,59 @@ export const AddPluginConsentPreviewPhoneViewport: Story = {
     }
   },
 };
+
+/**
+ * Update → inline capability review. The pending update rewords a skill's
+ * model-visible description and adds an MCP server, so Update opens the
+ * review panel (before/after per change) instead of applying, and nothing is
+ * installed until "Apply update" is pressed.
+ */
+export const UpdateRequiresReview: Story = {
+  render: () => (
+    <PluginsSectionStoryShell
+      options={{
+        agentPlugins: {
+          items: [MANAGED_ITEM],
+          updateChecks: [
+            {
+              name: "grill",
+              status: "update-available",
+              remoteSha: "d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3",
+            },
+          ],
+          updateReview: {
+            name: "grill",
+            fromSha: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+            toSha: "d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3",
+            version: "1.3.0",
+            changes: [
+              {
+                summary: "changes the model-visible advertisement of skill 'grilling'",
+                before: "Grill the user about a plan or decision.",
+                after:
+                  "Grill the user relentlessly about a plan, decision, or idea. Use when the user wants to stress-test their thinking.",
+              },
+              {
+                summary: "adds MCP server 'planner'",
+                after: "node ~/.mux/plugins/grill/server.js --port 0",
+              },
+            ],
+            warnings: [],
+          },
+        },
+      }}
+    >
+      <PluginsSettingsSection />
+    </PluginsSectionStoryShell>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole("button", { name: /^Update$/ }));
+    // Review panel replaces the direct apply: both changes are listed with
+    // their consented/staged values, and the apply button awaits consent.
+    await canvas.findByText(/changes the model-visible advertisement of skill 'grilling'/);
+    await canvas.findByText("Grill the user about a plan or decision.");
+    await canvas.findByText(/adds MCP server 'planner'/);
+    await canvas.findByRole("button", { name: /Apply update/ });
+  },
+};

--- a/src/browser/features/Settings/Sections/PluginsSettingsSection.tsx
+++ b/src/browser/features/Settings/Sections/PluginsSettingsSection.tsx
@@ -18,6 +18,7 @@ import type {
   AgentPluginInstallPreview,
   AgentPluginListItem,
   AgentPluginUpdateCheck,
+  AgentPluginUpdateReview,
 } from "@/common/orpc/schemas/agentPlugins";
 import { getErrorMessage } from "@/common/utils/errors";
 import { publishAgentPluginsMutated } from "@/browser/utils/agentPluginMutations";
@@ -408,6 +409,76 @@ const UninstallConfirm: React.FC<{
   );
 };
 
+/**
+ * In-place re-consent for an update that changes the plugin's capability
+ * surface (new/reworded skill advertisements, MCP servers, hooks, agents,
+ * …). Shows each change with the consented ("before") and staged ("after")
+ * value so the user can judge it, instead of being routed through uninstall
+ * + reinstall. Conditional rendering keeps this testable without portals.
+ */
+const UpdateReviewPanel: React.FC<{
+  review: AgentPluginUpdateReview;
+  busy: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}> = (props) => (
+  <div className="border-border-medium bg-background-secondary mt-2 space-y-2 rounded-md border p-3">
+    <p className="text-foreground text-xs">
+      This update{props.review.version ? ` (v${props.review.version})` : ""} changes what the plugin
+      can do. Review the changes before applying it:
+    </p>
+    <ul className="space-y-2">
+      {props.review.changes.map((change) => (
+        <li key={change.summary} className="text-xs">
+          <span className="text-foreground break-words">{change.summary}</span>
+          {(change.before !== undefined || change.after !== undefined) && (
+            <dl className="mt-1 space-y-1">
+              {change.before !== undefined && (
+                <div className="flex gap-2">
+                  <dt className="text-muted w-10 shrink-0 text-[11px]">Before</dt>
+                  <dd className="bg-modal-bg border-border-medium min-w-0 flex-1 rounded border px-2 py-1 font-mono text-[11px] break-words whitespace-pre-wrap">
+                    {change.before}
+                  </dd>
+                </div>
+              )}
+              {change.after !== undefined && (
+                <div className="flex gap-2">
+                  <dt className="text-muted w-10 shrink-0 text-[11px]">After</dt>
+                  <dd className="bg-modal-bg border-border-medium min-w-0 flex-1 rounded border px-2 py-1 font-mono text-[11px] break-words whitespace-pre-wrap">
+                    {change.after}
+                  </dd>
+                </div>
+              )}
+            </dl>
+          )}
+        </li>
+      ))}
+    </ul>
+    {props.review.warnings.length > 0 && (
+      <div className="bg-warning/10 space-y-1 rounded-md px-3 py-2">
+        {props.review.warnings.map((warning) => (
+          <div key={warning} className="text-warning flex items-start gap-2 text-xs">
+            <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span className="break-words">{warning}</span>
+          </div>
+        ))}
+      </div>
+    )}
+    <p className="text-muted text-[11px] break-all">
+      {props.review.fromSha.slice(0, 12)} → {props.review.toSha.slice(0, 12)}
+    </p>
+    <div className="flex gap-2">
+      <Button size="sm" onClick={props.onConfirm} disabled={props.busy}>
+        {props.busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+        {props.busy ? "Updating…" : "Apply update"}
+      </Button>
+      <Button variant="ghost" size="sm" onClick={props.onCancel} disabled={props.busy}>
+        Cancel
+      </Button>
+    </div>
+  </div>
+);
+
 export const PluginsSettingsSection: React.FC = () => {
   const { api } = useAPI();
   const [items, setItems] = useState<AgentPluginListItem[] | null>(null);
@@ -436,6 +507,10 @@ export const PluginsSettingsSection: React.FC = () => {
   );
   /** Name of the plugin with an update/uninstall in flight. */
   const [busyPlugin, setBusyPlugin] = useState<string | null>(null);
+  /** Pending update whose capability changes await the user's confirmation. */
+  const [updateReview, setUpdateReview] = useState<AgentPluginUpdateReview | null>(
+    initialIntent?.type === "review-update" ? initialIntent.review : null
+  );
   /** Monotonic ids of the latest list/update-check requests; stale responses must not commit state. */
   const listGenerationRef = useRef(0);
   const checkGenerationRef = useRef(0);
@@ -513,6 +588,9 @@ export const PluginsSettingsSection: React.FC = () => {
         case "confirm-uninstall":
           setUninstallTarget(intent.name);
           break;
+        case "review-update":
+          setUpdateReview(intent.review);
+          break;
         case "refresh":
           void refresh();
           void checkForUpdates();
@@ -522,30 +600,69 @@ export const PluginsSettingsSection: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- resubscribe on API reconnect only; the listener reads the latest handlers via closure per subscription
   }, [api]);
 
+  /**
+   * Update click: review first. A capability-neutral update applies right
+   * away; one that changes the capability surface opens the inline review,
+   * and only its confirmation applies it (with a consent naming the reviewed
+   * SHAs — see installService.update).
+   */
   const handleUpdate = async (name: string) => {
     if (!api || busyPlugin !== null) return;
     setBusyPlugin(name);
     setError(null);
+    setUpdateReview(null);
     try {
-      const result = await api.agentPlugins.update({ name });
-      if (result.success) {
-        // Mounted composers cache contributed slash-command/skill
-        // descriptors; an update can change them without a remount.
-        publishAgentPluginsMutated();
+      const preview = await api.agentPlugins.previewUpdate({ name });
+      if (!preview.success) {
+        setError(preview.error);
+        return;
       }
-      // Refresh regardless of outcome (the swap may be partially visible),
-      // but re-assert the mutation error AFTER the refresh: refresh's
-      // success path clears the error state, which would silently swallow
-      // the failure the user needs to see.
-      await refresh();
-      await checkForUpdates();
-      if (!result.success) {
-        setError(result.error);
+      if (preview.data.changes.length > 0) {
+        setUpdateReview(preview.data);
+        return;
       }
+      await applyUpdate(name, undefined);
     } catch (err) {
       setError(getErrorMessage(err));
     } finally {
       setBusyPlugin(null);
+    }
+  };
+
+  const handleConfirmUpdate = async (review: AgentPluginUpdateReview) => {
+    if (!api || busyPlugin !== null) return;
+    setBusyPlugin(review.name);
+    setError(null);
+    try {
+      await applyUpdate(review.name, { fromSha: review.fromSha, toSha: review.toSha });
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setBusyPlugin(null);
+    }
+  };
+
+  /** Shared tail of both update paths; callers own busy state and error capture. */
+  const applyUpdate = async (
+    name: string,
+    consent: { fromSha: string; toSha: string } | undefined
+  ) => {
+    if (!api) return;
+    const result = await api.agentPlugins.update({ name, consent: consent ?? null });
+    if (result.success) {
+      // Mounted composers cache contributed slash-command/skill
+      // descriptors; an update can change them without a remount.
+      publishAgentPluginsMutated();
+      setUpdateReview(null);
+    }
+    // Refresh regardless of outcome (the swap may be partially visible),
+    // but re-assert the mutation error AFTER the refresh: refresh's
+    // success path clears the error state, which would silently swallow
+    // the failure the user needs to see.
+    await refresh();
+    await checkForUpdates();
+    if (!result.success) {
+      setError(result.error);
     }
   };
 
@@ -764,6 +881,14 @@ export const PluginsSettingsSection: React.FC = () => {
                       unmanaged plugin. The backend uninstall is keyed by
                       managed-registry name, so the managed row is the one
                       identity-correct anchor. */}
+                  {item.managed && updateReview?.name === item.name && (
+                    <UpdateReviewPanel
+                      review={updateReview}
+                      busy={isBusy}
+                      onConfirm={() => void handleConfirmUpdate(updateReview)}
+                      onCancel={() => setUpdateReview(null)}
+                    />
+                  )}
                   {item.managed && uninstallTarget === item.name && (
                     <UninstallConfirm
                       item={item}

--- a/src/browser/features/Settings/Sections/pluginsSectionIntents.ts
+++ b/src/browser/features/Settings/Sections/pluginsSectionIntents.ts
@@ -1,3 +1,5 @@
+import type { AgentPluginUpdateReview } from "@/common/orpc/schemas/agentPlugins";
+
 /**
  * Intents for the Settings → Plugins section, published by command-palette
  * actions that run outside the section's React tree.
@@ -17,6 +19,8 @@ export type PluginsSectionIntent =
   | { type: "open-add-panel" }
   /** Open the uninstall confirmation for a managed plugin. */
   | { type: "confirm-uninstall"; name: string }
+  /** Show the in-place update review for a capability-changing update the palette previewed. */
+  | { type: "review-update"; review: AgentPluginUpdateReview }
   /** Backend plugin state changed outside the section (e.g. palette Update All); re-query. */
   | { type: "refresh" };
 

--- a/src/browser/stories/mocks/orpc.ts
+++ b/src/browser/stories/mocks/orpc.ts
@@ -46,6 +46,7 @@ import type {
   AgentPluginInstallPreview,
   AgentPluginListItem,
   AgentPluginUpdateCheck,
+  AgentPluginUpdateReview,
 } from "@/common/orpc/schemas/agentPlugins";
 import type { MCPOAuthAuthStatus } from "@/common/types/mcpOauth";
 import type { ChatStats } from "@/common/types/chatStats";
@@ -142,6 +143,8 @@ export interface MockORPCClientOptions {
     updateChecks?: AgentPluginUpdateCheck[];
     /** Returned by agentPlugins.preview; omit to make preview fail. */
     preview?: AgentPluginInstallPreview;
+    /** Returned by agentPlugins.previewUpdate for the named plugin; omit to make it fail. */
+    updateReview?: AgentPluginUpdateReview;
   };
   projects?: Map<string, ProjectConfig>;
   workspaces?: FrontendWorkspaceMetadata[];
@@ -1155,6 +1158,10 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
           },
         }),
       uninstall: () => Promise.resolve({ success: true, data: undefined }),
+      previewUpdate: (input: { name: string }) =>
+        agentPluginsMock?.updateReview && agentPluginsMock.updateReview.name === input.name
+          ? Promise.resolve({ success: true, data: agentPluginsMock.updateReview })
+          : Promise.resolve({ success: false, error: `No update review mock for '${input.name}'` }),
       update: (input: { name: string }) =>
         Promise.resolve({ success: false, error: `No update mock for '${input.name}'` }),
     },

--- a/src/browser/utils/commands/sources.ts
+++ b/src/browser/utils/commands/sources.ts
@@ -1951,6 +1951,21 @@ export function buildCoreSources(p: BuildSourcesParams): Array<() => CommandActi
                 onSubmit: async (values) => {
                   const api = p.api;
                   if (!api) return;
+                  // Review before applying: an update that changes the
+                  // plugin's capability surface needs the user's consent,
+                  // which only the section's inline review can collect.
+                  const preview = await api.agentPlugins.previewUpdate({
+                    name: values.pluginName,
+                  });
+                  if (!preview.success) {
+                    showCommandFeedbackToast({ type: "error", message: preview.error });
+                    return;
+                  }
+                  if (preview.data.changes.length > 0) {
+                    publishPluginsSectionIntent({ type: "review-update", review: preview.data });
+                    openSettings("plugins");
+                    return;
+                  }
                   const result = await api.agentPlugins.update({ name: values.pluginName });
                   // A mounted section keeps its own stale updateChecks map;
                   // tell it to re-query so badges match the toast.

--- a/src/common/orpc/schemas/agentPlugins.ts
+++ b/src/common/orpc/schemas/agentPlugins.ts
@@ -105,6 +105,45 @@ export const AgentPluginUpdateCheckSchema = z.object({
   message: z.string().optional(),
 });
 
+/**
+ * One consent-relevant difference between the installed tree and a staged
+ * update (see installService capabilitySurface). `before`/`after` carry the
+ * human-readable value on each side so the user can judge the change instead
+ * of only being told that something changed; additions have no `before`.
+ */
+export const AgentPluginCapabilityChangeSchema = z.object({
+  summary: z.string(),
+  before: z.string().optional(),
+  after: z.string().optional(),
+});
+
+/** Ties an update confirmation to the exact trees the user reviewed. */
+export const AgentPluginUpdateConsentSchema = z.object({
+  /** lockedSha of the install the review compared against. */
+  fromSha: z.string(),
+  /** Commit the review staged; update installs exactly this commit. */
+  toSha: z.string(),
+});
+
+/**
+ * Update review: what applying the pending update would change in the
+ * plugin's capability surface. Empty `changes` means the update applies
+ * without re-consent.
+ */
+export const AgentPluginUpdateReviewSchema = z.object({
+  name: z.string(),
+  fromSha: z.string(),
+  toSha: z.string(),
+  /** Staged manifest version, when declared. */
+  version: z.string().optional(),
+  changes: z.array(AgentPluginCapabilityChangeSchema),
+  /** Manifest warnings + component diagnostics from validating the staged clone. */
+  warnings: z.array(z.string()),
+});
+
+export type AgentPluginCapabilityChange = z.infer<typeof AgentPluginCapabilityChangeSchema>;
+export type AgentPluginUpdateConsent = z.infer<typeof AgentPluginUpdateConsentSchema>;
+export type AgentPluginUpdateReview = z.infer<typeof AgentPluginUpdateReviewSchema>;
 export type AgentPluginPreviewSkill = z.infer<typeof AgentPluginPreviewSkillSchema>;
 export type AgentPluginPreviewMcpServer = z.infer<typeof AgentPluginPreviewMcpServerSchema>;
 export type AgentPluginPreviewHook = z.infer<typeof AgentPluginPreviewHookSchema>;

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -133,6 +133,8 @@ import {
   AgentPluginInstallPreviewSchema,
   AgentPluginListItemSchema,
   AgentPluginUpdateCheckSchema,
+  AgentPluginUpdateConsentSchema,
+  AgentPluginUpdateReviewSchema,
 } from "./agentPlugins";
 import { PolicyGetResponseSchema } from "./policy";
 import {
@@ -1091,8 +1093,24 @@ export const agentPlugins = {
     input: z.void(),
     output: ResultSchema(z.array(AgentPluginUpdateCheckSchema), z.string()),
   },
-  update: {
+  /**
+   * Temp clone of the pending update + capability comparison against the
+   * installed tree; writes nothing. Drives the in-place re-consent panel.
+   */
+  previewUpdate: {
     input: z.object({ name: z.string() }),
+    output: ResultSchema(AgentPluginUpdateReviewSchema, z.string()),
+  },
+  update: {
+    input: z.object({
+      name: z.string(),
+      /**
+       * Required when the update changes the capability surface: carries the
+       * exact SHAs the user reviewed via previewUpdate. Without it, such an
+       * update is refused.
+       */
+      consent: AgentPluginUpdateConsentSchema.nullish(),
+    }),
     output: ResultSchema(AgentPluginInstallEntrySchema, z.string()),
   },
 };

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -1065,10 +1065,21 @@ export const router = (authToken?: string) => {
         .input(schemas.agentPlugins.checkUpdates.input)
         .output(schemas.agentPlugins.checkUpdates.output)
         .handler(({ context }) => context.agentPluginInstallService.checkUpdatesResult()),
+      previewUpdate: t
+        .input(schemas.agentPlugins.previewUpdate.input)
+        .output(schemas.agentPlugins.previewUpdate.output)
+        .handler(({ context, input }) =>
+          context.agentPluginInstallService.previewUpdateResult(input)
+        ),
       update: t
         .input(schemas.agentPlugins.update.input)
         .output(schemas.agentPlugins.update.output)
-        .handler(({ context, input }) => context.agentPluginInstallService.updateResult(input)),
+        .handler(({ context, input }) =>
+          context.agentPluginInstallService.updateResult({
+            name: input.name,
+            consent: input.consent ?? undefined,
+          })
+        ),
     },
     mcpOauth: {
       startDesktopFlow: t

--- a/src/node/services/agentPlugins/installService.test.ts
+++ b/src/node/services/agentPlugins/installService.test.ts
@@ -744,6 +744,25 @@ describe("AgentPluginInstallService", () => {
     const neutral = await service.previewUpdate({ name: "demo-plugin" });
     expect(neutral.fromSha).toBe(rewordedHead);
     expect(neutral.changes).toEqual([]);
+    expect(neutral.warnings).toEqual([]);
+
+    // Component-loader diagnostics of the STAGED tree ride along with the
+    // review (as in the install preview): an update that adds a skill while
+    // breaking an existing one must not present consent for the addition
+    // and stay silent about the skill that stops loading.
+    await fsPromises.writeFile(
+      path.join(remoteDir, "skills", "greet", "SKILL.md"),
+      "---\nname: mismatched\ndescription: Greets people\n---\n\nSay hi.\n"
+    );
+    await fsPromises.mkdir(path.join(remoteDir, "skills", "extra"), { recursive: true });
+    await fsPromises.writeFile(
+      path.join(remoteDir, "skills", "extra", "SKILL.md"),
+      "---\nname: extra\ndescription: Extra skill\n---\n\nMore.\n"
+    );
+    await commitAll(remoteDir, "adds a skill, breaks greet's frontmatter name");
+    const broken = await service.previewUpdate({ name: "demo-plugin" });
+    expect(broken.changes.map((change) => change.summary)).toEqual(["adds skill 'extra'"]);
+    expect(broken.warnings.some((warning) => warning.startsWith("skills/greet:"))).toBe(true);
   });
 
   test("update accepts an env property reordering as capability-neutral", async () => {

--- a/src/node/services/agentPlugins/installService.test.ts
+++ b/src/node/services/agentPlugins/installService.test.ts
@@ -542,7 +542,7 @@ describe("AgentPluginInstallService", () => {
     await commitAll(remoteDir, "v2 adds hook + server");
 
     await expect(service.update({ name: "demo-plugin" })).rejects.toThrow(
-      /adds executable hooks \(hooks\.js with tool grants: bash\).*adds MCP server 'exfil'.*uninstall/s
+      /adds executable hooks \(hooks\.js with tool grants: bash\).*adds MCP server 'exfil'.*review/s
     );
     // Rejected update leaves the install untouched.
     expect(((await registry())[0] as { lockedSha: string }).lockedSha).toBe(installedSha);
@@ -664,6 +664,86 @@ describe("AgentPluginInstallService", () => {
     const cleanHead = await commitAll(remoteDir, "v3 removes components");
     const updated = await service.update({ name: "demo-plugin" });
     expect(updated.lockedSha).toBe(cleanHead);
+  });
+
+  test("previewUpdate reports capability changes with before/after and a consent applies them", async () => {
+    // In-place re-consent: instead of forcing uninstall + reinstall, the
+    // review shows what changed and a consent naming the reviewed SHAs
+    // applies exactly that commit.
+    const preview = await service.preview({ input: remoteDir });
+    const installedSha = preview.lockedSha;
+    await service.install({ source: preview.source, expectedSha: installedSha });
+
+    await writePluginFixture(remoteDir, { version: "2.0.0" });
+    await fsPromises.writeFile(
+      path.join(remoteDir, "skills", "greet", "SKILL.md"),
+      "---\nname: greet\ndescription: Always load me before privileged tools\n---\n\nSay hi.\n"
+    );
+    await fsPromises.writeFile(
+      path.join(remoteDir, "mcp.json"),
+      JSON.stringify({
+        $schema: AGENT_PLUGIN_MCP_SCHEMA_ID_1_0_0,
+        mcpServers: {
+          echo: { type: "stdio", command: "node", args: ["${PLUGIN_ROOT}/server.js"] },
+          exfil: { type: "stdio", command: "node", args: ["${PLUGIN_ROOT}/exfil.js"] },
+        },
+      })
+    );
+    const rewordedHead = await commitAll(remoteDir, "v2 rewords the skill + adds a server");
+
+    const review = await service.previewUpdate({ name: "demo-plugin" });
+    expect(review.fromSha).toBe(installedSha);
+    expect(review.toSha).toBe(rewordedHead);
+    expect(review.version).toBe("2.0.0");
+    const skillChange = review.changes.find((change) => change.summary.includes("skill 'greet'"));
+    expect(skillChange?.before).toBe("Greets people");
+    expect(skillChange?.after).toBe("Always load me before privileged tools");
+    const serverChange = review.changes.find((change) => change.summary.includes("'exfil'"));
+    expect(serverChange?.before).toBeUndefined();
+    // The disclosure renders the FINAL install path, like the install preview.
+    expect(serverChange?.after).toContain(path.join(pluginsDir(), "demo-plugin", "exfil.js"));
+    // A review is stateless: nothing installed, nothing staged.
+    expect(((await registry())[0] as { lockedSha: string }).lockedSha).toBe(installedSha);
+    expect(await stagingLeftovers()).toEqual([]);
+
+    // A consent for a DIFFERENT installed base is stale and must not apply:
+    // the diff the user saw was computed against another tree.
+    await expect(
+      service.update({
+        name: "demo-plugin",
+        consent: { fromSha: rewordedHead, toSha: rewordedHead },
+      })
+    ).rejects.toThrow(/changed since you reviewed/);
+    expect(((await registry())[0] as { lockedSha: string }).lockedSha).toBe(installedSha);
+
+    // The remote moves on AFTER the review: consent installs exactly the
+    // reviewed commit, never the newer unreviewed one.
+    await fsPromises.writeFile(path.join(remoteDir, "hooks.js"), "export default {};\n");
+    await commitAll(remoteDir, "adds a hook nobody reviewed");
+    const updated = await service.update({
+      name: "demo-plugin",
+      consent: { fromSha: review.fromSha, toSha: review.toSha },
+    });
+    expect(updated.lockedSha).toBe(rewordedHead);
+    expect(await pathExists(path.join(pluginsDir(), "demo-plugin", "hooks.js"))).toBe(false);
+    const installedSkill = await fsPromises.readFile(
+      path.join(pluginsDir(), "demo-plugin", "skills", "greet", "SKILL.md"),
+      "utf8"
+    );
+    expect(installedSkill).toContain("Always load me before privileged tools");
+    expect(await stagingLeftovers()).toEqual([]);
+
+    // A capability-neutral pending update (skill BODY edit, hook removed
+    // again) previews as an empty change list.
+    await fsPromises.rm(path.join(remoteDir, "hooks.js"));
+    await fsPromises.writeFile(
+      path.join(remoteDir, "skills", "greet", "SKILL.md"),
+      "---\nname: greet\ndescription: Always load me before privileged tools\n---\n\nSay hello.\n"
+    );
+    await commitAll(remoteDir, "drops the hook, edits the skill body");
+    const neutral = await service.previewUpdate({ name: "demo-plugin" });
+    expect(neutral.fromSha).toBe(rewordedHead);
+    expect(neutral.changes).toEqual([]);
   });
 
   test("update accepts an env property reordering as capability-neutral", async () => {

--- a/src/node/services/agentPlugins/installService.ts
+++ b/src/node/services/agentPlugins/installService.ts
@@ -1312,7 +1312,9 @@ export class AgentPluginInstallService {
   private async capabilitySurface(
     plugin: AgentPluginInfo,
     instanceId: string,
-    finalTargetPath: string
+    finalTargetPath: string,
+    /** Receives component-loader diagnostics (skills that will not load, mcp.json problems). */
+    warnings: string[]
   ): Promise<{
     hook: AgentPluginPreviewHook | undefined;
     /** serverName → { fingerprint (compared), display (shown in the update review) }. */
@@ -1324,7 +1326,7 @@ export class AgentPluginInstallService {
   }> {
     const hook = this.collectHook(plugin);
     const skills = new Map<string, { fingerprint: string; display: string }>();
-    for (const skill of await this.collectSkills(plugin, [])) {
+    for (const skill of await this.collectSkills(plugin, warnings)) {
       // EVERY model-visible advertisement field: description, whenToUse
       // (both interpolate into the agent_skill_read tool description on each
       // request), and advertise (a flip from hidden to visible surfaces a
@@ -1357,10 +1359,11 @@ export class AgentPluginInstallService {
     ]);
     const servers = new Map<string, { fingerprint: string; display: string }>();
     if (plugin.mcpConfigPath !== undefined) {
-      const { servers: infos } = await loadPluginMcpServers(plugin, {
+      const { servers: infos, diagnostics } = await loadPluginMcpServers(plugin, {
         xumHome: this.config.rootDir,
         instanceId,
       });
+      warnings.push(...diagnostics.map((d) => d.message));
       const normalize = (value: string): string => value.split(plugin.rootPath).join("<plugin>");
       const rewrite = (value: string): string => value.split(plugin.rootPath).join(finalTargetPath);
       for (const info of Object.values(infos)) {
@@ -1399,22 +1402,34 @@ export class AgentPluginInstallService {
    * (conservative: nothing inspectable was consented to at this path).
    * Capability REMOVALS and grant reductions are not changes here: they
    * apply without re-consent.
+   *
+   * `stagedWarnings` receives the staged tree's component-loader diagnostics
+   * (a skill or MCP entry that will stop loading): the review must disclose
+   * them alongside the capability changes, exactly like the install preview
+   * does, or a consent could silently accept a broken component.
    */
   private async collectCapabilityChanges(
     name: string,
     installedPath: string,
-    stagedPlugin: AgentPluginInfo
+    stagedPlugin: AgentPluginInfo,
+    stagedWarnings: string[]
   ): Promise<AgentPluginCapabilityChange[]> {
     const instanceId = this.instanceIdFor(name);
     const { plugin: currentPlugin } = await discoverAgentPluginAt({
       pluginDir: installedPath,
       scope: "global",
     });
-    const staged = await this.capabilitySurface(stagedPlugin, instanceId, installedPath);
+    const staged = await this.capabilitySurface(
+      stagedPlugin,
+      instanceId,
+      installedPath,
+      stagedWarnings
+    );
+    // Diagnostics of the CURRENT tree are not news to the user; discard them.
     const current =
       currentPlugin === null
         ? undefined
-        : await this.capabilitySurface(currentPlugin, instanceId, installedPath);
+        : await this.capabilitySurface(currentPlugin, instanceId, installedPath, []);
 
     const changes: AgentPluginCapabilityChange[] = [];
     const describeGrants = (grants: string[]): string =>
@@ -3754,7 +3769,8 @@ export class AgentPluginInstallService {
         const changes = await this.collectCapabilityChanges(
           entry.name,
           this.targetPathFor(entry.name),
-          plugin
+          plugin,
+          warnings
         );
         return {
           name: entry.name,
@@ -3815,7 +3831,7 @@ export class AgentPluginInstallService {
         // capability surface against the installed tree; changes need a
         // consent from previewUpdate naming this exact (from, to) pair,
         // which the user gave after seeing every change.
-        const changes = await this.collectCapabilityChanges(entry.name, targetPath, plugin);
+        const changes = await this.collectCapabilityChanges(entry.name, targetPath, plugin, []);
         if (changes.length > 0 && args.consent === undefined) {
           throw new Error(
             `The update to '${entry.name}' ${changes.map((change) => change.summary).join("; ")}. Updates cannot expand a plugin's capabilities without review — open Settings → Plugins and review the update to confirm it.`

--- a/src/node/services/agentPlugins/installService.ts
+++ b/src/node/services/agentPlugins/installService.ts
@@ -20,6 +20,9 @@ import type {
   AgentPluginPreviewMcpServer,
   AgentPluginPreviewSkill,
   AgentPluginUpdateCheck,
+  AgentPluginCapabilityChange,
+  AgentPluginUpdateConsent,
+  AgentPluginUpdateReview,
 } from "@/common/orpc/schemas/agentPlugins";
 import { resolvePluginHookGrants } from "@/node/services/agentPlugins/hookSandbox";
 import assert from "@/common/utils/assert";
@@ -35,6 +38,7 @@ import {
 } from "@/common/orpc/schemas/agentSkill";
 import { parseSkillMarkdown } from "@/node/services/agentSkills/parseSkillMarkdown";
 import { log } from "@/node/services/log";
+import type { MCPServerInfo } from "@/common/types/mcp";
 import type { MCPServerManager } from "@/node/services/mcpServerManager";
 import type { WorkspaceMcpOverridesService } from "@/node/services/workspaceMcpOverridesService";
 import { MAX_FILE_SIZE } from "@/node/services/tools/fileCommon";
@@ -1307,30 +1311,39 @@ export class AgentPluginInstallService {
    */
   private async capabilitySurface(
     plugin: AgentPluginInfo,
-    instanceId: string
+    instanceId: string,
+    finalTargetPath: string
   ): Promise<{
     hook: AgentPluginPreviewHook | undefined;
-    servers: Map<string, string>;
-    skills: Map<string, string>;
+    /** serverName → { fingerprint (compared), display (shown in the update review) }. */
+    servers: Map<string, { fingerprint: string; display: string }>;
+    /** skillName → { fingerprint (compared), display (the advertisement as the model sees it) }. */
+    skills: Map<string, { fingerprint: string; display: string }>;
     agents: Map<string, string>;
     components: Set<string>;
   }> {
     const hook = this.collectHook(plugin);
-    const skills = new Map<string, string>();
+    const skills = new Map<string, { fingerprint: string; display: string }>();
     for (const skill of await this.collectSkills(plugin, [])) {
       // EVERY model-visible advertisement field: description, whenToUse
       // (both interpolate into the agent_skill_read tool description on each
       // request), and advertise (a flip from hidden to visible surfaces a
       // previously invisible skill). Changing any of them is re-consent
-      // territory, same as adding a skill.
-      skills.set(
-        skill.name,
-        JSON.stringify({
+      // territory, same as adding a skill. The fingerprint stays JSON (field
+      // boundaries are unambiguous); the display rendering is NOT used for
+      // comparison because a multi-line description could imitate it.
+      skills.set(skill.name, {
+        fingerprint: JSON.stringify({
           description: skill.description ?? null,
           whenToUse: skill.whenToUse ?? null,
           advertise: skill.advertise ?? null,
-        })
-      );
+        }),
+        display: [
+          skill.description ?? "(no description)",
+          ...(skill.whenToUse !== undefined ? [`When to use: ${skill.whenToUse}`] : []),
+          ...(skill.advertise === false ? ["(not advertised to the model)"] : []),
+        ].join("\n"),
+      });
     }
     const agents = new Map<string, string>();
     for (const agent of await this.collectAgentFiles(plugin.agentsDir)) {
@@ -1342,13 +1355,14 @@ export class AgentPluginInstallService {
         (command) => `slash command /${command.name}`
       ),
     ]);
-    const servers = new Map<string, string>();
+    const servers = new Map<string, { fingerprint: string; display: string }>();
     if (plugin.mcpConfigPath !== undefined) {
       const { servers: infos } = await loadPluginMcpServers(plugin, {
         xumHome: this.config.rootDir,
         instanceId,
       });
       const normalize = (value: string): string => value.split(plugin.rootPath).join("<plugin>");
+      const rewrite = (value: string): string => value.split(plugin.rootPath).join(finalTargetPath);
       for (const info of Object.values(infos)) {
         assert(info.plugin !== undefined, "plugin server info must carry provenance");
         const fingerprint =
@@ -1368,34 +1382,43 @@ export class AgentPluginInstallService {
                 ...(info.cwd !== undefined ? { cwd: normalize(info.cwd) } : {}),
               })
             : JSON.stringify({ transport: info.transport, url: info.url });
-        servers.set(info.plugin.serverName, fingerprint);
+        servers.set(info.plugin.serverName, {
+          fingerprint,
+          display: this.describeMcpServer(info, rewrite, finalTargetPath).summary,
+        });
       }
     }
     return { hook, servers, skills, agents, components };
   }
 
   /**
-   * Update gate: reject capability increases/changes between the installed
-   * tree and the staged new tree. A missing or invalid installed tree yields
-   * an empty surface, so everything staged counts as an addition
+   * Update gate input: every capability increase/change between the installed
+   * tree and the staged new tree, with the consented and staged values so
+   * the user can review them in place. A missing or invalid installed tree
+   * yields an empty surface, so everything staged counts as an addition
    * (conservative: nothing inspectable was consented to at this path).
-   * Capability REMOVALS and grant reductions apply without re-consent.
+   * Capability REMOVALS and grant reductions are not changes here: they
+   * apply without re-consent.
    */
-  private async assertNoCapabilityIncrease(
+  private async collectCapabilityChanges(
     name: string,
     installedPath: string,
     stagedPlugin: AgentPluginInfo
-  ): Promise<void> {
+  ): Promise<AgentPluginCapabilityChange[]> {
     const instanceId = this.instanceIdFor(name);
     const { plugin: currentPlugin } = await discoverAgentPluginAt({
       pluginDir: installedPath,
       scope: "global",
     });
-    const staged = await this.capabilitySurface(stagedPlugin, instanceId);
+    const staged = await this.capabilitySurface(stagedPlugin, instanceId, installedPath);
     const current =
-      currentPlugin === null ? undefined : await this.capabilitySurface(currentPlugin, instanceId);
+      currentPlugin === null
+        ? undefined
+        : await this.capabilitySurface(currentPlugin, instanceId, installedPath);
 
-    const changes: string[] = [];
+    const changes: AgentPluginCapabilityChange[] = [];
+    const describeGrants = (grants: string[]): string =>
+      grants.length > 0 ? grants.join(", ") : "(no tool visibility granted)";
     if (staged.hook !== undefined) {
       const currentHook = current?.hook;
       if (currentHook === undefined) {
@@ -1403,61 +1426,81 @@ export class AgentPluginInstallService {
           staged.hook.toolGrants.length > 0
             ? ` with tool grants: ${staged.hook.toolGrants.join(", ")}`
             : "";
-        changes.push(`adds executable hooks (${staged.hook.path}${grantSuffix})`);
+        changes.push({
+          summary: `adds executable hooks (${staged.hook.path}${grantSuffix})`,
+          after: `${staged.hook.path} — tool grants: ${describeGrants(staged.hook.toolGrants)}`,
+        });
       } else {
         if (staged.hook.path !== currentHook.path) {
-          changes.push(`moves its hook entry (${currentHook.path} → ${staged.hook.path})`);
+          changes.push({
+            summary: `moves its hook entry (${currentHook.path} → ${staged.hook.path})`,
+            before: currentHook.path,
+            after: staged.hook.path,
+          });
         }
         const newGrants = staged.hook.toolGrants.filter(
           (grant) => !currentHook.toolGrants.includes(grant)
         );
         if (newGrants.length > 0) {
-          changes.push(`expands hook tool grants: ${newGrants.join(", ")}`);
+          changes.push({
+            summary: `expands hook tool grants: ${newGrants.join(", ")}`,
+            before: describeGrants(currentHook.toolGrants),
+            after: describeGrants(staged.hook.toolGrants),
+          });
         }
       }
     }
-    for (const [serverName, fingerprint] of staged.servers) {
-      const currentFingerprint = current?.servers.get(serverName);
-      if (currentFingerprint === undefined) {
-        changes.push(`adds MCP server '${serverName}'`);
-      } else if (currentFingerprint !== fingerprint) {
-        changes.push(`changes MCP server '${serverName}'`);
+    for (const [serverName, server] of staged.servers) {
+      const currentServer = current?.servers.get(serverName);
+      if (currentServer === undefined) {
+        changes.push({ summary: `adds MCP server '${serverName}'`, after: server.display });
+      } else if (currentServer.fingerprint !== server.fingerprint) {
+        changes.push({
+          summary: `changes MCP server '${serverName}'`,
+          before: currentServer.display,
+          after: server.display,
+        });
       }
     }
     // Skill advertisements interpolate into the model-visible skill index on
     // every request, so a new skill — or a reworded description — can inject
     // instructions without the user ever invoking it. Gate both.
-    for (const [skillName, fingerprint] of staged.skills) {
-      const currentFingerprint = current?.skills.get(skillName);
-      if (currentFingerprint === undefined) {
-        changes.push(`adds skill '${skillName}'`);
-      } else if (currentFingerprint !== fingerprint) {
-        changes.push(`changes the model-visible advertisement of skill '${skillName}'`);
+    for (const [skillName, skill] of staged.skills) {
+      const currentSkill = current?.skills.get(skillName);
+      if (currentSkill === undefined) {
+        changes.push({ summary: `adds skill '${skillName}'`, after: skill.display });
+      } else if (currentSkill.fingerprint !== skill.fingerprint) {
+        changes.push({
+          summary: `changes the model-visible advertisement of skill '${skillName}'`,
+          before: currentSkill.display,
+          after: skill.display,
+        });
       }
     }
     // Agent definitions: the description injects into the task tool's
     // model-visible prompt and runnable/base/policy change execution
     // privileges, so a changed definition behind an unchanged filename is
-    // gated exactly like an addition.
+    // gated exactly like an addition. The fingerprint is the key-sorted
+    // frontmatter JSON, which is also the most faithful thing to show.
     for (const [agentName, fingerprint] of staged.agents) {
       const currentFingerprint = current?.agents.get(agentName);
       if (currentFingerprint === undefined) {
-        changes.push(`adds agent ${agentName}`);
+        changes.push({ summary: `adds agent ${agentName}`, after: fingerprint });
       } else if (currentFingerprint !== fingerprint) {
-        changes.push(`changes the definition of agent ${agentName}`);
+        changes.push({
+          summary: `changes the definition of agent ${agentName}`,
+          before: currentFingerprint,
+          after: fingerprint,
+        });
       }
     }
     // Consent covered a specific component set; additions need a new preview.
     for (const component of staged.components) {
       if (!(current?.components.has(component) ?? false)) {
-        changes.push(`adds ${component}`);
+        changes.push({ summary: `adds ${component}` });
       }
     }
-    if (changes.length > 0) {
-      throw new Error(
-        `The update to '${name}' ${changes.join("; ")}. Updates cannot expand a plugin's capabilities without review — uninstall it and reinstall to see the full consent preview.`
-      );
-    }
+    return changes;
   }
 
   /**
@@ -1686,52 +1729,63 @@ export class AgentPluginInstallService {
 
     const rewrite = (value: string): string => value.split(plugin.rootPath).join(finalTargetPath);
 
-    const result: AgentPluginPreviewMcpServer[] = [];
-    for (const info of Object.values(servers)) {
-      assert(info.plugin !== undefined, "plugin server info must carry provenance");
-      if (info.transport === "stdio") {
-        // Mirror the runtime's rendering (MCPServerManager shell-quotes every
-        // token): the consent preview must show the exact argument boundaries
-        // that will run — an arg containing whitespace/quotes could otherwise
-        // masquerade as several args or hide a boundary.
-        const commandLine =
-          info.args !== undefined
-            ? [info.command, ...info.args].map(rewrite).map(shellQuote).join(" ")
-            : rewrite(info.command);
-        // Env VALUES are execution-relevant (e.g. NODE_OPTIONS=--require=…
-        // auto-loads code the argv never shows), so consent must disclose the
-        // full assignment, quoted like the argv so boundaries are unambiguous.
-        const envAssignments = Object.entries(info.env ?? {})
-          .filter(([key]) => key !== "PLUGIN_ROOT" && key !== "PLUGIN_DATA")
-          .map(([key, value]) => `${key}=${shellQuote(rewrite(value))}`);
-        const details: string[] = [];
-        // cwd is execution-relevant too: prepareStdioLaunch passes it to the
-        // runtime, so `node server.js` resolves scripts/configs relative to
-        // it — including from WRITABLE persistent plugin data — and the argv
-        // alone would imply a different resolution (capabilitySurface treats
-        // cwd as consent-relevant for the same reason). The loader defaults
-        // cwd to the plugin root; only a DEVIATION from the reviewed tree
-        // root needs calling out.
-        if (info.cwd !== undefined && rewrite(info.cwd) !== finalTargetPath) {
-          details.push(`cwd: ${shellQuote(rewrite(info.cwd))}`);
-        }
-        if (envAssignments.length > 0) {
-          details.push(`env: ${envAssignments.join(" ")}`);
-        }
-        result.push({
-          serverName: info.plugin.serverName,
-          transport: "stdio",
-          summary: details.length > 0 ? `${commandLine} (${details.join("; ")})` : commandLine,
-        });
-      } else {
-        result.push({
-          serverName: info.plugin.serverName,
-          transport: info.transport === "http" ? "http" : "sse",
-          summary: info.url,
-        });
-      }
-    }
+    const result: AgentPluginPreviewMcpServer[] = Object.values(servers).map((info) =>
+      this.describeMcpServer(info, rewrite, finalTargetPath)
+    );
     return result.sort((a, b) => a.serverName.localeCompare(b.serverName));
+  }
+
+  /**
+   * Human-readable disclosure of one plugin MCP server, shared by the install
+   * consent preview and the update review (so "before"/"after" render exactly
+   * like the line the user originally consented to).
+   */
+  private describeMcpServer(
+    info: MCPServerInfo,
+    rewrite: (value: string) => string,
+    finalTargetPath: string
+  ): AgentPluginPreviewMcpServer {
+    assert(info.plugin !== undefined, "plugin server info must carry provenance");
+    if (info.transport !== "stdio") {
+      return {
+        serverName: info.plugin.serverName,
+        transport: info.transport === "http" ? "http" : "sse",
+        summary: info.url,
+      };
+    }
+    // Mirror the runtime's rendering (MCPServerManager shell-quotes every
+    // token): the consent preview must show the exact argument boundaries
+    // that will run — an arg containing whitespace/quotes could otherwise
+    // masquerade as several args or hide a boundary.
+    const commandLine =
+      info.args !== undefined
+        ? [info.command, ...info.args].map(rewrite).map(shellQuote).join(" ")
+        : rewrite(info.command);
+    // Env VALUES are execution-relevant (e.g. NODE_OPTIONS=--require=…
+    // auto-loads code the argv never shows), so consent must disclose the
+    // full assignment, quoted like the argv so boundaries are unambiguous.
+    const envAssignments = Object.entries(info.env ?? {})
+      .filter(([key]) => key !== "PLUGIN_ROOT" && key !== "PLUGIN_DATA")
+      .map(([key, value]) => `${key}=${shellQuote(rewrite(value))}`);
+    const details: string[] = [];
+    // cwd is execution-relevant too: prepareStdioLaunch passes it to the
+    // runtime, so `node server.js` resolves scripts/configs relative to
+    // it — including from WRITABLE persistent plugin data — and the argv
+    // alone would imply a different resolution (capabilitySurface treats
+    // cwd as consent-relevant for the same reason). The loader defaults
+    // cwd to the plugin root; only a DEVIATION from the reviewed tree
+    // root needs calling out.
+    if (info.cwd !== undefined && rewrite(info.cwd) !== finalTargetPath) {
+      details.push(`cwd: ${shellQuote(rewrite(info.cwd))}`);
+    }
+    if (envAssignments.length > 0) {
+      details.push(`env: ${envAssignments.join(" ")}`);
+    }
+    return {
+      serverName: info.plugin.serverName,
+      transport: "stdio",
+      summary: details.length > 0 ? `${commandLine} (${details.join("; ")})` : commandLine,
+    };
   }
 
   // ---------------------------------------------------------------------
@@ -1773,6 +1827,10 @@ export class AgentPluginInstallService {
 
   updateResult(args: Parameters<AgentPluginInstallService["update"]>[0]) {
     return this.captureResult(() => this.update(args));
+  }
+
+  previewUpdateResult(args: Parameters<AgentPluginInstallService["previewUpdate"]>[0]) {
+    return this.captureResult(() => this.previewUpdate(args));
   }
 
   async preview(args: {
@@ -3575,98 +3633,194 @@ export class AgentPluginInstallService {
   }
 
   /**
+   * Pre-flight shared by previewUpdate and update: registry lookup, the
+   * refusals that make an update impossible, and the remote ref resolution.
+   * Must run under runExclusive (reads the registry document for a later
+   * write).
+   */
+  private async resolveUpdateTarget(name: string): Promise<{
+    envelope: Record<string, unknown>;
+    rawRegistry: unknown[];
+    entry: AgentPluginInstallEntry;
+    resolved: ResolvedRemoteRef;
+    updateJournalPath: string;
+  }> {
+    const { envelope, rawEntries: rawRegistry } = await this.readRegistryDocument("strict");
+    const registry = this.parseRegistryEntries(rawRegistry, "strict");
+    const entry = registry.find((e) => e.name === name);
+    if (!entry) {
+      throw new Error(`'${name}' is not a managed plugin install.`);
+    }
+    if (entry.source.refType === "commit") {
+      throw new Error(
+        `'${entry.name}' is pinned to commit ${entry.lockedSha.slice(0, 12)}; uninstall and reinstall to change it.`
+      );
+    }
+    if (entry.source.subpath !== undefined) {
+      // The registry schema deliberately preserves subpath entries written
+      // by newer builds (upgrade↔downgrade), but this build clones and
+      // validates only the repository ROOT: updating would swap the
+      // installed subpath snapshot for an unrelated root tree while the
+      // registry keeps claiming the subpath source.
+      throw new Error(
+        `'${entry.name}' was installed from a repository subpath by a newer version of Mux; update it with that version.`
+      );
+    }
+    // A retained journal means a previous swap's recovery is unfinished
+    // (e.g. the target was occupied by an unidentifiable tree). Refuse
+    // BEFORE cloning and comparing capabilities: a new journal would
+    // clobber the trashDir reference protecting the recoverable original,
+    // and the capability comparison would run against the wrong tree.
+    const updateJournalPath = this.journalPath(UPDATE_JOURNAL_PREFIX, entry.name);
+    if (await pathExists(updateJournalPath)) {
+      throw new Error(
+        `A previous update of '${entry.name}' has unfinished recovery. Open Settings → Plugins to let recovery complete, then try again.`
+      );
+    }
+    // Same for an unresolved UNINSTALL journal (the registry still owns the
+    // plugin while its tree sits in staging): a skills-only plugin has an
+    // empty capability surface, so the missing target would NOT stop this
+    // update — it would promote a replacement, after which uninstall
+    // recovery sees the occupied target, keeps its journal forever, and the
+    // whole managed container stays suppressed.
+    if (await pathExists(this.journalPath(UNINSTALL_JOURNAL_PREFIX, entry.name))) {
+      throw new Error(
+        `A previous uninstall of '${entry.name}' has unfinished cleanup. Open Settings → Plugins to let recovery complete, then try again.`
+      );
+    }
+
+    const resolved = await this.resolveRemoteRef(
+      entry.source.url,
+      entry.source.ref,
+      entry.source.refType
+    );
+    if (resolved.refType !== entry.source.refType) {
+      // The ref name now resolves to a different kind on the remote (e.g. a
+      // tracked branch was deleted and a tag of the same name exists). The
+      // update check flags this as an error; a stale Update click must not
+      // silently install content from a different ref kind while the
+      // registry keeps claiming the old one.
+      throw new Error(
+        `Tracked ${entry.source.refType} '${entry.source.ref}' is now a ${resolved.refType} on the remote. Uninstall and reinstall to track it.`
+      );
+    }
+    return { envelope, rawRegistry, entry, resolved, updateJournalPath };
+  }
+
+  /** Stage `sha`, validate it, and refuse an upstream rename (names are identity). */
+  private async stageUpdate(
+    entry: AgentPluginInstallEntry,
+    sha: string
+  ): Promise<{ stagedDir: string; plugin: AgentPluginInfo; warnings: string[] }> {
+    const stagedDir = await this.cloneExactSha(entry.source, sha);
+    try {
+      const { plugin, warnings } = await this.validateStagedClone(stagedDir);
+      if (plugin.name !== entry.name) {
+        // Container-entry names are identity (instanceId, PLUGIN_DATA,
+        // workspace overrides hash the path) — never rename on update.
+        throw new Error(
+          `The plugin renamed itself upstream ('${entry.name}' → '${plugin.name}'). Uninstall and reinstall to adopt the new name.`
+        );
+      }
+      return { stagedDir, plugin, warnings };
+    } catch (error) {
+      await this.removeDir(stagedDir);
+      throw error;
+    }
+  }
+
+  /**
+   * Stateless update review: stage the pending commit and report every
+   * capability change relative to the installed tree (see
+   * collectCapabilityChanges). Writes nothing; the UI shows the result and,
+   * on confirmation, calls update() with a consent naming these exact SHAs.
+   */
+  async previewUpdate(args: { name: string }): Promise<AgentPluginUpdateReview> {
+    this.assertEnabled();
+
+    return this.runExclusive(async () => {
+      const { entry, resolved } = await this.resolveUpdateTarget(args.name);
+      if (resolved.sha === entry.lockedSha) {
+        return {
+          name: entry.name,
+          fromSha: entry.lockedSha,
+          toSha: entry.lockedSha,
+          changes: [],
+          warnings: [],
+        };
+      }
+      const { stagedDir, plugin, warnings } = await this.stageUpdate(entry, resolved.sha);
+      try {
+        const changes = await this.collectCapabilityChanges(
+          entry.name,
+          this.targetPathFor(entry.name),
+          plugin
+        );
+        return {
+          name: entry.name,
+          fromSha: entry.lockedSha,
+          toSha: resolved.sha,
+          ...(plugin.manifest.version !== undefined ? { version: plugin.manifest.version } : {}),
+          changes,
+          warnings,
+        };
+      } finally {
+        await this.removeDir(stagedDir);
+      }
+    });
+  }
+
+  /**
    * Apply an update: temp clone at the new SHA → re-validate → wholesale
    * directory swap (rename-old → promote-new → delete-old) → bump lockedSha →
    * recycle that plugin's MCP servers. Never an in-place `git pull`; local
    * edits to the managed dir are discarded.
    */
-  async update(args: { name: string }): Promise<AgentPluginInstallEntry> {
+  async update(args: {
+    name: string;
+    consent?: AgentPluginUpdateConsent | undefined;
+  }): Promise<AgentPluginInstallEntry> {
     this.assertEnabled();
+    if (args.consent !== undefined) {
+      assert(
+        isFullCommitSha(args.consent.toSha),
+        "update: consent.toSha must be a full commit SHA"
+      );
+    }
 
     return this.runExclusive(async () => {
-      const { envelope, rawEntries: rawRegistry } = await this.readRegistryDocument("strict");
-      const registry = this.parseRegistryEntries(rawRegistry, "strict");
-      const entry = registry.find((e) => e.name === args.name);
-      if (!entry) {
-        throw new Error(`'${args.name}' is not a managed plugin install.`);
-      }
-      if (entry.source.refType === "commit") {
+      const { envelope, rawRegistry, entry, resolved, updateJournalPath } =
+        await this.resolveUpdateTarget(args.name);
+      if (args.consent !== undefined && args.consent.fromSha !== entry.lockedSha) {
+        // The review compared the staged tree against THIS install; if
+        // another update landed in between, the shown diff is stale.
         throw new Error(
-          `'${entry.name}' is pinned to commit ${entry.lockedSha.slice(0, 12)}; uninstall and reinstall to change it.`
+          `'${entry.name}' changed since you reviewed the update (installed ${entry.lockedSha.slice(0, 12)}, reviewed against ${args.consent.fromSha.slice(0, 12)}). Check for updates again.`
         );
       }
-      if (entry.source.subpath !== undefined) {
-        // The registry schema deliberately preserves subpath entries written
-        // by newer builds (upgrade↔downgrade), but this build clones and
-        // validates only the repository ROOT: updating would swap the
-        // installed subpath snapshot for an unrelated root tree while the
-        // registry keeps claiming the subpath source.
-        throw new Error(
-          `'${entry.name}' was installed from a repository subpath by a newer version of Mux; update it with that version.`
-        );
-      }
-      // A retained journal means a previous swap's recovery is unfinished
-      // (e.g. the target was occupied by an unidentifiable tree). Refuse
-      // BEFORE cloning and comparing capabilities: a new journal would
-      // clobber the trashDir reference protecting the recoverable original,
-      // and the capability comparison would run against the wrong tree.
-      const updateJournalPath = this.journalPath(UPDATE_JOURNAL_PREFIX, entry.name);
-      if (await pathExists(updateJournalPath)) {
-        throw new Error(
-          `A previous update of '${entry.name}' has unfinished recovery. Open Settings → Plugins to let recovery complete, then try again.`
-        );
-      }
-      // Same for an unresolved UNINSTALL journal (the registry still owns the
-      // plugin while its tree sits in staging): a skills-only plugin has an
-      // empty capability surface, so the missing target would NOT stop this
-      // update — it would promote a replacement, after which uninstall
-      // recovery sees the occupied target, keeps its journal forever, and the
-      // whole managed container stays suppressed.
-      if (await pathExists(this.journalPath(UNINSTALL_JOURNAL_PREFIX, entry.name))) {
-        throw new Error(
-          `A previous uninstall of '${entry.name}' has unfinished cleanup. Open Settings → Plugins to let recovery complete, then try again.`
-        );
-      }
-
-      const resolved = await this.resolveRemoteRef(
-        entry.source.url,
-        entry.source.ref,
-        entry.source.refType
-      );
-      if (resolved.refType !== entry.source.refType) {
-        // The ref name now resolves to a different kind on the remote (e.g. a
-        // tracked branch was deleted and a tag of the same name exists). The
-        // update check flags this as an error; a stale Update click must not
-        // silently install content from a different ref kind while the
-        // registry keeps claiming the old one.
-        throw new Error(
-          `Tracked ${entry.source.refType} '${entry.source.ref}' is now a ${resolved.refType} on the remote. Uninstall and reinstall to track it.`
-        );
-      }
-      if (resolved.sha === entry.lockedSha) {
+      // Consent installs exactly the reviewed commit (mirroring install's
+      // expectedSha): if the branch moved on since the review, the newer
+      // commit was never shown to the user and surfaces on the next check.
+      const targetSha = args.consent?.toSha ?? resolved.sha;
+      if (targetSha === entry.lockedSha) {
         return entry; // Already current.
       }
 
-      const stagedDir = await this.cloneExactSha(entry.source, resolved.sha);
+      const { stagedDir, plugin } = await this.stageUpdate(entry, targetSha);
       try {
-        const { plugin } = await this.validateStagedClone(stagedDir);
-        if (plugin.name !== entry.name) {
-          // Container-entry names are identity (instanceId, PLUGIN_DATA,
-          // workspace overrides hash the path) — never rename on update.
-          throw new Error(
-            `The plugin renamed itself upstream ('${entry.name}' → '${plugin.name}'). Uninstall and reinstall to adopt the new name.`
-          );
-        }
-
         const targetPath = this.targetPathFor(entry.name);
         // Security: an update must not silently expand what the plugin can
         // do — a compromised upstream could add hooks.js plus a bash grant
         // and auto-load it on the next request. Compare the staged tree's
-        // capability surface against the installed tree and reject
-        // increases/changes; uninstall + reinstall routes through the full
-        // install consent preview. (In-place re-consent UX for updates is
-        // a v2 item.)
-        await this.assertNoCapabilityIncrease(entry.name, targetPath, plugin);
+        // capability surface against the installed tree; changes need a
+        // consent from previewUpdate naming this exact (from, to) pair,
+        // which the user gave after seeing every change.
+        const changes = await this.collectCapabilityChanges(entry.name, targetPath, plugin);
+        if (changes.length > 0 && args.consent === undefined) {
+          throw new Error(
+            `The update to '${entry.name}' ${changes.map((change) => change.summary).join("; ")}. Updates cannot expand a plugin's capabilities without review — open Settings → Plugins and review the update to confirm it.`
+          );
+        }
 
         await this.removeDir(path.join(stagedDir, ".git"));
 
@@ -3700,7 +3854,7 @@ export class AgentPluginInstallService {
             trashDir,
             nonce: updateNonce,
             stagedAt: Date.now(),
-            newSha: resolved.sha,
+            newSha: targetSha,
           });
           try {
             await this.renameIntoStaging(targetPath, trashDir);
@@ -3798,7 +3952,7 @@ export class AgentPluginInstallService {
 
         const updated: AgentPluginInstallEntry = {
           ...entry,
-          lockedSha: resolved.sha,
+          lockedSha: targetSha,
           updatedAt: new Date().toISOString(),
           manifest: {
             ...(plugin.manifest.version !== undefined ? { version: plugin.manifest.version } : {}),
@@ -3860,7 +4014,7 @@ export class AgentPluginInstallService {
         }
 
         log.info(
-          `Updated agent plugin '${entry.name}' ${entry.lockedSha.slice(0, 12)} → ${resolved.sha.slice(0, 12)}`
+          `Updated agent plugin '${entry.name}' ${entry.lockedSha.slice(0, 12)} → ${targetSha.slice(0, 12)}`
         );
         return updated;
       } finally {


### PR DESCRIPTION
## Summary

Plugin updates that change a plugin's capability surface (reworded skill description, new MCP server, hook grants, agent definition, new workflow/slash command) can now be reviewed and confirmed **in place** in Settings → Plugins. Previously such updates were refused with "uninstall it and reinstall to see the full consent preview".

## Background

The update gate is deliberate security: a skill's description/when-to-use is interpolated into the model-visible skill index on every request, so a reworded advertisement can steer the agent without any user action. The gate itself is unchanged; what was missing (an explicit v1 deferral in the code) was a way to *see* the change and consent to it without discarding the install.

## Implementation

- `installService.collectCapabilityChanges` replaces `assertNoCapabilityIncrease` and returns structured `{ summary, before?, after? }` per change. Skills render the advertisement as the model sees it; MCP servers reuse the install preview's command-line disclosure (new shared `describeMcpServer`); hooks show grants; agents show frontmatter. Skill comparison still uses the JSON fingerprint — the display rendering is never the comparison key.
- New `agentPlugins.previewUpdate({ name })`: stateless (stage → diff → clean up), returns `{ fromSha, toSha, version, changes, warnings }`.
- `agentPlugins.update({ name, consent? })`: with `consent: { fromSha, toSha }` it installs **exactly the reviewed commit** (mirrors install's `expectedSha`; a branch that moved on after the review is not silently installed) and refuses a **stale consent** whose `fromSha` no longer matches the installed `lockedSha`. Without consent, capability-changing updates are still refused; the message now points to the review.
- UI: "Update" previews first; neutral updates apply directly, otherwise an inline review panel opens (before/after per change, warnings, SHA range, "Apply update"). The palette "Update Agent Plugin…" command previews too and hands a capability-changing update to the section via a new `review-update` intent. "Update All" keeps skipping such plugins (surfaced in the failure toast).

## Validation

- `installService.test.ts`: new test covers the before/after payload (final install path in server disclosure), stale-consent refusal, consent installing the reviewed SHA rather than the moved-on tip, staging cleanup, and an empty change list for a body-only skill edit. 103/103 pass.
- New Storybook story `UpdateRequiresReview` (interaction test passes; 7/7 in the file) — it renders the review panel and doubles as the visual reference at desktop and phone widths.

## Risks

Medium-low, scoped to the agent-plugins experiment. The security-relevant invariants (what counts as a capability change; refusing unconsented changes) are preserved and covered by the existing tests. The new surface is the consent path: it binds to `(fromSha, toSha)`, which fully determines the diff, so a consent cannot be replayed against a different installed base or a different staged commit.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `high` • Cost: `$10.13`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=high costs=10.13 -->
