### PR TITLE
[ci] 🤖 isolate QuickJS integration tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -197,6 +197,8 @@ jobs:
             src/node/services/workflows/WorkflowRunner.test.ts
             src/node/services/ptc/quickjsRuntime.test.ts
             src/node/services/tools/code_execution.test.ts
+            # This suite also creates QuickJS runtimes. Shared coverage can trap during startup.
+            src/node/services/tools/code_execution.integration.test.ts
             src/node/services/sandbox/sandboxHostService.test.ts
             src/node/services/agentPlugins/hookService.test.ts
             src/node/orpc/router.test.ts


### PR DESCRIPTION
## Summary

Run the QuickJS integration suite in its own CI process, like the other QuickJS suites.

## Background

[Merge queue job 102238491947](https://github.com/coder/xum/actions/runs/34278847407/job/102238491947) fails during QuickJS startup, before the missing-file assertion runs.
The error is `RuntimeError: access to a null reference`.
The existing workflow isolates QuickJS suites because shared Bun coverage can crash or lose callbacks.
The isolation list omits `code_execution.integration.test.ts`.

## Implementation

Add the integration suite to the existing isolation list.
The shared coverage command automatically excludes listed suites.
Keep all test assertions and existing retry rules unchanged.

The original crash does not reproduce locally. CI must confirm this isolation fix.

---

_Generated with `xum` • Model: `openai:gpt-6-astra` • Thinking: `high` • Cost: `$4.99`_

<!-- mux-attribution: model=openai:gpt-6-astra thinking=high costs=4.99 -->
