### PR TITLE
🤖 fix: honor interrupt_active while a delegated turn is still PREPARING

### DIFF
--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -855,6 +855,17 @@ export function parseWorkspaceTurnTaskCorrelation(
   return { taskHandleId, ownerWorkspaceId, turnId };
 }
 
+export function isSameWorkspaceTurnTaskCorrelation(
+  first: WorkspaceTurnTaskCorrelation,
+  second: WorkspaceTurnTaskCorrelation
+): boolean {
+  return (
+    first.taskHandleId === second.taskHandleId &&
+    first.ownerWorkspaceId === second.ownerWorkspaceId &&
+    first.turnId === second.turnId
+  );
+}
+
 export function getCompactionFollowUpContent(
   metadata?: MuxMessageMetadata
 ): CompactionRequestData["followUpContent"] | undefined {

--- a/src/node/services/agentSession.preparationAdmission.test.ts
+++ b/src/node/services/agentSession.preparationAdmission.test.ts
@@ -530,4 +530,42 @@ describe("preparation admission", () => {
       await h.session.waitForIdle();
     }
   );
+
+  test.each([
+    ["delegated", { taskHandleId: "task", ownerWorkspaceId: "parent", turnId: "turn" }],
+    ["manual", undefined],
+  ] as const)(
+    "a stoppable PREPARING %s send is reported only between engine startup registration and idle",
+    async (kind, correlation) => {
+      const h = await harness(`stoppable-preparing-${kind}`);
+      const entered = Promise.withResolvers<Parameters<typeof h.aiService.streamMessage>[0]>();
+      const release = Promise.withResolvers<void>();
+      spyOn(h.aiService, "streamMessage").mockImplementation(async (request) => {
+        entered.resolve(request);
+        await release.promise;
+        return Ok(createStartedTurnHandle(h.session.closingSignal));
+      });
+      const sent = h.session.sendMessage(
+        "head",
+        {
+          ...options,
+          ...(correlation ? { muxMetadata: { type: "workspace-turn-task", ...correlation } } : {}),
+        },
+        { startStreamInBackground: true }
+      );
+      const request = await entered.promise;
+      // PREPARING, but the engine has not registered the startup: a stopStream here would
+      // only notify, so the turn is not reported as stoppable.
+      expect(h.session.isPreparingTurn()).toBe(true);
+      expect(h.session.getStoppablePreparingWorkspaceTurn()).toBeUndefined();
+
+      request.onStreamStarting?.("starting-1");
+      expect(h.session.getStoppablePreparingWorkspaceTurn()).toEqual(correlation);
+
+      release.resolve();
+      expect((await sent).success).toBe(true);
+      await h.session.waitForIdle();
+      expect(h.session.getStoppablePreparingWorkspaceTurn()).toBeUndefined();
+    }
+  );
 });

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -147,6 +147,7 @@ import {
   type MuxMessage,
   type ReviewNoteDataForDisplay,
   type StartupRetrySendOptions,
+  type WorkspaceTurnTaskCorrelation,
 } from "@/common/types/message";
 import { toValidGoalId } from "@/common/types/goal";
 import { selectKeepRecentTailStartIndex } from "@/common/utils/messages/keepRecentTail";
@@ -8960,6 +8961,30 @@ export class AgentSession {
     }
     const candidate = this.messageQueue.getNextQueueCutCandidate();
     return candidate != null ? { stage: "queued", ...candidate } : undefined;
+  }
+
+  /**
+   * Correlation of the delegated workspace turn whose PREPARING send has already handed its
+   * startup to the engine, the only PREPARING state stopStream() cancels: earlier PREPARING
+   * work (history acceptance, request preparation) has no pending stream start, so a stop
+   * there only notifies and the turn still streams. Undefined for user sends and every other
+   * phase. The interrupt_active archive gates use this to tell an interruptible delegated
+   * turn from user input that merely looks like a queued message.
+   */
+  getStoppablePreparingWorkspaceTurn(): WorkspaceTurnTaskCorrelation | undefined {
+    const preparing = this.preparingWorkspaceTurnMetadata;
+    if (
+      preparing == null ||
+      this.coordinator.phase !== "preparing" ||
+      !this.coordinator.startupRegistered
+    ) {
+      return undefined;
+    }
+    return {
+      taskHandleId: preparing.taskHandleId,
+      ownerWorkspaceId: preparing.ownerWorkspaceId,
+      turnId: preparing.turnId,
+    };
   }
 
   /** Whether a message queued with this dedupe key is still pending (see MessageQueue.addOnce). */

--- a/src/node/services/taskWorkspaceSeam.testUtils.ts
+++ b/src/node/services/taskWorkspaceSeam.testUtils.ts
@@ -37,6 +37,8 @@ export function makeWorkspaceHostFake(overrides: Partial<WorkspaceHost> = {}): W
       terminalSessions: false,
       desktopSession: false,
     }),
+    getStoppablePreparingWorkspaceTurn: () => undefined,
+    waitForIdle: () => Promise.resolve(),
     hasRunningBackgroundBashProcesses: () => Promise.resolve(false),
     hasUntrackableExternalAppOpen: () => Promise.resolve(false),
     // Keep-style behavior makes archive eligibility independent of untracked files.

--- a/src/node/services/taskWorkspaceSeam.ts
+++ b/src/node/services/taskWorkspaceSeam.ts
@@ -461,6 +461,8 @@ export interface WorkspaceLifecycleHost {
     }
   ): Result<Disposable>;
   listLiveWorkspaceActivity(workspaceId: string): WorkspaceLiveActivity;
+  getStoppablePreparingWorkspaceTurn(workspaceId: string): WorkspaceTurnTaskCorrelation | undefined;
+  waitForIdle(workspaceId: string): Promise<void>;
   hasRunningBackgroundBashProcesses(workspaceId: string): Promise<boolean>;
   hasUntrackableExternalAppOpen(workspaceId: string): Promise<boolean>;
   isSnapshotArchiveEligibilityMutationSensitive(

--- a/src/node/services/turnCoordinator.ts
+++ b/src/node/services/turnCoordinator.ts
@@ -772,6 +772,10 @@ export class TurnCoordinator {
     const operation = this.state.turn.operation;
     return operation?.messageId ?? operation?.startupMessageId;
   }
+  /** Whether the current operation has handed its startup to the engine (pending stream start). */
+  get startupRegistered(): boolean {
+    return this.state.turn.operation?.startupMessageId != null;
+  }
   get disposed(): boolean {
     return this.state.lifetime === "disposed";
   }

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -15572,6 +15572,160 @@ describe("WorkspaceService archive lifecycle hooks", () => {
     expect(releases).toBe(2);
   });
 
+  test("acquirePreInterruptionArchiveHold exempts only a stoppable PREPARING delegated turn", () => {
+    const delegated = { taskHandleId: "wt-1", ownerWorkspaceId: "owner-1", turnId: "turn-1" };
+    const session = workspaceService.getOrCreateSession(workspaceId);
+    session.isPreparingTurn = () => true;
+    let stoppable: typeof delegated | undefined = delegated;
+    session.getStoppablePreparingWorkspaceTurn = () => stoppable;
+    let queued = 0;
+    session.queuedMessageEntryCount = () => queued;
+
+    // The collected turn itself is PREPARING with its startup registered: interruptWorkspaceTurn's
+    // stopStream cancels it, so the hold is granted.
+    const held = workspaceService.acquirePreInterruptionArchiveHold(workspaceId, {
+      queuedDelegatedTurnCount: 0,
+      expectedDelegatedTurnCorrelations: [delegated],
+    });
+    expect(held.success).toBe(true);
+    if (held.success) held.data[Symbol.dispose]();
+
+    // A user entry queued behind the exempt delegated turn is still user work.
+    queued = 1;
+    const refusedQueued = workspaceService.acquirePreInterruptionArchiveHold(workspaceId, {
+      queuedDelegatedTurnCount: 0,
+      expectedDelegatedTurnCorrelations: [delegated],
+    });
+    expect(refusedQueued.success).toBe(false);
+    if (!refusedQueued.success) {
+      expect(refusedQueued.error).toContain("queued messages beyond the delegated turns");
+      expect(refusedQueued.error).not.toContain("a message dispatching");
+    }
+    queued = 0;
+
+    // PREPARING for a different turn than the collected one (the collected turn ended and
+    // another delegated turn took the session) is not the work the caller is interrupting.
+    stoppable = { ...delegated, turnId: "turn-2" };
+    const refusedMismatch = workspaceService.acquirePreInterruptionArchiveHold(workspaceId, {
+      queuedDelegatedTurnCount: 0,
+      expectedDelegatedTurnCorrelations: [delegated],
+    });
+    expect(refusedMismatch.success).toBe(false);
+    if (!refusedMismatch.success) {
+      expect(refusedMismatch.error).toContain("a message dispatching");
+    }
+
+    // PREPARING work that has not handed its startup to the engine (or a user send) reports no
+    // stoppable turn: a stop there would not cancel it, so the hold fails closed.
+    stoppable = undefined;
+    const refusedUnstoppable = workspaceService.acquirePreInterruptionArchiveHold(workspaceId, {
+      queuedDelegatedTurnCount: 0,
+      expectedDelegatedTurnCorrelations: [delegated],
+    });
+    expect(refusedUnstoppable.success).toBe(false);
+    if (!refusedUnstoppable.success) {
+      expect(refusedUnstoppable.error).toContain("a message dispatching");
+    }
+  });
+
+  test("archive sink admits a PREPARING delegated turn once its interruption has settled", async () => {
+    // End to end through a real session: the delegated send is PREPARING with its startup
+    // registered, the hold exempts it, the engine-side stop cancels it, and the sink accepts
+    // only after the aborted turn has unwound (stopStream resolves before that happens).
+    const delegated = { taskHandleId: "wt-prep", ownerWorkspaceId: "owner-1", turnId: "turn-prep" };
+    const syntheticMessageId = "starting-prep";
+    const aiEmitter = new EventEmitter();
+    const entered = Promise.withResolvers<void>();
+    const abortController = new AbortController();
+    // StreamManager.stopStream for a pending start: abort it and deliver the startup abort.
+    const stopStream = mock(() => {
+      abortController.abort("system");
+      aiEmitter.emit("stream-abort", {
+        type: "stream-abort",
+        workspaceId,
+        messageId: syntheticMessageId,
+        abortReason: "system",
+        metadata: {},
+      });
+      return Promise.resolve(Ok(undefined));
+    });
+    const harness = await createAgentSessionHarness({
+      workspaceId,
+      historyService,
+      aiEmitter,
+      aiServiceOverrides: {
+        streamMessage: mock(async (request: Parameters<AIService["streamMessage"]>[0]) => {
+          // StreamManager registers the pending start before its first await.
+          request.onStreamStarting?.(syntheticMessageId);
+          entered.resolve();
+          await new Promise<void>((resolve) => {
+            abortController.signal.addEventListener("abort", () => resolve(), { once: true });
+          });
+          const completion: TurnCompletion = { status: "aborted", abortReason: "system" };
+          return Ok({ messageId: syntheticMessageId, completion: Promise.resolve(completion) });
+        }),
+        stopStream,
+      },
+    });
+    const internal = workspaceService as unknown as {
+      sessions: Map<string, AgentSession>;
+      aiService: typeof harness.aiService;
+    };
+    internal.sessions.set(workspaceId, harness.session);
+    internal.aiService = harness.aiService;
+    try {
+      const sent = harness.session.sendMessage(
+        "Summarize",
+        {
+          model: "anthropic:claude-sonnet-4-5",
+          agentId: "exec",
+          muxMetadata: { type: "workspace-turn-task", ...delegated },
+        },
+        { startStreamInBackground: true }
+      );
+      await entered.promise;
+      // The PREPARING send reads as a queued message to the coarse activity snapshot; the
+      // correlation is what tells it apart from user input.
+      expect(workspaceService.listLiveWorkspaceActivity(workspaceId).queuedMessages).toBe(true);
+      expect(workspaceService.getStoppablePreparingWorkspaceTurn(workspaceId)).toEqual(delegated);
+
+      const refused = workspaceService.acquirePreInterruptionArchiveHold(workspaceId, {
+        queuedDelegatedTurnCount: 0,
+        expectedDelegatedTurnCorrelations: [],
+      });
+      expect(refused.success).toBe(false);
+      if (!refused.success) {
+        expect(refused.error).toContain("a message dispatching");
+      }
+      expect(harness.session.isPreparingTurn()).toBe(true);
+
+      const hold = workspaceService.acquirePreInterruptionArchiveHold(workspaceId, {
+        queuedDelegatedTurnCount: 0,
+        expectedDelegatedTurnCorrelations: [delegated],
+      });
+      expect(hold.success).toBe(true);
+      if (!hold.success) return;
+      try {
+        // What interruptWorkspaceTurn does for a running handle. The engine has aborted when
+        // this resolves, but the session's aborted turn has not reached policy yet.
+        expect((await stopStream()).success).toBe(true);
+        expect(harness.session.isPreparingTurn()).toBe(true);
+
+        await workspaceService.waitForIdle(workspaceId);
+        expect((await sent).success).toBe(true);
+        expect(harness.session.hasActiveOrPendingTurnWork()).toBe(false);
+        expect(
+          await workspaceService.archive(workspaceId, undefined, { refuseLiveUserActivity: true })
+        ).toEqual(Ok({ kind: "archived" }));
+      } finally {
+        hold.data[Symbol.dispose]();
+      }
+    } finally {
+      internal.sessions.delete(workspaceId);
+      await harness.session.dispose();
+    }
+  });
+
   test("fork() refuses while the source workspace is being archived", async () => {
     // Source-fork admission pairs with the archive gates: a Coder-stop archive must not stop
     // the dedicated remote workspace mid-clone while a fork shares it.

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -195,6 +195,7 @@ import { UIModeSchema, type UIMode } from "@/common/types/mode";
 import {
   createMuxMessage,
   getCompactionFollowUpContent,
+  isSameWorkspaceTurnTaskCorrelation,
   parseWorkspaceTurnTaskCorrelation,
   pickPreservedSendOptions,
   type CompactionFollowUpRequest,
@@ -8425,8 +8426,8 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
    * (active streams, the delegated queue entries themselves) is intentionally NOT checked:
    * the caller is about to interrupt those turns, and the sink's admission-hold recheck
    * re-validates queue emptiness after interruption. Queue entries beyond
-   * queuedDelegatedTurnCount — or any entry already dispatching (PREPARING) — fail closed
-   * here instead.
+   * queuedDelegatedTurnCount — or any dispatching (PREPARING) entry other than a collected
+   * delegated turn that stopStream can still cancel — fail closed here instead.
    *
    * The sink adds/removes the same Set entry around its own gate; both operations are
    * idempotent, and by the time the sink's finally removes it either archivedAt is
@@ -8484,11 +8485,8 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       );
       const streamIsExpectedDelegatedTurn =
         streamCorrelation != null &&
-        options.expectedDelegatedTurnCorrelations.some(
-          (expected) =>
-            expected.taskHandleId === streamCorrelation.taskHandleId &&
-            expected.ownerWorkspaceId === streamCorrelation.ownerWorkspaceId &&
-            expected.turnId === streamCorrelation.turnId
+        options.expectedDelegatedTurnCorrelations.some((expected) =>
+          isSameWorkspaceTurnTaskCorrelation(expected, streamCorrelation)
         );
       if (!streamIsExpectedDelegatedTurn) {
         activityLabels.push("an active stream not attributable to the delegated turns");
@@ -8533,11 +8531,27 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
     // queued delegated turn before the entry-count comparison below could attribute it.
     // (Queued entries cannot dispatch into PREPARING after this check: the turn-admission
     // hold above freezes queue dispatch for the hold's lifetime.)
-    if (session.isPreparingTurn() || session.hasPendingAutoRetry()) {
-      // A dispatching (PREPARING) entry has left the queue but not yet registered a
-      // stream, so the queue comparison below cannot attribute it — fail closed.
+    // A PREPARING send is exempt only when it IS one of the collected active delegated turns
+    // (exact correlation) and has handed its startup to the engine, so interruptWorkspaceTurn's
+    // stopStream cancels it. Any other PREPARING entry has left the queue without registering
+    // a stream, so the queue comparison below cannot attribute it — fail closed. The same
+    // correlation binding as the stream check above keeps a user send that replaced an ended
+    // delegated turn, or a delegated turn still holding a queued handle, out of the exemption.
+    const preparingTurn = session.getStoppablePreparingWorkspaceTurn();
+    const preparingIsExpectedDelegatedTurn =
+      preparingTurn != null &&
+      options.expectedDelegatedTurnCorrelations.some((expected) =>
+        isSameWorkspaceTurnTaskCorrelation(expected, preparingTurn)
+      );
+    if (
+      (session.isPreparingTurn() && !preparingIsExpectedDelegatedTurn) ||
+      session.hasPendingAutoRetry()
+    ) {
       activityLabels.push("a message dispatching");
-    } else if (session.queuedMessageEntryCount() > options.queuedDelegatedTurnCount) {
+    }
+    // Checked even while an exempt delegated turn is PREPARING: user entries queued behind it
+    // are still user work the archive would silently drop.
+    if (session.queuedMessageEntryCount() > options.queuedDelegatedTurnCount) {
       activityLabels.push("queued messages beyond the delegated turns");
     }
     if (activityLabels.length > 0) {
@@ -12349,6 +12363,13 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
   getQueueCutCutter(workspaceId: string): QueueCutCutter | undefined {
     const session = this.sessions.get(workspaceId.trim());
     return session?.getQueueCutCutter();
+  }
+
+  /** See AgentSession.getStoppablePreparingWorkspaceTurn. */
+  getStoppablePreparingWorkspaceTurn(
+    workspaceId: string
+  ): WorkspaceTurnTaskCorrelation | undefined {
+    return this.sessions.get(workspaceId.trim())?.getStoppablePreparingWorkspaceTurn();
   }
 
   /**

--- a/src/node/services/workspaceTurnManager.test.ts
+++ b/src/node/services/workspaceTurnManager.test.ts
@@ -24,6 +24,7 @@ import { createMuxMessage, type MuxMessageMetadata } from "@/common/types/messag
 import type { WorkspaceMetadata } from "@/common/types/workspace";
 import type { QueueCutAttributionSnapshot } from "@/node/services/taskWorkspaceSeam";
 import type { InitStateManager } from "@/node/services/initStateManager";
+import { waitForCondition } from "@/node/services/testDispatchHelpers";
 import assert from "node:assert";
 import {
   createAIServiceMocks,
@@ -381,6 +382,9 @@ describe("WorkspaceTurnManager", () => {
       unarchive?: ReturnType<typeof mock>;
       preflightArchive?: ReturnType<typeof mock>;
       listLiveWorkspaceActivity?: ReturnType<typeof mock>;
+      getStoppablePreparingWorkspaceTurn?: ReturnType<typeof mock>;
+      acquirePreInterruptionArchiveHold?: ReturnType<typeof mock>;
+      waitForIdle?: ReturnType<typeof mock>;
       hasRunningBackgroundBashProcesses?: ReturnType<typeof mock>;
       isSnapshotArchiveEligibilityMutationSensitive?: ReturnType<typeof mock>;
       hasUntrackableExternalAppOpen?: ReturnType<typeof mock>;
@@ -1584,6 +1588,115 @@ describe("WorkspaceTurnManager", () => {
     expect(data?.status).toBe("active");
     expect(data?.status === "active" ? (data.note ?? "") : "").toContain("queued messages");
     expect(harness.archive).not.toHaveBeenCalled();
+  });
+
+  test("workspace lifecycle interrupts a delegated turn whose send is still PREPARING", async () => {
+    // A fresh delegated turn's handle already reads "running" while the target session is
+    // PREPARING, which listLiveWorkspaceActivity reports as queued messages. The exemption
+    // must bind to the exact correlation of the collected turn, not to PREPARING alone.
+    const preparingTurn = {
+      taskHandleId: "wst_running",
+      ownerWorkspaceId: "",
+      turnId: "turn-running",
+    };
+    const getStoppablePreparingWorkspaceTurn = mock(() => preparingTurn);
+    const acquirePreInterruptionArchiveHold = mock(() => Ok({ [Symbol.dispose]: () => undefined }));
+    const harness = await createWorkspaceLifecycleHarness({
+      listLiveWorkspaceActivity: mock(() => ({
+        streaming: false,
+        queuedMessages: true,
+        backgroundBashProcesses: false,
+        terminalSessions: false,
+        desktopSession: false,
+      })),
+      getStoppablePreparingWorkspaceTurn,
+      acquirePreInterruptionArchiveHold,
+    });
+    preparingTurn.ownerWorkspaceId = harness.parentId;
+    await harness.taskHandleStore.upsertWorkspaceTurn(
+      workspaceTurnRecord(harness.parentId, "childworkspace", "wst_running", "running", {
+        turnId: "turn-running",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      })
+    );
+    markWorkspaceTurnActive(harness.taskService, "childworkspace", "wst_running", harness.parentId);
+
+    // A PREPARING send correlated to some other turn (the collected turn ended and a
+    // different delegated turn, or none, took the session) is not explained by the
+    // collected handle: still user-shaped work, still refused.
+    getStoppablePreparingWorkspaceTurn.mockReturnValueOnce({
+      ...preparingTurn,
+      turnId: "turn-other",
+    });
+    const mismatched = await harness.taskService.archiveOwnedWorkspaceTurnWorkspace(
+      harness.parentId,
+      { workspaceId: "childworkspace" },
+      { interruptActive: true }
+    );
+    expect(mismatched.success).toBe(true);
+    const mismatchedData = mismatched.success ? mismatched.data : undefined;
+    expect(mismatchedData?.status).toBe("active");
+    expect(mismatchedData?.status === "active" ? (mismatchedData.note ?? "") : "").toContain(
+      "queued messages"
+    );
+    expect(harness.archive).not.toHaveBeenCalled();
+
+    const result = await harness.taskService.archiveOwnedWorkspaceTurnWorkspace(
+      harness.parentId,
+      { workspaceId: "childworkspace" },
+      { interruptActive: true }
+    );
+
+    expect(result).toEqual(
+      Ok({
+        status: "archived",
+        action: "archive",
+        workspaceId: "childworkspace",
+        displayName: "Child workspace",
+      })
+    );
+    // The hold binds the interruptible turn by correlation so a stream that starts for it
+    // between the gate and interruption is still recognized as the delegated turn.
+    expect(acquirePreInterruptionArchiveHold).toHaveBeenLastCalledWith("childworkspace", {
+      queuedDelegatedTurnCount: 0,
+      expectedDelegatedTurnCorrelations: [preparingTurn],
+    });
+    expect(harness.archive).toHaveBeenCalledTimes(1);
+    const record = await harness.taskHandleStore.getWorkspaceTurn(harness.parentId, "wst_running");
+    expect(record?.status).toBe("interrupted");
+  });
+
+  test("workspace lifecycle waits for interrupted turns to settle before the archive sink", async () => {
+    // stopStream resolves before the target session leaves PREPARING/COMPLETING; entering
+    // the sink on that residue would refuse with the turns already destroyed.
+    const settled = Promise.withResolvers<void>();
+    const waitForIdle = mock(() => settled.promise);
+    const harness = await createWorkspaceLifecycleHarness({ waitForIdle });
+    await harness.taskHandleStore.upsertWorkspaceTurn(
+      workspaceTurnRecord(harness.parentId, "childworkspace", "wst_running", "running", {
+        turnId: "turn-running",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      })
+    );
+    markWorkspaceTurnActive(harness.taskService, "childworkspace", "wst_running", harness.parentId);
+
+    const archivePromise = harness.taskService.archiveOwnedWorkspaceTurnWorkspace(
+      harness.parentId,
+      { workspaceId: "childworkspace" },
+      { interruptActive: true }
+    );
+    await waitForCondition(() => waitForIdle.mock.calls.length === 1);
+    expect(waitForIdle).toHaveBeenCalledWith("childworkspace");
+    const record = await harness.taskHandleStore.getWorkspaceTurn(harness.parentId, "wst_running");
+    expect(record?.status).toBe("interrupted");
+    expect(harness.archive).not.toHaveBeenCalled();
+
+    settled.resolve();
+    const result = await archivePromise;
+    expect(result.success ? result.data.status : result.error).toBe("archived");
+    expect(harness.archive).toHaveBeenCalledTimes(1);
   });
 
   test("workspace lifecycle refuses archive of a dedicated Coder workspace under the delete policy", async () => {

--- a/src/node/services/workspaceTurnManager.ts
+++ b/src/node/services/workspaceTurnManager.ts
@@ -59,10 +59,13 @@ import {
 } from "@/common/types/backgroundWorkAttention";
 import {
   createMuxMessage,
+  isSameWorkspaceTurnTaskCorrelation,
   parseWorkspaceTurnTaskCorrelation,
   type MuxMessage,
   type MuxMessageMetadata,
 } from "@/common/types/message";
+import { raceWithAbortAndTimeout } from "@/node/utils/concurrency/withTimeout";
+import { TASK_TERMINATION_STOP_STREAM_TIMEOUT_MS } from "@/constants/terminationTimeouts";
 import {
   createTaskFailureMessageId,
   createTaskReportMessageId,
@@ -3389,20 +3392,44 @@ export class WorkspaceTurnManager {
           const liveActivity = this.workspaceService.listLiveWorkspaceActivity(
             resolved.workspaceId
           );
-          const hasRunningDelegatedStream = activeTurns.some(
-            (turn) => turn.workspaceId === resolved.workspaceId && turn.status === "running"
+          const targetTurns = activeTurns.filter(
+            (turn) => turn.workspaceId === resolved.workspaceId
           );
-          // A queued delegated follow-up also surfaces as a queued message; only unexplained
-          // queue entries are treated as user work. Mixed queues (user + delegated entries)
-          // conservatively fail closed at the sink's admission-hold recheck instead.
-          const hasQueuedDelegatedTurn = activeTurns.some(
-            (turn) => turn.workspaceId === resolved.workspaceId && turn.status === "queued"
+          const hasRunningDelegatedStream = targetTurns.some((turn) => turn.status === "running");
+          // A queued delegated follow-up also surfaces as a queued message, and so does a
+          // delegated turn whose send is still PREPARING (its handle already reads running);
+          // only unexplained queue entries are treated as user work. The PREPARING exemption
+          // is bound to the exact correlation of a collected non-queued turn, so a user send
+          // preparing behind an ended delegated turn stays user work. Mixed queues (user +
+          // delegated entries) conservatively fail closed at the sink's admission-hold
+          // recheck instead.
+          const hasQueuedDelegatedTurn = targetTurns.some((turn) => turn.status === "queued");
+          const preparingTurn = this.workspaceService.getStoppablePreparingWorkspaceTurn(
+            resolved.workspaceId
           );
+          const hasPreparingDelegatedTurn =
+            preparingTurn != null &&
+            targetTurns.some(
+              (turn) =>
+                turn.status !== "queued" &&
+                isSameWorkspaceTurnTaskCorrelation(
+                  {
+                    taskHandleId: turn.handleId,
+                    ownerWorkspaceId: turn.ownerWorkspaceId,
+                    turnId: turn.turnId,
+                  },
+                  preparingTurn
+                )
+            );
           const nonTurnActivity: string[] = [];
           if (liveActivity.streaming && !hasRunningDelegatedStream) {
             nonTurnActivity.push("an active stream");
           }
-          if (liveActivity.queuedMessages && !hasQueuedDelegatedTurn) {
+          if (
+            liveActivity.queuedMessages &&
+            !hasQueuedDelegatedTurn &&
+            !hasPreparingDelegatedTurn
+          ) {
             nonTurnActivity.push("queued messages");
           }
           // Detached background bash outlives its spawning turn: interruption does not stop it,
@@ -3587,6 +3614,27 @@ export class WorkspaceTurnManager {
                 activeTurns
               );
               if (interruptFailure != null) return Ok(interruptFailure);
+              // stopStream resolves once the engine has aborted, but the target session's turn
+              // unwinds asynchronously: a canceled PREPARING send still reads PREPARING until
+              // its aborted handle reaches turn policy, and the sink's synchronous live-activity
+              // gate would refuse on that residue with the turns already destroyed. Wait for the
+              // session to settle first; the hold keeps admission frozen meanwhile, so nothing
+              // new can claim the session. The bound is a hang guard for a turn whose abort
+              // never lands, not a grace period.
+              const settled = await raceWithAbortAndTimeout(
+                this.workspaceService.waitForIdle(resolved.workspaceId),
+                { timeoutMs: TASK_TERMINATION_STOP_STREAM_TIMEOUT_MS }
+              );
+              if (settled.kind !== "ok") {
+                return Ok({
+                  status: "error",
+                  action: "archive",
+                  ...this.lifecycleTargetFields(resolved),
+                  activeTaskIds: activeTurns.map((turn) => turn.handleId),
+                  error:
+                    "The interrupted turns did not settle in time, so the workspace was not archived. Wait for them to stop, then archive again.",
+                });
+              }
             }
 
             // WhileTaskTreeLocked: the tree lock is already held for the whole lifecycle operation


### PR DESCRIPTION
## Summary

`task_workspace_lifecycle` with `interrupt_active: true` now interrupts and archives a workspace whose delegated turn is still in AgentSession's PREPARING phase, instead of refusing with `status: "active"` and "queued messages" for the whole startup window.

Fixes #3943

## Background

A newly created delegated workspace turn's durable handle already reads `running` while the target session is PREPARING, and `listLiveWorkspaceActivity().queuedMessages` is true during PREPARING (it includes `isPreparingTurn()`). Both archive gates only exempted delegated turns whose handle was `queued`:

- the manager pre-gate in `archiveOwnedWorkspaceTurnWorkspace` classified the PREPARING send as unrelated queued user work, and
- `acquirePreInterruptionArchiveHold` refused every PREPARING session outright ("a message dispatching").

Codex round 15 P2 on #3940 flagged this as fail-safe over-refusal. The exemption has to distinguish the collected delegated turn's own PREPARING send from a user message dequeued into PREPARING, without reopening the queued-message races #3940 closed (turn-admission hold, synchronous send guards).

## Implementation

- `AgentSession.getStoppablePreparingWorkspaceTurn()` returns the PREPARING send's workspace-turn correlation only once the engine has registered its startup (`TurnCoordinator.startupRegistered`, set by `onStreamStarting` when StreamManager's pending start exists). That is the only PREPARING state `stopStream()` cancels; before it (history acceptance, request preparation) a stop only notifies and the turn still streams, so those sub-windows keep refusing. Exposed on `WorkspaceService` and the `WorkspaceLifecycleHost` seam.
- Manager pre-gate: "queued messages" is also explained when that correlation matches a collected non-queued turn on the target (`isSameWorkspaceTurnTaskCorrelation`, shared with the hold's existing stream check).
- Hold: a PREPARING session refuses only when its PREPARING send is not one of the expected delegated turns (or an auto-retry is pending). The queue-count check now runs independently of the PREPARING check, so user entries queued behind the exempt delegated turn still refuse. Queued-handle turns stay out of the exemption: they are interrupted by targeted queue removal, not `stopStream`.
- After `interruptActiveWorkspaceLifecycleTurns`, the archive waits for the target session to reach idle (deterministic `waitForIdle`, bounded by `TASK_TERMINATION_STOP_STREAM_TIMEOUT_MS` as a hang guard) before entering the sink. `stopStream` resolves before the aborted PREPARING turn reaches turn policy, so the sink's synchronous `isPreparingTurn`/`hasActiveOrPendingTurnWork` checks would otherwise refuse with the turns already destroyed. The pre-interruption hold keeps admission frozen during the wait. A timeout returns `status: "error"` without bypassing the sink checks.

## Validation

- Real-session tests (`createAgentSessionHarness`): the accessor is undefined before `onStreamStarting`, equals the correlation afterwards, and is undefined for a manual send and after idle. A real `WorkspaceService` + `AgentSession` test drives a delegated send into PREPARING, checks the hold refuses without the correlation and grants with it, emulates StreamManager's pending-start abort, asserts the session still reads PREPARING when `stopStream` resolves, and archives through the real `refuseLiveUserActivity` sink after `waitForIdle`.
- Manager tests: mismatched correlation still refuses "queued messages"; the exact correlation archives and passes it to the hold; the sink is not entered until `waitForIdle` resolves.
- Each new guard was toggled off individually and its test failed (gate exemption, hold exemption, settle wait, startup-registration requirement).

## Risks

Medium, confined to model-driven `task_workspace_lifecycle` archive with `interrupt_active`. The exemption is bound to the exact owner + handle + turn correlation of a collected non-queued turn plus a registered engine startup, so a user send that took over the session, a delegated turn still holding a queued handle, or a PREPARING send that a stop cannot cancel all keep refusing as before. The new settle wait applies to every interrupted turn; for streaming turns the session is already idle when `stopStream` resolves, so it is a no-op there. Dogfood UAT was not run: the fixed window is a sub-second backend admission state with no UI surface, and the remote UAT skill is not available in this workspace.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$6.03`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=6.03 -->

