### PR TITLE
🤖 fix: preserve staged attachments across snapshot archives

### DIFF
--- a/src/common/schemas/project.ts
+++ b/src/common/schemas/project.ts
@@ -41,6 +41,22 @@ export const WorktreeArchiveSnapshotProjectSchema = z.object({
   unstagedPatchPath: z.string().optional().meta({
     description: "Session-dir-relative path to the unstaged tracked diff artifact.",
   }),
+  stagedAttachmentDirs: z
+    .array(
+      z.object({
+        repoRelativeDir: z.string().meta({
+          description: "Repo-relative staged attachment directory restored into the checkout.",
+        }),
+        artifactPath: z.string().meta({
+          description: "Session-dir-relative directory holding a copy of the staged attachments.",
+        }),
+      })
+    )
+    .optional()
+    .meta({
+      description:
+        "Git-excluded chat attachment directories copied out of the checkout because tracked diffs cannot capture them.",
+    }),
 });
 
 export const WorktreeArchiveSnapshotSchema = z.object({

--- a/src/node/services/worktreeArchiveSnapshotService.test.ts
+++ b/src/node/services/worktreeArchiveSnapshotService.test.ts
@@ -617,12 +617,109 @@ describe("WorktreeArchiveSnapshotService", () => {
       workspaceId: fixture.workspaceId,
       workspaceMetadata: fixture.metadata,
     });
-    expect(restoreResult.success).toBe(false);
-    if (restoreResult.success) {
+    // The malformed entry is skipped rather than turning every unarchive into the same failure;
+    // its artifact stays behind for manual recovery.
+    expect(restoreResult).toEqual({ success: true, data: "restored" });
+    expect(await fs.readFile(path.join(fixture.workspacePath, "src", "notes.txt"), "utf-8")).toBe(
+      "code\n"
+    );
+    expect(await pathExists(path.join(sessionDir, artifactPath ?? ""))).toBe(true);
+  });
+
+  test("treats a symlinked attachment artifact root as absent and never touches its target", async () => {
+    const bytes = Buffer.from("attachment payload");
+    const staged = await stageWorkspaceAttachment({
+      runtime: new LocalRuntime(fixture.workspacePath),
+      workspacePath: fixture.workspacePath,
+      filename: "notes.txt",
+      mediaType: "text/plain",
+      sizeBytes: bytes.byteLength,
+      dataBase64: bytes.toString("base64"),
+    });
+    expect(staged.success).toBe(true);
+    const sessionDir = path.join(fixture.config.sessionsDir, fixture.workspaceId);
+    const outsideDir = path.join(fixture.muxRoot, "outside-root");
+    const outsideFile = path.join(
+      outsideDir,
+      "project",
+      ".xum",
+      "user-attachments",
+      "x",
+      "keep.txt"
+    );
+    await fs.mkdir(path.dirname(outsideFile), { recursive: true });
+    await fs.writeFile(outsideFile, "keep", "utf-8");
+    await fs.mkdir(sessionDir, { recursive: true });
+    await fs.symlink(outsideDir, path.join(sessionDir, "archive-attachments"));
+
+    const captureResult = await fixture.service.captureSnapshotForArchive({
+      workspaceId: fixture.workspaceId,
+      workspaceMetadata: fixture.metadata,
+    });
+    expect(captureResult.success).toBe(false);
+    if (captureResult.success) {
       return;
     }
-    expect(restoreResult.error).toContain("is not a staged attachment directory");
-    expect(await pathExists(fixture.workspacePath)).toBe(false);
+    expect(captureResult.error).toContain("not a plain directory");
+    expect(await fs.readFile(outsideFile, "utf-8")).toBe("keep");
+
+    // A snapshot referencing the entry reconciles the existing checkout without deleting through
+    // the link either.
+    await fixture.config.editConfig((cfg) => {
+      const workspace = cfg.projects.get(fixture.projectPath)?.workspaces[0];
+      if (!workspace) {
+        throw new Error("Missing workspace entry");
+      }
+      workspace.worktreeArchiveSnapshot = {
+        version: 1,
+        capturedAt: new Date().toISOString(),
+        stateDirPath: "archive-state",
+        projects: [
+          {
+            projectPath: fixture.projectPath,
+            projectName: "project",
+            storageKey: "project",
+            branchName: fixture.workspaceName,
+            trunkBranch: "main",
+            baseSha: fixture.baseSha,
+            headSha: fixture.baseSha,
+            stagedAttachmentDirs: [
+              {
+                repoRelativeDir: path.join(".xum", "user-attachments"),
+                artifactPath: path.join(
+                  "archive-attachments",
+                  "project",
+                  ".xum",
+                  "user-attachments"
+                ),
+              },
+            ],
+          },
+        ],
+      };
+      return cfg;
+    });
+    const restoreResult = await fixture.service.restoreSnapshotAfterUnarchive({
+      workspaceId: fixture.workspaceId,
+      workspaceMetadata: fixture.metadata,
+    });
+    expect(restoreResult).toEqual({ success: true, data: "skipped" });
+    expect(await fs.readFile(outsideFile, "utf-8")).toBe("keep");
+  });
+
+  test("sweeps temp directories left behind by an interrupted capture", async () => {
+    const sessionDir = path.join(fixture.config.sessionsDir, fixture.workspaceId);
+    const stale = path.join(sessionDir, "archive-attachments.tmp-stale", "project", "big.bin");
+    await fs.mkdir(path.dirname(stale), { recursive: true });
+    await fs.writeFile(stale, "leftover", "utf-8");
+    await makeWorkspaceDirty(fixture);
+
+    const captureResult = await fixture.service.captureSnapshotForArchive({
+      workspaceId: fixture.workspaceId,
+      workspaceMetadata: fixture.metadata,
+    });
+    expect(captureResult.success).toBe(true);
+    expect(await pathExists(path.dirname(path.dirname(stale)))).toBe(false);
   });
 
   test("fails capture when the staging directory resolves outside the checkout", async () => {

--- a/src/node/services/worktreeArchiveSnapshotService.test.ts
+++ b/src/node/services/worktreeArchiveSnapshotService.test.ts
@@ -7,7 +7,9 @@ import * as path from "node:path";
 import { Err } from "@/common/types/result";
 import type { WorkspaceMetadata } from "@/common/types/workspace";
 import { Config } from "@/node/config";
+import { LocalRuntime } from "@/node/runtime/LocalRuntime";
 import { WorktreeArchiveSnapshotService } from "@/node/services/worktreeArchiveSnapshotService";
+import { stageWorkspaceAttachment } from "@/node/utils/attachments/stageWorkspaceAttachment";
 
 interface TestFixture {
   muxRoot: string;
@@ -258,6 +260,132 @@ describe("WorktreeArchiveSnapshotService", () => {
     expect(
       await pathExists(path.join(fixture.config.sessionsDir, fixture.workspaceId, "archive-state"))
     ).toBe(false);
+  });
+
+  test.each([
+    { name: "workspace root", subProject: false },
+    { name: "sub-project execution path", subProject: true },
+  ])(
+    "captures git-excluded staged attachments under the $name and restores them",
+    async ({ subProject }) => {
+      // Attachments are staged relative to the workspace execution path, which a sub-project
+      // workspace moves below the repo root.
+      let stagingRoot = fixture.workspacePath;
+      if (subProject) {
+        await fs.mkdir(path.join(fixture.workspacePath, "pkg"));
+        await fs.writeFile(path.join(fixture.workspacePath, "pkg", "README.md"), "pkg\n", "utf-8");
+        runGit(fixture.workspacePath, ["add", "pkg"]);
+        runGit(fixture.workspacePath, ["commit", "-m", "pkg"]);
+        fixture.metadata.subProjectPath = path.join(fixture.projectPath, "pkg");
+        stagingRoot = path.join(fixture.workspacePath, "pkg");
+      }
+      const bytes = Buffer.from("attachment payload");
+      const staged = await stageWorkspaceAttachment({
+        runtime: new LocalRuntime(stagingRoot),
+        workspacePath: stagingRoot,
+        filename: "notes.txt",
+        mediaType: "text/plain",
+        sizeBytes: bytes.byteLength,
+        dataBase64: bytes.toString("base64"),
+      });
+      expect(staged.success).toBe(true);
+      if (!staged.success) {
+        return;
+      }
+      // Staging excludes the directory, so it is invisible to the untracked-file check.
+      expect(runGit(fixture.workspacePath, ["status", "--porcelain"])).toBe("");
+
+      const captureResult = await fixture.service.captureSnapshotForArchive({
+        workspaceId: fixture.workspaceId,
+        workspaceMetadata: fixture.metadata,
+      });
+      expect(captureResult.success).toBe(true);
+      if (!captureResult.success) {
+        return;
+      }
+      await fixture.config.editConfig((cfg) => {
+        const workspace = cfg.projects.get(fixture.projectPath)?.workspaces[0];
+        if (!workspace) {
+          throw new Error("Missing workspace entry");
+        }
+        workspace.worktreeArchiveSnapshot = captureResult.data;
+        return cfg;
+      });
+
+      runGit(fixture.projectPath, ["worktree", "remove", "--force", fixture.workspacePath]);
+      expect(await pathExists(fixture.workspacePath)).toBe(false);
+
+      const restoreResult = await fixture.service.restoreSnapshotAfterUnarchive({
+        workspaceId: fixture.workspaceId,
+        workspaceMetadata: fixture.metadata,
+      });
+      expect(restoreResult).toEqual({ success: true, data: "restored" });
+
+      // The persisted chat notice keeps pointing at the same execution-path-relative path.
+      expect(await fs.readFile(path.join(stagingRoot, staged.data.stagedPath))).toEqual(bytes);
+      // The recreated worktree gets a fresh info/exclude, so the restore must re-exclude the
+      // directory or the attachments would surface as untracked files.
+      expect(runGit(fixture.workspacePath, ["status", "--porcelain"])).toBe("");
+      expect(
+        await pathExists(
+          path.join(fixture.config.sessionsDir, fixture.workspaceId, "archive-state")
+        )
+      ).toBe(false);
+    }
+  );
+
+  test("fails restore when a referenced staged attachments artifact is missing", async () => {
+    const bytes = Buffer.from("attachment payload");
+    const staged = await stageWorkspaceAttachment({
+      runtime: new LocalRuntime(fixture.workspacePath),
+      workspacePath: fixture.workspacePath,
+      filename: "notes.txt",
+      mediaType: "text/plain",
+      sizeBytes: bytes.byteLength,
+      dataBase64: bytes.toString("base64"),
+    });
+    expect(staged.success).toBe(true);
+
+    const captureResult = await fixture.service.captureSnapshotForArchive({
+      workspaceId: fixture.workspaceId,
+      workspaceMetadata: fixture.metadata,
+    });
+    expect(captureResult.success).toBe(true);
+    if (!captureResult.success) {
+      return;
+    }
+    const attachmentArtifacts = captureResult.data.projects[0]?.stagedAttachmentDirs ?? [];
+    expect(attachmentArtifacts.length).toBeGreaterThan(0);
+    await fixture.config.editConfig((cfg) => {
+      const workspace = cfg.projects.get(fixture.projectPath)?.workspaces[0];
+      if (!workspace) {
+        throw new Error("Missing workspace entry");
+      }
+      workspace.worktreeArchiveSnapshot = captureResult.data;
+      return cfg;
+    });
+    runGit(fixture.projectPath, ["worktree", "remove", "--force", fixture.workspacePath]);
+    for (const artifact of attachmentArtifacts) {
+      await fs.rm(
+        path.join(fixture.config.sessionsDir, fixture.workspaceId, artifact.artifactPath),
+        { recursive: true, force: true }
+      );
+    }
+
+    const restoreResult = await fixture.service.restoreSnapshotAfterUnarchive({
+      workspaceId: fixture.workspaceId,
+      workspaceMetadata: fixture.metadata,
+    });
+    expect(restoreResult.success).toBe(false);
+    if (restoreResult.success) {
+      return;
+    }
+    expect(restoreResult.error).toContain("staged attachments artifact is unavailable");
+    // Failed restores clean up the partially recreated checkout and keep the snapshot for retry.
+    expect(await pathExists(fixture.workspacePath)).toBe(false);
+    const storedWorkspace = fixture.config.loadConfigOrDefault().projects.get(fixture.projectPath)
+      ?.workspaces[0];
+    expect(storedWorkspace?.worktreeArchiveSnapshot).toEqual(captureResult.data);
   });
 
   test("falls back to base commit + mailbox replay when the archived head commit is gone", async () => {

--- a/src/node/services/worktreeArchiveSnapshotService.test.ts
+++ b/src/node/services/worktreeArchiveSnapshotService.test.ts
@@ -303,6 +303,16 @@ describe("WorktreeArchiveSnapshotService", () => {
       if (!captureResult.success) {
         return;
       }
+      // An older build's restore deletes archive-state wholesale, so the uploads must live
+      // beside it to survive a downgrade.
+      for (const artifact of captureResult.data.projects[0]?.stagedAttachmentDirs ?? []) {
+        expect(artifact.artifactPath.startsWith("archive-state")).toBe(false);
+        expect(
+          await pathExists(
+            path.join(fixture.config.sessionsDir, fixture.workspaceId, artifact.artifactPath)
+          )
+        ).toBe(true);
+      }
       await fixture.config.editConfig((cfg) => {
         const workspace = cfg.projects.get(fixture.projectPath)?.workspaces[0];
         if (!workspace) {
@@ -326,13 +336,159 @@ describe("WorktreeArchiveSnapshotService", () => {
       // The recreated worktree gets a fresh info/exclude, so the restore must re-exclude the
       // directory or the attachments would surface as untracked files.
       expect(runGit(fixture.workspacePath, ["status", "--porcelain"])).toBe("");
-      expect(
-        await pathExists(
-          path.join(fixture.config.sessionsDir, fixture.workspaceId, "archive-state")
-        )
-      ).toBe(false);
+      const sessionDir = path.join(fixture.config.sessionsDir, fixture.workspaceId);
+      expect(await pathExists(path.join(sessionDir, "archive-state"))).toBe(false);
+      expect(await pathExists(path.join(sessionDir, "archive-attachments"))).toBe(false);
     }
   );
+
+  test("restores missing staged attachments into an existing matching checkout before clearing the snapshot", async () => {
+    const bytes = Buffer.from("attachment payload");
+    const staged = await stageWorkspaceAttachment({
+      runtime: new LocalRuntime(fixture.workspacePath),
+      workspacePath: fixture.workspacePath,
+      filename: "notes.txt",
+      mediaType: "text/plain",
+      sizeBytes: bytes.byteLength,
+      dataBase64: bytes.toString("base64"),
+    });
+    expect(staged.success).toBe(true);
+    if (!staged.success) {
+      return;
+    }
+    const captureResult = await fixture.service.captureSnapshotForArchive({
+      workspaceId: fixture.workspaceId,
+      workspaceMetadata: fixture.metadata,
+    });
+    expect(captureResult.success).toBe(true);
+    if (!captureResult.success) {
+      return;
+    }
+    await fixture.config.editConfig((cfg) => {
+      const workspace = cfg.projects.get(fixture.projectPath)?.workspaces[0];
+      if (!workspace) {
+        throw new Error("Missing workspace entry");
+      }
+      workspace.worktreeArchiveSnapshot = captureResult.data;
+      return cfg;
+    });
+    // The checkout survived (archive-time deletion failed) but lost its ignored uploads; git
+    // state still matches the snapshot exactly.
+    await fs.rm(path.join(fixture.workspacePath, ".xum"), { recursive: true, force: true });
+
+    const restoreResult = await fixture.service.restoreSnapshotAfterUnarchive({
+      workspaceId: fixture.workspaceId,
+      workspaceMetadata: fixture.metadata,
+    });
+    expect(restoreResult).toEqual({ success: true, data: "skipped" });
+    expect(await fs.readFile(path.join(fixture.workspacePath, staged.data.stagedPath))).toEqual(
+      bytes
+    );
+    expect(runGit(fixture.workspacePath, ["status", "--porcelain"])).toBe("");
+    const sessionDir = path.join(fixture.config.sessionsDir, fixture.workspaceId);
+    expect(await pathExists(path.join(sessionDir, "archive-state"))).toBe(false);
+    expect(await pathExists(path.join(sessionDir, "archive-attachments"))).toBe(false);
+  });
+
+  test("fails capture when the staged attachment directory cannot be inspected", async () => {
+    const bytes = Buffer.from("attachment payload");
+    const staged = await stageWorkspaceAttachment({
+      runtime: new LocalRuntime(fixture.workspacePath),
+      workspacePath: fixture.workspacePath,
+      filename: "notes.txt",
+      mediaType: "text/plain",
+      sizeBytes: bytes.byteLength,
+      dataBase64: bytes.toString("base64"),
+    });
+    expect(staged.success).toBe(true);
+
+    const realStat = fs.stat;
+    const statSpy = spyOn(fs, "stat").mockImplementation(((
+      targetPath: Parameters<typeof fs.stat>[0]
+    ) => {
+      if (String(targetPath).endsWith(path.join(".xum", "user-attachments"))) {
+        return Promise.reject(
+          Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" })
+        );
+      }
+      return realStat(targetPath);
+    }) as typeof fs.stat);
+    try {
+      const captureResult = await fixture.service.captureSnapshotForArchive({
+        workspaceId: fixture.workspaceId,
+        workspaceMetadata: fixture.metadata,
+      });
+      expect(captureResult.success).toBe(false);
+      if (captureResult.success) {
+        return;
+      }
+      expect(captureResult.error).toContain("EACCES");
+    } finally {
+      statSpy.mockRestore();
+    }
+    const sessionDirEntries = await fs.readdir(
+      path.join(fixture.config.sessionsDir, fixture.workspaceId)
+    );
+    expect(sessionDirEntries.filter((entry) => entry.startsWith("archive-"))).toEqual([]);
+  });
+
+  test("refuses to restore staged attachments through a symlink that leaves the checkout", async () => {
+    const outsideDir = path.join(fixture.muxRoot, "outside");
+    await fs.mkdir(outsideDir);
+    await fs.symlink(outsideDir, path.join(fixture.workspacePath, "link"));
+    runGit(fixture.workspacePath, ["add", "link"]);
+    runGit(fixture.workspacePath, ["commit", "-m", "tracked symlink"]);
+    const bytes = Buffer.from("attachment payload");
+    const staged = await stageWorkspaceAttachment({
+      runtime: new LocalRuntime(fixture.workspacePath),
+      workspacePath: fixture.workspacePath,
+      filename: "notes.txt",
+      mediaType: "text/plain",
+      sizeBytes: bytes.byteLength,
+      dataBase64: bytes.toString("base64"),
+    });
+    expect(staged.success).toBe(true);
+
+    const captureResult = await fixture.service.captureSnapshotForArchive({
+      workspaceId: fixture.workspaceId,
+      workspaceMetadata: fixture.metadata,
+    });
+    expect(captureResult.success).toBe(true);
+    if (!captureResult.success) {
+      return;
+    }
+    // Config is user-editable: point the restore target through the repo's symlink.
+    await fixture.config.editConfig((cfg) => {
+      const workspace = cfg.projects.get(fixture.projectPath)?.workspaces[0];
+      if (!workspace) {
+        throw new Error("Missing workspace entry");
+      }
+      workspace.worktreeArchiveSnapshot = {
+        ...captureResult.data,
+        projects: captureResult.data.projects.map((project) => ({
+          ...project,
+          stagedAttachmentDirs: project.stagedAttachmentDirs?.map((entry) => ({
+            ...entry,
+            repoRelativeDir: path.join("link", "user-attachments"),
+          })),
+        })),
+      };
+      return cfg;
+    });
+    runGit(fixture.projectPath, ["worktree", "remove", "--force", fixture.workspacePath]);
+
+    const restoreResult = await fixture.service.restoreSnapshotAfterUnarchive({
+      workspaceId: fixture.workspaceId,
+      workspaceMetadata: fixture.metadata,
+    });
+    expect(restoreResult.success).toBe(false);
+    if (restoreResult.success) {
+      return;
+    }
+    expect(restoreResult.error).toContain("refusing to restore outside");
+    expect(await pathExists(path.join(outsideDir, "user-attachments"))).toBe(false);
+    expect(await pathExists(fixture.workspacePath)).toBe(false);
+  });
 
   test("fails restore when a referenced staged attachments artifact is missing", async () => {
     const bytes = Buffer.from("attachment payload");

--- a/src/node/services/worktreeArchiveSnapshotService.test.ts
+++ b/src/node/services/worktreeArchiveSnapshotService.test.ts
@@ -504,6 +504,127 @@ describe("WorktreeArchiveSnapshotService", () => {
     ).toEqual(bytes);
   });
 
+  test("fails capture when the staged attachment tree contains a symlink", async () => {
+    const bytes = Buffer.from("attachment payload");
+    const staged = await stageWorkspaceAttachment({
+      runtime: new LocalRuntime(fixture.workspacePath),
+      workspacePath: fixture.workspacePath,
+      filename: "notes.txt",
+      mediaType: "text/plain",
+      sizeBytes: bytes.byteLength,
+      dataBase64: bytes.toString("base64"),
+    });
+    expect(staged.success).toBe(true);
+    if (!staged.success) {
+      return;
+    }
+    // A link into the checkout would be archived as a link to a directory that is about to go.
+    await fs.symlink(
+      path.join(fixture.workspacePath, "tracked.txt"),
+      path.join(fixture.workspacePath, path.dirname(staged.data.stagedPath), "linked.txt")
+    );
+
+    const captureResult = await fixture.service.captureSnapshotForArchive({
+      workspaceId: fixture.workspaceId,
+      workspaceMetadata: fixture.metadata,
+    });
+    expect(captureResult.success).toBe(false);
+    if (captureResult.success) {
+      return;
+    }
+    expect(captureResult.error).toContain("contain a symlink");
+    expect(await pathExists(fixture.workspacePath)).toBe(true);
+  });
+
+  test("never restores into or deletes anything but staged attachment paths from tampered metadata", async () => {
+    const bytes = Buffer.from("attachment payload");
+    const staged = await stageWorkspaceAttachment({
+      runtime: new LocalRuntime(fixture.workspacePath),
+      workspacePath: fixture.workspacePath,
+      filename: "notes.txt",
+      mediaType: "text/plain",
+      sizeBytes: bytes.byteLength,
+      dataBase64: bytes.toString("base64"),
+    });
+    expect(staged.success).toBe(true);
+    const captureResult = await fixture.service.captureSnapshotForArchive({
+      workspaceId: fixture.workspaceId,
+      workspaceMetadata: fixture.metadata,
+    });
+    expect(captureResult.success).toBe(true);
+    if (!captureResult.success) {
+      return;
+    }
+    const sessionDir = path.join(fixture.config.sessionsDir, fixture.workspaceId);
+    await fs.writeFile(path.join(sessionDir, "chat.jsonl"), "history\n", "utf-8");
+    const tamper = (repoRelativeDir: string, artifactPath: string) =>
+      fixture.config.editConfig((cfg) => {
+        const workspace = cfg.projects.get(fixture.projectPath)?.workspaces[0];
+        if (!workspace) {
+          throw new Error("Missing workspace entry");
+        }
+        workspace.worktreeArchiveSnapshot = {
+          ...captureResult.data,
+          projects: captureResult.data.projects.map((project) => ({
+            ...project,
+            stagedAttachmentDirs: [{ repoRelativeDir, artifactPath }],
+          })),
+        };
+        return cfg;
+      });
+
+    // Existing checkout matches git state; an artifactPath aimed at chat history must be neither
+    // copied nor removed when the snapshot is cleared.
+    await tamper(path.join(".xum", "user-attachments"), "chat.jsonl");
+    const reconcile = await fixture.service.restoreSnapshotAfterUnarchive({
+      workspaceId: fixture.workspaceId,
+      workspaceMetadata: fixture.metadata,
+    });
+    expect(reconcile).toEqual({ success: true, data: "skipped" });
+    expect(await fs.readFile(path.join(sessionDir, "chat.jsonl"), "utf-8")).toBe("history\n");
+
+    // A repoRelativeDir naming a tracked directory must not receive the payload on a fresh restore.
+    await fs.mkdir(path.join(fixture.workspacePath, "src"));
+    await fs.writeFile(path.join(fixture.workspacePath, "src", "notes.txt"), "code\n", "utf-8");
+    runGit(fixture.workspacePath, ["add", "src"]);
+    runGit(fixture.workspacePath, ["commit", "-m", "src"]);
+    const recapture = await fixture.service.captureSnapshotForArchive({
+      workspaceId: fixture.workspaceId,
+      workspaceMetadata: fixture.metadata,
+    });
+    expect(recapture.success).toBe(true);
+    if (!recapture.success) {
+      return;
+    }
+    const artifactPath = recapture.data.projects[0]?.stagedAttachmentDirs?.[0]?.artifactPath;
+    expect(artifactPath).toBeDefined();
+    await fixture.config.editConfig((cfg) => {
+      const workspace = cfg.projects.get(fixture.projectPath)?.workspaces[0];
+      if (!workspace) {
+        throw new Error("Missing workspace entry");
+      }
+      workspace.worktreeArchiveSnapshot = {
+        ...recapture.data,
+        projects: recapture.data.projects.map((project) => ({
+          ...project,
+          stagedAttachmentDirs: [{ repoRelativeDir: "src", artifactPath: artifactPath ?? "" }],
+        })),
+      };
+      return cfg;
+    });
+    runGit(fixture.projectPath, ["worktree", "remove", "--force", fixture.workspacePath]);
+    const restoreResult = await fixture.service.restoreSnapshotAfterUnarchive({
+      workspaceId: fixture.workspaceId,
+      workspaceMetadata: fixture.metadata,
+    });
+    expect(restoreResult.success).toBe(false);
+    if (restoreResult.success) {
+      return;
+    }
+    expect(restoreResult.error).toContain("is not a staged attachment directory");
+    expect(await pathExists(fixture.workspacePath)).toBe(false);
+  });
+
   test("fails capture when the staging directory resolves outside the checkout", async () => {
     const outsideDir = path.join(fixture.muxRoot, "outside-attachments");
     await fs.mkdir(path.join(outsideDir, "upload"), { recursive: true });
@@ -659,7 +780,7 @@ describe("WorktreeArchiveSnapshotService", () => {
           ...project,
           stagedAttachmentDirs: project.stagedAttachmentDirs?.map((entry) => ({
             ...entry,
-            repoRelativeDir: path.join("link", "user-attachments"),
+            repoRelativeDir: path.join("link", ".xum", "user-attachments"),
           })),
         })),
       };

--- a/src/node/services/worktreeArchiveSnapshotService.test.ts
+++ b/src/node/services/worktreeArchiveSnapshotService.test.ts
@@ -390,6 +390,94 @@ describe("WorktreeArchiveSnapshotService", () => {
     expect(await pathExists(path.join(sessionDir, "archive-attachments"))).toBe(false);
   });
 
+  test("leaves attachment copies a snapshot does not reference alone when clearing it", async () => {
+    // A downgrade cycle can strand copies here: the older build restores (deleting only
+    // archive-state) and re-archives without stagedAttachmentDirs.
+    const orphan = path.join(
+      fixture.config.sessionsDir,
+      fixture.workspaceId,
+      "archive-attachments",
+      "project",
+      ".xum",
+      "user-attachments",
+      "old-upload",
+      "notes.txt"
+    );
+    await fs.mkdir(path.dirname(orphan), { recursive: true });
+    await fs.writeFile(orphan, "kept", "utf-8");
+    await makeWorkspaceDirty(fixture);
+
+    const captureResult = await fixture.service.captureSnapshotForArchive({
+      workspaceId: fixture.workspaceId,
+      workspaceMetadata: fixture.metadata,
+    });
+    expect(captureResult.success).toBe(true);
+    if (!captureResult.success) {
+      return;
+    }
+    expect(captureResult.data.projects[0]?.stagedAttachmentDirs).toBeUndefined();
+    await fixture.config.editConfig((cfg) => {
+      const workspace = cfg.projects.get(fixture.projectPath)?.workspaces[0];
+      if (!workspace) {
+        throw new Error("Missing workspace entry");
+      }
+      workspace.worktreeArchiveSnapshot = captureResult.data;
+      return cfg;
+    });
+    runGit(fixture.projectPath, ["worktree", "remove", "--force", fixture.workspacePath]);
+
+    const restoreResult = await fixture.service.restoreSnapshotAfterUnarchive({
+      workspaceId: fixture.workspaceId,
+      workspaceMetadata: fixture.metadata,
+    });
+    expect(restoreResult).toEqual({ success: true, data: "restored" });
+    expect(await fs.readFile(orphan, "utf-8")).toBe("kept");
+  });
+
+  test("captures the contents behind a symlinked staging directory instead of the link", async () => {
+    // The staging directory is a link to an ignored directory elsewhere in the checkout; the
+    // worktree removal would take the target with it, so the copy must hold real files.
+    const storeDir = path.join(fixture.workspacePath, "store");
+    await fs.mkdir(path.join(storeDir, "upload"), { recursive: true });
+    await fs.writeFile(path.join(storeDir, "upload", "notes.txt"), "payload", "utf-8");
+    await fs.mkdir(path.join(fixture.workspacePath, ".xum"));
+    await fs.symlink(storeDir, path.join(fixture.workspacePath, ".xum", "user-attachments"));
+    const excludePath = runGit(fixture.workspacePath, ["rev-parse", "--git-path", "info/exclude"]);
+    await fs.mkdir(path.dirname(path.resolve(fixture.workspacePath, excludePath)), {
+      recursive: true,
+    });
+    await fs.writeFile(
+      path.resolve(fixture.workspacePath, excludePath),
+      "/.xum/user-attachments\n/store/\n",
+      "utf-8"
+    );
+    expect(runGit(fixture.workspacePath, ["status", "--porcelain"])).toBe("");
+
+    const captureResult = await fixture.service.captureSnapshotForArchive({
+      workspaceId: fixture.workspaceId,
+      workspaceMetadata: fixture.metadata,
+    });
+    expect(captureResult.success).toBe(true);
+    if (!captureResult.success) {
+      return;
+    }
+    const artifact = captureResult.data.projects[0]?.stagedAttachmentDirs?.[0];
+    expect(artifact).toBeDefined();
+    if (!artifact) {
+      return;
+    }
+    runGit(fixture.projectPath, ["worktree", "remove", "--force", fixture.workspacePath]);
+    const artifactDir = path.join(
+      fixture.config.sessionsDir,
+      fixture.workspaceId,
+      artifact.artifactPath
+    );
+    expect((await fs.lstat(artifactDir)).isSymbolicLink()).toBe(false);
+    expect(await fs.readFile(path.join(artifactDir, "upload", "notes.txt"), "utf-8")).toBe(
+      "payload"
+    );
+  });
+
   test("fails capture when the staged attachment directory cannot be inspected", async () => {
     const bytes = Buffer.from("attachment payload");
     const staged = await stageWorkspaceAttachment({

--- a/src/node/services/worktreeArchiveSnapshotService.test.ts
+++ b/src/node/services/worktreeArchiveSnapshotService.test.ts
@@ -1626,6 +1626,38 @@ describe("WorktreeArchiveSnapshotService", () => {
     }
   });
 
+  test("keeps warning about a container that holds ignored files besides staged attachments", async () => {
+    const bytes = Buffer.from("attachment payload");
+    const staged = await stageWorkspaceAttachment({
+      runtime: new LocalRuntime(fixture.workspacePath),
+      workspacePath: fixture.workspacePath,
+      filename: "notes.txt",
+      mediaType: "text/plain",
+      sizeBytes: bytes.byteLength,
+      dataBase64: bytes.toString("base64"),
+    });
+    expect(staged.success).toBe(true);
+    // A workspace MCP override is excluded the same way but is not captured by the snapshot.
+    await fs.writeFile(
+      path.join(fixture.workspacePath, ".xum", "mcp.local.jsonc"),
+      "{}\n",
+      "utf-8"
+    );
+    const excludePath = runGit(fixture.workspacePath, ["rev-parse", "--git-path", "info/exclude"]);
+    await fs.appendFile(
+      path.resolve(fixture.workspacePath, excludePath),
+      "/.xum/mcp.local.jsonc\n",
+      "utf-8"
+    );
+    expect(runGit(fixture.workspacePath, ["status", "--porcelain"])).toBe("");
+
+    const result = await fixture.service.getUnsupportedUntrackedPaths({
+      workspaceId: fixture.workspaceId,
+      workspaceMetadata: fixture.metadata,
+    });
+    expect(result).toEqual({ success: true, data: [".xum/"] });
+  });
+
   test("captureSnapshotForArchive succeeds with matching acknowledgedUntrackedPaths", async () => {
     // Make workspace dirty (tracked changes) so snapshot captures something meaningful.
     await makeWorkspaceDirty(fixture);

--- a/src/node/services/worktreeArchiveSnapshotService.test.ts
+++ b/src/node/services/worktreeArchiveSnapshotService.test.ts
@@ -1626,37 +1626,50 @@ describe("WorktreeArchiveSnapshotService", () => {
     }
   });
 
-  test("keeps warning about a container that holds ignored files besides staged attachments", async () => {
-    const bytes = Buffer.from("attachment payload");
-    const staged = await stageWorkspaceAttachment({
-      runtime: new LocalRuntime(fixture.workspacePath),
-      workspacePath: fixture.workspacePath,
-      filename: "notes.txt",
-      mediaType: "text/plain",
-      sizeBytes: bytes.byteLength,
-      dataBase64: bytes.toString("base64"),
-    });
-    expect(staged.success).toBe(true);
-    // A workspace MCP override is excluded the same way but is not captured by the snapshot.
-    await fs.writeFile(
-      path.join(fixture.workspacePath, ".xum", "mcp.local.jsonc"),
-      "{}\n",
-      "utf-8"
-    );
-    const excludePath = runGit(fixture.workspacePath, ["rev-parse", "--git-path", "info/exclude"]);
-    await fs.appendFile(
-      path.resolve(fixture.workspacePath, excludePath),
-      "/.xum/mcp.local.jsonc\n",
-      "utf-8"
-    );
-    expect(runGit(fixture.workspacePath, ["status", "--porcelain"])).toBe("");
+  test.each([
+    {
+      name: "an ignored file",
+      // A workspace MCP override is excluded the same way but is not captured by the snapshot.
+      addSibling: async (workspacePath: string) => {
+        await fs.writeFile(path.join(workspacePath, ".xum", "mcp.local.jsonc"), "{}\n", "utf-8");
+        const excludePath = runGit(workspacePath, ["rev-parse", "--git-path", "info/exclude"]);
+        await fs.appendFile(
+          path.resolve(workspacePath, excludePath),
+          "/.xum/mcp.local.jsonc\n",
+          "utf-8"
+        );
+      },
+    },
+    {
+      name: "an empty directory",
+      // Git lists neither empty directories nor their parent when everything else is ignored.
+      addSibling: async (workspacePath: string) => {
+        await fs.mkdir(path.join(workspacePath, ".xum", "empty-dir"));
+      },
+    },
+  ])(
+    "keeps warning about a container that holds $name besides staged attachments",
+    async ({ addSibling }) => {
+      const bytes = Buffer.from("attachment payload");
+      const staged = await stageWorkspaceAttachment({
+        runtime: new LocalRuntime(fixture.workspacePath),
+        workspacePath: fixture.workspacePath,
+        filename: "notes.txt",
+        mediaType: "text/plain",
+        sizeBytes: bytes.byteLength,
+        dataBase64: bytes.toString("base64"),
+      });
+      expect(staged.success).toBe(true);
+      await addSibling(fixture.workspacePath);
+      expect(runGit(fixture.workspacePath, ["status", "--porcelain"])).toBe("");
 
-    const result = await fixture.service.getUnsupportedUntrackedPaths({
-      workspaceId: fixture.workspaceId,
-      workspaceMetadata: fixture.metadata,
-    });
-    expect(result).toEqual({ success: true, data: [".xum/"] });
-  });
+      const result = await fixture.service.getUnsupportedUntrackedPaths({
+        workspaceId: fixture.workspaceId,
+        workspaceMetadata: fixture.metadata,
+      });
+      expect(result).toEqual({ success: true, data: [".xum/"] });
+    }
+  );
 
   test("captureSnapshotForArchive succeeds with matching acknowledgedUntrackedPaths", async () => {
     // Make workspace dirty (tracked changes) so snapshot captures something meaningful.

--- a/src/node/services/worktreeArchiveSnapshotService.test.ts
+++ b/src/node/services/worktreeArchiveSnapshotService.test.ts
@@ -434,6 +434,108 @@ describe("WorktreeArchiveSnapshotService", () => {
     expect(await fs.readFile(orphan, "utf-8")).toBe("kept");
   });
 
+  test("replaces a stale copy at the captured path but keeps unrelated attachment copies", async () => {
+    const attachmentsRoot = path.join(
+      fixture.config.sessionsDir,
+      fixture.workspaceId,
+      "archive-attachments"
+    );
+    // Same path as the upcoming capture: a leftover the user has since deleted must not return.
+    const stale = path.join(
+      attachmentsRoot,
+      "project",
+      ".xum",
+      "user-attachments",
+      "stale",
+      "old.txt"
+    );
+    // Different storage key: stranded by another cycle, not this snapshot's to remove.
+    const unrelated = path.join(
+      attachmentsRoot,
+      "other",
+      ".xum",
+      "user-attachments",
+      "keep",
+      "k.txt"
+    );
+    for (const file of [stale, unrelated]) {
+      await fs.mkdir(path.dirname(file), { recursive: true });
+      await fs.writeFile(file, "x", "utf-8");
+    }
+    const bytes = Buffer.from("attachment payload");
+    const staged = await stageWorkspaceAttachment({
+      runtime: new LocalRuntime(fixture.workspacePath),
+      workspacePath: fixture.workspacePath,
+      filename: "notes.txt",
+      mediaType: "text/plain",
+      sizeBytes: bytes.byteLength,
+      dataBase64: bytes.toString("base64"),
+    });
+    expect(staged.success).toBe(true);
+    if (!staged.success) {
+      return;
+    }
+
+    const captureResult = await fixture.service.captureSnapshotForArchive({
+      workspaceId: fixture.workspaceId,
+      workspaceMetadata: fixture.metadata,
+    });
+    expect(captureResult.success).toBe(true);
+    if (!captureResult.success) {
+      return;
+    }
+    const artifact = captureResult.data.projects[0]?.stagedAttachmentDirs?.[0];
+    expect(artifact?.artifactPath).toBe(
+      path.join("archive-attachments", "project", ".xum", "user-attachments")
+    );
+    expect(await pathExists(stale)).toBe(false);
+    expect(await pathExists(unrelated)).toBe(true);
+    expect(
+      await fs.readFile(
+        path.join(
+          attachmentsRoot,
+          "project",
+          path.relative(
+            fixture.workspacePath,
+            path.join(fixture.workspacePath, staged.data.stagedPath)
+          )
+        )
+      )
+    ).toEqual(bytes);
+  });
+
+  test("fails capture when the staging directory resolves outside the checkout", async () => {
+    const outsideDir = path.join(fixture.muxRoot, "outside-attachments");
+    await fs.mkdir(path.join(outsideDir, "upload"), { recursive: true });
+    await fs.writeFile(path.join(outsideDir, "upload", "notes.txt"), "payload", "utf-8");
+    await fs.mkdir(path.join(fixture.workspacePath, ".xum"));
+    await fs.symlink(outsideDir, path.join(fixture.workspacePath, ".xum", "user-attachments"));
+    const excludePath = runGit(fixture.workspacePath, ["rev-parse", "--git-path", "info/exclude"]);
+    await fs.mkdir(path.dirname(path.resolve(fixture.workspacePath, excludePath)), {
+      recursive: true,
+    });
+    await fs.writeFile(
+      path.resolve(fixture.workspacePath, excludePath),
+      "/.xum/user-attachments\n",
+      "utf-8"
+    );
+
+    const captureResult = await fixture.service.captureSnapshotForArchive({
+      workspaceId: fixture.workspaceId,
+      workspaceMetadata: fixture.metadata,
+    });
+    expect(captureResult.success).toBe(false);
+    if (captureResult.success) {
+      return;
+    }
+    expect(captureResult.error).toContain("resolve outside");
+    expect(await pathExists(fixture.workspacePath)).toBe(true);
+    const sessionDirEntries = await fs.readdir(
+      path.join(fixture.config.sessionsDir, fixture.workspaceId)
+    );
+    expect(sessionDirEntries.filter((entry) => entry.startsWith("archive-"))).toEqual([]);
+  });
+
   test("captures the contents behind a symlinked staging directory instead of the link", async () => {
     // The staging directory is a link to an ignored directory elsewhere in the checkout; the
     // worktree removal would take the target with it, so the copy must hold real files.
@@ -1499,6 +1601,19 @@ describe("WorktreeArchiveSnapshotService", () => {
     await fs.writeFile(path.join(fixture.workspacePath, "a-file.txt"), "a\n", "utf-8");
     await fs.mkdir(path.join(fixture.workspacePath, "cache-dir"));
     await fs.writeFile(path.join(fixture.workspacePath, "cache-dir", "tmp"), "t\n", "utf-8");
+    // Empty directories stay in the lossy list; a container holding only captured staged
+    // attachments does not.
+    await fs.mkdir(path.join(fixture.workspacePath, "empty-dir"));
+    const bytes = Buffer.from("attachment payload");
+    const staged = await stageWorkspaceAttachment({
+      runtime: new LocalRuntime(fixture.workspacePath),
+      workspacePath: fixture.workspacePath,
+      filename: "notes.txt",
+      mediaType: "text/plain",
+      sizeBytes: bytes.byteLength,
+      dataBase64: bytes.toString("base64"),
+    });
+    expect(staged.success).toBe(true);
 
     const result = await fixture.service.getUnsupportedUntrackedPaths({
       workspaceId: fixture.workspaceId,
@@ -1507,7 +1622,7 @@ describe("WorktreeArchiveSnapshotService", () => {
 
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data).toEqual(["a-file.txt", "cache-dir/", "z-file.txt"]);
+      expect(result.data).toEqual(["a-file.txt", "cache-dir/", "empty-dir/", "z-file.txt"]);
     }
   });
 

--- a/src/node/services/worktreeArchiveSnapshotService.ts
+++ b/src/node/services/worktreeArchiveSnapshotService.ts
@@ -27,11 +27,16 @@ import {
 import { log } from "@/node/services/log";
 import { ensureGitInfoExclude } from "@/node/utils/git/ensureGitInfoExclude";
 import { execFileAsync } from "@/node/utils/disposableExec";
+import { isErrnoWithCode } from "@/node/utils/fs";
 import { GIT_NO_HOOKS_ENV } from "@/node/utils/gitNoHooksEnv";
 import { isPathInsideDir } from "@/node/utils/pathUtils";
 
 const SNAPSHOT_VERSION = 1;
 const SNAPSHOT_DIR_NAME = "archive-state";
+// Kept outside SNAPSHOT_DIR_NAME on purpose: an older build restoring a newer snapshot ignores
+// stagedAttachmentDirs and deletes archive-state, so a sibling directory keeps the only copy of
+// the uploads recoverable across a downgrade instead of destroying it.
+const ATTACHMENTS_DIR_NAME = "archive-attachments";
 const SNAPSHOT_METADATA_FILE_NAME = "metadata.json";
 const NOOP_INIT_LOGGER: InitLogger = {
   logStep: () => undefined,
@@ -255,14 +260,16 @@ export class WorktreeArchiveSnapshotService {
 
     const sessionDir = path.join(this.config.sessionsDir, args.workspaceId);
     const stateDir = path.join(sessionDir, SNAPSHOT_DIR_NAME);
-    const tempStateDir = path.join(
-      sessionDir,
-      `${SNAPSHOT_DIR_NAME}.tmp-${Date.now()}-${Math.random().toString(16).slice(2)}`
-    );
+    const attachmentsDir = path.join(sessionDir, ATTACHMENTS_DIR_NAME);
+    const tempSuffix = `.tmp-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const tempStateDir = path.join(sessionDir, `${SNAPSHOT_DIR_NAME}${tempSuffix}`);
+    const tempAttachmentsDir = path.join(sessionDir, `${ATTACHMENTS_DIR_NAME}${tempSuffix}`);
 
     await fsPromises.mkdir(sessionDir, { recursive: true });
     await fsPromises.rm(tempStateDir, { recursive: true, force: true });
     await fsPromises.mkdir(tempStateDir, { recursive: true });
+    await fsPromises.rm(tempAttachmentsDir, { recursive: true, force: true });
+    await fsPromises.mkdir(tempAttachmentsDir, { recursive: true });
 
     try {
       const projectRepos = getWorkspaceProjectRepos({
@@ -382,7 +389,7 @@ export class WorktreeArchiveSnapshotService {
           workspaceName,
           projectRepo,
           sessionDir,
-          stateDir: tempStateDir,
+          attachmentsDir: tempAttachmentsDir,
         });
 
         projectSnapshots.push({
@@ -412,6 +419,12 @@ export class WorktreeArchiveSnapshotService {
         JSON.stringify(snapshot, null, 2),
         "utf-8"
       );
+      // Attachments land first so the metadata rename (the commit point) never references
+      // artifacts that are not in place yet.
+      await fsPromises.rm(attachmentsDir, { recursive: true, force: true });
+      if (projectSnapshots.some((project) => project.stagedAttachmentDirs != null)) {
+        await fsPromises.rename(tempAttachmentsDir, attachmentsDir);
+      }
       await fsPromises.rm(stateDir, { recursive: true, force: true });
       await fsPromises.rename(tempStateDir, stateDir);
 
@@ -420,6 +433,7 @@ export class WorktreeArchiveSnapshotService {
       return Err(`Failed to capture archive snapshot: ${getErrorMessage(error)}`);
     } finally {
       await fsPromises.rm(tempStateDir, { recursive: true, force: true });
+      await fsPromises.rm(tempAttachmentsDir, { recursive: true, force: true });
     }
   }
 
@@ -474,6 +488,18 @@ export class WorktreeArchiveSnapshotService {
             projectSnapshot: existingProjectSnapshot,
           }))
         ) {
+          // The git checks above say nothing about ignored uploads, so put them back before the
+          // snapshot (and with it their only other copy) is cleared.
+          await this.restoreStagedAttachments({
+            workspaceId: args.workspaceId,
+            projectSnapshot: existingProjectSnapshot,
+            workspacePath: persistedWorkspacePath,
+            runtime: createRuntime(args.workspaceMetadata.runtimeConfig, {
+              projectPath: existingProjectSnapshot.projectPath,
+              workspaceName,
+            }),
+            tolerateMissingArtifacts: true,
+          });
           await this.clearSnapshotState(args.workspaceId, snapshot);
           return Ok("skipped");
         }
@@ -604,6 +630,7 @@ export class WorktreeArchiveSnapshotService {
           projectSnapshot,
           workspacePath: restoreResult.workspacePath,
           runtime,
+          tolerateMissingArtifacts: false,
         });
       }
 
@@ -940,7 +967,7 @@ export class WorktreeArchiveSnapshotService {
     workspaceName: string;
     projectRepo: WorkspaceProjectRepo;
     sessionDir: string;
-    stateDir: string;
+    attachmentsDir: string;
   }): Promise<WorktreeArchiveSnapshotProject["stagedAttachmentDirs"]> {
     const runtime = createRuntime(args.workspaceMetadata.runtimeConfig, {
       projectPath: args.projectRepo.projectPath,
@@ -955,17 +982,19 @@ export class WorktreeArchiveSnapshotService {
     const captured: NonNullable<WorktreeArchiveSnapshotProject["stagedAttachmentDirs"]> = [];
     for (const relativeDir of STAGED_ATTACHMENT_DIRS) {
       const sourceDir = path.join(stagingRoot, relativeDir);
-      if (!(await this.isDirectory(sourceDir))) {
+      if (!(await this.isExistingDirectory(sourceDir))) {
+        continue;
+      }
+      // A repo-controlled symlink (e.g. a tracked `.xum`) can point the staging directory outside
+      // the checkout; whatever lives there is not removed with the worktree, so leave it alone.
+      if (!(await this.realPathIsInsideDir(args.projectRepo.repoCwd, sourceDir))) {
         continue;
       }
       const repoRelativeDir = path.relative(args.projectRepo.repoCwd, sourceDir);
 
-      // Written under the temp state dir, recorded under its final name (like writeArtifact).
-      const artifactRelativeDir = path.join(
-        `${args.projectRepo.storageKey}.attachments`,
-        repoRelativeDir
-      );
-      const artifactDir = path.join(args.stateDir, artifactRelativeDir);
+      // Written under the temp attachments dir, recorded under its final name (like writeArtifact).
+      const artifactRelativeDir = path.join(args.projectRepo.storageKey, repoRelativeDir);
+      const artifactDir = path.join(args.attachmentsDir, artifactRelativeDir);
       assert(
         isPathInsideDir(args.sessionDir, artifactDir),
         `captureStagedAttachments: artifact path escaped session dir (${artifactDir})`
@@ -973,7 +1002,7 @@ export class WorktreeArchiveSnapshotService {
       await fsPromises.cp(sourceDir, artifactDir, { recursive: true });
       captured.push({
         repoRelativeDir,
-        artifactPath: path.join(SNAPSHOT_DIR_NAME, artifactRelativeDir),
+        artifactPath: path.join(ATTACHMENTS_DIR_NAME, artifactRelativeDir),
       });
     }
     return captured.length > 0 ? captured : undefined;
@@ -984,19 +1013,30 @@ export class WorktreeArchiveSnapshotService {
     projectSnapshot: WorktreeArchiveSnapshotProject;
     workspacePath: string;
     runtime: Runtime;
+    /**
+     * A fresh restore has no other copy, so a missing artifact fails it (like the patch
+     * artifacts). Reconciling an existing checkout has nothing left to recover from a missing
+     * artifact, so it skips the entry the same way missing tracked artifacts are treated there.
+     */
+    tolerateMissingArtifacts: boolean;
   }): Promise<void> {
     const sessionDir = path.join(this.config.sessionsDir, args.workspaceId);
     for (const entry of args.projectSnapshot.stagedAttachmentDirs ?? []) {
       const artifactDir = this.resolveSessionRelativePath(sessionDir, entry.artifactPath);
-      if (!(await this.isDirectory(artifactDir))) {
+      if (!(await this.isExistingDirectory(artifactDir))) {
+        if (args.tolerateMissingArtifacts) {
+          continue;
+        }
         throw new Error(
           `Failed to restore ${args.projectSnapshot.projectName}: staged attachments artifact is unavailable.`
         );
       }
-      // repoRelativeDir comes from user-editable config, so keep the copy inside the checkout.
+      // repoRelativeDir comes from user-editable config and its ancestors from the repo, so the
+      // copy target is checked through symlinks, not just lexically.
       const targetDir = path.resolve(args.workspacePath, entry.repoRelativeDir);
       assert(
-        isPathInsideDir(args.workspacePath, targetDir) && targetDir !== args.workspacePath,
+        targetDir !== path.resolve(args.workspacePath) &&
+          (await this.realPathIsInsideDir(args.workspacePath, targetDir)),
         `restoreStagedAttachments: refusing to restore outside ${args.workspacePath}`
       );
       await fsPromises.cp(artifactDir, targetDir, { recursive: true });
@@ -1016,12 +1056,36 @@ export class WorktreeArchiveSnapshotService {
     }
   }
 
-  private async isDirectory(targetPath: string): Promise<boolean> {
+  /** Only genuine absence counts as "not a directory"; other stat failures must abort. */
+  private async isExistingDirectory(targetPath: string): Promise<boolean> {
     try {
       return (await fsPromises.stat(targetPath)).isDirectory();
-    } catch {
-      return false;
+    } catch (error) {
+      if (isErrnoWithCode(error, "ENOENT") || isErrnoWithCode(error, "ENOTDIR")) {
+        return false;
+      }
+      throw error;
     }
+  }
+
+  /**
+   * Symlink-aware containment: resolves the deepest existing ancestor of targetPath so a link
+   * anywhere above it cannot redirect reads or writes outside rootDir.
+   */
+  private async realPathIsInsideDir(rootDir: string, targetPath: string): Promise<boolean> {
+    let existing = path.resolve(targetPath);
+    while (!(await this.pathExists(existing))) {
+      const parent = path.dirname(existing);
+      if (parent === existing) {
+        return false;
+      }
+      existing = parent;
+    }
+    const realTarget = path.join(
+      await fsPromises.realpath(existing),
+      path.relative(existing, path.resolve(targetPath))
+    );
+    return isPathInsideDir(await fsPromises.realpath(rootDir), realTarget);
   }
 
   private async writeArtifact(args: {
@@ -1050,6 +1114,10 @@ export class WorktreeArchiveSnapshotService {
     const sessionDir = path.join(this.config.sessionsDir, workspaceId);
     const stateDir = this.resolveSessionRelativePath(sessionDir, snapshot.stateDirPath);
     await fsPromises.rm(stateDir, { recursive: true, force: true });
+    await fsPromises.rm(path.join(sessionDir, ATTACHMENTS_DIR_NAME), {
+      recursive: true,
+      force: true,
+    });
 
     await this.config.editConfig((config) => {
       const workspaceEntry = findWorkspaceEntryByIdOrPath(this.config, config, workspaceId);

--- a/src/node/services/worktreeArchiveSnapshotService.ts
+++ b/src/node/services/worktreeArchiveSnapshotService.ts
@@ -296,9 +296,10 @@ export class WorktreeArchiveSnapshotService {
     const tempAttachmentsDir = path.join(sessionDir, `${ATTACHMENTS_DIR_NAME}${tempSuffix}`);
 
     await fsPromises.mkdir(sessionDir, { recursive: true });
-    await fsPromises.rm(tempStateDir, { recursive: true, force: true });
+    // A crash mid-capture leaves the previous generation's temp dirs behind (the attachment copy
+    // can be large), and every capture picks a fresh suffix, so sweep them here.
+    await this.removeStaleTempDirs(sessionDir);
     await fsPromises.mkdir(tempStateDir, { recursive: true });
-    await fsPromises.rm(tempAttachmentsDir, { recursive: true, force: true });
     await fsPromises.mkdir(tempAttachmentsDir, { recursive: true });
 
     try {
@@ -1106,7 +1107,11 @@ export class WorktreeArchiveSnapshotService {
           args.sessionDir,
           entry.artifactPath
         );
-        assert(artifactDir != null, "commitStagedAttachmentArtifacts: artifact path escaped");
+        if (artifactDir == null) {
+          throw new Error(
+            `Refusing to store staged attachments: ${ATTACHMENTS_DIR_NAME} in the session dir is not a plain directory.`
+          );
+        }
         const tempArtifactDir = path.join(
           args.tempAttachmentsDir,
           path.relative(ATTACHMENTS_DIR_NAME, entry.artifactPath)
@@ -1133,13 +1138,19 @@ export class WorktreeArchiveSnapshotService {
     const sessionDir = path.join(this.config.sessionsDir, args.workspaceId);
     for (const entry of args.projectSnapshot.stagedAttachmentDirs ?? []) {
       // Both fields come from user-editable config: only a staged attachment directory may be
-      // written into the checkout, and only the attachment artifact subtree may be read.
-      assert(
-        isStagedAttachmentRelativeDir(entry.repoRelativeDir),
-        `restoreStagedAttachments: ${entry.repoRelativeDir} is not a staged attachment directory`
-      );
+      // written into the checkout, and only the attachment artifact subtree may be read. A
+      // malformed entry is skipped (its artifact is left in place for manual recovery) rather than
+      // turning every unarchive attempt into the same failure.
       const artifactDir = await this.resolveAttachmentArtifactDir(sessionDir, entry.artifactPath);
-      if (artifactDir == null || !(await this.isExistingDirectory(artifactDir))) {
+      if (!isStagedAttachmentRelativeDir(entry.repoRelativeDir) || artifactDir == null) {
+        log.warn("Skipping malformed staged attachment entry", {
+          workspaceId: args.workspaceId,
+          repoRelativeDir: entry.repoRelativeDir,
+          artifactPath: entry.artifactPath,
+        });
+        continue;
+      }
+      if (!(await this.isExistingDirectory(artifactDir))) {
         if (args.tolerateMissingArtifacts) {
           continue;
         }
@@ -1220,11 +1231,38 @@ export class WorktreeArchiveSnapshotService {
     sessionDir: string,
     artifactPath: string
   ): Promise<string | null> {
-    const attachmentsRoot = path.join(sessionDir, ATTACHMENTS_DIR_NAME);
-    if (!(await this.isExistingDirectory(attachmentsRoot))) {
+    const attachmentsRoot = await this.resolveAttachmentsRoot(sessionDir);
+    if (attachmentsRoot == null) {
       return null;
     }
     return this.resolveContainedRealPath(attachmentsRoot, path.resolve(sessionDir, artifactPath));
+  }
+
+  /**
+   * The artifact root itself must be a real directory: a symlink there (corrupted or hand-edited
+   * session state) would make an external tree look contained to the realpath checks.
+   */
+  private async resolveAttachmentsRoot(sessionDir: string): Promise<string | null> {
+    const attachmentsRoot = path.join(sessionDir, ATTACHMENTS_DIR_NAME);
+    try {
+      return (await fsPromises.lstat(attachmentsRoot)).isDirectory() ? attachmentsRoot : null;
+    } catch (error) {
+      if (isErrnoWithCode(error, "ENOENT")) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  private async removeStaleTempDirs(sessionDir: string): Promise<void> {
+    for (const entry of await fsPromises.readdir(sessionDir)) {
+      if (
+        entry.startsWith(`${SNAPSHOT_DIR_NAME}.tmp-`) ||
+        entry.startsWith(`${ATTACHMENTS_DIR_NAME}.tmp-`)
+      ) {
+        await fsPromises.rm(path.join(sessionDir, entry), { recursive: true, force: true });
+      }
+    }
   }
 
   private async findSymlink(root: string): Promise<string | null> {
@@ -1295,12 +1333,16 @@ export class WorktreeArchiveSnapshotService {
     for (const project of snapshot.projects) {
       for (const entry of project.stagedAttachmentDirs ?? []) {
         const artifactDir = await this.resolveAttachmentArtifactDir(sessionDir, entry.artifactPath);
-        if (artifactDir != null) {
+        // Same rule as restore: a malformed entry keeps its artifact for manual recovery.
+        if (isStagedAttachmentRelativeDir(entry.repoRelativeDir) && artifactDir != null) {
           await fsPromises.rm(artifactDir, { recursive: true, force: true });
         }
       }
     }
-    await this.pruneEmptyDirs(path.join(sessionDir, ATTACHMENTS_DIR_NAME));
+    const attachmentsRoot = await this.resolveAttachmentsRoot(sessionDir);
+    if (attachmentsRoot != null) {
+      await this.pruneEmptyDirs(attachmentsRoot);
+    }
 
     await this.config.editConfig((config) => {
       const workspaceEntry = findWorkspaceEntryByIdOrPath(this.config, config, workspaceId);

--- a/src/node/services/worktreeArchiveSnapshotService.ts
+++ b/src/node/services/worktreeArchiveSnapshotService.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import * as fsPromises from "node:fs/promises";
 import * as path from "node:path";
 
+import { STAGED_ATTACHMENT_DIRS } from "@/common/constants/stagedAttachments";
 import { Err, Ok, type Result } from "@/common/types/result";
 import type { ArchiveLossyUntrackedFilesConfirmation } from "@/common/orpc/schemas/api";
 import type { WorkspaceMetadata } from "@/common/types/workspace";
@@ -16,10 +17,15 @@ import { detectDefaultTrunkBranch } from "@/node/git";
 import { ContainerManager } from "@/node/multiProject/containerManager";
 import { isGitRepository } from "@/node/utils/pathUtils";
 import { createRuntime } from "@/node/runtime/runtimeFactory";
-import type { InitLogger } from "@/node/runtime/Runtime";
+import type { InitLogger, Runtime } from "@/node/runtime/Runtime";
+import { appendSubProjectRelativePath } from "@/node/runtime/runtimeHelpers";
 import { coerceNonEmptyString, findWorkspaceEntry } from "@/node/services/taskUtils";
-import { getWorkspaceProjectRepos } from "@/node/services/workspaceProjectRepos";
+import {
+  getWorkspaceProjectRepos,
+  type WorkspaceProjectRepo,
+} from "@/node/services/workspaceProjectRepos";
 import { log } from "@/node/services/log";
+import { ensureGitInfoExclude } from "@/node/utils/git/ensureGitInfoExclude";
 import { execFileAsync } from "@/node/utils/disposableExec";
 import { GIT_NO_HOOKS_ENV } from "@/node/utils/gitNoHooksEnv";
 import { isPathInsideDir } from "@/node/utils/pathUtils";
@@ -371,6 +377,14 @@ export class WorktreeArchiveSnapshotService {
               })
             : undefined;
 
+        const stagedAttachmentDirs = await this.captureStagedAttachments({
+          workspaceMetadata: args.workspaceMetadata,
+          workspaceName,
+          projectRepo,
+          sessionDir,
+          stateDir: tempStateDir,
+        });
+
         projectSnapshots.push({
           projectPath: projectRepo.projectPath,
           projectName: projectRepo.projectName,
@@ -382,6 +396,7 @@ export class WorktreeArchiveSnapshotService {
           committedPatchPath,
           stagedPatchPath,
           unstagedPatchPath,
+          stagedAttachmentDirs,
         });
       }
 
@@ -583,6 +598,13 @@ export class WorktreeArchiveSnapshotService {
             unstagedPatchPath,
           ]);
         }
+
+        await this.restoreStagedAttachments({
+          workspaceId: args.workspaceId,
+          projectSnapshot,
+          workspacePath: restoreResult.workspacePath,
+          runtime,
+        });
       }
 
       if (snapshot.projects.length > 1) {
@@ -689,11 +711,15 @@ export class WorktreeArchiveSnapshotService {
    * Returns a sorted, normalized array of relative paths.
    */
   private async listUnsupportedUntrackedFiles(repoCwd: string): Promise<string[]> {
+    // --no-empty-directory matches `git status`: a directory whose only contents are ignored
+    // (the staged-attachment container `.xum/`, whose exclude targets the child directory) is
+    // not lossy untracked data. Staged attachments are captured by captureStagedAttachments.
     const untrackedOutput = await this.gitStdout(repoCwd, [
       "ls-files",
       "--others",
       "--exclude-standard",
       "--directory",
+      "--no-empty-directory",
     ]);
     return untrackedOutput
       .split("\n")
@@ -902,6 +928,100 @@ export class WorktreeArchiveSnapshotService {
       isPathInsideDir(sessionDir, absolutePath) && absolutePath !== sessionDir;
     assert(isStrictChildPath, `resolveSessionRelativePath: refusing to escape ${sessionDir}`);
     return absolutePath;
+  }
+
+  /**
+   * Chat uploads are staged into git-excluded `.xum/user-attachments` (legacy `.mux/`) under the
+   * workspace execution path, so the tracked-diff artifacts above never see them. Copy them into
+   * the snapshot so persisted chat/draft paths still resolve after the checkout is recreated.
+   */
+  private async captureStagedAttachments(args: {
+    workspaceMetadata: WorkspaceMetadata;
+    workspaceName: string;
+    projectRepo: WorkspaceProjectRepo;
+    sessionDir: string;
+    stateDir: string;
+  }): Promise<WorktreeArchiveSnapshotProject["stagedAttachmentDirs"]> {
+    const runtime = createRuntime(args.workspaceMetadata.runtimeConfig, {
+      projectPath: args.projectRepo.projectPath,
+      workspaceName: args.workspaceName,
+    });
+    const stagingRoot = appendSubProjectRelativePath(
+      args.workspaceMetadata,
+      runtime,
+      args.projectRepo.repoCwd
+    );
+
+    const captured: NonNullable<WorktreeArchiveSnapshotProject["stagedAttachmentDirs"]> = [];
+    for (const relativeDir of STAGED_ATTACHMENT_DIRS) {
+      const sourceDir = path.join(stagingRoot, relativeDir);
+      if (!(await this.isDirectory(sourceDir))) {
+        continue;
+      }
+      const repoRelativeDir = path.relative(args.projectRepo.repoCwd, sourceDir);
+
+      // Written under the temp state dir, recorded under its final name (like writeArtifact).
+      const artifactRelativeDir = path.join(
+        `${args.projectRepo.storageKey}.attachments`,
+        repoRelativeDir
+      );
+      const artifactDir = path.join(args.stateDir, artifactRelativeDir);
+      assert(
+        isPathInsideDir(args.sessionDir, artifactDir),
+        `captureStagedAttachments: artifact path escaped session dir (${artifactDir})`
+      );
+      await fsPromises.cp(sourceDir, artifactDir, { recursive: true });
+      captured.push({
+        repoRelativeDir,
+        artifactPath: path.join(SNAPSHOT_DIR_NAME, artifactRelativeDir),
+      });
+    }
+    return captured.length > 0 ? captured : undefined;
+  }
+
+  private async restoreStagedAttachments(args: {
+    workspaceId: string;
+    projectSnapshot: WorktreeArchiveSnapshotProject;
+    workspacePath: string;
+    runtime: Runtime;
+  }): Promise<void> {
+    const sessionDir = path.join(this.config.sessionsDir, args.workspaceId);
+    for (const entry of args.projectSnapshot.stagedAttachmentDirs ?? []) {
+      const artifactDir = this.resolveSessionRelativePath(sessionDir, entry.artifactPath);
+      if (!(await this.isDirectory(artifactDir))) {
+        throw new Error(
+          `Failed to restore ${args.projectSnapshot.projectName}: staged attachments artifact is unavailable.`
+        );
+      }
+      // repoRelativeDir comes from user-editable config, so keep the copy inside the checkout.
+      const targetDir = path.resolve(args.workspacePath, entry.repoRelativeDir);
+      assert(
+        isPathInsideDir(args.workspacePath, targetDir) && targetDir !== args.workspacePath,
+        `restoreStagedAttachments: refusing to restore outside ${args.workspacePath}`
+      );
+      await fsPromises.cp(artifactDir, targetDir, { recursive: true });
+
+      // The recreated worktree starts with an empty info/exclude, so re-exclude the directory or
+      // the restored uploads would surface as untracked files.
+      const excludeResult = await ensureGitInfoExclude({
+        runtime: args.runtime,
+        workspacePath: args.workspacePath,
+        relativeDir: entry.repoRelativeDir,
+      });
+      if (excludeResult.status === "failed") {
+        throw new Error(
+          `Failed to restore ${args.projectSnapshot.projectName}: could not mark staged attachments as ignored: ${excludeResult.error}`
+        );
+      }
+    }
+  }
+
+  private async isDirectory(targetPath: string): Promise<boolean> {
+    try {
+      return (await fsPromises.stat(targetPath)).isDirectory();
+    } catch {
+      return false;
+    }
   }
 
   private async writeArtifact(args: {

--- a/src/node/services/worktreeArchiveSnapshotService.ts
+++ b/src/node/services/worktreeArchiveSnapshotService.ts
@@ -60,15 +60,14 @@ const STAGED_ATTACHMENT_CONTAINERS = new Map(
 
 /**
  * For a `git ls-files --directory` entry (trailing slash) named like a staged-attachment container,
- * the entry its staged attachment directory would produce in the same listing.
+ * the name of the staged attachment directory it may hold.
  */
-function stagedAttachmentDirInContainer(untrackedPath: string): string | null {
+function stagedAttachmentChildInContainer(untrackedPath: string): string | null {
   const segments = untrackedPath.replace(/\\/gu, "/").split("/");
   if (segments.at(-1) !== "") {
     return null;
   }
-  const child = STAGED_ATTACHMENT_CONTAINERS.get(segments.at(-2) ?? "");
-  return child == null ? null : `${untrackedPath}${child}/`;
+  return STAGED_ATTACHMENT_CONTAINERS.get(segments.at(-2) ?? "") ?? null;
 }
 
 interface CreatedRestoreWorkspace {
@@ -777,9 +776,9 @@ export class WorktreeArchiveSnapshotService {
     const untrackedPaths = await listOthers([]);
     // `--directory` reports a directory whose only contents are ignored, which is exactly what
     // the staged-attachment container (`.xum/`, whose exclude targets the child directory) looks
-    // like. Drop it only when those ignored contents are the uploads captureStagedAttachments
-    // preserves; anything else ignored in there (e.g. a workspace MCP override) is still lost
-    // with the worktree and keeps the warning, as does every other entry.
+    // like. Drop it only when it holds nothing but the uploads captureStagedAttachments
+    // preserves; anything else in there (e.g. an ignored workspace MCP override or an empty
+    // directory) is still lost with the worktree and keeps the warning, as does every other entry.
     const nonEmptyPaths = new Set(await listOthers(["--no-empty-directory"]));
     const lossyPaths: string[] = [];
     for (const untrackedPath of untrackedPaths) {
@@ -794,33 +793,21 @@ export class WorktreeArchiveSnapshotService {
     return lossyPaths.sort();
   }
 
+  /**
+   * True when the container directory holds nothing but the staged attachment directory. Checked
+   * on the filesystem rather than through git so ignored files and empty sibling directories,
+   * which git omits, still keep the container in the lossy warning.
+   */
   private async holdsOnlyStagedAttachments(
     repoCwd: string,
     containerPath: string
   ): Promise<boolean> {
-    const stagedDir = stagedAttachmentDirInContainer(containerPath);
-    if (stagedDir == null) {
+    const stagedChild = stagedAttachmentChildInContainer(containerPath);
+    if (stagedChild == null) {
       return false;
     }
-    const ignoredEntries = (
-      await this.gitStdout(repoCwd, [
-        "ls-files",
-        "--others",
-        "--ignored",
-        "--exclude-standard",
-        "--directory",
-        "--",
-        containerPath,
-      ])
-    )
-      .split("\n")
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0 && line !== containerPath);
-    // A symlinked staging directory lists without the trailing slash; it is captured by contents.
-    return (
-      ignoredEntries.length > 0 &&
-      ignoredEntries.every((entry) => entry === stagedDir || `${entry}/` === stagedDir)
-    );
+    const entries = await fsPromises.readdir(path.join(repoCwd, containerPath));
+    return entries.length === 1 && entries[0] === stagedChild;
   }
 
   private async ensureNoUnsupportedUntrackedFiles(repoCwd: string): Promise<void> {

--- a/src/node/services/worktreeArchiveSnapshotService.ts
+++ b/src/node/services/worktreeArchiveSnapshotService.ts
@@ -70,6 +70,15 @@ function stagedAttachmentChildInContainer(untrackedPath: string): string | null 
   return STAGED_ATTACHMENT_CONTAINERS.get(segments.at(-2) ?? "") ?? null;
 }
 
+/** Persisted repoRelativeDir values must name a staged attachment directory, nothing else. */
+function isStagedAttachmentRelativeDir(repoRelativeDir: string): boolean {
+  const normalized = repoRelativeDir.replace(/\\/gu, "/").replace(/^\.\//u, "");
+  if (normalized.split("/").some((segment) => segment === "..")) {
+    return false;
+  }
+  return STAGED_ATTACHMENT_DIRS.some((dir) => normalized === dir || normalized.endsWith(`/${dir}`));
+}
+
 interface CreatedRestoreWorkspace {
   projectPath: string;
   projectName: string;
@@ -1056,6 +1065,14 @@ export class WorktreeArchiveSnapshotService {
         );
       }
       const repoRelativeDir = path.relative(args.projectRepo.repoCwd, sourceDir);
+      // Staging writes regular files only; a link planted inside would be archived as a link into
+      // the checkout that is about to be deleted, so the payload could never be restored.
+      const symlink = await this.findSymlink(realSourceDir);
+      if (symlink != null) {
+        throw new Error(
+          `Staged attachments at ${relativeDir} contain a symlink (${path.relative(realSourceDir, symlink)}); remove it before archiving.`
+        );
+      }
 
       const artifactRelativeDir = path.join(args.projectRepo.storageKey, repoRelativeDir);
       const tempArtifactDir = path.join(args.tempAttachmentsDir, artifactRelativeDir);
@@ -1082,9 +1099,14 @@ export class WorktreeArchiveSnapshotService {
     tempAttachmentsDir: string;
     projects: WorktreeArchiveSnapshotProject[];
   }): Promise<void> {
+    await fsPromises.mkdir(path.join(args.sessionDir, ATTACHMENTS_DIR_NAME), { recursive: true });
     for (const project of args.projects) {
       for (const entry of project.stagedAttachmentDirs ?? []) {
-        const artifactDir = this.resolveSessionRelativePath(args.sessionDir, entry.artifactPath);
+        const artifactDir = await this.resolveAttachmentArtifactDir(
+          args.sessionDir,
+          entry.artifactPath
+        );
+        assert(artifactDir != null, "commitStagedAttachmentArtifacts: artifact path escaped");
         const tempArtifactDir = path.join(
           args.tempAttachmentsDir,
           path.relative(ATTACHMENTS_DIR_NAME, entry.artifactPath)
@@ -1110,8 +1132,14 @@ export class WorktreeArchiveSnapshotService {
   }): Promise<void> {
     const sessionDir = path.join(this.config.sessionsDir, args.workspaceId);
     for (const entry of args.projectSnapshot.stagedAttachmentDirs ?? []) {
-      const artifactDir = this.resolveSessionRelativePath(sessionDir, entry.artifactPath);
-      if (!(await this.isExistingDirectory(artifactDir))) {
+      // Both fields come from user-editable config: only a staged attachment directory may be
+      // written into the checkout, and only the attachment artifact subtree may be read.
+      assert(
+        isStagedAttachmentRelativeDir(entry.repoRelativeDir),
+        `restoreStagedAttachments: ${entry.repoRelativeDir} is not a staged attachment directory`
+      );
+      const artifactDir = await this.resolveAttachmentArtifactDir(sessionDir, entry.artifactPath);
+      if (artifactDir == null || !(await this.isExistingDirectory(artifactDir))) {
         if (args.tolerateMissingArtifacts) {
           continue;
         }
@@ -1184,6 +1212,37 @@ export class WorktreeArchiveSnapshotService {
     return realTarget !== realRoot && isPathInsideDir(realRoot, realTarget) ? realTarget : null;
   }
 
+  /**
+   * Resolves a persisted artifactPath, or null unless it lands (through symlinks) strictly inside
+   * the attachment artifact subtree; anything else in the session dir is never read or deleted.
+   */
+  private async resolveAttachmentArtifactDir(
+    sessionDir: string,
+    artifactPath: string
+  ): Promise<string | null> {
+    const attachmentsRoot = path.join(sessionDir, ATTACHMENTS_DIR_NAME);
+    if (!(await this.isExistingDirectory(attachmentsRoot))) {
+      return null;
+    }
+    return this.resolveContainedRealPath(attachmentsRoot, path.resolve(sessionDir, artifactPath));
+  }
+
+  private async findSymlink(root: string): Promise<string | null> {
+    for (const entry of await fsPromises.readdir(root, { withFileTypes: true })) {
+      const entryPath = path.join(root, entry.name);
+      if (entry.isSymbolicLink()) {
+        return entryPath;
+      }
+      if (entry.isDirectory()) {
+        const nested = await this.findSymlink(entryPath);
+        if (nested != null) {
+          return nested;
+        }
+      }
+    }
+    return null;
+  }
+
   /** Removes directories under root that hold nothing but empty directories, root included. */
   private async pruneEmptyDirs(root: string): Promise<boolean> {
     let entries: Dirent[];
@@ -1235,10 +1294,10 @@ export class WorktreeArchiveSnapshotService {
     await fsPromises.rm(stateDir, { recursive: true, force: true });
     for (const project of snapshot.projects) {
       for (const entry of project.stagedAttachmentDirs ?? []) {
-        await fsPromises.rm(this.resolveSessionRelativePath(sessionDir, entry.artifactPath), {
-          recursive: true,
-          force: true,
-        });
+        const artifactDir = await this.resolveAttachmentArtifactDir(sessionDir, entry.artifactPath);
+        if (artifactDir != null) {
+          await fsPromises.rm(artifactDir, { recursive: true, force: true });
+        }
       }
     }
     await this.pruneEmptyDirs(path.join(sessionDir, ATTACHMENTS_DIR_NAME));

--- a/src/node/services/worktreeArchiveSnapshotService.ts
+++ b/src/node/services/worktreeArchiveSnapshotService.ts
@@ -36,8 +36,8 @@ const SNAPSHOT_VERSION = 1;
 const SNAPSHOT_DIR_NAME = "archive-state";
 // Kept outside SNAPSHOT_DIR_NAME on purpose: an older build restoring a newer snapshot ignores
 // stagedAttachmentDirs and deletes archive-state, so a sibling directory keeps the only copy of
-// the uploads recoverable across a downgrade instead of destroying it. Entries are only ever
-// merged in and removed individually, so such orphans survive later captures and restores too.
+// the uploads recoverable across a downgrade instead of destroying it. Entries are replaced and
+// removed individually, so such orphans survive later captures and restores too.
 const ATTACHMENTS_DIR_NAME = "archive-attachments";
 const SNAPSHOT_METADATA_FILE_NAME = "metadata.json";
 const NOOP_INIT_LOGGER: InitLogger = {
@@ -49,6 +49,21 @@ const NOOP_INIT_LOGGER: InitLogger = {
 };
 
 type CaptureSnapshotForArchiveError = string | ArchiveLossyUntrackedFilesConfirmation;
+
+const STAGED_ATTACHMENT_CONTAINERS = new Set(
+  STAGED_ATTACHMENT_DIRS.map((dir) => dir.split("/")[0])
+);
+
+/** Matches `--directory` entries (trailing slash) named like a staged-attachment container. */
+function isStagedAttachmentContainer(untrackedPath: string): boolean {
+  const segments = untrackedPath.replace(/\\/gu, "/").split("/");
+  const directoryName = segments.at(-2);
+  return (
+    segments.at(-1) === "" &&
+    directoryName != null &&
+    STAGED_ATTACHMENT_CONTAINERS.has(directoryName)
+  );
+}
 
 interface CreatedRestoreWorkspace {
   projectPath: string;
@@ -262,14 +277,15 @@ export class WorktreeArchiveSnapshotService {
 
     const sessionDir = path.join(this.config.sessionsDir, args.workspaceId);
     const stateDir = path.join(sessionDir, SNAPSHOT_DIR_NAME);
-    const tempStateDir = path.join(
-      sessionDir,
-      `${SNAPSHOT_DIR_NAME}.tmp-${Date.now()}-${Math.random().toString(16).slice(2)}`
-    );
+    const tempSuffix = `.tmp-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const tempStateDir = path.join(sessionDir, `${SNAPSHOT_DIR_NAME}${tempSuffix}`);
+    const tempAttachmentsDir = path.join(sessionDir, `${ATTACHMENTS_DIR_NAME}${tempSuffix}`);
 
     await fsPromises.mkdir(sessionDir, { recursive: true });
     await fsPromises.rm(tempStateDir, { recursive: true, force: true });
     await fsPromises.mkdir(tempStateDir, { recursive: true });
+    await fsPromises.rm(tempAttachmentsDir, { recursive: true, force: true });
+    await fsPromises.mkdir(tempAttachmentsDir, { recursive: true });
 
     try {
       const projectRepos = getWorkspaceProjectRepos({
@@ -389,6 +405,7 @@ export class WorktreeArchiveSnapshotService {
           workspaceName,
           projectRepo,
           sessionDir,
+          tempAttachmentsDir,
         });
 
         projectSnapshots.push({
@@ -418,6 +435,13 @@ export class WorktreeArchiveSnapshotService {
         JSON.stringify(snapshot, null, 2),
         "utf-8"
       );
+      // Attachment entries land before the metadata rename (the commit point) so it never
+      // references artifacts that are not in place yet.
+      await this.commitStagedAttachmentArtifacts({
+        sessionDir,
+        tempAttachmentsDir,
+        projects: projectSnapshots,
+      });
       await fsPromises.rm(stateDir, { recursive: true, force: true });
       await fsPromises.rename(tempStateDir, stateDir);
 
@@ -426,6 +450,7 @@ export class WorktreeArchiveSnapshotService {
       return Err(`Failed to capture archive snapshot: ${getErrorMessage(error)}`);
     } finally {
       await fsPromises.rm(tempStateDir, { recursive: true, force: true });
+      await fsPromises.rm(tempAttachmentsDir, { recursive: true, force: true });
     }
   }
 
@@ -730,20 +755,27 @@ export class WorktreeArchiveSnapshotService {
    * Returns a sorted, normalized array of relative paths.
    */
   private async listUnsupportedUntrackedFiles(repoCwd: string): Promise<string[]> {
-    // --no-empty-directory matches `git status`: a directory whose only contents are ignored
-    // (the staged-attachment container `.xum/`, whose exclude targets the child directory) is
-    // not lossy untracked data. Staged attachments are captured by captureStagedAttachments.
-    const untrackedOutput = await this.gitStdout(repoCwd, [
-      "ls-files",
-      "--others",
-      "--exclude-standard",
-      "--directory",
-      "--no-empty-directory",
-    ]);
-    return untrackedOutput
-      .split("\n")
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0)
+    const listOthers = async (extraArgs: string[]) =>
+      (
+        await this.gitStdout(repoCwd, [
+          "ls-files",
+          "--others",
+          "--exclude-standard",
+          "--directory",
+          ...extraArgs,
+        ])
+      )
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+    const untrackedPaths = await listOthers([]);
+    // `--directory` reports a directory whose only contents are ignored, which is exactly what
+    // the staged-attachment container (`.xum/`, whose exclude targets the child directory) looks
+    // like. Those uploads are captured by captureStagedAttachments, so drop the container when
+    // it holds nothing else; every other entry keeps the existing lossy-data warning.
+    const nonEmptyPaths = new Set(await listOthers(["--no-empty-directory"]));
+    return untrackedPaths
+      .filter((line) => nonEmptyPaths.has(line) || !isStagedAttachmentContainer(line))
       .sort();
   }
 
@@ -953,14 +985,15 @@ export class WorktreeArchiveSnapshotService {
    * Chat uploads are staged into git-excluded `.xum/user-attachments` (legacy `.mux/`) under the
    * workspace execution path, so the tracked-diff artifacts above never see them. Copy them into
    * the session dir so persisted chat/draft paths still resolve after the checkout is recreated.
-   * Copies are merged into the existing artifact tree rather than replacing it (see
-   * ATTACHMENTS_DIR_NAME), so a failed capture leaves nothing a later one would not rewrite.
+   * Entries are written under tempAttachmentsDir and moved into place by
+   * commitStagedAttachmentArtifacts once the whole capture succeeded.
    */
   private async captureStagedAttachments(args: {
     workspaceMetadata: WorkspaceMetadata;
     workspaceName: string;
     projectRepo: WorkspaceProjectRepo;
     sessionDir: string;
+    tempAttachmentsDir: string;
   }): Promise<WorktreeArchiveSnapshotProject["stagedAttachmentDirs"]> {
     const runtime = createRuntime(args.workspaceMetadata.runtimeConfig, {
       projectPath: args.projectRepo.projectPath,
@@ -980,29 +1013,56 @@ export class WorktreeArchiveSnapshotService {
       }
       // Copy from the resolved path: a symlinked staging directory must yield its contents, not
       // a link that dangles once the worktree is gone. A repo-controlled link that leaves the
-      // checkout is skipped; whatever lives there is not removed with the worktree.
+      // checkout cannot be preserved either way (the link itself goes with the worktree), so
+      // refuse to archive rather than report success for uploads that will not come back.
       const realSourceDir = await this.resolveContainedRealPath(
         args.projectRepo.repoCwd,
         sourceDir
       );
       if (realSourceDir == null) {
-        continue;
+        throw new Error(
+          `Staged attachments at ${relativeDir} resolve outside the ${args.projectRepo.projectName} checkout.`
+        );
       }
       const repoRelativeDir = path.relative(args.projectRepo.repoCwd, sourceDir);
 
       const artifactRelativeDir = path.join(args.projectRepo.storageKey, repoRelativeDir);
-      const artifactDir = path.join(args.sessionDir, ATTACHMENTS_DIR_NAME, artifactRelativeDir);
+      const tempArtifactDir = path.join(args.tempAttachmentsDir, artifactRelativeDir);
       assert(
-        isPathInsideDir(args.sessionDir, artifactDir),
-        `captureStagedAttachments: artifact path escaped session dir (${artifactDir})`
+        isPathInsideDir(args.sessionDir, tempArtifactDir),
+        `captureStagedAttachments: artifact path escaped session dir (${tempArtifactDir})`
       );
-      await fsPromises.cp(realSourceDir, artifactDir, { recursive: true });
+      await fsPromises.cp(realSourceDir, tempArtifactDir, { recursive: true });
       captured.push({
         repoRelativeDir,
         artifactPath: path.join(ATTACHMENTS_DIR_NAME, artifactRelativeDir),
       });
     }
     return captured.length > 0 ? captured : undefined;
+  }
+
+  /**
+   * Replaces exactly the entries this capture produced, so a stale copy at the same path (from a
+   * failed capture or a downgrade cycle) cannot resurrect a deleted upload, while entries the
+   * snapshot does not own are left alone.
+   */
+  private async commitStagedAttachmentArtifacts(args: {
+    sessionDir: string;
+    tempAttachmentsDir: string;
+    projects: WorktreeArchiveSnapshotProject[];
+  }): Promise<void> {
+    for (const project of args.projects) {
+      for (const entry of project.stagedAttachmentDirs ?? []) {
+        const artifactDir = this.resolveSessionRelativePath(args.sessionDir, entry.artifactPath);
+        const tempArtifactDir = path.join(
+          args.tempAttachmentsDir,
+          path.relative(ATTACHMENTS_DIR_NAME, entry.artifactPath)
+        );
+        await fsPromises.rm(artifactDir, { recursive: true, force: true });
+        await fsPromises.mkdir(path.dirname(artifactDir), { recursive: true });
+        await fsPromises.rename(tempArtifactDir, artifactDir);
+      }
+    }
   }
 
   private async restoreStagedAttachments(args: {

--- a/src/node/services/worktreeArchiveSnapshotService.ts
+++ b/src/node/services/worktreeArchiveSnapshotService.ts
@@ -50,19 +50,25 @@ const NOOP_INIT_LOGGER: InitLogger = {
 
 type CaptureSnapshotForArchiveError = string | ArchiveLossyUntrackedFilesConfirmation;
 
-const STAGED_ATTACHMENT_CONTAINERS = new Set(
-  STAGED_ATTACHMENT_DIRS.map((dir) => dir.split("/")[0])
+// Container directory name to the staged attachment directory inside it (".xum" -> "user-attachments").
+const STAGED_ATTACHMENT_CONTAINERS = new Map(
+  STAGED_ATTACHMENT_DIRS.map((dir) => {
+    const [container, ...rest] = dir.split("/");
+    return [container, rest.join("/")] as const;
+  })
 );
 
-/** Matches `--directory` entries (trailing slash) named like a staged-attachment container. */
-function isStagedAttachmentContainer(untrackedPath: string): boolean {
+/**
+ * For a `git ls-files --directory` entry (trailing slash) named like a staged-attachment container,
+ * the entry its staged attachment directory would produce in the same listing.
+ */
+function stagedAttachmentDirInContainer(untrackedPath: string): string | null {
   const segments = untrackedPath.replace(/\\/gu, "/").split("/");
-  const directoryName = segments.at(-2);
-  return (
-    segments.at(-1) === "" &&
-    directoryName != null &&
-    STAGED_ATTACHMENT_CONTAINERS.has(directoryName)
-  );
+  if (segments.at(-1) !== "") {
+    return null;
+  }
+  const child = STAGED_ATTACHMENT_CONTAINERS.get(segments.at(-2) ?? "");
+  return child == null ? null : `${untrackedPath}${child}/`;
 }
 
 interface CreatedRestoreWorkspace {
@@ -771,12 +777,50 @@ export class WorktreeArchiveSnapshotService {
     const untrackedPaths = await listOthers([]);
     // `--directory` reports a directory whose only contents are ignored, which is exactly what
     // the staged-attachment container (`.xum/`, whose exclude targets the child directory) looks
-    // like. Those uploads are captured by captureStagedAttachments, so drop the container when
-    // it holds nothing else; every other entry keeps the existing lossy-data warning.
+    // like. Drop it only when those ignored contents are the uploads captureStagedAttachments
+    // preserves; anything else ignored in there (e.g. a workspace MCP override) is still lost
+    // with the worktree and keeps the warning, as does every other entry.
     const nonEmptyPaths = new Set(await listOthers(["--no-empty-directory"]));
-    return untrackedPaths
-      .filter((line) => nonEmptyPaths.has(line) || !isStagedAttachmentContainer(line))
-      .sort();
+    const lossyPaths: string[] = [];
+    for (const untrackedPath of untrackedPaths) {
+      if (
+        !nonEmptyPaths.has(untrackedPath) &&
+        (await this.holdsOnlyStagedAttachments(repoCwd, untrackedPath))
+      ) {
+        continue;
+      }
+      lossyPaths.push(untrackedPath);
+    }
+    return lossyPaths.sort();
+  }
+
+  private async holdsOnlyStagedAttachments(
+    repoCwd: string,
+    containerPath: string
+  ): Promise<boolean> {
+    const stagedDir = stagedAttachmentDirInContainer(containerPath);
+    if (stagedDir == null) {
+      return false;
+    }
+    const ignoredEntries = (
+      await this.gitStdout(repoCwd, [
+        "ls-files",
+        "--others",
+        "--ignored",
+        "--exclude-standard",
+        "--directory",
+        "--",
+        containerPath,
+      ])
+    )
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && line !== containerPath);
+    // A symlinked staging directory lists without the trailing slash; it is captured by contents.
+    return (
+      ignoredEntries.length > 0 &&
+      ignoredEntries.every((entry) => entry === stagedDir || `${entry}/` === stagedDir)
+    );
   }
 
   private async ensureNoUnsupportedUntrackedFiles(repoCwd: string): Promise<void> {

--- a/src/node/services/worktreeArchiveSnapshotService.ts
+++ b/src/node/services/worktreeArchiveSnapshotService.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import type { Dirent } from "node:fs";
 import * as fsPromises from "node:fs/promises";
 import * as path from "node:path";
 
@@ -35,7 +36,8 @@ const SNAPSHOT_VERSION = 1;
 const SNAPSHOT_DIR_NAME = "archive-state";
 // Kept outside SNAPSHOT_DIR_NAME on purpose: an older build restoring a newer snapshot ignores
 // stagedAttachmentDirs and deletes archive-state, so a sibling directory keeps the only copy of
-// the uploads recoverable across a downgrade instead of destroying it.
+// the uploads recoverable across a downgrade instead of destroying it. Entries are only ever
+// merged in and removed individually, so such orphans survive later captures and restores too.
 const ATTACHMENTS_DIR_NAME = "archive-attachments";
 const SNAPSHOT_METADATA_FILE_NAME = "metadata.json";
 const NOOP_INIT_LOGGER: InitLogger = {
@@ -260,16 +262,14 @@ export class WorktreeArchiveSnapshotService {
 
     const sessionDir = path.join(this.config.sessionsDir, args.workspaceId);
     const stateDir = path.join(sessionDir, SNAPSHOT_DIR_NAME);
-    const attachmentsDir = path.join(sessionDir, ATTACHMENTS_DIR_NAME);
-    const tempSuffix = `.tmp-${Date.now()}-${Math.random().toString(16).slice(2)}`;
-    const tempStateDir = path.join(sessionDir, `${SNAPSHOT_DIR_NAME}${tempSuffix}`);
-    const tempAttachmentsDir = path.join(sessionDir, `${ATTACHMENTS_DIR_NAME}${tempSuffix}`);
+    const tempStateDir = path.join(
+      sessionDir,
+      `${SNAPSHOT_DIR_NAME}.tmp-${Date.now()}-${Math.random().toString(16).slice(2)}`
+    );
 
     await fsPromises.mkdir(sessionDir, { recursive: true });
     await fsPromises.rm(tempStateDir, { recursive: true, force: true });
     await fsPromises.mkdir(tempStateDir, { recursive: true });
-    await fsPromises.rm(tempAttachmentsDir, { recursive: true, force: true });
-    await fsPromises.mkdir(tempAttachmentsDir, { recursive: true });
 
     try {
       const projectRepos = getWorkspaceProjectRepos({
@@ -389,7 +389,6 @@ export class WorktreeArchiveSnapshotService {
           workspaceName,
           projectRepo,
           sessionDir,
-          attachmentsDir: tempAttachmentsDir,
         });
 
         projectSnapshots.push({
@@ -419,12 +418,6 @@ export class WorktreeArchiveSnapshotService {
         JSON.stringify(snapshot, null, 2),
         "utf-8"
       );
-      // Attachments land first so the metadata rename (the commit point) never references
-      // artifacts that are not in place yet.
-      await fsPromises.rm(attachmentsDir, { recursive: true, force: true });
-      if (projectSnapshots.some((project) => project.stagedAttachmentDirs != null)) {
-        await fsPromises.rename(tempAttachmentsDir, attachmentsDir);
-      }
       await fsPromises.rm(stateDir, { recursive: true, force: true });
       await fsPromises.rename(tempStateDir, stateDir);
 
@@ -433,7 +426,6 @@ export class WorktreeArchiveSnapshotService {
       return Err(`Failed to capture archive snapshot: ${getErrorMessage(error)}`);
     } finally {
       await fsPromises.rm(tempStateDir, { recursive: true, force: true });
-      await fsPromises.rm(tempAttachmentsDir, { recursive: true, force: true });
     }
   }
 
@@ -960,14 +952,15 @@ export class WorktreeArchiveSnapshotService {
   /**
    * Chat uploads are staged into git-excluded `.xum/user-attachments` (legacy `.mux/`) under the
    * workspace execution path, so the tracked-diff artifacts above never see them. Copy them into
-   * the snapshot so persisted chat/draft paths still resolve after the checkout is recreated.
+   * the session dir so persisted chat/draft paths still resolve after the checkout is recreated.
+   * Copies are merged into the existing artifact tree rather than replacing it (see
+   * ATTACHMENTS_DIR_NAME), so a failed capture leaves nothing a later one would not rewrite.
    */
   private async captureStagedAttachments(args: {
     workspaceMetadata: WorkspaceMetadata;
     workspaceName: string;
     projectRepo: WorkspaceProjectRepo;
     sessionDir: string;
-    attachmentsDir: string;
   }): Promise<WorktreeArchiveSnapshotProject["stagedAttachmentDirs"]> {
     const runtime = createRuntime(args.workspaceMetadata.runtimeConfig, {
       projectPath: args.projectRepo.projectPath,
@@ -985,21 +978,25 @@ export class WorktreeArchiveSnapshotService {
       if (!(await this.isExistingDirectory(sourceDir))) {
         continue;
       }
-      // A repo-controlled symlink (e.g. a tracked `.xum`) can point the staging directory outside
-      // the checkout; whatever lives there is not removed with the worktree, so leave it alone.
-      if (!(await this.realPathIsInsideDir(args.projectRepo.repoCwd, sourceDir))) {
+      // Copy from the resolved path: a symlinked staging directory must yield its contents, not
+      // a link that dangles once the worktree is gone. A repo-controlled link that leaves the
+      // checkout is skipped; whatever lives there is not removed with the worktree.
+      const realSourceDir = await this.resolveContainedRealPath(
+        args.projectRepo.repoCwd,
+        sourceDir
+      );
+      if (realSourceDir == null) {
         continue;
       }
       const repoRelativeDir = path.relative(args.projectRepo.repoCwd, sourceDir);
 
-      // Written under the temp attachments dir, recorded under its final name (like writeArtifact).
       const artifactRelativeDir = path.join(args.projectRepo.storageKey, repoRelativeDir);
-      const artifactDir = path.join(args.attachmentsDir, artifactRelativeDir);
+      const artifactDir = path.join(args.sessionDir, ATTACHMENTS_DIR_NAME, artifactRelativeDir);
       assert(
         isPathInsideDir(args.sessionDir, artifactDir),
         `captureStagedAttachments: artifact path escaped session dir (${artifactDir})`
       );
-      await fsPromises.cp(sourceDir, artifactDir, { recursive: true });
+      await fsPromises.cp(realSourceDir, artifactDir, { recursive: true });
       captured.push({
         repoRelativeDir,
         artifactPath: path.join(ATTACHMENTS_DIR_NAME, artifactRelativeDir),
@@ -1033,10 +1030,12 @@ export class WorktreeArchiveSnapshotService {
       }
       // repoRelativeDir comes from user-editable config and its ancestors from the repo, so the
       // copy target is checked through symlinks, not just lexically.
-      const targetDir = path.resolve(args.workspacePath, entry.repoRelativeDir);
+      const targetDir = await this.resolveContainedRealPath(
+        args.workspacePath,
+        path.join(args.workspacePath, entry.repoRelativeDir)
+      );
       assert(
-        targetDir !== path.resolve(args.workspacePath) &&
-          (await this.realPathIsInsideDir(args.workspacePath, targetDir)),
+        targetDir != null,
         `restoreStagedAttachments: refusing to restore outside ${args.workspacePath}`
       );
       await fsPromises.cp(artifactDir, targetDir, { recursive: true });
@@ -1069,23 +1068,52 @@ export class WorktreeArchiveSnapshotService {
   }
 
   /**
-   * Symlink-aware containment: resolves the deepest existing ancestor of targetPath so a link
-   * anywhere above it cannot redirect reads or writes outside rootDir.
+   * Symlink-aware containment: resolves targetPath through its deepest existing ancestor and
+   * returns that real path, or null when it is not strictly inside rootDir, so a link anywhere
+   * above the target cannot redirect reads or writes outside rootDir.
    */
-  private async realPathIsInsideDir(rootDir: string, targetPath: string): Promise<boolean> {
-    let existing = path.resolve(targetPath);
+  private async resolveContainedRealPath(
+    rootDir: string,
+    targetPath: string
+  ): Promise<string | null> {
+    const absoluteTarget = path.resolve(targetPath);
+    let existing = absoluteTarget;
     while (!(await this.pathExists(existing))) {
       const parent = path.dirname(existing);
       if (parent === existing) {
-        return false;
+        return null;
       }
       existing = parent;
     }
     const realTarget = path.join(
       await fsPromises.realpath(existing),
-      path.relative(existing, path.resolve(targetPath))
+      path.relative(existing, absoluteTarget)
     );
-    return isPathInsideDir(await fsPromises.realpath(rootDir), realTarget);
+    const realRoot = await fsPromises.realpath(rootDir);
+    return realTarget !== realRoot && isPathInsideDir(realRoot, realTarget) ? realTarget : null;
+  }
+
+  /** Removes directories under root that hold nothing but empty directories, root included. */
+  private async pruneEmptyDirs(root: string): Promise<boolean> {
+    let entries: Dirent[];
+    try {
+      entries = await fsPromises.readdir(root, { withFileTypes: true });
+    } catch (error) {
+      if (isErrnoWithCode(error, "ENOENT")) {
+        return true;
+      }
+      throw error;
+    }
+    let empty = true;
+    for (const entry of entries) {
+      if (!entry.isDirectory() || !(await this.pruneEmptyDirs(path.join(root, entry.name)))) {
+        empty = false;
+      }
+    }
+    if (empty) {
+      await fsPromises.rmdir(root);
+    }
+    return empty;
   }
 
   private async writeArtifact(args: {
@@ -1114,10 +1142,15 @@ export class WorktreeArchiveSnapshotService {
     const sessionDir = path.join(this.config.sessionsDir, workspaceId);
     const stateDir = this.resolveSessionRelativePath(sessionDir, snapshot.stateDirPath);
     await fsPromises.rm(stateDir, { recursive: true, force: true });
-    await fsPromises.rm(path.join(sessionDir, ATTACHMENTS_DIR_NAME), {
-      recursive: true,
-      force: true,
-    });
+    for (const project of snapshot.projects) {
+      for (const entry of project.stagedAttachmentDirs ?? []) {
+        await fsPromises.rm(this.resolveSessionRelativePath(sessionDir, entry.artifactPath), {
+          recursive: true,
+          force: true,
+        });
+      }
+    }
+    await this.pruneEmptyDirs(path.join(sessionDir, ATTACHMENTS_DIR_NAME));
 
     await this.config.editConfig((config) => {
       const workspaceEntry = findWorkspaceEntryByIdOrPath(this.config, config, workspaceId);


### PR DESCRIPTION
## Summary

Snapshot archives (the `snapshot` worktree archive behavior) capture only git-visible state before removing the managed worktree, so chat uploads staged into the git-excluded `.xum/user-attachments` directory were silently lost: after unarchive, persisted chat/draft attachment paths pointed at files that no longer existed. The snapshot now copies those directories into the session dir at capture time and restores them into the recreated checkout.

Fixes #3947

## Background

`WorkspaceService.stageAttachment` writes uploads into `.xum/user-attachments` under the workspace execution path and excludes that directory through the worktree's `info/exclude`, so the agent can read them with ordinary filesystem tools. `WorktreeArchiveSnapshotService.captureSnapshotForArchive` only records a format-patch mailbox plus staged/unstaged diffs, and ignored paths never reach any of those. Origin: Codex round 19 P2 on #3940 (placement leg; #3940 closed the in-flight race).

## Implementation

Of the three directions in the issue, this takes option 2 (include the attachment directories in the snapshot) rather than moving staged writes into the session dir (option 1) or rewriting chat references at archive time (option 3):

- Staged paths are read by the agent through runtime tools (`bash`, `file_read`) inside the workspace runtime. For SSH, Coder, Docker and devcontainer workspaces the session dir lives on the xum host, not on the runtime, so attachments have to stay inside the checkout there. Option 1 would need runtime-conditional placement plus a compat story for every persisted `.xum/user-attachments/...` reference (chat notices, drafts, fork copies, download). Option 3 rewrites persisted chat history.
- Option 2 keeps every persisted path stable, so there is nothing to migrate, and it follows the existing artifact conventions in the snapshot service (session-relative artifact paths recorded as optional fields in `WorktreeArchiveSnapshotProjectSchema`, written under a temp dir and renamed with the metadata).
- Snapshot archives only ever delete single-project worktrees (the after-archive hook skips multi-project checkouts), so the capture runs per project repo and resolves the staging root the same way staging does (`appendSubProjectRelativePath`), which also covers sub-project workspaces.

Capture copies each existing `.xum/user-attachments` (and legacy `.mux/user-attachments`) directory (resolved through symlinks, so a linked staging directory yields its contents rather than a link that dangles once the worktree is gone) into `<sessionDir>/archive-attachments/<storageKey>/<repo-relative dir>` and records `{ repoRelativeDir, artifactPath }` entries in the new optional `stagedAttachmentDirs` field. Entries are written to a temp dir and each one atomically replaces the same path in that tree before the metadata is committed; clearing a snapshot removes only the entries it references (empty parents pruned). A staging directory that resolves outside the checkout, or one containing a symlink, fails the capture: the link would be lost with the worktree and the payload could not be restored. Persisted `repoRelativeDir` values must name a `.xum`/`.mux` staged attachment directory and `artifactPath` values must resolve (through symlinks) inside a real `archive-attachments/` directory; a malformed entry is skipped with a warning (its artifact left in place for manual recovery) instead of blocking every unarchive, and a symlinked artifact root is treated as absent so nothing outside the session dir is read or deleted. Temp directories left by an interrupted capture are swept at the start of the next one. Restore copies them back after the patch replay and re-runs `ensureGitInfoExclude`, because the recreated worktree starts with an empty `info/exclude` and the uploads would otherwise surface as untracked files. The existing-checkout fast path (git state already matches the snapshot) restores missing uploads before the snapshot is cleared. A referenced artifact that is missing on a fresh restore fails it like the existing patch artifacts do (checkout cleaned up, snapshot kept for retry); a stat failure other than ENOENT/ENOTDIR aborts capture instead of treating the directory as absent; and the restore target is checked through symlinks (deepest existing ancestor realpath) so a repo-controlled link cannot redirect the copy outside the checkout.

`listUnsupportedUntrackedFiles` drops a `.xum/` or `.mux/` container entry only when the directory holds nothing but the staged attachment directory the snapshot now preserves (checked on the filesystem, since git lists neither ignored files nor empty directories). `git ls-files --others --directory` reports a directory whose contents are all ignored, so every workspace with a staged attachment triggered the "lossy untracked files" confirmation for `.xum/`; anything else in there (for example an ignored workspace MCP override or an empty directory) is still lost with the worktree and keeps the warning, as do empty directories elsewhere.

Upgrade/downgrade: the snapshot version stays 1 and the new field is optional. The attachment copies deliberately live beside `archive-state`, not inside it: an older build restoring a newer snapshot ignores the field and deletes `archive-state`, so keeping the uploads in a sibling directory means the downgrade restores the checkout exactly as that build always did (without attachments) while the copies stay recoverable instead of being destroyed. A newer build restoring an older snapshot sees no field and skips the step. Because entries are replaced and removed individually, copies stranded by such a downgrade cycle are neither deleted by a later capture of other paths nor by clearing a snapshot that does not reference them; they stay in the session dir until the workspace is deleted or a later capture of the same path supersedes them.

## Validation

- New `WorktreeArchiveSnapshotService` tests stage a real attachment through `stageWorkspaceAttachment`, capture, remove the worktree with git, restore, and assert the bytes are back at the same relative path with a clean `git status` (workspace root and sub-project execution path). Further cases: missing-artifact failure, reconciliation into an existing matching checkout, capture abort on an EACCES stat, refusal to restore through a tracked symlink that leaves the checkout, unreferenced copies surviving a snapshot clear, a stale same-path copy replaced while unrelated copies survive, capture refusal when the staging directory resolves outside the checkout, a symlinked staging directory captured by contents, empty directories still reported as lossy while an attachments-only `.xum/` is not, a `.xum/` holding another ignored file or an empty sibling directory still reported, a symlink inside the staged tree refusing capture, tampered `artifactPath`/`repoRelativeDir` metadata neither deleting session files nor writing into tracked directories (and not blocking the restore), a symlinked artifact root never being written through or deleted through, and stale capture temp directories being swept. Each guard was verified red first by removing it.

## Risks

Low. The change is confined to the snapshot capture/restore path and only adds work when an attachment directory exists. The lossy-untracked filter only affects `.xum/` and `.mux/` entries whose ignored contents are exactly the captured uploads, so it removes a misleading warning, not data.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$8.42`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=8.42 -->
