### PR TITLE
🤖 fix: pair workspace MCP server lifecycle with archive gating

### DIFF
--- a/src/node/services/agentPlugins/workspacePluginOperations.test.ts
+++ b/src/node/services/agentPlugins/workspacePluginOperations.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { ORPCContext } from "@/node/orpc/context";
+import { Ok } from "@/common/types/result";
+import { listWorkspaceMcpPrompts } from "./workspacePluginOperations";
+
+const workspaceId = "ws-mcp-prompts";
+const metadata = {
+  id: workspaceId,
+  name: "ws",
+  projectName: "proj",
+  projectPath: "/tmp/proj",
+  runtimeConfig: { type: "local" as const, srcBaseDir: "/tmp" },
+};
+
+function createContext(options: {
+  admission: Disposable | undefined;
+  getPromptsForWorkspace: () => Promise<never[]>;
+}) {
+  const waitForInit = mock(() => Promise.resolve());
+  const ensureReady = mock(() => Promise.resolve({ ready: true as const }));
+  const getPromptsForWorkspace = mock(options.getPromptsForWorkspace);
+  const context = {
+    workspaceService: {
+      acquireMcpPromptDiscoveryAdmission: mock(() => options.admission),
+    },
+    initStateManager: { waitForInit },
+    aiService: {
+      getWorkspaceMetadata: mock(() => Promise.resolve(Ok(metadata))),
+      createWorkspaceRuntimeContext: mock(() =>
+        Ok({ runtime: { ensureReady }, workspacePath: "/tmp/proj/ws", hostCheckoutRoot: undefined })
+      ),
+    },
+    workspaceMcpOverridesService: {
+      getOverridesForWorkspace: mock(() => Promise.resolve({ overrides: {}, revision: "r1" })),
+    },
+    secretsStore: { getEffectiveSecrets: mock(() => []) },
+    config: { loadConfigOrDefault: mock(() => ({ projects: new Map() })) },
+    mcpServerManager: { getPromptsForWorkspace },
+  } as unknown as ORPCContext;
+  return { context, waitForInit, ensureReady, getPromptsForWorkspace };
+}
+
+describe("listWorkspaceMcpPrompts archive admission", () => {
+  test("refused discovery returns an empty catalog without readying the runtime", async () => {
+    // Mid-archive (or archived) discovery must not reconnect the runtime: ensureReady would
+    // re-wake a stopped Coder workspace and server startup would spawn stdio processes inside a
+    // checkout the archive is removing.
+    const fixture = createContext({
+      admission: undefined,
+      getPromptsForWorkspace: () => Promise.reject(new Error("should not start servers")),
+    });
+
+    expect(await listWorkspaceMcpPrompts(fixture.context, workspaceId)).toEqual([]);
+
+    expect(fixture.waitForInit).not.toHaveBeenCalled();
+    expect(fixture.ensureReady).not.toHaveBeenCalled();
+    expect(fixture.getPromptsForWorkspace).not.toHaveBeenCalled();
+  });
+
+  test("admitted discovery holds its admission until server startup settles", async () => {
+    let releaseStartup: () => void = () => undefined;
+    const startupGate = new Promise<never[]>((resolve) => {
+      releaseStartup = () => resolve([]);
+    });
+    let markStartupReached: () => void = () => undefined;
+    const startupReached = new Promise<void>((resolve) => {
+      markStartupReached = resolve;
+    });
+    const dispose = mock(() => undefined);
+    const fixture = createContext({
+      admission: { [Symbol.dispose]: dispose },
+      getPromptsForWorkspace: () => {
+        markStartupReached();
+        return startupGate;
+      },
+    });
+
+    const discovery = listWorkspaceMcpPrompts(fixture.context, workspaceId);
+    // Park inside getPromptsForWorkspace: the admission acquired at entry is still held, so
+    // an archive gate consulting the counter sees the in-flight startup.
+    await startupReached;
+    expect(fixture.ensureReady).toHaveBeenCalledTimes(1);
+    expect(dispose).not.toHaveBeenCalled();
+
+    releaseStartup();
+    expect(await discovery).toEqual([]);
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/node/services/agentPlugins/workspacePluginOperations.ts
+++ b/src/node/services/agentPlugins/workspacePluginOperations.ts
@@ -70,6 +70,12 @@ export async function listWorkspaceMcpPrompts(
   workspaceId: string,
   signal?: AbortSignal
 ) {
+  // Archive admission pairing (see WorkspaceService.acquireMcpPromptDiscoveryAdmission): held
+  // through ensureReady and server startup below, both of which would otherwise re-wake a
+  // stopped Coder workspace or start stdio servers inside a checkout the archive is removing.
+  // Discovery degrades to an empty catalog instead of erroring, like file completions.
+  using admission = context.workspaceService.acquireMcpPromptDiscoveryAdmission(workspaceId);
+  if (admission === undefined) return [];
   await context.initStateManager.waitForInit(workspaceId, signal);
   const metadataResult = await context.aiService.getWorkspaceMetadata(workspaceId);
   if (!metadataResult.success) throw new Error(metadataResult.error);
@@ -86,7 +92,9 @@ export async function listWorkspaceMcpPrompts(
       ? mergeMultiProjectSecrets(metadata, context.secretsStore)
       : context.secretsStore.getEffectiveSecrets(metadata.projectPath)
   );
-  return context.mcpServerManager.getPromptsForWorkspace(
+  // `return await`, not `return`: `using` disposes at block exit, and a bare returned promise
+  // would release the admission before server startup settles.
+  return await context.mcpServerManager.getPromptsForWorkspace(
     {
       workspaceId,
       projectPath: metadata.projectPath,

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -58,6 +58,7 @@ import { makeAgentTaskIntegrationFake } from "./taskWorkspaceSeam.testUtils";
 import type { BackgroundProcessManager } from "./backgroundProcessManager";
 import type { TerminalService } from "@/node/services/terminalService";
 import type { DesktopSessionManager } from "@/node/services/desktop/DesktopSessionManager";
+import type { MCPServerManager } from "@/node/services/mcpServerManager";
 import type { WorktreeArchiveSnapshot } from "@/common/schemas/project";
 import type { BashToolResult } from "@/common/types/tools";
 import type { SendMessageOptions, WorkspaceChatMessage } from "@/common/orpc/types";
@@ -15443,6 +15444,20 @@ describe("WorkspaceService archive lifecycle hooks", () => {
       expect(refused.error).toContain("workflow run");
     }
 
+    // MCP prompt discovery admitted before the hold pairs the same way: its counter refuses
+    // the hold before any delegated turn is interrupted.
+    const discovery = workspaceService.acquireMcpPromptDiscoveryAdmission(workspaceId);
+    expect(discovery).toBeDefined();
+    const refusedByDiscovery = workspaceService.acquirePreInterruptionArchiveHold(workspaceId, {
+      queuedDelegatedTurnCount: 0,
+      expectedDelegatedTurnCorrelations: [],
+    });
+    expect(refusedByDiscovery.success).toBe(false);
+    if (!refusedByDiscovery.success) {
+      expect(refusedByDiscovery.error).toContain("MCP prompt discovery in progress");
+    }
+    discovery![Symbol.dispose]();
+
     // In-flight editor/terminal opens are visible only through the pending-open counters
     // until their durable markers persist; the hold must refuse on them before the caller
     // interrupts anything (the sink's untrackable-app check would refuse only afterwards).
@@ -15475,6 +15490,7 @@ describe("WorkspaceService archive lifecycle hooks", () => {
       if (!refusedOpen.success) {
         expect(refusedOpen.error).toContain("being archived");
       }
+      expect(workspaceService.acquireMcpPromptDiscoveryAdmission(workspaceId)).toBeUndefined();
     } finally {
       hold.data[Symbol.dispose]();
     }
@@ -16353,6 +16369,102 @@ describe("WorkspaceService archive snapshots", () => {
     });
   });
 
+  test("archive() stops cached MCP servers before snapshot capture", async () => {
+    const order: string[] = [];
+    const stopServers = mock(
+      (_workspaceId: string, _options?: { retainRestartOptions?: boolean }) => {
+        order.push("stop-mcp");
+        return Promise.resolve();
+      }
+    );
+    workspaceService.setMCPServerManager({ stopServers } as unknown as MCPServerManager);
+    const snapshot = {
+      version: 1 as const,
+      capturedAt: "2026-03-30T00:00:00.000Z",
+      stateDirPath: "archive-state",
+      projects: [],
+    };
+    workspaceService.setWorktreeArchiveSnapshotService({
+      preflightSnapshotForArchive: mock(() => Promise.resolve(Ok(undefined))),
+      captureSnapshotForArchive: mock(() => {
+        order.push("capture");
+        return Promise.resolve(Ok(snapshot));
+      }),
+      restoreSnapshotAfterUnarchive: mock(() => Promise.resolve(Ok("skipped" as const))),
+      getUnsupportedUntrackedPaths: mock(() => Promise.resolve(Ok([]))),
+    });
+
+    const result = await workspaceService.archive(workspaceId);
+
+    expect(result).toEqual(Ok({ kind: "archived" }));
+    // Removal-style stop (no retainRestartOptions) so its stop epoch retires in-flight startups.
+    expect(stopServers).toHaveBeenCalledWith(workspaceId);
+    expect(order).toEqual(["stop-mcp", "capture"]);
+  });
+
+  test("in-flight MCP prompt discovery holds the model-facing archive gate until released", async () => {
+    workspaceService.setWorktreeArchiveSnapshotService({
+      preflightSnapshotForArchive: mock(() => Promise.resolve(Ok(undefined))),
+      captureSnapshotForArchive: mock(() => Promise.resolve(Err("unused"))),
+      restoreSnapshotAfterUnarchive: mock(() => Promise.resolve(Ok("skipped" as const))),
+      getUnsupportedUntrackedPaths: mock(() => Promise.resolve(Ok([]))),
+    });
+
+    const admission = workspaceService.acquireMcpPromptDiscoveryAdmission(workspaceId);
+    expect(admission).toBeDefined();
+
+    const refused = await workspaceService.archive(workspaceId, undefined, {
+      refuseLiveUserActivity: true,
+    });
+    expect(refused.success).toBe(false);
+    if (!refused.success) {
+      expect(refused.error).toContain("an MCP prompt discovery in progress");
+    }
+    expect(configState.projects.get(projectPath)?.workspaces[0]?.archivedAt).toBeUndefined();
+
+    admission![Symbol.dispose]();
+
+    const afterRelease = await workspaceService.archive(workspaceId, undefined, {
+      refuseLiveUserActivity: true,
+    });
+    if (!afterRelease.success) {
+      expect(afterRelease.error).not.toContain("MCP prompt discovery");
+    }
+  });
+
+  test("acquireMcpPromptDiscoveryAdmission refuses archiving and archived workspaces", () => {
+    addToArchivingWorkspaces(workspaceService, workspaceId);
+    expect(workspaceService.acquireMcpPromptDiscoveryAdmission(workspaceId)).toBeUndefined();
+
+    // Discovery on an archived workspace would re-wake its runtime; refuse it durably too.
+    const archivedService = createWorkspaceServiceForTest({
+      config: {
+        srcDir: "/tmp/src",
+        sessionsDir: "/tmp/test/sessions",
+        loadConfigOrDefault: mock(() => ({
+          projects: new Map([
+            [
+              projectPath,
+              {
+                workspaces: [
+                  {
+                    path: workspacePath,
+                    id: workspaceId,
+                    name: "ws-archive-snapshot",
+                    archivedAt: "2026-01-01T00:00:00.000Z",
+                  },
+                ],
+              },
+            ],
+          ]),
+        })),
+      } as unknown as Config,
+      historyService,
+    });
+    expect(archivedService.acquireMcpPromptDiscoveryAdmission(workspaceId)).toBeUndefined();
+    expect(archivedService.acquireMcpPromptDiscoveryAdmission("ws-other")).toBeDefined();
+  });
+
   test("archive() does not close live sessions when archive readiness checks fail", async () => {
     const closeWorkspaceSessions = mock(() => undefined);
     workspaceService.setTerminalService({
@@ -16365,6 +16477,9 @@ describe("WorkspaceService archive snapshots", () => {
       close: closeDesktopSession,
       setWorkspaceArchiveGuard: () => undefined,
     } as unknown as DesktopSessionManager);
+
+    const stopServers = mock(() => Promise.resolve());
+    workspaceService.setMCPServerManager({ stopServers } as unknown as MCPServerManager);
 
     const captureSnapshotForArchive = mock(() => Promise.resolve(Err("should not run")));
     workspaceService.setWorktreeArchiveSnapshotService({
@@ -16380,6 +16495,7 @@ describe("WorkspaceService archive snapshots", () => {
     expect(captureSnapshotForArchive).not.toHaveBeenCalled();
     expect(closeWorkspaceSessions).not.toHaveBeenCalled();
     expect(closeDesktopSession).not.toHaveBeenCalled();
+    expect(stopServers).not.toHaveBeenCalled();
   });
 
   test("archive() skips snapshot capture for multi-project workspaces", async () => {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -2264,6 +2264,10 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
   // re-wake a stopped Coder workspace). See acquirePreflightAdmission.
   private readonly preflightStagingCounts = new Map<string, number>();
   private readonly preflightFileCompletionCounts = new Map<string, number>();
+  // Same pairing for renderer MCP prompt discovery (workspace.mcp.prompts.list): it readies the
+  // runtime (which can re-wake a stopped Coder workspace) and starts cached stdio servers inside
+  // the checkout. See acquireMcpPromptDiscoveryAdmission.
+  private readonly preflightMcpPromptDiscoveryCounts = new Map<string, number>();
   /**
    * In-flight forks counted per SOURCE workspace. A fork clones the source checkout and (for
    * SSH/Coder runtimes) shares its remote workspace, so a model-driven archive admitted
@@ -3397,6 +3401,13 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
 
     // Archiving hides workspace UI; do not leave terminal PTYs running headless.
     this.terminalService?.closeWorkspaceSessions(workspaceId);
+
+    // Cached MCP servers outlive the stream that started them, and stdio ones run inside the
+    // checkout a snapshot archive is about to delete. Removal-style stop (no
+    // retainRestartOptions): its stop-epoch bump makes a startup already in flight close its late
+    // clients instead of publishing them; servers restart lazily on the first MCP use after
+    // unarchive.
+    await this.mcpServerManager?.stopServers(workspaceId);
   }
 
   /**
@@ -8506,6 +8517,9 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
     if ((this.preflightForkCounts.get(workspaceId) ?? 0) > 0) {
       activityLabels.push("a fork of this workspace in progress");
     }
+    if ((this.preflightMcpPromptDiscoveryCounts.get(workspaceId) ?? 0) > 0) {
+      activityLabels.push("an MCP prompt discovery in progress");
+    }
     // In-flight native-terminal/editor opens passed their own archive guards before this
     // hold armed and surface only through the pending-open counters until their durable
     // markers persist; the sink's untrackable-app check would refuse on them after the
@@ -8616,6 +8630,9 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
         }
         if ((this.preflightForkCounts.get(workspaceId) ?? 0) > 0) {
           activityLabels.push("a fork of this workspace in progress");
+        }
+        if ((this.preflightMcpPromptDiscoveryCounts.get(workspaceId) ?? 0) > 0) {
+          activityLabels.push("an MCP prompt discovery in progress");
         }
         if (liveActivity.queuedMessages) activityLabels.push("queued messages");
         if (liveActivity.backgroundBashProcesses) {
@@ -10778,6 +10795,30 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
         }
       },
     };
+  }
+
+  /**
+   * Archive admission pairing for MCP prompt discovery (workspace.mcp.prompts.list), which
+   * readies the runtime and starts cached stdio servers outside any stream. The guard check and
+   * the counter increment run in one synchronous block, mirroring executeBash: a discovery
+   * admitted first holds the archive gate open until the caller disposes the admission, and one
+   * entering after the gate armed (or against an archived workspace) is refused with undefined.
+   */
+  acquireMcpPromptDiscoveryAdmission(workspaceId: string): Disposable | undefined {
+    if (this.archivingWorkspaces.has(workspaceId)) {
+      return undefined;
+    }
+    const workspaceEntry = findWorkspaceEntry(this.config.loadConfigOrDefault(), workspaceId);
+    if (
+      workspaceEntry != null &&
+      isWorkspaceArchived(
+        workspaceEntry.workspace.archivedAt,
+        workspaceEntry.workspace.unarchivedAt
+      )
+    ) {
+      return undefined;
+    }
+    return this.acquirePreflightAdmission(this.preflightMcpPromptDiscoveryCounts, workspaceId);
   }
 
   async stageAttachment(input: {


### PR DESCRIPTION
## Summary

Model-driven archives (`task_workspace_lifecycle`, `refuseLiveUserActivity`) now pair with the workspace MCP server lifecycle: MCP prompt discovery (`workspace.mcp.prompts.list`) participates in the archive admission gate like bash, staging, and file completions, and archive stops the workspace's cached MCP servers before snapshot capture instead of leaving stdio processes running under a checkout it is about to delete.

Fixes #3946

## Background

#3940 paired archive admission with streams, sends, queued turns, background bash, terminals, desktop sessions, workflows, executeBash, attachment staging, and file-completion refreshes, but not MCP (Codex round 19 P2). Two consequences:

- Only workspace **removal** called `stopServers`; a snapshot archive deleted the managed worktree beneath a cached stdio MCP server, losing post-snapshot writes.
- `listWorkspaceMcpPrompts` had no archive guard at all: entering mid-archive (or against an already archived workspace) it called `runtime.ensureReady()` and started servers, which can re-wake a Coder workspace the archive just stopped.

## Implementation

- `WorkspaceService.acquireMcpPromptDiscoveryAdmission(workspaceId)`: the established synchronous-entry pattern (`archivingWorkspaces` + archived-entry check, then `acquirePreflightAdmission` on a new `preflightMcpPromptDiscoveryCounts` counter). Both gate sites (`archiveUnlocked` under `refuseLiveUserActivity` and `acquirePreInterruptionArchiveHold`) report "an MCP prompt discovery in progress".
- `listWorkspaceMcpPrompts` takes the admission with `using` before `waitForInit`/`ensureReady` and returns `[]` when refused (degrades to empty like file completions; the composer already tolerates both). The final call is `return await` on purpose: `using` disposes at block exit, so a bare returned promise would release the admission before server startup settled (the new operation-level test caught exactly this).
- `stopLiveWorkspaceActivityForArchive` adds a removal-style `mcpServerManager.stopServers(workspaceId)` after the stream interrupt and terminal close. Snapshot archives therefore stop servers before capture and checkout deletion; non-snapshot archives stop them after `archivedAt` persists (same place the stream is stopped). Removal-style (no `retainRestartOptions`) so the stop-epoch bump makes a startup already in flight close its late clients instead of publishing them; servers restart lazily on the first MCP use after unarchive.

Scope note: like the other preflight counters, the admission only refuses model-driven archives. A user-driven archive racing an in-flight discovery proceeds; the epoch bump covers startups already past the gate, and new discovery against the archiving/archived workspace is refused synchronously.

## Validation

- Red-green: removing the archive-time `stopServers` call and the gate check fails the two new `WorkspaceService` tests; restoring passes them.
- `tests/ipc/config/mcpPrompts.test.ts` (real router + WorkspaceService path, 5 tests) passes, so the admission does not disturb normal discovery.
- `workspaceService`, `workspaceTurnManager`, `mcpServerManager`, and the new `workspacePluginOperations` unit files: 732 pass. `make static-check` green.

## Risks

Low. The new gate label only fires under `refuseLiveUserActivity`; user archives are unchanged apart from stopping MCP servers, which already happens on idle timeout and removal and which streams cannot observe (the gate refuses live streams, and user archives interrupt the stream first).

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$7.91`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=7.91 -->
