### PR TITLE
🤖 fix: avoid local-agent warning flashes for sub-agents

### DIFF
--- a/scripts/check_codex_comments_test.py
+++ b/scripts/check_codex_comments_test.py
@@ -141,6 +141,17 @@ else:
                         cache=data if cached else None,
                     )
 
+    def test_auto_triggered_security_heading_does_not_hide_findings(self):
+        header = "### 🛡️ Codex Security Review · _Automatically triggered_\n\n"
+        clean = FIXTURES["security_no_findings"]["body"]
+        for body, expected in (
+            (clean, 0),
+            (clean + "\n\n[P1] A security issue still needs fixing.", 1),
+            ("Security review completed. Found a P1 credential disclosure.", 1),
+        ):
+            with self.subTest(body=body):
+                self.assert_gate(expected, snapshot([comment(header + body)]))
+
     def test_summary_completion_requires_metadata_and_every_review_row(self):
         completed = FIXTURES["summary"]["body"]
         completed_pr_opened = (

--- a/scripts/lib/codex_comments.jq
+++ b/scripts/lib/codex_comments.jq
@@ -4,7 +4,8 @@
 # Strip only the observed help text: a heading alone must not hide a finding
 # added inside the details section, or a second section appended after it.
 def codex_without_help:
-  rtrimstr("\n\n<details> <summary>ℹ️ About Codex in GitHub</summary>\n<br/>\n\n"
+  ltrimstr("### 🛡️ Codex Security Review · _Automatically triggered_\n\n")
+  | rtrimstr("\n\n<details> <summary>ℹ️ About Codex in GitHub</summary>\n<br/>\n\n"
     + "[Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you\n"
     + "- Open a pull request for review\n- Mark a draft as ready\n- Comment \"@codex review\" or \"@codex security review\".\n\n"
     + "Codex reacts with 👀 while any review is running, comments if it has suggestions, and reacts with 👍 once all reviews finish with no findings.\n\n</details>")

--- a/src/browser/components/ConcurrentLocalWarning/ConcurrentLocalWarning.test.tsx
+++ b/src/browser/components/ConcurrentLocalWarning/ConcurrentLocalWarning.test.tsx
@@ -11,16 +11,16 @@ import { WORKSPACE_STREAMING_STATUS_TRANSITION_MS } from "@/constants/streaming"
 import { useConcurrentLocalStreamingWorkspaceName } from "./ConcurrentLocalWarning";
 
 const subscribers = new Set<() => void>();
-let canInterrupt = true;
+const streamingWorkspaceIds = new Set<string>();
 
 const fakeStore = {
   subscribeKey: (_workspaceId: string, listener: () => void) => {
     subscribers.add(listener);
     return () => subscribers.delete(listener);
   },
-  getWorkspaceSidebarState: () => {
+  getWorkspaceSidebarState: (workspaceId: string) => {
     const state: WorkspaceSidebarState = {
-      canInterrupt,
+      canInterrupt: streamingWorkspaceIds.has(workspaceId),
       isStarting: false,
       awaitingUserQuestion: false,
       lastAbortReason: null,
@@ -47,11 +47,16 @@ const otherWorkspaceMetadata: FrontendWorkspaceMetadata = {
   namedWorkspacePath: "/repo",
   runtimeConfig: { type: "local" },
 };
-const workspaceMetadata = new Map([[otherWorkspaceMetadata.id, otherWorkspaceMetadata]]);
+const currentWorkspaceMetadata: FrontendWorkspaceMetadata = {
+  ...otherWorkspaceMetadata,
+  id: "current-workspace",
+  name: "current",
+};
+const workspaceMetadata = new Map<string, FrontendWorkspaceMetadata>();
 
-function WarningNameProbe() {
+function WarningNameProbe(props: { workspaceId?: string }) {
   const streamingWorkspaceName = useConcurrentLocalStreamingWorkspaceName({
-    workspaceId: "current-workspace",
+    workspaceId: props.workspaceId ?? currentWorkspaceMetadata.id,
     projectPath: "/repo",
     runtimeConfig: { type: "local" },
   });
@@ -71,7 +76,11 @@ describe("ConcurrentLocalWarning", () => {
   beforeEach(() => {
     cleanupDom = installDom();
     subscribers.clear();
-    canInterrupt = true;
+    streamingWorkspaceIds.clear();
+    streamingWorkspaceIds.add(otherWorkspaceMetadata.id);
+    workspaceMetadata.clear();
+    workspaceMetadata.set(currentWorkspaceMetadata.id, currentWorkspaceMetadata);
+    workspaceMetadata.set(otherWorkspaceMetadata.id, otherWorkspaceMetadata);
     spyOn(WorkspaceStoreModule, "useWorkspaceStoreRaw").mockReturnValue(fakeStore);
     spyOn(WorkspaceContextModule, "useWorkspaceContext").mockReturnValue({
       workspaceMetadata,
@@ -86,12 +95,93 @@ describe("ConcurrentLocalWarning", () => {
     subscribers.clear();
   });
 
+  test.each([
+    ["child", undefined, "current-workspace"],
+    ["parent", "other-workspace", undefined],
+    ["sibling with an absent parent row", "parent", "parent"],
+    ["nested child", undefined, "current-child"],
+    ["cousin", "current-child", "other-child"],
+  ])(
+    "does not flash for an active %s in the same task family",
+    (_label, currentParent, otherParent) => {
+      workspaceMetadata.set(currentWorkspaceMetadata.id, {
+        ...currentWorkspaceMetadata,
+        parentWorkspaceId: currentParent,
+      });
+      workspaceMetadata.set(otherWorkspaceMetadata.id, {
+        ...otherWorkspaceMetadata,
+        parentWorkspaceId: otherParent,
+      });
+      workspaceMetadata.set("current-child", {
+        ...currentWorkspaceMetadata,
+        id: "current-child",
+        parentWorkspaceId: currentParent ? "root" : currentWorkspaceMetadata.id,
+      });
+      workspaceMetadata.set("other-child", {
+        ...otherWorkspaceMetadata,
+        id: "other-child",
+        parentWorkspaceId: "root",
+      });
+
+      const result = render(<WarningNameProbe />);
+      expect(result.queryByText(otherWorkspaceMetadata.name)).toBeNull();
+      act(() => {
+        streamingWorkspaceIds.clear();
+        notifyWorkspaceStateChanged();
+        streamingWorkspaceIds.add(otherWorkspaceMetadata.id);
+        notifyWorkspaceStateChanged();
+      });
+      expect(result.queryByText(otherWorkspaceMetadata.name)).toBeNull();
+    }
+  );
+
+  test("still warns for an unrelated task family's active sub-agent", () => {
+    workspaceMetadata.set(otherWorkspaceMetadata.id, {
+      ...otherWorkspaceMetadata,
+      parentWorkspaceId: "unrelated-root",
+    });
+    const result = render(<WarningNameProbe />);
+    expect(result.getByText(otherWorkspaceMetadata.name)).toBeTruthy();
+  });
+
+  test.each([
+    { projectPath: "/other-repo" },
+    { runtimeConfig: { type: "worktree" as const, srcBaseDir: "/worktrees" } },
+    { runtimeConfig: { type: "local" as const, srcBaseDir: "/legacy-worktrees" } },
+  ])("does not warn about an isolated or different project: %j", (override) => {
+    workspaceMetadata.set(otherWorkspaceMetadata.id, { ...otherWorkspaceMetadata, ...override });
+    const result = render(<WarningNameProbe />);
+    expect(result.queryByText(otherWorkspaceMetadata.name)).toBeNull();
+  });
+
+  test("terminates safely on a malformed parent cycle", () => {
+    workspaceMetadata.set(otherWorkspaceMetadata.id, {
+      ...otherWorkspaceMetadata,
+      parentWorkspaceId: otherWorkspaceMetadata.id,
+    });
+    const result = render(<WarningNameProbe />);
+    expect(result.getByText(otherWorkspaceMetadata.name)).toBeTruthy();
+  });
+
+  test("does not carry a warning into the active agent's own sub-agent", () => {
+    workspaceMetadata.set("child", {
+      ...currentWorkspaceMetadata,
+      id: "child",
+      parentWorkspaceId: otherWorkspaceMetadata.id,
+    });
+    const result = render(<WarningNameProbe />);
+    expect(result.getByText(otherWorkspaceMetadata.name)).toBeTruthy();
+
+    result.rerender(<WarningNameProbe workspaceId="child" />);
+    expect(result.queryByText(otherWorkspaceMetadata.name)).toBeNull();
+  });
+
   test("holds the warning across a brief activity handoff", async () => {
     const result = render(<WarningNameProbe />);
     expect(result.getByText("refactor-db")).toBeTruthy();
 
     act(() => {
-      canInterrupt = false;
+      streamingWorkspaceIds.clear();
       notifyWorkspaceStateChanged();
     });
 

--- a/src/browser/components/ConcurrentLocalWarning/ConcurrentLocalWarning.test.tsx
+++ b/src/browser/components/ConcurrentLocalWarning/ConcurrentLocalWarning.test.tsx
@@ -95,39 +95,25 @@ describe("ConcurrentLocalWarning", () => {
     subscribers.clear();
   });
 
-  test.each([
-    ["child", undefined, "current-workspace"],
-    ["parent", "other-workspace", undefined],
-    ["sibling with an absent parent row", "parent", "parent"],
-    ["nested child", undefined, "current-child"],
-    ["cousin", "current-child", "other-child"],
-  ])(
-    "does not flash for an active %s in the same task family",
-    (_label, currentParent, otherParent) => {
+  test.each([undefined, "root"])(
+    "does not flash for a same-family stream with archived ancestry (root=%s)",
+    (rootWorkspaceId) => {
       workspaceMetadata.set(currentWorkspaceMetadata.id, {
         ...currentWorkspaceMetadata,
-        parentWorkspaceId: currentParent,
+        rootWorkspaceId,
       });
       workspaceMetadata.set(otherWorkspaceMetadata.id, {
         ...otherWorkspaceMetadata,
-        parentWorkspaceId: otherParent,
+        parentWorkspaceId: "archived-parent",
+        rootWorkspaceId: rootWorkspaceId ?? currentWorkspaceMetadata.id,
       });
-      workspaceMetadata.set("current-child", {
-        ...currentWorkspaceMetadata,
-        id: "current-child",
-        parentWorkspaceId: currentParent ? "root" : currentWorkspaceMetadata.id,
-      });
-      workspaceMetadata.set("other-child", {
-        ...otherWorkspaceMetadata,
-        id: "other-child",
-        parentWorkspaceId: "root",
-      });
-
       const result = render(<WarningNameProbe />);
       expect(result.queryByText(otherWorkspaceMetadata.name)).toBeNull();
       act(() => {
         streamingWorkspaceIds.clear();
         notifyWorkspaceStateChanged();
+      });
+      act(() => {
         streamingWorkspaceIds.add(otherWorkspaceMetadata.id);
         notifyWorkspaceStateChanged();
       });
@@ -139,6 +125,7 @@ describe("ConcurrentLocalWarning", () => {
     workspaceMetadata.set(otherWorkspaceMetadata.id, {
       ...otherWorkspaceMetadata,
       parentWorkspaceId: "unrelated-root",
+      rootWorkspaceId: "unrelated-root",
     });
     const result = render(<WarningNameProbe />);
     expect(result.getByText(otherWorkspaceMetadata.name)).toBeTruthy();
@@ -154,20 +141,12 @@ describe("ConcurrentLocalWarning", () => {
     expect(result.queryByText(otherWorkspaceMetadata.name)).toBeNull();
   });
 
-  test("terminates safely on a malformed parent cycle", () => {
-    workspaceMetadata.set(otherWorkspaceMetadata.id, {
-      ...otherWorkspaceMetadata,
-      parentWorkspaceId: otherWorkspaceMetadata.id,
-    });
-    const result = render(<WarningNameProbe />);
-    expect(result.getByText(otherWorkspaceMetadata.name)).toBeTruthy();
-  });
-
   test("does not carry a warning into the active agent's own sub-agent", () => {
     workspaceMetadata.set("child", {
       ...currentWorkspaceMetadata,
       id: "child",
       parentWorkspaceId: otherWorkspaceMetadata.id,
+      rootWorkspaceId: otherWorkspaceMetadata.id,
     });
     const result = render(<WarningNameProbe />);
     expect(result.getByText(otherWorkspaceMetadata.name)).toBeTruthy();

--- a/src/browser/components/ConcurrentLocalWarning/ConcurrentLocalWarning.tsx
+++ b/src/browser/components/ConcurrentLocalWarning/ConcurrentLocalWarning.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useSyncExternalStore } from "react";
+import React, { useRef, useSyncExternalStore } from "react";
 import { AlertTriangle } from "lucide-react";
 import { useWorkspaceContext } from "@/browser/contexts/WorkspaceContext";
 import { useWorkspaceStoreRaw } from "@/browser/stores/WorkspaceStore";
@@ -26,60 +26,57 @@ export function useConcurrentLocalStreamingWorkspaceName(
   const { workspaceMetadata } = useWorkspaceContext();
   const store = useWorkspaceStoreRaw();
 
-  const otherLocalWorkspaceIds = useMemo(() => {
-    if (!isLocalProject) {
-      return [];
+  // Sub-agents share their family's checkout intentionally, not as competing local agents.
+  const getRootWorkspaceId = (id: string): string => {
+    const visited = new Set<string>();
+    while (!visited.has(id)) {
+      visited.add(id);
+      const parentId = workspaceMetadata.get(id)?.parentWorkspaceId;
+      if (!parentId) break;
+      id = parentId;
     }
+    return id;
+  };
+  const rootWorkspaceId = getRootWorkspaceId(props.workspaceId);
+  const otherLocalWorkspaces = Array.from(workspaceMetadata.values()).filter(
+    (meta) =>
+      isLocalProject &&
+      meta.projectPath === props.projectPath &&
+      isLocalProjectRuntime(meta.runtimeConfig) &&
+      getRootWorkspaceId(meta.id) !== rootWorkspaceId
+  );
 
-    const result: string[] = [];
-    for (const [id, meta] of workspaceMetadata) {
-      if (id === props.workspaceId) {
-        continue;
-      }
-      if (meta.projectPath !== props.projectPath) {
-        continue;
-      }
-      if (!isLocalProjectRuntime(meta.runtimeConfig)) {
-        continue;
-      }
-      result.push(id);
-    }
-    return result;
-  }, [isLocalProject, props.projectPath, props.workspaceId, workspaceMetadata]);
-
-  const streamingWorkspaceName = useSyncExternalStore(
+  const streamingWorkspaceId = useSyncExternalStore(
     (listener) => {
-      const unsubscribers = otherLocalWorkspaceIds.map((id) => store.subscribeKey(id, listener));
+      const unsubscribers = otherLocalWorkspaces.map((meta) =>
+        store.subscribeKey(meta.id, listener)
+      );
       return () => unsubscribers.forEach((unsubscribe) => unsubscribe());
     },
-    () => {
-      for (const id of otherLocalWorkspaceIds) {
+    () =>
+      otherLocalWorkspaces.find((meta) => {
         try {
-          const state = store.getWorkspaceSidebarState(id);
-          if (state.canInterrupt) {
-            const meta = workspaceMetadata.get(id);
-            return meta?.name ?? id;
-          }
+          return store.getWorkspaceSidebarState(meta.id).canInterrupt;
         } catch {
           // Workspace may not be registered yet, skip.
+          return false;
         }
-      }
-      return null;
-    },
+      })?.id ?? null,
     () => null
   );
-  const lastStreamingWorkspaceNameRef = useRef(streamingWorkspaceName);
-  if (streamingWorkspaceName !== null) {
-    lastStreamingWorkspaceNameRef.current = streamingWorkspaceName;
+  const lastStreamingIdRef = useRef(streamingWorkspaceId);
+  if (streamingWorkspaceId !== null) {
+    lastStreamingIdRef.current = streamingWorkspaceId;
   }
   const { displayPhase } = useWorkspaceStreamingStatusPhase(
-    streamingWorkspaceName === null ? null : "streaming"
+    streamingWorkspaceId === null ? null : "streaming"
   );
 
-  // Activity snapshots can hand off through a brief idle frame between adjacent stream phases.
-  // Hold the last concrete workspace name for the same transition window used by sidebar status,
-  // so the warning does not blink while the underlying agent is still visibly working elsewhere.
-  return displayPhase === null ? null : lastStreamingWorkspaceNameRef.current;
+  // Hold brief activity handoffs only while the workspace is still a potential conflict.
+  // Resolve the held identity against current candidates rather than retaining a stale name.
+  return displayPhase === null
+    ? null
+    : (otherLocalWorkspaces.find((meta) => meta.id === lastStreamingIdRef.current)?.name ?? null);
 }
 
 interface ConcurrentLocalWarningViewProps {

--- a/src/browser/components/ConcurrentLocalWarning/ConcurrentLocalWarning.tsx
+++ b/src/browser/components/ConcurrentLocalWarning/ConcurrentLocalWarning.tsx
@@ -27,23 +27,14 @@ export function useConcurrentLocalStreamingWorkspaceName(
   const store = useWorkspaceStoreRaw();
 
   // Sub-agents share their family's checkout intentionally, not as competing local agents.
-  const getRootWorkspaceId = (id: string): string => {
-    const visited = new Set<string>();
-    while (!visited.has(id)) {
-      visited.add(id);
-      const parentId = workspaceMetadata.get(id)?.parentWorkspaceId;
-      if (!parentId) break;
-      id = parentId;
-    }
-    return id;
-  };
-  const rootWorkspaceId = getRootWorkspaceId(props.workspaceId);
+  const rootWorkspaceId =
+    workspaceMetadata.get(props.workspaceId)?.rootWorkspaceId ?? props.workspaceId;
   const otherLocalWorkspaces = Array.from(workspaceMetadata.values()).filter(
     (meta) =>
       isLocalProject &&
       meta.projectPath === props.projectPath &&
       isLocalProjectRuntime(meta.runtimeConfig) &&
-      getRootWorkspaceId(meta.id) !== rootWorkspaceId
+      (meta.rootWorkspaceId ?? meta.id) !== rootWorkspaceId
   );
 
   const streamingWorkspaceId = useSyncExternalStore(
@@ -84,35 +75,29 @@ interface ConcurrentLocalWarningViewProps {
   className?: string;
 }
 
-export const ConcurrentLocalWarningView: React.FC<ConcurrentLocalWarningViewProps> = (props) => {
-  return (
-    <div
-      role="status"
-      className={cn("text-muted flex h-6 items-center gap-2 text-xs leading-none", props.className)}
-    >
-      <AlertTriangle aria-hidden="true" className="text-warning size-3.5 shrink-0" />
-      <span className="min-w-0 truncate">
-        <span className="text-foreground font-medium">{props.streamingWorkspaceName}</span> is also
-        running in this project directory — agents may interfere
-      </span>
-    </div>
-  );
-};
-
 export const ConcurrentLocalWarningDecoration: React.FC<ConcurrentLocalWarningViewProps> = (
   props
 ) => {
   const columnWidthClass = useChatDockColumnWidthClass();
-
   return (
     <div
       className={cn("bg-surface-primary", CHAT_DOCK_GUTTER_CLASS)}
       data-component="ConcurrentLocalWarningDecoration"
     >
-      <ConcurrentLocalWarningView
-        streamingWorkspaceName={props.streamingWorkspaceName}
-        className={cn(columnWidthClass, props.className)}
-      />
+      <div
+        role="status"
+        className={cn(
+          "text-muted flex h-6 items-center gap-2 text-xs leading-none",
+          columnWidthClass,
+          props.className
+        )}
+      >
+        <AlertTriangle aria-hidden="true" className="text-warning size-3.5 shrink-0" />
+        <span className="min-w-0 truncate">
+          <span className="text-foreground font-medium">{props.streamingWorkspaceName}</span> is
+          also running in this project directory — agents may interfere
+        </span>
+      </div>
     </div>
   );
 };

--- a/src/common/orpc/schemas/workspace.ts
+++ b/src/common/orpc/schemas/workspace.ts
@@ -286,6 +286,9 @@ export const WorkspaceMetadataSchema = z.object({
 });
 
 export const FrontendWorkspaceMetadataSchema = WorkspaceMetadataSchema.extend({
+  rootWorkspaceId: z.string().optional().meta({
+    description: "Task-family root derived from complete metadata, including archived ancestors.",
+  }),
   namedWorkspacePath: z
     .string()
     .meta({ description: "Worktree path (uses workspace name as directory)" }),

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -2831,6 +2831,57 @@ describe("Config", () => {
   });
 
   describe("getAllWorkspaceMetadata with migration", () => {
+    it.each([false, true])(
+      "derives task-family roots through archived rows and cycles (reversed=%s)",
+      async (reversed) => {
+        const projectPath = path.join(tempDir, "project");
+        const nodes = [
+          { id: "root" },
+          { id: "archived", parentWorkspaceId: "root", archivedAt: "2025-01-01T00:00:00.000Z" },
+          { id: "grandchild", parentWorkspaceId: "archived" },
+          { id: "sibling", parentWorkspaceId: "root" },
+          { id: "other-root" },
+          { id: "other-child", parentWorkspaceId: "other-root" },
+          { id: "orphan", parentWorkspaceId: "missing" },
+          { id: "cycle-a", parentWorkspaceId: "cycle-b" },
+          { id: "cycle-b", parentWorkspaceId: "cycle-a" },
+          { id: "cycle-tail", parentWorkspaceId: "cycle-b" },
+        ];
+        await config.editConfig((cfg) => {
+          cfg.projects.set(projectPath, {
+            workspaces: (reversed ? nodes.toReversed() : nodes).map((node) => ({
+              ...node,
+              name: node.id,
+              path: projectPath,
+              createdAt: "2025-01-01T00:00:00.000Z",
+              runtimeConfig: { type: "local" },
+            })),
+          });
+          return cfg;
+        });
+
+        const metadata = await new Config(tempDir).getAllWorkspaceMetadata();
+        expect(Object.fromEntries(metadata.map((row) => [row.id, row.rootWorkspaceId]))).toEqual({
+          root: "root",
+          archived: "root",
+          grandchild: "root",
+          sibling: "root",
+          "other-root": "other-root",
+          "other-child": "other-root",
+          orphan: "missing",
+          "cycle-a": "cycle-a",
+          "cycle-b": "cycle-a",
+          "cycle-tail": "cycle-a",
+        });
+        expect(
+          config
+            .loadConfigOrDefault()
+            .projects.get(projectPath)
+            ?.workspaces.every((row) => !("rootWorkspaceId" in row))
+        ).toBe(true);
+      }
+    );
+
     it("should migrate legacy workspace without metadata file", async () => {
       const projectPath = "/fake/project";
       const workspacePath = path.join(config.srcDir, "project", "feature-branch");

--- a/src/node/config/index.ts
+++ b/src/node/config/index.ts
@@ -3675,6 +3675,19 @@ export class Config {
       });
     }
 
+    // Derive family identity before archived rows are filtered out for the renderer.
+    const parentById = new Map(workspaceMetadata.map((meta) => [meta.id, meta.parentWorkspaceId]));
+    for (const metadata of workspaceMetadata) {
+      const chain: string[] = [];
+      let root = metadata.id;
+      while (parentById.get(root) && !chain.includes(root)) {
+        chain.push(root);
+        root = parentById.get(root)!;
+      }
+      // A malformed cycle gets one representative, even for descendants entering it.
+      const cycle = chain.indexOf(root);
+      metadata.rootWorkspaceId = cycle < 0 ? root : chain.slice(cycle).sort()[0];
+    }
     return workspaceMetadata;
   }
 


### PR DESCRIPTION
## Summary

Prevent the local-agent interference warning from flashing for coordinated sub-agents, while retaining it for unrelated local task families sharing the project directory. Follow-up UX fix after #4153.

## Implementation

- Derive frontend-only family roots during the existing bulk metadata load, before archived rows are filtered. Cycle members and incoming descendants share a deterministic representative; no extra IPC, disk reads, or persisted state.
- Compare those roots in the UI, excluding coordinated ancestors, descendants, siblings, and cousins while still warning about unrelated families' active sub-agents.
- Retain workspace identity rather than a display name during activity handoffs, and resolve it against current candidates so navigation into that agent's family cannot leave a stale warning.
- Replace manual memoized ID collection and repeated metadata lookup with filtered metadata and a direct active-workspace selection; inline the single-use warning view. No new timer or effect.
- In a separate CI compatibility commit, recognize Codex's observed automatic security-review heading without exempting actual findings.

## Validation

- Five same-family cases reproduced the false warning before the fix; a separate regression reproduced the held-warning leak when switching into the active agent's child.
- All 232 focused config/warning/workspace-family tests and 1,021 workspace/task service tests pass. Real-config tests cover archived ancestry, cycle members/incoming descendants in both input orders, unrelated trees, and non-persistence of derived roots.
- Codex gate tests reproduce the new-heading false positive and verify that explicit or appended security findings remain blocking.
- Headless Storybook-manager checks passed at 1140px and the existing pinned 375px phone viewport: one-line warning, ellipsis on phone, no horizontal overflow or composer displacement.
- Local `make static-check` passes.

## Subtractive ledger

**P1: 61 production lines added, 62 removed; net −1.** The warning fix is +59/−61 (net −2); the separate CI-format compatibility fix is +2/−1 (net +1). Removed frontend ancestry traversal, manual ID-list memoization, redundant metadata lookup/fallback, stale display-name retention, and a single-use view wrapper. Complete family scope is derived during the existing bulk metadata read, not synchronized through new state.

## Risks

This changes warning eligibility and adds an optional derived frontend metadata field, not task execution, isolation, or persisted config. Unrelated task trees still warn; existing activity smoothing and unregistered-workspace protection remain intact.

---

_Generated with `xum` • Model: `openai:gpt-6-astra` • Thinking: `xhigh` • Cost: `$63.33`_

<!-- mux-attribution: model=openai:gpt-6-astra thinking=xhigh costs=63.33 -->
