### PR TITLE
[xum] 🤖 feat: copy selected chat text as Markdown

### DIFF
--- a/src/browser/features/Messages/MarkdownComponents.tsx
+++ b/src/browser/features/Messages/MarkdownComponents.tsx
@@ -33,6 +33,9 @@ interface SummaryProps {
 }
 
 interface AnchorProps {
+  id?: string;
+  "data-footnote-ref"?: boolean;
+  "data-footnote-backref"?: boolean;
   href?: string;
   children?: ReactNode;
 }
@@ -321,7 +324,18 @@ function MarkdownAnchor(props: AnchorProps): ReactNode {
       : props.href;
 
   return (
-    <a href={normalizedHref} target="_blank" rel="noopener noreferrer">
+    <a
+      href={normalizedHref}
+      id={props.id}
+      data-footnote-ref={props["data-footnote-ref"]}
+      data-footnote-backref={props["data-footnote-backref"]}
+      target={
+        props["data-footnote-ref"] != null || props["data-footnote-backref"] != null
+          ? undefined
+          : "_blank"
+      }
+      rel="noopener noreferrer"
+    >
       {props.children}
     </a>
   );

--- a/src/browser/features/Messages/MarkdownComponents.tsx
+++ b/src/browser/features/Messages/MarkdownComponents.tsx
@@ -223,7 +223,7 @@ const CodeBlock: React.FC<CodeBlockProps> = ({ code, language, highlightLanguage
     <div
       className={`code-block-wrapper${isSingleLine ? " code-block-single-line" : ""}${showRunButton ? " code-block-runnable" : ""}`}
     >
-      <div className="code-block-container">
+      <div className="code-block-container" data-code-language={language}>
         {lines.map((content, idx) => (
           <React.Fragment key={idx}>
             <div className="line-number">{idx + 1}</div>

--- a/src/browser/features/Messages/MarkdownCore.tsx
+++ b/src/browser/features/Messages/MarkdownCore.tsx
@@ -175,10 +175,27 @@ const rehypePreserveUnknownRawHtml: Plugin<[], Root> = () => {
   };
 };
 
+function stripRawKatexClasses(parent: Root | Element): void {
+  for (const child of parent.children) {
+    if (child.type !== "element") continue;
+    const className = child.properties.className;
+    if (typeof className === "string" || Array.isArray(className)) {
+      const classes = typeof className === "string" ? className.split(/\s+/) : className;
+      child.properties.className = classes.filter((name) => !String(name).startsWith("katex"));
+    }
+    stripRawKatexClasses(child);
+  }
+}
+
+// SECURITY AUDIT: Raw HTML cannot claim KaTeX metadata that the clipboard trusts as rendered math.
+// Run before rehypeKatex so only the math renderer can create the reserved classes.
+const rehypeReserveKatexClasses: Plugin<[], Root> = () => stripRawKatexClasses;
+
 const REHYPE_PLUGINS: Pluggable[] = [
   rehypePreserveUnknownRawHtml,
   rehypeRaw, // Parse HTML elements first
   [rehypeSanitize, sanitizeSchema], // Sanitize HTML to prevent XSS (strips dangerous elements/attributes)
+  rehypeReserveKatexClasses,
   [
     harden, // Additional URL filtering for links and images
     {

--- a/src/browser/features/Messages/MarkdownCore.tsx
+++ b/src/browser/features/Messages/MarkdownCore.tsx
@@ -59,30 +59,7 @@ const sanitizeSchema = {
   ...defaultSchema,
   tagNames: [
     ...(defaultSchema.tagNames ?? []),
-    // KaTeX MathML elements
-    "math",
-    "mrow",
-    "mi",
-    "mo",
-    "mn",
-    "msup",
-    "msub",
-    "mfrac",
-    "munder",
-    "mover",
-    "mtable",
-    "mtr",
-    "mtd",
-    "mspace",
-    "mtext",
-    "semantics",
-    "annotation",
-    "munderover",
-    "msqrt",
-    "mroot",
-    "mpadded",
-    "mphantom",
-    "menclose",
+    // MathML comes only from rehypeKatex after sanitization, never from raw HTML.
     // Collapsible sections (GitHub-style)
     "details",
     "summary",
@@ -93,13 +70,9 @@ const sanitizeSchema = {
   },
   attributes: {
     ...defaultSchema.attributes,
-    // KaTeX uses style for coloring and positioning
-    span: [...(defaultSchema.attributes?.span ?? []), "style"],
-    // MathML elements need various attributes
-    math: ["xmlns", "display"],
-    annotation: ["encoding"],
-    // Allow class on all elements for styling
-    "*": [...(defaultSchema.attributes?.["*"] ?? []), "className", "class"],
+    // SECURITY AUDIT: Raw CSS can conceal copied text. Only semantic Markdown classes are allowed.
+    // KaTeX adds its trusted classes and styles after sanitization.
+    code: [["className", /^language-./, "math-inline", "math-display"]],
   },
 };
 
@@ -175,27 +148,10 @@ const rehypePreserveUnknownRawHtml: Plugin<[], Root> = () => {
   };
 };
 
-function stripRawKatexClasses(parent: Root | Element): void {
-  for (const child of parent.children) {
-    if (child.type !== "element") continue;
-    const className = child.properties.className;
-    if (typeof className === "string" || Array.isArray(className)) {
-      const classes = typeof className === "string" ? className.split(/\s+/) : className;
-      child.properties.className = classes.filter((name) => !String(name).startsWith("katex"));
-    }
-    stripRawKatexClasses(child);
-  }
-}
-
-// SECURITY AUDIT: Raw HTML cannot claim KaTeX metadata that the clipboard trusts as rendered math.
-// Run before rehypeKatex so only the math renderer can create the reserved classes.
-const rehypeReserveKatexClasses: Plugin<[], Root> = () => stripRawKatexClasses;
-
 const REHYPE_PLUGINS: Pluggable[] = [
   rehypePreserveUnknownRawHtml,
   rehypeRaw, // Parse HTML elements first
   [rehypeSanitize, sanitizeSchema], // Sanitize HTML to prevent XSS (strips dangerous elements/attributes)
-  rehypeReserveKatexClasses,
   [
     harden, // Additional URL filtering for links and images
     {

--- a/src/browser/features/Messages/MarkdownCore.tsx
+++ b/src/browser/features/Messages/MarkdownCore.tsx
@@ -148,10 +148,28 @@ const rehypePreserveUnknownRawHtml: Plugin<[], Root> = () => {
   };
 };
 
+// Sanitization prefixes IDs. Keep generated footnote links paired with those safe IDs.
+const rehypeFootnoteLinks: Plugin<[], Root> = () => (tree) => {
+  const visit = (node: Root | RootContent) => {
+    if (
+      node.type === "element" &&
+      node.tagName === "a" &&
+      (node.properties.dataFootnoteRef != null || node.properties.dataFootnoteBackref != null) &&
+      typeof node.properties.href === "string" &&
+      node.properties.href.startsWith("#")
+    ) {
+      node.properties.href = "#" + defaultSchema.clobberPrefix + node.properties.href.slice(1);
+    }
+    if ("children" in node) node.children.forEach(visit);
+  };
+  visit(tree);
+};
+
 const REHYPE_PLUGINS: Pluggable[] = [
   rehypePreserveUnknownRawHtml,
   rehypeRaw, // Parse HTML elements first
   [rehypeSanitize, sanitizeSchema], // Sanitize HTML to prevent XSS (strips dangerous elements/attributes)
+  rehypeFootnoteLinks,
   [
     harden, // Additional URL filtering for links and images
     {

--- a/src/browser/features/Messages/MarkdownRenderer.raw-html.test.tsx
+++ b/src/browser/features/Messages/MarkdownRenderer.raw-html.test.tsx
@@ -142,6 +142,48 @@ describe("MarkdownRenderer raw HTML handling", () => {
     expect(copied!.html).toContain('align="right"');
   });
 
+  test("safe raw blocks retain separate text boundaries when copied", () => {
+    const { copied } = copyRenderedMarkdown(
+      "<div>first</div><div>second</div><dl><dt>Term</dt><dd>Definition</dd></dl>"
+    );
+    const pasted = renderMarkdown(copied!.text);
+    expect(copied!.html).toContain("</div><div>");
+    expect(copied!.text).not.toContain("firstsecond");
+    expect(pasted.container.textContent).toContain("first");
+    expect(pasted.container.textContent).toContain("Definition");
+  });
+
+  test("row headers do not promote the first data row to a column header", () => {
+    const { copied } = copyRenderedMarkdown(
+      "<table><tr><th>One</th><td>A</td></tr><tr><th>Two</th><td>B</td></tr></table>"
+    );
+    const pasted = renderMarkdown(copied!.text);
+    expect(pasted.container.querySelector("thead")?.textContent?.trim()).toBe("");
+    expect(pasted.container.querySelector("tbody tr")?.textContent).toBe("OneA");
+  });
+
+  test("copying follows rendered numbering when unsupported reversed markup is stripped", () => {
+    const { view, copied } = copyRenderedMarkdown(
+      '<ol reversed start="5"><li>First</li><li>Second</li></ol>'
+    );
+    expect(view.container.querySelector("ol")?.hasAttribute("reversed")).toBe(false);
+    const pasted = renderMarkdown(copied!.text);
+    expect(pasted.container.querySelector("ol")?.start).toBe(5);
+    expect(copied!.html).toContain('start="5"');
+  });
+
+  test("right-clicking a rendered math SVG keeps the selected formula copyable", () => {
+    const { view } = copyRenderedMarkdown("$$\\sqrt{x}$$");
+    const target = view.container.querySelector(".katex svg path")!;
+    expect(target).not.toBeNull();
+    const copied = getTranscriptContextMenuMarkdown({
+      transcriptRoot: view.container,
+      target,
+      selection: window.getSelection(),
+    });
+    expect(copied?.text).toBe("$$\\sqrt{x}$$");
+  });
+
   test("closed disclosures do not copy their hidden body", () => {
     const { copied } = copyRenderedMarkdown(
       "<details><summary>Visible</summary><p>HIDDEN</p></details>"

--- a/src/browser/features/Messages/MarkdownRenderer.raw-html.test.tsx
+++ b/src/browser/features/Messages/MarkdownRenderer.raw-html.test.tsx
@@ -104,15 +104,38 @@ describe("MarkdownRenderer raw HTML handling", () => {
     expect(pasted.container.querySelector("li .katex annotation")?.textContent).toBe("x^2");
   });
 
-  test("rendered Mermaid fences survive copying and parsing", () => {
-    const chart = "graph TD\nA-->B";
-    const { copied } = copyRenderedMarkdown("```mermaid\n" + chart + "\n```");
+  test.each([true, false])("footnote selection ends at visible text (complete=%s)", (complete) => {
+    const { view } = copyRenderedMarkdown("Text[^note].\n\n[^note]: Definition **content**");
+    const quoteRoot = view.container.querySelector<HTMLElement>("[data-transcript-quote-root]")!;
+    const end = quoteRoot.querySelector('li [data-streamdown="strong"]')!.firstChild!;
+    const range = document.createRange();
+    range.setStart(quoteRoot, 0);
+    range.setEnd(end, end.textContent!.length - (complete ? 0 : 1));
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+    const copied = getTranscriptContextMenuMarkdown({
+      transcriptRoot: view.container,
+      target: quoteRoot,
+      selection,
+    })!;
     const rich = document.createElement("div");
-    rich.innerHTML = copied!.html;
-    expect(rich.querySelector("pre code.language-mermaid")?.textContent?.trim()).toBe(chart);
-    const pasted = renderMarkdown(copied!.text);
-    expect(pasted.container.querySelector(".mermaid-container")).not.toBeNull();
-    expect(pasted.container.querySelector(".code-block-container")).toBeNull();
+    rich.innerHTML = copied.html;
+    const pasted = renderMarkdown(copied.text);
+    for (const root of [rich, pasted.container]) {
+      const reference = root.querySelector("sup a[href]");
+      if (complete) {
+        const definition = Array.from(root.querySelectorAll("[id]")).find(
+          (element) => "#" + element.id === reference?.getAttribute("href")
+        );
+        expect(definition?.textContent).toContain("Definition content");
+        expect(definition?.querySelector("a")?.getAttribute("href")).toBe("#" + reference!.id);
+      } else {
+        expect(reference).toBeNull();
+        expect(root.textContent).toContain("Definition conten");
+        expect(root.textContent).not.toContain("Definition content");
+      }
+    }
   });
 
   test("forged Mermaid metadata cannot replace selected visible text", () => {

--- a/src/browser/features/Messages/MarkdownRenderer.raw-html.test.tsx
+++ b/src/browser/features/Messages/MarkdownRenderer.raw-html.test.tsx
@@ -43,7 +43,9 @@ describe("MarkdownRenderer raw HTML handling", () => {
     const view = render(
       <div data-transcript-message>
         <div data-transcript-quote-root>
-          <MarkdownRenderer content={content} />
+          <ThemeProvider forcedTheme="dark">
+            <MarkdownRenderer content={content} />
+          </ThemeProvider>
         </div>
       </div>
     );
@@ -60,6 +62,103 @@ describe("MarkdownRenderer raw HTML handling", () => {
     });
     return { view, copied };
   }
+
+  test("definition lists retain nested Markdown, math, and code after copying", () => {
+    const { copied } = copyRenderedMarkdown(
+      "<dl><dt>Term</dt><dd>\n\n$$x^2$$ and **bold**\n\n<dl><dt>Nested</dt><dd>\n\n```ts\nconst x = 1;\n```\n\n</dd></dl>\n\n</dd></dl>"
+    );
+    const pasted = renderMarkdown(copied!.text);
+    expect(pasted.container.querySelectorAll("dl")).toHaveLength(2);
+    expect(pasted.container.querySelector("dt")?.textContent?.trim()).toBe("Term");
+    expect(pasted.container.querySelector("dd .katex annotation")?.textContent).toBe("x^2");
+    expect(pasted.container.querySelector('dd [data-streamdown="strong"]')?.textContent).toBe(
+      "bold"
+    );
+    expect(pasted.container.querySelector("dd dd .code-line")?.textContent).toContain(
+      "const x = 1;"
+    );
+  });
+
+  test("footnotes retain forward links, repeated references, and backlinks in both formats", () => {
+    const { copied } = copyRenderedMarkdown(
+      "First[^note] and again[^note].\n\n[^note]: **Definition** with $$x^2$$."
+    );
+    const rich = document.createElement("div");
+    rich.innerHTML = copied!.html;
+    const pasted = renderMarkdown(copied!.text);
+    for (const root of [rich, pasted.container]) {
+      const references = root.querySelectorAll("sup a[href]");
+      expect(references).toHaveLength(2);
+      for (const reference of references) {
+        const target = Array.from(root.querySelectorAll("[id]")).find(
+          (element) => "#" + element.id === reference.getAttribute("href")
+        );
+        expect(target?.textContent).toContain("Definition");
+        expect(
+          Array.from(target!.querySelectorAll("a[href]")).some(
+            (backlink) => backlink.getAttribute("href") === "#" + reference.id
+          )
+        ).toBe(true);
+      }
+    }
+    expect(pasted.container.querySelector("li .katex annotation")?.textContent).toBe("x^2");
+  });
+
+  test("rendered Mermaid fences survive copying and parsing", () => {
+    const chart = "graph TD\nA-->B";
+    const { copied } = copyRenderedMarkdown("```mermaid\n" + chart + "\n```");
+    const rich = document.createElement("div");
+    rich.innerHTML = copied!.html;
+    expect(rich.querySelector("pre code.language-mermaid")?.textContent?.trim()).toBe(chart);
+    const pasted = renderMarkdown(copied!.text);
+    expect(pasted.container.querySelector(".mermaid-container")).not.toBeNull();
+    expect(pasted.container.querySelector(".code-block-container")).toBeNull();
+  });
+
+  test("forged Mermaid metadata cannot replace selected visible text", () => {
+    const { copied } = copyRenderedMarkdown(
+      '<div class="mermaid-container" data-mermaid-source="graph TD; hidden-->payload">Visible</div>'
+    );
+    const pasted = renderMarkdown(copied!.text);
+    expect(pasted.container.textContent).toBe("Visible");
+    expect(pasted.container.querySelector(".mermaid-container")).toBeNull();
+  });
+
+  test.each(["reference", "definition", "partial-definition"])(
+    "partial footnote selection has no broken links: %s",
+    (part) => {
+      const { view } = copyRenderedMarkdown("Text[^note].\n\n[^note]: Definition content.");
+      const quoteRoot = view.container.querySelector<HTMLElement>("[data-transcript-quote-root]")!;
+      const reference = quoteRoot.querySelector("sup")!;
+      const definition = quoteRoot.querySelector("li")!;
+      const range = document.createRange();
+      if (part === "reference") range.selectNodeContents(reference);
+      else if (part === "definition") range.selectNodeContents(definition);
+      else {
+        range.setStartBefore(reference);
+        range.setEnd(definition.querySelector("p")!.firstChild!, 10);
+      }
+      const selection = window.getSelection()!;
+      selection.removeAllRanges();
+      selection.addRange(range);
+      const copied = getTranscriptContextMenuMarkdown({
+        transcriptRoot: view.container,
+        target: quoteRoot,
+        selection,
+      })!;
+      const pasted = renderMarkdown(copied.text);
+      const rich = document.createElement("div");
+      rich.innerHTML = copied.html;
+      for (const root of [pasted.container, rich]) {
+        expect(root.querySelector('a[href^="#"]')).toBeNull();
+        expect(root.textContent).not.toContain("blocked");
+        expect(root.textContent).toContain(part === "definition" ? "Definition content." : "1");
+      }
+      if (part === "reference") expect(pasted.container.textContent).not.toContain("Definition");
+      if (part === "partial-definition")
+        expect(pasted.container.textContent).not.toContain("content.");
+    }
+  );
 
   test("raw HTML cannot substitute hidden TeX for selected visible text", () => {
     const { view, copied } = copyRenderedMarkdown(

--- a/src/browser/features/Messages/MarkdownRenderer.raw-html.test.tsx
+++ b/src/browser/features/Messages/MarkdownRenderer.raw-html.test.tsx
@@ -114,6 +114,34 @@ describe("MarkdownRenderer raw HTML handling", () => {
     ).toBe("x^2");
   });
 
+  test("spanning tables retain rendered math after copying", () => {
+    const { view, copied } = copyRenderedMarkdown(
+      '<table><tr><td colspan="2">\n\n$$x^2$$\n\n</td></tr></table>'
+    );
+    expect(view.container.querySelector("td .katex")).not.toBeNull();
+    const pasted = renderMarkdown(copied!.text);
+    expect(pasted.container.querySelector("td")?.getAttribute("colspan")).toBe("2");
+    expect(
+      pasted.container.querySelector('td .katex annotation[encoding="application/x-tex"]')
+        ?.textContent
+    ).toBe("x^2");
+    expect(copied!.text).not.toContain("data-clipboard-math");
+  });
+
+  test("GFM table alignment survives copying", () => {
+    const { copied } = copyRenderedMarkdown(
+      "| L | C | R |\n| :--- | :---: | ---: |\n| a | b | c |"
+    );
+    const pasted = renderMarkdown(copied!.text);
+    expect(
+      Array.from(
+        pasted.container.querySelectorAll("th"),
+        (cell) => cell.style.textAlign || cell.getAttribute("align")
+      )
+    ).toEqual(["left", "center", "right"]);
+    expect(copied!.html).toContain('align="right"');
+  });
+
   test("closed disclosures do not copy their hidden body", () => {
     const { copied } = copyRenderedMarkdown(
       "<details><summary>Visible</summary><p>HIDDEN</p></details>"

--- a/src/browser/features/Messages/MarkdownRenderer.raw-html.test.tsx
+++ b/src/browser/features/Messages/MarkdownRenderer.raw-html.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { installDom } from "../../../../tests/ui/dom";
 import { rawHtmlUsesOnlyAllowedTags } from "./MarkdownCore";
 import { MarkdownRenderer } from "./MarkdownRenderer";
+import { getTranscriptContextMenuMarkdown } from "@/browser/utils/messages/transcriptContextMenu";
 
 function renderMarkdown(content: string) {
   return render(<MarkdownRenderer content={content} preserveLineBreaks />);
@@ -31,6 +32,47 @@ describe("MarkdownRenderer raw HTML handling", () => {
     expect(view.container.textContent).toContain("<SignOutButton/>");
     expect(view.container.textContent).toContain("You can only pass a single child component");
     expect(view.container.querySelector("signoutbutton")).toBeNull();
+  });
+
+  function copyRenderedMarkdown(content: string) {
+    const view = render(
+      <div data-transcript-message>
+        <div data-transcript-quote-root>
+          <MarkdownRenderer content={content} />
+        </div>
+      </div>
+    );
+    const quoteRoot = view.container.querySelector<HTMLElement>("[data-transcript-quote-root]")!;
+    const range = document.createRange();
+    range.selectNodeContents(quoteRoot);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+    const copied = getTranscriptContextMenuMarkdown({
+      transcriptRoot: view.container,
+      target: quoteRoot,
+      selection,
+    });
+    return { view, copied };
+  }
+
+  test("raw HTML cannot substitute hidden TeX for selected visible text", () => {
+    const { view, copied } = copyRenderedMarkdown(
+      '<span class="katex"><span>Visible</span><span style="display:none"><math><semantics><annotation encoding="application/x-tex">HIDDEN PAYLOAD</annotation></semantics></math></span></span>'
+    );
+    expect(view.container.querySelector(".katex")).toBeNull();
+    expect(copied?.text).toBe("Visible");
+    expect(copied?.html).not.toContain("HIDDEN PAYLOAD");
+  });
+
+  test("genuine rendered math still copies and renders as math", () => {
+    const { view, copied } = copyRenderedMarkdown("$$x^2$$");
+    expect(view.container.querySelector(".katex")).not.toBeNull();
+    expect(copied?.text).toBe("$$x^2$$");
+    const pasted = renderMarkdown(copied!.text);
+    expect(
+      pasted.container.querySelector('.katex annotation[encoding="application/x-tex"]')?.textContent
+    ).toBe("x^2");
   });
 
   test("keeps supported collapsible HTML on the raw HTML path", () => {

--- a/src/browser/features/Messages/MarkdownRenderer.raw-html.test.tsx
+++ b/src/browser/features/Messages/MarkdownRenderer.raw-html.test.tsx
@@ -5,10 +5,15 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { installDom } from "../../../../tests/ui/dom";
 import { rawHtmlUsesOnlyAllowedTags } from "./MarkdownCore";
 import { MarkdownRenderer } from "./MarkdownRenderer";
+import { ThemeProvider } from "@/browser/contexts/ThemeContext";
 import { getTranscriptContextMenuMarkdown } from "@/browser/utils/messages/transcriptContextMenu";
 
 function renderMarkdown(content: string) {
-  return render(<MarkdownRenderer content={content} preserveLineBreaks />);
+  return render(
+    <ThemeProvider forcedTheme="dark">
+      <MarkdownRenderer content={content} preserveLineBreaks />
+    </ThemeProvider>
+  );
 }
 
 describe("MarkdownRenderer raw HTML handling", () => {
@@ -61,8 +66,17 @@ describe("MarkdownRenderer raw HTML handling", () => {
       '<span class="katex"><span>Visible</span><span style="display:none"><math><semantics><annotation encoding="application/x-tex">HIDDEN PAYLOAD</annotation></semantics></math></span></span>'
     );
     expect(view.container.querySelector(".katex")).toBeNull();
-    expect(copied?.text).toBe("Visible");
-    expect(copied?.html).not.toContain("HIDDEN PAYLOAD");
+    expect(view.container.querySelector("math, annotation")).toBeNull();
+    expect(view.container.textContent).toContain("HIDDEN PAYLOAD");
+    const pasted = renderMarkdown(copied!.text);
+    expect(pasted.container.querySelector("math, annotation, .katex")).toBeNull();
+    expect(pasted.container.textContent).toBe(view.container.textContent);
+  });
+
+  test("rendered Markdown emphasis survives copying", () => {
+    const { copied } = copyRenderedMarkdown("**bold** and *italic*");
+    expect(copied?.text).toBe("**bold** and _italic_");
+    expect(copied?.html).toBe("<p><strong>bold</strong> and <em>italic</em></p>");
   });
 
   test("genuine rendered math still copies and renders as math", () => {
@@ -73,6 +87,50 @@ describe("MarkdownRenderer raw HTML handling", () => {
     expect(
       pasted.container.querySelector('.katex annotation[encoding="application/x-tex"]')?.textContent
     ).toBe("x^2");
+  });
+
+  test.each([
+    'style="position:fixed;left:-10000px"',
+    'style="clip-path:inset(100%);opacity:0"',
+    'class="sr-only opacity-0"',
+  ])("raw CSS cannot conceal copied text: %s", (attributes) => {
+    const { view, copied } = copyRenderedMarkdown("<span " + attributes + ">Payload</span>");
+    const span = view.container.querySelector("span")!;
+    expect(span.getAttribute("style")).toBeNull();
+    expect(span.className).toBe("");
+    expect(copied?.text).toBe("Payload");
+  });
+
+  test("math inside an expanded disclosure survives copying and rendering", () => {
+    const { view, copied } = copyRenderedMarkdown(
+      "<details open>\n<summary>More</summary>\n\n$$x^2$$\n\n</details>"
+    );
+    expect(view.container.querySelector("details .katex")).not.toBeNull();
+    expect(copied?.text).not.toContain("data-clipboard-math");
+    const pasted = renderMarkdown(copied!.text);
+    expect(
+      pasted.container.querySelector('details .katex annotation[encoding="application/x-tex"]')
+        ?.textContent
+    ).toBe("x^2");
+  });
+
+  test("closed disclosures do not copy their hidden body", () => {
+    const { copied } = copyRenderedMarkdown(
+      "<details><summary>Visible</summary><p>HIDDEN</p></details>"
+    );
+    expect(copied?.text).toContain("Visible");
+    expect(copied?.text).not.toContain("HIDDEN");
+    expect(copied?.html).not.toContain("HIDDEN");
+  });
+
+  test("semantic task and code classes survive raw CSS removal", () => {
+    const view = renderMarkdown("- [x] done\n\n```typescript\nconst x = 1;\n```");
+    expect(view.container.querySelector<HTMLInputElement>('input[type="checkbox"]')?.checked).toBe(
+      true
+    );
+    expect(
+      view.container.querySelector(".code-block-container")?.getAttribute("data-code-language")
+    ).toBe("typescript");
   });
 
   test("keeps supported collapsible HTML on the raw HTML path", () => {

--- a/src/browser/features/Messages/Mermaid.test.tsx
+++ b/src/browser/features/Messages/Mermaid.test.tsx
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { GlobalWindow } from "happy-dom";
 import { StreamingContext } from "./StreamingContext";
 import { Mermaid, sanitizeMermaidSvg } from "./Mermaid";
+import { getTranscriptContextMenuMarkdown } from "@/browser/utils/messages/transcriptContextMenu";
+import MarkdownIt from "markdown-it";
 
 const DEFAULT_SVG =
   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10" /></svg>';
@@ -57,6 +59,61 @@ describe("Mermaid layout stability", () => {
     globalThis.HTMLElement = originalHTMLElement;
     mermaidParse.mockClear();
     mermaidRender.mockClear();
+  });
+
+  test("copies a selected textless diagram and excludes diagram controls", async () => {
+    const chart = "graph TD\nA-->B";
+    const view = render(
+      <div data-transcript-message>
+        <div data-transcript-quote-root>
+          <p>Before</p>
+          <Mermaid chart={chart} />
+          <p>After</p>
+        </div>
+      </div>
+    );
+    await waitFor(() =>
+      expect(view.container.querySelector(".mermaid-container svg")).not.toBeNull()
+    );
+    const diagram = view.container.querySelector(".mermaid-container")!;
+    const range = document.createRange();
+    range.selectNodeContents(diagram);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+    expect(selection.toString()).toBe("");
+    const options = {
+      transcriptRoot: view.container,
+      selection,
+      target: diagram.querySelector("rect"),
+    };
+    const copied = getTranscriptContextMenuMarkdown(options)!;
+    const parsed = document.createElement("div");
+    parsed.innerHTML = new MarkdownIt().render(copied.text);
+    expect(parsed.querySelector("code.language-mermaid")?.textContent?.trim()).toBe(chart);
+    expect(copied.html).not.toContain("svg");
+    expect(
+      getTranscriptContextMenuMarkdown({
+        ...options,
+        target: view.container.querySelector("button"),
+      })
+    ).toBeNull();
+
+    const first = view.container.querySelector("p")!;
+    range.setStart(first.firstChild!, 0);
+    range.setEndBefore(diagram.parentElement!);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    expect(getTranscriptContextMenuMarkdown({ ...options, target: first })?.text).toBe("Before");
+
+    range.setEndAfter(diagram.parentElement!);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    const mixed = getTranscriptContextMenuMarkdown({ ...options, target: first })!;
+    parsed.innerHTML = new MarkdownIt().render(mixed.text);
+    expect(parsed.querySelector("p")?.textContent).toBe("Before");
+    expect(parsed.querySelector("code.language-mermaid")?.textContent?.trim()).toBe(chart);
+    expect(parsed.textContent).not.toContain("After");
   });
 
   test("guest Escape cannot close an expanded host diagram", async () => {

--- a/src/browser/features/Messages/Mermaid.test.tsx
+++ b/src/browser/features/Messages/Mermaid.test.tsx
@@ -1,10 +1,12 @@
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { GlobalWindow } from "happy-dom";
 import { StreamingContext } from "./StreamingContext";
 import { Mermaid, sanitizeMermaidSvg } from "./Mermaid";
 import { getTranscriptContextMenuMarkdown } from "@/browser/utils/messages/transcriptContextMenu";
 import MarkdownIt from "markdown-it";
+import { MarkdownRenderer } from "./MarkdownRenderer";
+import { ThemeProvider } from "@/browser/contexts/ThemeContext";
 
 const DEFAULT_SVG =
   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10" /></svg>';
@@ -114,6 +116,61 @@ describe("Mermaid layout stability", () => {
     expect(parsed.querySelector("p")?.textContent).toBe("Before");
     expect(parsed.querySelector("code.language-mermaid")?.textContent?.trim()).toBe(chart);
     expect(parsed.textContent).not.toContain("After");
+  });
+
+  test("copies the displayed chart during pending and invalid streaming updates", async () => {
+    const first = "graph TD\nA-->B";
+    const next = "graph TD\nB-->C";
+    const renderContent = (chart: string) => (
+      <ThemeProvider forcedTheme="dark">
+        <StreamingContext.Provider value={{ isStreaming: true }}>
+          <div data-transcript-message>
+            <div data-transcript-quote-root>
+              <MarkdownRenderer content={"```mermaid\n" + chart + "\n```"} />
+            </div>
+          </div>
+        </StreamingContext.Provider>
+      </ThemeProvider>
+    );
+    const view = render(renderContent(first));
+    const copySource = () => {
+      const diagram = view.container.querySelector(".mermaid-container")!;
+      const range = document.createRange();
+      range.selectNodeContents(diagram);
+      const selection = window.getSelection()!;
+      selection.removeAllRanges();
+      selection.addRange(range);
+      const copied = getTranscriptContextMenuMarkdown({
+        transcriptRoot: view.container,
+        selection,
+        target: diagram,
+      })!;
+      const parsed = document.createElement("div");
+      parsed.innerHTML = new MarkdownIt().render(copied.text);
+      return parsed.querySelector("code.language-mermaid")?.textContent?.trim();
+    };
+    await waitFor(() => expect(view.container.querySelector("svg")).not.toBeNull());
+    expect(copySource()).toBe(first);
+    const pending = Promise.withResolvers<void>();
+    mermaidParse.mockImplementation(() => pending.promise);
+    view.rerender(renderContent(next));
+    expect(copySource()).toBe(first);
+    await waitFor(() => expect(mermaidParse).toHaveBeenCalledWith(next + "\n"));
+    expect(copySource()).toBe(first);
+    await act(async () => {
+      pending.reject(new Error("Incomplete diagram"));
+      await pending.promise.catch(() => undefined);
+    });
+    expect(copySource()).toBe(first);
+
+    mermaidParse.mockImplementation(() => Promise.resolve());
+    const third = "graph TD\nC-->D";
+    view.rerender(renderContent(third));
+    await waitFor(() => expect(copySource()).toBe(third));
+    const pasted = render(renderContent(copySource()!));
+    await waitFor(() =>
+      expect(pasted.container.querySelector(".mermaid-container svg")).not.toBeNull()
+    );
   });
 
   test("guest Escape cannot close an expanded host diagram", async () => {

--- a/src/browser/features/Messages/Mermaid.tsx
+++ b/src/browser/features/Messages/Mermaid.tsx
@@ -286,8 +286,11 @@ export const Mermaid: React.FC<{ chart: string }> = ({ chart }) => {
   const modalContainerRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [svg, setSvg] = useState<string>("");
-  const lastValidSvgRef = useRef<string>("");
+  // Keep the source and SVG together while a newer chart is pending or invalid.
+  const [renderedDiagram, setRenderedDiagram] = useState<{ svg: string; chart: string } | null>(
+    null
+  );
+  const svg = renderedDiagram?.svg ?? "";
   const stableId = useId();
 
   // Debounce chart changes to avoid flickering during streaming
@@ -341,8 +344,7 @@ export const Mermaid: React.FC<{ chart: string }> = ({ chart }) => {
           throw new Error("Mermaid returned invalid SVG output");
         }
 
-        lastValidSvgRef.current = sanitizedSvg;
-        setSvg(sanitizedSvg);
+        setRenderedDiagram({ svg: sanitizedSvg, chart: debouncedChart });
         setError(null);
       } catch (err) {
         if (cancelled) return;
@@ -387,7 +389,7 @@ export const Mermaid: React.FC<{ chart: string }> = ({ chart }) => {
   // Keep one stable diagram frame while streaming or while the async Mermaid render is pending.
   // When no SVG has rendered yet, reserve the normal minimum diagram height so the transcript
   // doesn't expand from a short placeholder to a full diagram after debounce/parse/render.
-  const displaySvg = svg || (isStreaming ? lastValidSvgRef.current : "");
+  const displaySvg = svg;
   const showPendingPlaceholder = !displaySvg;
 
   return (
@@ -429,7 +431,9 @@ export const Mermaid: React.FC<{ chart: string }> = ({ chart }) => {
         <div
           className="mermaid-container"
           ref={(element) => {
-            if (element) transcriptMermaidSources.set(element, chart);
+            if (!element) return;
+            if (renderedDiagram) transcriptMermaidSources.set(element, renderedDiagram.chart);
+            else transcriptMermaidSources.delete(element);
           }}
           style={{
             maxWidth: "70%",

--- a/src/browser/features/Messages/Mermaid.tsx
+++ b/src/browser/features/Messages/Mermaid.tsx
@@ -5,6 +5,7 @@ import { StreamingContext } from "./StreamingContext";
 import { TooltipIfPresent } from "@/browser/components/Tooltip/Tooltip";
 import { isDesktopViewportFocused } from "@/browser/utils/ui/keybinds";
 import { usePersistedState } from "@/browser/hooks/usePersistedState";
+import { transcriptMermaidSources } from "@/browser/utils/messages/transcriptQuoteAttributes";
 
 const MIN_HEIGHT = 300;
 const DEFAULT_ZOOM = 1;
@@ -427,6 +428,9 @@ export const Mermaid: React.FC<{ chart: string }> = ({ chart }) => {
         </div>
         <div
           className="mermaid-container"
+          ref={(element) => {
+            if (element) transcriptMermaidSources.set(element, chart);
+          }}
           style={{
             maxWidth: "70%",
             margin: "0 auto",

--- a/src/browser/features/Messages/ReasoningMessage.test.tsx
+++ b/src/browser/features/Messages/ReasoningMessage.test.tsx
@@ -1,4 +1,7 @@
+import * as RealMarkdownCore from "./MarkdownCore";
+import * as RealSmoothStreaming from "@/browser/hooks/useSmoothStreamingText";
 import { cleanup, fireEvent, render } from "@testing-library/react";
+import { ReasoningMessage } from "./ReasoningMessage";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type React from "react";
 import { installDom } from "../../../../tests/ui/dom";
@@ -12,23 +15,33 @@ import type { AutoExpandPrefs } from "./useStickyExpand";
 // Streaming reasoning uses TypewriterMarkdown → useSmoothStreamingText, which drives
 // a RAF loop. happy-dom doesn't ship requestAnimationFrame, and we only care about
 // the reasoning collapse/transition behavior here, so stub the smooth engine out.
-void mock.module("@/browser/hooks/useSmoothStreamingText", () => ({
-  useSmoothStreamingText: (options: UseSmoothStreamingTextOptions) => ({
-    visibleText: options.fullText,
-    isCaughtUp: !options.isStreaming,
-  }),
-}));
+// Scope module mocks to each test so renderer assertions use the real pipeline.
+const realModules: Array<[string, Record<string, unknown>]> = [
+  ["./MarkdownCore", { ...RealMarkdownCore }],
+  ["@/browser/hooks/useSmoothStreamingText", { ...RealSmoothStreaming }],
+];
 
-// Streamdown's async markdown pipeline is heavy and not what we're testing here —
-// the layout-stability contract is independent of how the inner content is rendered.
-// A stand-in MarkdownCore keeps the text queryable and render times bounded.
-void mock.module("./MarkdownCore", () => ({
-  MarkdownCore: (props: { content: string }) => (
-    <div data-testid="markdown-core-stub">{props.content}</div>
-  ),
-}));
+async function installModuleMocks() {
+  await mock.module("@/browser/hooks/useSmoothStreamingText", () => ({
+    useSmoothStreamingText: (options: UseSmoothStreamingTextOptions) => ({
+      visibleText: options.fullText,
+      isCaughtUp: !options.isStreaming,
+    }),
+  }));
 
-import { ReasoningMessage } from "./ReasoningMessage";
+  // Streamdown's async markdown pipeline is heavy and not what we're testing here —
+  // the layout-stability contract is independent of how the inner content is rendered.
+  // A stand-in MarkdownCore keeps the text queryable and render times bounded.
+  await mock.module("./MarkdownCore", () => ({
+    MarkdownCore: (props: { content: string }) => (
+      <div data-testid="markdown-core-stub">{props.content}</div>
+    ),
+  }));
+}
+
+async function restoreModuleMocks() {
+  for (const [path, exports] of realModules) await mock.module(path, () => exports);
+}
 
 function createReasoningMessage(
   content: string,
@@ -60,12 +73,14 @@ function makeWrapper(workspaceId: string) {
 describe("ReasoningMessage", () => {
   let cleanupDom: (() => void) | null = null;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    await installModuleMocks();
     cleanupDom = installDom();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     cleanup();
+    await restoreModuleMocks();
     cleanupDom?.();
     cleanupDom = null;
   });

--- a/src/browser/features/Messages/TranscriptContextMenu.stories.tsx
+++ b/src/browser/features/Messages/TranscriptContextMenu.stories.tsx
@@ -2,20 +2,27 @@ import { useRef } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, fireEvent, fn, userEvent, waitFor, within } from "storybook/test";
 import { useTranscriptContextMenu } from "./useTranscriptContextMenu";
+import { MarkdownRenderer } from "./MarkdownRenderer";
 
-function TranscriptSelection() {
+function TranscriptSelection(props: { markdown?: string }) {
   const root = useRef<HTMLDivElement>(null);
   const menu = useTranscriptContextMenu({ transcriptRootRef: root, onQuoteText: () => undefined });
   return (
     <div ref={root} onContextMenu={menu.onContextMenu} className="p-4">
       <div data-transcript-message>
         <div data-transcript-quote-root>
-          <p>
-            Before <strong data-testid="selection">bold selection</strong> after
-          </p>
-          <p>
-            <a href="https://example.com">Example link</a>
-          </p>
+          {props.markdown ? (
+            <MarkdownRenderer content={props.markdown} />
+          ) : (
+            <>
+              <p>
+                Before <strong data-testid="selection">bold selection</strong> after
+              </p>
+              <p>
+                <a href="https://example.com">Example link</a>
+              </p>
+            </>
+          )}
         </div>
       </div>
       {menu.menu}
@@ -35,7 +42,10 @@ export const SelectedMarkdown: Story = {
     const document = canvasElement.ownerDocument;
     const canvas = within(canvasElement);
     const body = within(document.body);
-    const selected = canvas.getByTestId("selection");
+    const selected = await canvas.findByText("bold selection", {
+      selector: 'strong, [data-streamdown="strong"]',
+    });
+    await waitFor(() => expect(selected).toBeVisible());
     const range = document.createRange();
     range.selectNodeContents(selected);
     const selection = document.getSelection()!;
@@ -97,5 +107,29 @@ export const SelectedMarkdownPhone: Story = {
     await expect(context.parameters).toMatchObject({ pixel: { matrix: { viewports: ["phone"] } } });
     await expect(context.globals).toMatchObject({ viewport: { value: "phone390" } });
     await SelectedMarkdown.play?.(context);
+  },
+};
+
+const renderedMarkdown = [
+  "Before **bold selection** after",
+  "- [x] parent\n  - [ ] child",
+  "<details open>\n<summary>Math</summary>\n\n$$x^2$$\n\n</details>",
+  "```typescript\nconst x = 1;\n```",
+  '<span class="sr-only" style="position:fixed;left:-10000px">Raw HTML cannot conceal this text.</span>',
+].join("\n\n");
+
+export const RenderedMarkdown: Story = {
+  ...SelectedMarkdown,
+  args: { markdown: renderedMarkdown },
+  play: async (context) => {
+    await SelectedMarkdown.play?.(context);
+  },
+};
+
+export const RenderedMarkdownPhone: Story = {
+  ...SelectedMarkdownPhone,
+  args: { markdown: renderedMarkdown },
+  play: async (context) => {
+    await SelectedMarkdownPhone.play?.(context);
   },
 };

--- a/src/browser/features/Messages/TranscriptContextMenu.stories.tsx
+++ b/src/browser/features/Messages/TranscriptContextMenu.stories.tsx
@@ -1,0 +1,101 @@
+import { useRef } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fireEvent, fn, userEvent, waitFor, within } from "storybook/test";
+import { useTranscriptContextMenu } from "./useTranscriptContextMenu";
+
+function TranscriptSelection() {
+  const root = useRef<HTMLDivElement>(null);
+  const menu = useTranscriptContextMenu({ transcriptRootRef: root, onQuoteText: () => undefined });
+  return (
+    <div ref={root} onContextMenu={menu.onContextMenu} className="p-4">
+      <div data-transcript-message>
+        <div data-transcript-quote-root>
+          <p>
+            Before <strong data-testid="selection">bold selection</strong> after
+          </p>
+          <p>
+            <a href="https://example.com">Example link</a>
+          </p>
+        </div>
+      </div>
+      {menu.menu}
+    </div>
+  );
+}
+
+const meta = {
+  title: "App/Chat/Transcript Context Menu",
+  component: TranscriptSelection,
+} satisfies Meta<typeof TranscriptSelection>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SelectedMarkdown: Story = {
+  play: async ({ canvasElement }) => {
+    const document = canvasElement.ownerDocument;
+    const canvas = within(canvasElement);
+    const body = within(document.body);
+    const selected = canvas.getByTestId("selection");
+    const range = document.createRange();
+    range.selectNodeContents(selected);
+    const selection = document.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+    const openMenu = async () => {
+      const rect = selected.getBoundingClientRect();
+      await fireEvent.contextMenu(selected, { clientX: rect.right, clientY: rect.bottom });
+      return body.findByRole("button", { name: /Copy Markdown/ });
+    };
+    const originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+    const write = fn<(items: ClipboardItem[]) => Promise<void>>().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: { write } });
+    try {
+      const copy = await openMenu();
+      await waitFor(() => expect(copy).toBeVisible());
+      await userEvent.click(copy);
+      await waitFor(() => expect(write).toHaveBeenCalledTimes(1));
+      const item = write.mock.calls[0][0][0];
+      await expect(await (await item.getType("text/plain")).text()).toBe("**bold selection**");
+      await expect(await (await item.getType("text/html")).text()).toBe(
+        "<p><strong>bold selection</strong></p>"
+      );
+
+      await waitFor(() => expect(copy).not.toBeInTheDocument());
+      selection.removeAllRanges();
+      selection.addRange(range);
+      const keyboardCopy = await openMenu();
+      await waitFor(() => expect(keyboardCopy).toBeVisible());
+      await userEvent.keyboard("m");
+      await waitFor(() => expect(write).toHaveBeenCalledTimes(2));
+
+      selection.removeAllRanges();
+      await fireEvent.contextMenu(selected);
+      await expect(body.queryByRole("button", { name: /Copy Markdown/ })).not.toBeInTheDocument();
+      await userEvent.keyboard("{Escape}");
+      selection.addRange(range);
+      const visibleCopy = await openMenu();
+      await waitFor(async () => {
+        const rect = visibleCopy.getBoundingClientRect();
+        await expect(rect.left).toBeGreaterThanOrEqual(0);
+        await expect(rect.right).toBeLessThanOrEqual(document.documentElement.clientWidth);
+      });
+      if (document.documentElement.clientWidth < 640) {
+        await expect(within(visibleCopy).getByText("(M)")).not.toBeVisible();
+      }
+    } finally {
+      if (originalClipboard) Object.defineProperty(navigator, "clipboard", originalClipboard);
+      else Reflect.deleteProperty(navigator, "clipboard");
+    }
+  },
+};
+
+export const SelectedMarkdownPhone: Story = {
+  ...SelectedMarkdown,
+  globals: { viewport: { value: "phone390", isRotated: false } },
+  parameters: { pixel: { matrix: { viewports: ["phone"] } } },
+  play: async (context) => {
+    await expect(context.parameters).toMatchObject({ pixel: { matrix: { viewports: ["phone"] } } });
+    await expect(context.globals).toMatchObject({ viewport: { value: "phone390" } });
+    await SelectedMarkdown.play?.(context);
+  },
+};

--- a/src/browser/features/Messages/useTranscriptContextMenu.tsx
+++ b/src/browser/features/Messages/useTranscriptContextMenu.tsx
@@ -7,7 +7,12 @@ import {
   type FormattedClipboardContent,
 } from "@/browser/utils/clipboard";
 import { stopKeyboardPropagation } from "@/browser/utils/events";
-import { isEditableElement } from "@/browser/utils/ui/keybinds";
+import {
+  isEditableElement,
+  KEYBINDS,
+  matchesKeybind,
+  formatKeybind,
+} from "@/browser/utils/ui/keybinds";
 import {
   formatTranscriptTextAsQuote,
   getTranscriptContextMenuLink,
@@ -65,9 +70,12 @@ export function useTranscriptContextMenu(
       }
 
       const selection = typeof window === "undefined" ? null : window.getSelection();
-      setMarkdown(
-        getTranscriptContextMenuMarkdown({ transcriptRoot, target: event.target, selection })
-      );
+      const selectedMarkdown = getTranscriptContextMenuMarkdown({
+        transcriptRoot,
+        target: event.target,
+        selection,
+      });
+      setMarkdown(selectedMarkdown);
 
       // Links get priority: right-clicking an anchor should offer "Copy link"
       // rather than falling through to text quote/copy actions. Electron has
@@ -90,12 +98,12 @@ export function useTranscriptContextMenu(
         selection,
       });
 
-      if (!text) {
+      if (!text && !selectedMarkdown) {
         transcriptMenu.close();
         return;
       }
 
-      transcriptMenuTextRef.current = text;
+      transcriptMenuTextRef.current = text ?? selectedMarkdown!.text;
       transcriptMenuLinkRef.current = "";
       setMode({ kind: "text" });
       transcriptMenu.onContextMenu(event);
@@ -129,14 +137,7 @@ export function useTranscriptContextMenu(
     if (!transcriptMenu.isOpen || !markdown) return;
     // Right-click menus can leave focus on the transcript instead of the menu.
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (
-        event.key.toLowerCase() !== "m" ||
-        event.ctrlKey ||
-        event.metaKey ||
-        event.altKey ||
-        isEditableElement(event.target)
-      )
-        return;
+      if (!matchesKeybind(event, KEYBINDS.COPY_MARKDOWN) || isEditableElement(event.target)) return;
       event.preventDefault();
       stopKeyboardPropagation(event);
       handleCopyMarkdown(markdown, transcriptMenu.close).catch(console.error);
@@ -171,7 +172,7 @@ export function useTranscriptContextMenu(
           <PositionedMenuItem
             icon={<Clipboard />}
             label="Copy Markdown"
-            shortcut="M"
+            shortcut={formatKeybind(KEYBINDS.COPY_MARKDOWN)}
             onClick={() => {
               handleCopyMarkdown(markdown, transcriptMenu.close).catch(console.error);
             }}

--- a/src/browser/features/Messages/useTranscriptContextMenu.tsx
+++ b/src/browser/features/Messages/useTranscriptContextMenu.tsx
@@ -1,10 +1,17 @@
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Clipboard, Link as LinkIcon, TextQuote } from "lucide-react";
 import { useContextMenuPosition } from "@/browser/hooks/useContextMenuPosition";
-import { copyToClipboard } from "@/browser/utils/clipboard";
+import {
+  copyToClipboard,
+  copyFormattedToClipboard,
+  type FormattedClipboardContent,
+} from "@/browser/utils/clipboard";
+import { stopKeyboardPropagation } from "@/browser/utils/events";
+import { isEditableElement } from "@/browser/utils/ui/keybinds";
 import {
   formatTranscriptTextAsQuote,
   getTranscriptContextMenuLink,
+  getTranscriptContextMenuMarkdown,
   getTranscriptContextMenuText,
 } from "@/browser/utils/messages/transcriptContextMenu";
 import {
@@ -37,6 +44,7 @@ export function useTranscriptContextMenu(
   // Mode drives which menu items render; use state so the menu re-renders
   // to reflect link vs text actions when it opens.
   const [mode, setMode] = useState<TranscriptContextMenuMode | null>(null);
+  const [markdown, setMarkdown] = useState<FormattedClipboardContent | null>(null);
   const hasInputTarget = options.hasInputTarget ?? true;
 
   const handleTranscriptContextMenu = useCallback(
@@ -45,6 +53,11 @@ export function useTranscriptContextMenu(
       if (!transcriptRoot) {
         return;
       }
+
+      const selection = typeof window === "undefined" ? null : window.getSelection();
+      setMarkdown(
+        getTranscriptContextMenuMarkdown({ transcriptRoot, target: event.target, selection })
+      );
 
       // Links get priority: right-clicking an anchor should offer "Copy link"
       // rather than falling through to text quote/copy actions. Electron has
@@ -61,7 +74,6 @@ export function useTranscriptContextMenu(
         return;
       }
 
-      const selection = typeof window === "undefined" ? null : window.getSelection();
       const text = getTranscriptContextMenuText({
         transcriptRoot,
         target: event.target,
@@ -103,6 +115,36 @@ export function useTranscriptContextMenu(
     transcriptMenu.close();
   }, [options, transcriptMenu]);
 
+  const handleCopyMarkdown = useCallback(async () => {
+    if (!markdown) return;
+    transcriptMenu.close();
+    try {
+      await copyFormattedToClipboard(markdown);
+    } catch (error) {
+      console.error("Failed to copy Markdown:", error);
+    }
+  }, [markdown, transcriptMenu]);
+
+  useEffect(() => {
+    if (!transcriptMenu.isOpen || !markdown) return;
+    // Right-click menus can leave focus on the transcript instead of the menu.
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key.toLowerCase() !== "m" ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.altKey ||
+        isEditableElement(event.target)
+      )
+        return;
+      event.preventDefault();
+      stopKeyboardPropagation(event);
+      handleCopyMarkdown().catch(console.error);
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [transcriptMenu.isOpen, markdown, handleCopyMarkdown]);
+
   return {
     onContextMenu: handleTranscriptContextMenu,
     menu: (
@@ -124,6 +166,16 @@ export function useTranscriptContextMenu(
             ) : null}
             <PositionedMenuItem icon={<Clipboard />} label="Copy text" onClick={handleCopyText} />
           </>
+        )}
+        {markdown && (
+          <PositionedMenuItem
+            icon={<Clipboard />}
+            label="Copy Markdown"
+            shortcut="M"
+            onClick={() => {
+              handleCopyMarkdown().catch(console.error);
+            }}
+          />
         )}
       </PositionedMenu>
     ),

--- a/src/browser/features/Messages/useTranscriptContextMenu.tsx
+++ b/src/browser/features/Messages/useTranscriptContextMenu.tsx
@@ -35,6 +35,16 @@ interface UseTranscriptContextMenuReturn {
   menu: React.ReactNode;
 }
 
+async function handleCopyMarkdown(markdown: FormattedClipboardContent | null, close: () => void) {
+  if (!markdown) return;
+  close();
+  try {
+    await copyFormattedToClipboard(markdown);
+  } catch (error) {
+    console.error("Failed to copy Markdown:", error);
+  }
+}
+
 export function useTranscriptContextMenu(
   options: UseTranscriptContextMenuOptions
 ): UseTranscriptContextMenuReturn {
@@ -115,16 +125,6 @@ export function useTranscriptContextMenu(
     transcriptMenu.close();
   }, [options, transcriptMenu]);
 
-  const handleCopyMarkdown = useCallback(async () => {
-    if (!markdown) return;
-    transcriptMenu.close();
-    try {
-      await copyFormattedToClipboard(markdown);
-    } catch (error) {
-      console.error("Failed to copy Markdown:", error);
-    }
-  }, [markdown, transcriptMenu]);
-
   useEffect(() => {
     if (!transcriptMenu.isOpen || !markdown) return;
     // Right-click menus can leave focus on the transcript instead of the menu.
@@ -139,11 +139,11 @@ export function useTranscriptContextMenu(
         return;
       event.preventDefault();
       stopKeyboardPropagation(event);
-      handleCopyMarkdown().catch(console.error);
+      handleCopyMarkdown(markdown, transcriptMenu.close).catch(console.error);
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [transcriptMenu.isOpen, markdown, handleCopyMarkdown]);
+  }, [transcriptMenu, markdown]);
 
   return {
     onContextMenu: handleTranscriptContextMenu,
@@ -173,7 +173,7 @@ export function useTranscriptContextMenu(
             label="Copy Markdown"
             shortcut="M"
             onClick={() => {
-              handleCopyMarkdown().catch(console.error);
+              handleCopyMarkdown(markdown, transcriptMenu.close).catch(console.error);
             }}
           />
         )}

--- a/src/browser/features/RightSidebar/PlanFileDialog.test.tsx
+++ b/src/browser/features/RightSidebar/PlanFileDialog.test.tsx
@@ -1,8 +1,11 @@
+import * as RealMarkdownCore from "../Messages/MarkdownCore";
+import * as RealMarkdownRenderer from "../Messages/MarkdownRenderer";
+import * as RealAPI from "@/browser/contexts/API";
 import type { ReactNode } from "react";
+import { PlanFileDialog } from "./PlanFileDialog";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { GlobalWindow } from "happy-dom";
 import { cleanup, render, waitFor } from "@testing-library/react";
-import { restoreModulesAfterSuite } from "../../../../tests/ui/moduleMocks";
 import * as RealDialogModule from "@/browser/components/Dialog/Dialog";
 
 type GetPlanContentResult =
@@ -17,49 +20,60 @@ interface MockApiClient {
 
 let mockApi: MockApiClient | null = null;
 
-restoreModulesAfterSuite([["@/browser/components/Dialog/Dialog", { ...RealDialogModule }]]);
+// Scope module mocks to each test so renderer assertions use the real pipeline.
+const realModules: Array<[string, Record<string, unknown>]> = [
+  ["@/browser/components/Dialog/Dialog", { ...RealDialogModule }],
+  ["@/browser/features/Messages/MarkdownCore", { ...RealMarkdownCore }],
+  ["@/browser/features/Messages/MarkdownRenderer", { ...RealMarkdownRenderer }],
+  ["@/browser/contexts/API", { ...RealAPI }],
+];
 
-void mock.module("@/browser/components/Dialog/Dialog", () => ({
-  Dialog: (props: { open: boolean; children: ReactNode }) =>
-    props.open ? <div>{props.children}</div> : null,
-  DialogContent: (props: { children: ReactNode; className?: string }) => (
-    <div className={props.className}>{props.children}</div>
-  ),
-  DialogHeader: (props: { children: ReactNode }) => <div>{props.children}</div>,
-  DialogTitle: (props: { children: ReactNode; className?: string }) => (
-    <h2 className={props.className}>{props.children}</h2>
-  ),
-}));
+async function installModuleMocks() {
+  await mock.module("@/browser/components/Dialog/Dialog", () => ({
+    Dialog: (props: { open: boolean; children: ReactNode }) =>
+      props.open ? <div>{props.children}</div> : null,
+    DialogContent: (props: { children: ReactNode; className?: string }) => (
+      <div className={props.className}>{props.children}</div>
+    ),
+    DialogHeader: (props: { children: ReactNode }) => <div>{props.children}</div>,
+    DialogTitle: (props: { children: ReactNode; className?: string }) => (
+      <h2 className={props.className}>{props.children}</h2>
+    ),
+  }));
 
-void mock.module("@/browser/features/Messages/MarkdownCore", () => ({
-  MarkdownCore: (props: { content: string }) => (
-    <div data-testid="plan-markdown-core">{props.content}</div>
-  ),
-}));
+  await mock.module("@/browser/features/Messages/MarkdownCore", () => ({
+    MarkdownCore: (props: { content: string }) => (
+      <div data-testid="plan-markdown-core">{props.content}</div>
+    ),
+  }));
 
-void mock.module("@/browser/features/Messages/MarkdownRenderer", () => ({
-  PlanMarkdownContainer: (props: { children: ReactNode }) => (
-    <div data-testid="plan-markdown-container">{props.children}</div>
-  ),
-}));
+  await mock.module("@/browser/features/Messages/MarkdownRenderer", () => ({
+    PlanMarkdownContainer: (props: { children: ReactNode }) => (
+      <div data-testid="plan-markdown-container">{props.children}</div>
+    ),
+  }));
 
-void mock.module("@/browser/contexts/API", () => ({
-  useAPI: () => ({
-    api: mockApi,
-    status: mockApi ? "connected" : "error",
-    error: mockApi ? null : "API unavailable",
-    authenticate: () => undefined,
-    retry: () => undefined,
-  }),
-}));
+  await mock.module("@/browser/contexts/API", () => ({
+    useAPI: () => ({
+      api: mockApi,
+      status: mockApi ? "connected" : "error",
+      error: mockApi ? null : "API unavailable",
+      authenticate: () => undefined,
+      retry: () => undefined,
+    }),
+  }));
+}
 
-import { PlanFileDialog } from "./PlanFileDialog";
+async function restoreModuleMocks() {
+  for (const [path, exports] of realModules) await mock.module(path, () => exports);
+}
 
 describe("PlanFileDialog", () => {
   let originalWindow: typeof globalThis.window;
   let originalDocument: typeof globalThis.document;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    await installModuleMocks();
     originalWindow = globalThis.window;
     originalDocument = globalThis.document;
     globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
@@ -67,8 +81,9 @@ describe("PlanFileDialog", () => {
     mockApi = null;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     cleanup();
+    await restoreModuleMocks();
     mock.restore();
     globalThis.window = originalWindow;
     globalThis.document = originalDocument;

--- a/src/browser/features/Settings/Sections/KeybindsSection.tsx
+++ b/src/browser/features/Settings/Sections/KeybindsSection.tsx
@@ -103,6 +103,8 @@ const KEYBIND_LABELS: Record<keyof typeof KEYBINDS, string> = {
   REVIEW_FOCUS_NOTES: "Focus notes sidebar (immersive)",
   REVIEW_COPY_FILE: "Copy file contents (immersive)",
   TOGGLE_PLAN_ANNOTATE: "Toggle plan annotate mode",
+  // Transcript-menu-only actions show their shortcuts in that menu.
+  COPY_MARKDOWN: "Copy Markdown (transcript context menu)",
   // Image-viewer-scoped keybinds (lightbox / image context menu); intentionally
   // omitted from KEYBIND_GROUPS because they only apply while an image surface
   // is focused.

--- a/src/browser/utils/clipboard.test.ts
+++ b/src/browser/utils/clipboard.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { copyFormattedToClipboard } from "./clipboard";
+
+const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+const originalClipboardItem = Object.getOwnPropertyDescriptor(globalThis, "ClipboardItem");
+
+afterEach(() => {
+  for (const [key, descriptor] of [
+    ["navigator", originalNavigator],
+    ["ClipboardItem", originalClipboardItem],
+  ] as const) {
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else Reflect.deleteProperty(globalThis, key);
+  }
+});
+
+describe("copyFormattedToClipboard", () => {
+  function setup() {
+    const write = mock(() => Promise.resolve());
+    const writeText = mock(() => Promise.resolve());
+    const payloads: Array<Record<string, Blob>> = [];
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: { clipboard: { write, writeText } },
+    });
+    Object.defineProperty(globalThis, "ClipboardItem", {
+      configurable: true,
+      value: class {
+        constructor(data: Record<string, Blob>) {
+          payloads.push(data);
+        }
+      },
+    });
+    return { write, writeText, payloads };
+  }
+
+  test("writes Markdown and HTML in the same clipboard item", async () => {
+    const { write, writeText, payloads } = setup();
+    await copyFormattedToClipboard({ text: "**selected**", html: "<strong>selected</strong>" });
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(writeText).not.toHaveBeenCalled();
+    expect(payloads).toHaveLength(1);
+    expect(await payloads[0]["text/plain"].text()).toBe("**selected**");
+    expect(await payloads[0]["text/html"].text()).toBe("<strong>selected</strong>");
+  });
+
+  test("copies Markdown when rich clipboard support is unavailable", async () => {
+    const { write, writeText } = setup();
+    Reflect.deleteProperty(globalThis, "ClipboardItem");
+    await copyFormattedToClipboard({ text: "**selected**", html: "<strong>selected</strong>" });
+    expect(write).not.toHaveBeenCalled();
+    expect(writeText).toHaveBeenCalledWith("**selected**");
+  });
+
+  test("reports a clipboard rejection instead of silently losing formatting", async () => {
+    const { write, writeText } = setup();
+    write.mockRejectedValueOnce(new Error("Permission denied"));
+    const error = await copyFormattedToClipboard({
+      text: "selected",
+      html: "<p>selected</p>",
+    }).catch((error: unknown) => error);
+    expect(error).toEqual(new Error("Permission denied"));
+    expect(writeText).not.toHaveBeenCalled();
+  });
+});

--- a/src/browser/utils/clipboard.test.ts
+++ b/src/browser/utils/clipboard.test.ts
@@ -1,13 +1,16 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import { GlobalWindow } from "happy-dom";
 import { copyFormattedToClipboard } from "./clipboard";
 
 const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
 const originalClipboardItem = Object.getOwnPropertyDescriptor(globalThis, "ClipboardItem");
 
 afterEach(() => {
   for (const [key, descriptor] of [
     ["navigator", originalNavigator],
     ["ClipboardItem", originalClipboardItem],
+    ["document", originalDocument],
   ] as const) {
     if (descriptor) Object.defineProperty(globalThis, key, descriptor);
     else Reflect.deleteProperty(globalThis, key);
@@ -52,14 +55,70 @@ describe("copyFormattedToClipboard", () => {
     expect(writeText).toHaveBeenCalledWith("**selected**");
   });
 
-  test("reports a clipboard rejection instead of silently losing formatting", async () => {
+  test.each(["constructor", "write"])(
+    "falls back after a rich clipboard %s rejection",
+    async (stage) => {
+      const { write, writeText } = setup();
+      if (stage === "write") write.mockRejectedValueOnce(new Error("Permission denied"));
+      else
+        Object.defineProperty(globalThis, "ClipboardItem", {
+          configurable: true,
+          value: class {
+            constructor() {
+              throw new Error("Unsupported MIME type");
+            }
+          },
+        });
+      await copyFormattedToClipboard({ text: "**selected**", html: "<strong>selected</strong>" });
+      expect(writeText).toHaveBeenCalledWith("**selected**");
+    }
+  );
+
+  test("propagates a terminal plain-text rejection", async () => {
     const { write, writeText } = setup();
-    write.mockRejectedValueOnce(new Error("Permission denied"));
+    write.mockRejectedValueOnce(new Error("Rich write failed"));
+    writeText.mockRejectedValueOnce(new Error("Plain write failed"));
     const error = await copyFormattedToClipboard({
       text: "selected",
       html: "<p>selected</p>",
     }).catch((error: unknown) => error);
-    expect(error).toEqual(new Error("Permission denied"));
-    expect(writeText).not.toHaveBeenCalled();
+    expect(error).toEqual(new Error("Plain write failed"));
+    expect(writeText).toHaveBeenCalledWith("selected");
   });
+
+  test("uses writeText when write is unavailable", async () => {
+    const { writeText } = setup();
+    Reflect.deleteProperty(navigator.clipboard, "write");
+    await copyFormattedToClipboard({ text: "selected", html: "<p>selected</p>" });
+    expect(writeText).toHaveBeenCalledWith("selected");
+  });
+
+  test.each(["success", "false", "throw"])(
+    "legacy fallback reports %s and removes its textarea",
+    async (result) => {
+      setup();
+      Reflect.deleteProperty(navigator, "clipboard");
+      const document = new GlobalWindow().document;
+      Object.defineProperty(globalThis, "document", { configurable: true, value: document });
+      const copy = mock(() => {
+        expect(document.querySelector("textarea")?.value).toBe("**selected**");
+        if (result === "throw") throw new Error("Legacy copy failed");
+        return result === "success";
+      });
+      Object.defineProperty(document, "execCommand", { configurable: true, value: copy });
+      const copying = copyFormattedToClipboard({
+        text: "**selected**",
+        html: "<strong>selected</strong>",
+      });
+      if (result === "success") await copying;
+      else {
+        const error = await copying.catch((error: unknown) => error);
+        expect(error).toEqual(
+          new Error(result === "throw" ? "Legacy copy failed" : "Clipboard copy failed")
+        );
+      }
+      expect(copy).toHaveBeenCalledWith("copy");
+      expect(document.querySelector("textarea")).toBeNull();
+    }
+  );
 });

--- a/src/browser/utils/clipboard.ts
+++ b/src/browser/utils/clipboard.ts
@@ -17,8 +17,11 @@ export async function copyToClipboard(text: string): Promise<void> {
   textarea.style.opacity = "0";
   document.body.appendChild(textarea);
   textarea.select();
-  document.execCommand("copy");
-  document.body.removeChild(textarea);
+  try {
+    if (!document.execCommand("copy")) throw new Error("Clipboard copy failed");
+  } finally {
+    document.body.removeChild(textarea);
+  }
 }
 
 export interface FormattedClipboardContent {
@@ -29,13 +32,18 @@ export interface FormattedClipboardContent {
 /** Copy Markdown and rich text together so formatted paste works in Slack. */
 export async function copyFormattedToClipboard(content: FormattedClipboardContent): Promise<void> {
   if (navigator.clipboard?.write && typeof ClipboardItem !== "undefined") {
-    await navigator.clipboard.write([
-      new ClipboardItem({
-        "text/plain": new Blob([content.text], { type: "text/plain" }),
-        "text/html": new Blob([content.html], { type: "text/html" }),
-      }),
-    ]);
-    return;
+    try {
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          "text/plain": new Blob([content.text], { type: "text/plain" }),
+          "text/html": new Blob([content.html], { type: "text/html" }),
+        }),
+      ]);
+      return;
+    } catch {
+      // Some browsers expose rich clipboard APIs but reject their MIME types or permissions.
+      // Keep the selected Markdown available through the plain-text path.
+    }
   }
 
   await copyToClipboard(content.text);

--- a/src/browser/utils/clipboard.ts
+++ b/src/browser/utils/clipboard.ts
@@ -20,3 +20,23 @@ export async function copyToClipboard(text: string): Promise<void> {
   document.execCommand("copy");
   document.body.removeChild(textarea);
 }
+
+export interface FormattedClipboardContent {
+  text: string;
+  html: string;
+}
+
+/** Copy Markdown and rich text together so formatted paste works in Slack. */
+export async function copyFormattedToClipboard(content: FormattedClipboardContent): Promise<void> {
+  if (navigator.clipboard?.write && typeof ClipboardItem !== "undefined") {
+    await navigator.clipboard.write([
+      new ClipboardItem({
+        "text/plain": new Blob([content.text], { type: "text/plain" }),
+        "text/html": new Blob([content.html], { type: "text/html" }),
+      }),
+    ]);
+    return;
+  }
+
+  await copyToClipboard(content.text);
+}

--- a/src/browser/utils/messages/transcriptContextMenu.test.ts
+++ b/src/browser/utils/messages/transcriptContextMenu.test.ts
@@ -78,6 +78,41 @@ describe("transcriptContextMenu", () => {
       expect(result).toEqual({ text: "Body", html: "<p>Body</p>" });
     });
 
+    test.each(["p", "li"])("omits empty %s wrappers at selection boundaries", (tag) => {
+      const blocks = `<${tag} id="before">before</${tag}><${tag} id="selected">selected</${tag}><${tag} id="after">after</${tag}>`;
+      const root = createTranscriptRoot(
+        createQuoteableTranscriptMessage(tag === "li" ? `<ol start="4">${blocks}</ol>` : blocks)
+      );
+      const copied = getTranscriptContextMenuMarkdown(select(root, "#before", "#after", 6, 0));
+      expect(copied?.html).toBe(
+        tag === "li" ? '<ol start="5"><li>selected</li></ol>' : "<p>selected</p>"
+      );
+    });
+
+    test.each(["#first", "#second", "#third"])("preserves list value resets from %s", (start) => {
+      const root = createTranscriptRoot(
+        createQuoteableTranscriptMessage(
+          '<ol><li id="first" value="5">Five</li><li id="second">Six</li><li id="third" value="10">Ten</li><li id="last">Eleven</li></ol>'
+        )
+      );
+      const copied = getTranscriptContextMenuMarkdown(select(root, start, "#last"))!;
+      const pasted = document.createElement("div");
+      pasted.innerHTML = new MarkdownIt({ html: true }).render(copied.text);
+      const numbers = (container: Element) => {
+        let number = container.querySelector("ol")!.start;
+        return Array.from(container.querySelectorAll("li"), (item) => {
+          if (item.hasAttribute("value")) number = item.value;
+          return number++;
+        });
+      };
+      const rich = document.createElement("div");
+      rich.innerHTML = copied.html;
+      const expected =
+        start === "#first" ? [5, 6, 10, 11] : start === "#second" ? [6, 10, 11] : [10, 11];
+      expect(numbers(pasted)).toEqual(expected);
+      expect(numbers(rich)).toEqual(expected);
+    });
+
     test("preserves links when the selection target is an anchor", () => {
       const root = createTranscriptRoot(
         createQuoteableTranscriptMessage(

--- a/src/browser/utils/messages/transcriptContextMenu.test.ts
+++ b/src/browser/utils/messages/transcriptContextMenu.test.ts
@@ -142,6 +142,24 @@ describe("transcriptContextMenu", () => {
       expect(code?.textContent?.trimEnd()).toBe("const x = 1;\n  x++;");
     });
 
+    test("structured HTML escapes URL attributes before Markdown parsing", () => {
+      const href = 'mailto:team@example.com"><img src=x onerror=alert(1)>';
+      const root = createTranscriptRoot(
+        createQuoteableTranscriptMessage('<dl><a id="part">Contact</a></dl>')
+      );
+      root.querySelector("a")!.setAttribute("href", href);
+      const copied = getTranscriptContextMenuMarkdown(select(root, "#part"))!;
+      for (const html of [copied.html, new MarkdownIt({ html: true }).render(copied.text)]) {
+        const pasted = document.createElement("div");
+        pasted.innerHTML = html;
+        expect(pasted.querySelector("img, [onerror]")).toBeNull();
+        expect(pasted.querySelectorAll("a")).toHaveLength(1);
+        expect(pasted.querySelector("a")?.getAttribute("href")).toStartWith(
+          "mailto:team@example.com"
+        );
+      }
+    });
+
     test("preserves links when the selection target is an anchor", () => {
       const root = createTranscriptRoot(
         createQuoteableTranscriptMessage(

--- a/src/browser/utils/messages/transcriptContextMenu.test.ts
+++ b/src/browser/utils/messages/transcriptContextMenu.test.ts
@@ -223,10 +223,15 @@ describe("transcriptContextMenu", () => {
         )
       );
       const result = getTranscriptContextMenuMarkdown(select(root, "#first", "#last"));
-      expect(result?.text).toBe(
+      const pasted = document.createElement("div");
+      pasted.innerHTML = new MarkdownIt({ html: true }).render(result?.text ?? "");
+      expect(pasted.querySelector("details")?.open).toBe(true);
+      expect(pasted.querySelector("summary")?.textContent?.trim()).toBe("More");
+      expect(pasted.textContent).toContain("Selected");
+      expect(pasted.textContent).not.toContain("Excluded");
+      expect(result?.html).toBe(
         '<details open=""><summary>More</summary><p>Selected</p></details>'
       );
-      expect(result?.html).toBe(result?.text);
     });
 
     test("preserves the language of highlighted code", () => {
@@ -284,6 +289,52 @@ describe("transcriptContextMenu", () => {
       expect(result?.text).toBe("Before after");
       expect(result?.html).not.toContain("HIDDEN PAYLOAD");
     });
+
+    test.each([false, true])(
+      "keeps only selected task ancestry (includeParent=%s)",
+      (includeParent) => {
+        const root = createTranscriptRoot(
+          createQuoteableTranscriptMessage(
+            '<ul><li><input type="checkbox" disabled checked><span id="parent">parent</span><ul><li><input type="checkbox" disabled><span id="child">child</span></li><li><input type="checkbox" disabled checked><span id="next">next</span></li></ul></li></ul>'
+          )
+        );
+        const result = getTranscriptContextMenuMarkdown(
+          select(root, includeParent ? "#parent" : "#child", "#next")
+        );
+        const pasted = document.createElement("div");
+        pasted.innerHTML = result?.html ?? "";
+        expect(pasted.querySelectorAll("li").length).toBe(includeParent ? 3 : 2);
+        expect(result?.text).toContain("[ ] child");
+        expect(result?.text).toContain("[x] next");
+        if (includeParent) expect(result?.text).toContain("[x] parent");
+        else expect(result?.text).not.toContain("parent");
+      }
+    );
+
+    test.each([false, true])(
+      "preserves spanning-table layout without unselected text (partial=%s)",
+      (partial) => {
+        const root = createTranscriptRoot(
+          createQuoteableTranscriptMessage(
+            '<table><tr><th id="first" colspan="2">Heading</th></tr><tr><td rowspan="2">Left</td><td id="part">Selected</td></tr><tr><td id="last">Other</td></tr></table>'
+          )
+        );
+        const result = getTranscriptContextMenuMarkdown(
+          select(root, partial ? "#part" : "#first", partial ? "#part" : "#last")
+        );
+        const pasted = document.createElement("div");
+        pasted.innerHTML = new MarkdownIt({ html: true }).render(result?.text ?? "");
+        expect(pasted.querySelector("th")?.colSpan).toBe(2);
+        expect(pasted.querySelector("td")?.rowSpan).toBe(2);
+        expect(pasted.querySelectorAll("tr").length).toBe(3);
+        expect(pasted.textContent).toContain("Selected");
+        if (partial) {
+          expect(pasted.textContent?.trim()).toBe("Selected");
+          expect(result?.html).not.toContain("Heading");
+          expect(result?.html).not.toContain("Left");
+        }
+      }
+    );
 
     test("removes unsafe URLs, attributes, and active content", () => {
       const root = createTranscriptRoot(

--- a/src/browser/utils/messages/transcriptContextMenu.test.ts
+++ b/src/browser/utils/messages/transcriptContextMenu.test.ts
@@ -68,6 +68,16 @@ describe("transcriptContextMenu", () => {
       expect(result).toEqual({ text: "**beta**", html: "<p><strong>beta</strong></p>" });
     });
 
+    test("body-only disclosure selections omit the disclosure control", () => {
+      const root = createTranscriptRoot(
+        createQuoteableTranscriptMessage(
+          '<details open><summary>Title</summary><p id="part">Body</p></details>'
+        )
+      );
+      const result = getTranscriptContextMenuMarkdown(select(root, "#part"));
+      expect(result).toEqual({ text: "Body", html: "<p>Body</p>" });
+    });
+
     test("preserves links when the selection target is an anchor", () => {
       const root = createTranscriptRoot(
         createQuoteableTranscriptMessage(

--- a/src/browser/utils/messages/transcriptContextMenu.test.ts
+++ b/src/browser/utils/messages/transcriptContextMenu.test.ts
@@ -210,7 +210,7 @@ describe("transcriptContextMenu", () => {
           )
         );
         const result = getTranscriptContextMenuMarkdown(select(root, "#part"));
-        expect(result?.text).toBe(display ? "$$\nx^2\n$$" : "$x^2$");
+        expect(result?.text).toBe(display ? "$$\nx^2\n$$" : "$$x^2$$");
         expect(result?.html).not.toContain("x2");
         expect(result?.html).not.toContain("<math");
       }

--- a/src/browser/utils/messages/transcriptContextMenu.test.ts
+++ b/src/browser/utils/messages/transcriptContextMenu.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { GlobalWindow } from "happy-dom";
+import MarkdownIt from "markdown-it";
 import {
   formatTranscriptTextAsQuote,
   getTranscriptContextMenuLink,
@@ -74,7 +75,7 @@ describe("transcriptContextMenu", () => {
         )
       );
       const result = getTranscriptContextMenuMarkdown(select(root, "#part"));
-      expect(result?.text).toBe("[Example](https://example.com)");
+      expect(result?.text).toBe("[Example](<https://example.com>)");
       expect(result?.html).toContain('href="https://example.com"');
     });
 
@@ -150,6 +151,9 @@ describe("transcriptContextMenu", () => {
     test.each([
       "src/main.ts",
       "../my file.ts",
+      "docs/(file).ts",
+      "docs/file>next.ts",
+      "docs/%20exists.md",
       "#usage",
       "/docs",
       "https://example.com",
@@ -161,7 +165,9 @@ describe("transcriptContextMenu", () => {
       root.querySelector("a")!.setAttribute("href", href);
       const result = getTranscriptContextMenuMarkdown(select(root, "#part"));
       expect(result?.html).toContain('href="' + href + '"');
-      expect(result?.text).toContain("[Link](");
+      const tokens = new MarkdownIt().parseInline(result?.text ?? "", {});
+      const link = tokens[0].children?.find((token) => token.type === "link_open");
+      expect(link?.attrGet("href")).toBe(href.replace(/[<>\s]/g, encodeURIComponent));
     });
 
     test.each([
@@ -232,6 +238,51 @@ describe("transcriptContextMenu", () => {
       const result = getTranscriptContextMenuMarkdown(select(root, "#part"));
       expect(result?.text).toBe(["```typescript", "const x = 1;", "```"].join("\n"));
       expect(result?.html).toBe('<pre><code class="language-typescript">const x = 1;</code></pre>');
+    });
+
+    test.each([true, false])(
+      "retains task state when only item text is selected (checked=%s)",
+      (checked) => {
+        const root = createTranscriptRoot(
+          createQuoteableTranscriptMessage(
+            '<ul><li><input type="checkbox" disabled ' +
+              (checked ? "checked" : "") +
+              '><span id="part">done</span></li><li>Excluded</li></ul>'
+          )
+        );
+        const result = getTranscriptContextMenuMarkdown(select(root, "#part"));
+        expect(result?.text).toBe(checked ? "*   [x] done" : "*   [ ] done");
+        expect(result?.html).not.toContain("Excluded");
+      }
+    );
+
+    test("preserves subscript and superscript semantics", () => {
+      const root = createTranscriptRoot(
+        createQuoteableTranscriptMessage(
+          '<p><span id="first">H</span><sub onclick="alert(1)">2</sub>O and x<sup id="last">2</sup></p>'
+        )
+      );
+      const result = getTranscriptContextMenuMarkdown(select(root, "#first", "#last"));
+      expect(result?.text).toBe("H<sub>2</sub>O and x<sup>2</sup>");
+      expect(result?.html).toBe("<p>H<sub>2</sub>O and x<sup>2</sup></p>");
+    });
+
+    test.each([
+      'class="sr-only"',
+      'style="display:none"',
+      'style="visibility:hidden"',
+      'style="opacity:0"',
+    ])("excludes visually hidden text: %s", (attributes) => {
+      const root = createTranscriptRoot(
+        createQuoteableTranscriptMessage(
+          '<p><span id="first">Before </span><span ' +
+            attributes +
+            '>HIDDEN PAYLOAD</span><span id="last"> after</span></p>'
+        )
+      );
+      const result = getTranscriptContextMenuMarkdown(select(root, "#first", "#last"));
+      expect(result?.text).toBe("Before after");
+      expect(result?.html).not.toContain("HIDDEN PAYLOAD");
     });
 
     test("removes unsafe URLs, attributes, and active content", () => {

--- a/src/browser/utils/messages/transcriptContextMenu.test.ts
+++ b/src/browser/utils/messages/transcriptContextMenu.test.ts
@@ -3,6 +3,7 @@ import { GlobalWindow } from "happy-dom";
 import {
   formatTranscriptTextAsQuote,
   getTranscriptContextMenuLink,
+  getTranscriptContextMenuMarkdown,
   getTranscriptContextMenuText,
 } from "./transcriptContextMenu";
 
@@ -35,6 +36,159 @@ describe("transcriptContextMenu", () => {
   afterEach(() => {
     globalThis.window = undefined as unknown as Window & typeof globalThis;
     globalThis.document = undefined as unknown as Document;
+  });
+
+  describe("selected Markdown", () => {
+    function select(
+      root: HTMLElement,
+      start: string,
+      end = start,
+      startOffset = 0,
+      endOffset?: number
+    ) {
+      const first = getFirstTextNode(root.querySelector(start));
+      const last = getFirstTextNode(root.querySelector(end));
+      const range = document.createRange();
+      range.setStart(first, startOffset);
+      range.setEnd(last, endOffset ?? last.length);
+      const selection = window.getSelection()!;
+      selection.removeAllRanges();
+      selection.addRange(range);
+      return { transcriptRoot: root, target: first.parentElement, selection };
+    }
+
+    test("preserves formatting around a partial text selection", () => {
+      const root = createTranscriptRoot(
+        createQuoteableTranscriptMessage(
+          '<p>Before <strong id="part">Alpha beta gamma</strong> after</p>'
+        )
+      );
+      const result = getTranscriptContextMenuMarkdown(select(root, "#part", "#part", 6, 10));
+      expect(result).toEqual({ text: "**beta**", html: "<p><strong>beta</strong></p>" });
+    });
+
+    test("preserves links when the selection target is an anchor", () => {
+      const root = createTranscriptRoot(
+        createQuoteableTranscriptMessage(
+          '<p><a id="part" href="https://example.com">Example</a></p>'
+        )
+      );
+      const result = getTranscriptContextMenuMarkdown(select(root, "#part"));
+      expect(result?.text).toBe("[Example](https://example.com)");
+      expect(result?.html).toContain('href="https://example.com"');
+    });
+
+    test("preserves lists, emphasis, and paragraph boundaries", () => {
+      const root = createTranscriptRoot(
+        createQuoteableTranscriptMessage(
+          '<p id="start">Introduction</p><ul><li><em>First</em></li><li id="end">Second</li></ul><p>Excluded</p>'
+        )
+      );
+      const result = getTranscriptContextMenuMarkdown(select(root, "#start", "#end"));
+      expect(result?.text).toBe("Introduction\n\n*   _First_\n*   Second");
+      expect(result?.html).toBe(
+        "<p>Introduction</p><ul><li><em>First</em></li><li>Second</li></ul>"
+      );
+    });
+
+    test("preserves selected code whitespace without syntax-highlighting markup", () => {
+      const root = createTranscriptRoot(
+        createQuoteableTranscriptMessage(
+          '<pre><code><span id="part" style="color:red">  const x = 1;\n  x++;</span></code></pre>'
+        )
+      );
+      const result = getTranscriptContextMenuMarkdown(select(root, "#part"));
+      expect(result?.text).toBe(["```", "  const x = 1;", "  x++;", "```"].join("\n"));
+      expect(result?.html).toBe("<pre><code>  const x = 1;\n  x++;</code></pre>");
+    });
+
+    test("preserves partial highlighted code lines without line numbers or controls", () => {
+      const root = createTranscriptRoot(
+        createQuoteableTranscriptMessage(
+          '<div class="code-block-wrapper"><div class="code-block-container"><div class="line-number">1</div><div class="code-line"><span id="first">before selected</span></div><div class="line-number">2</div><div class="code-line"><span id="last">  next after</span></div></div><button>Copy</button></div>'
+        )
+      );
+      const result = getTranscriptContextMenuMarkdown(select(root, "#first", "#last", 7, 6));
+      expect(result?.text).toBe(["```", "selected", "  next", "```"].join("\n"));
+      expect(result?.html).toBe("<pre><code>selected\n  next</code></pre>");
+    });
+
+    test("preserves the starting number of a partial ordered list", () => {
+      const root = createTranscriptRoot(
+        createQuoteableTranscriptMessage(
+          '<ol start="4"><li>Before</li><li id="part">Selected</li><li>After</li></ol>'
+        )
+      );
+      const result = getTranscriptContextMenuMarkdown(select(root, "#part"));
+      expect(result?.text).toBe("5.  Selected");
+      expect(result?.html).toBe('<ol start="5"><li>Selected</li></ol>');
+    });
+
+    test("preserves table columns and escapes cell separators", () => {
+      const root = createTranscriptRoot(
+        createQuoteableTranscriptMessage(
+          '<table><thead><tr><th id="first">Name</th><th>Value</th></tr></thead><tbody><tr><td>A|B</td><td id="last">Two</td></tr></tbody></table>'
+        )
+      );
+      const result = getTranscriptContextMenuMarkdown(select(root, "#first", "#last"));
+      expect(result?.text).toBe("| Name | Value |\n| --- | --- |\n| A\\|B | Two |");
+      expect(result?.html).toContain("<table>");
+    });
+
+    test("keeps column positions when a table selection starts in the second column", () => {
+      const root = createTranscriptRoot(
+        createQuoteableTranscriptMessage(
+          '<table><thead><tr><th>Excluded</th><th id="first">Value</th></tr></thead><tbody><tr><td>A</td><td id="last">Two</td></tr></tbody></table>'
+        )
+      );
+      const result = getTranscriptContextMenuMarkdown(select(root, "#first", "#last"));
+      expect(result?.text).toBe("|  | Value |\n| --- | --- |\n| A | Two |");
+      expect(result?.html).toContain("<tr><th></th><th>Value</th></tr>");
+      expect(result?.html).not.toContain("Excluded");
+    });
+
+    test("removes unsafe URLs, attributes, and active content", () => {
+      const root = createTranscriptRoot(
+        createQuoteableTranscriptMessage(
+          '<p><span id="start">&lt;script&gt;</span><a href="javascript:alert(1)" onclick="alert(1)">link</a><img src="https://example.com/tracker"><script>bad()</script><span id="end" style="color:red">end</span></p>'
+        )
+      );
+      const result = getTranscriptContextMenuMarkdown(select(root, "#start", "#end"));
+      expect(result?.html).toBe("<p>&lt;script&gt;<a>link</a>end</p>");
+      expect(result?.text).not.toContain("bad()");
+    });
+
+    test("requires a selection and rejects cross-message selections and ignored controls", () => {
+      const root = createTranscriptRoot(
+        createQuoteableTranscriptMessage(
+          '<p id="first">First</p><button data-transcript-ignore-context-menu>Copy</button><p id="last">Last</p>'
+        ) + createQuoteableTranscriptMessage('<p id="other">Other</p>')
+      );
+      expect(
+        getTranscriptContextMenuMarkdown({
+          transcriptRoot: root,
+          target: root.querySelector("#first"),
+          selection: null,
+        })
+      ).toBeNull();
+      expect(getTranscriptContextMenuMarkdown(select(root, "#first", "#other"))).toBeNull();
+      expect(getTranscriptContextMenuMarkdown(select(root, "#first", "#last"))).toBeNull();
+      const options = select(root, "#first");
+      options.selection.collapseToStart();
+      expect(getTranscriptContextMenuMarkdown(options)).toBeNull();
+    });
+
+    test("does not copy a selection from another message or outside the transcript", () => {
+      const root = createTranscriptRoot(
+        createQuoteableTranscriptMessage('<p id="first">First</p>') +
+          createQuoteableTranscriptMessage('<p id="other">Other</p>')
+      );
+      const options = select(root, "#first");
+      expect(
+        getTranscriptContextMenuMarkdown({ ...options, target: root.querySelector("#other") })
+      ).toBeNull();
+      expect(getTranscriptContextMenuMarkdown({ ...options, target: document.body })).toBeNull();
+    });
   });
 
   test("prefers selected transcript text over hovered text", () => {

--- a/src/browser/utils/messages/transcriptContextMenu.test.ts
+++ b/src/browser/utils/messages/transcriptContextMenu.test.ts
@@ -113,6 +113,20 @@ describe("transcriptContextMenu", () => {
       expect(numbers(rich)).toEqual(expected);
     });
 
+    test("table cells preserve selected code blocks and their language", () => {
+      const root = createTranscriptRoot(
+        createQuoteableTranscriptMessage(
+          '<table><tr><td><pre><code class="language-ts" id="part">const x = 1;\n  x++;</code></pre></td></tr></table>'
+        )
+      );
+      const copied = getTranscriptContextMenuMarkdown(select(root, "#part"))!;
+      const pasted = document.createElement("div");
+      pasted.innerHTML = new MarkdownIt({ html: true }).render(copied.text);
+      const code = pasted.querySelector("td pre code");
+      expect(code?.className).toBe("language-ts");
+      expect(code?.textContent?.trimEnd()).toBe("const x = 1;\n  x++;");
+    });
+
     test("preserves links when the selection target is an anchor", () => {
       const root = createTranscriptRoot(
         createQuoteableTranscriptMessage(

--- a/src/browser/utils/messages/transcriptContextMenu.test.ts
+++ b/src/browser/utils/messages/transcriptContextMenu.test.ts
@@ -68,6 +68,21 @@ describe("transcriptContextMenu", () => {
       expect(result).toEqual({ text: "**beta**", html: "<p><strong>beta</strong></p>" });
     });
 
+    test("definition-list selections retain only selected terms and definitions", () => {
+      const root = createTranscriptRoot(
+        createQuoteableTranscriptMessage(
+          '<dl><dt id="before">Other</dt><dd id="first">First definition</dd><dt id="last">Last</dt><dd>Unselected</dd></dl>'
+        )
+      );
+      const copied = getTranscriptContextMenuMarkdown(select(root, "#before", "#last", 5, 0))!;
+      const pasted = document.createElement("div");
+      pasted.innerHTML = new MarkdownIt({ html: true }).render(copied.text);
+      expect(pasted.querySelectorAll("dl > dd")).toHaveLength(1);
+      expect(pasted.querySelector("dt")).toBeNull();
+      expect(pasted.textContent?.trim()).toBe("First definition");
+      expect(copied.html).toBe("<dl><dd>First definition</dd></dl>");
+    });
+
     test("body-only disclosure selections omit the disclosure control", () => {
       const root = createTranscriptRoot(
         createQuoteableTranscriptMessage(

--- a/src/browser/utils/messages/transcriptContextMenu.test.ts
+++ b/src/browser/utils/messages/transcriptContextMenu.test.ts
@@ -147,6 +147,93 @@ describe("transcriptContextMenu", () => {
       expect(result?.html).not.toContain("Excluded");
     });
 
+    test.each([
+      "src/main.ts",
+      "../my file.ts",
+      "#usage",
+      "/docs",
+      "https://example.com",
+      "mailto:team@example.com",
+    ])("preserves a safe link destination: %s", (href) => {
+      const root = createTranscriptRoot(
+        createQuoteableTranscriptMessage('<p><a id="part">Link</a></p>')
+      );
+      root.querySelector("a")!.setAttribute("href", href);
+      const result = getTranscriptContextMenuMarkdown(select(root, "#part"));
+      expect(result?.html).toContain('href="' + href + '"');
+      expect(result?.text).toContain("[Link](");
+    });
+
+    test.each([
+      "javascript:alert(1)",
+      "java\tscript:alert(1)",
+      "data:text/html,bad",
+      "vbscript:bad",
+      "\\evil.example",
+    ])("excludes an unsafe link destination: %s", (href) => {
+      const root = createTranscriptRoot(
+        createQuoteableTranscriptMessage('<p><a id="part">Link</a></p>')
+      );
+      root.querySelector("a")!.setAttribute("href", href);
+      expect(getTranscriptContextMenuMarkdown(select(root, "#part"))?.html).toBe(
+        "<p><a>Link</a></p>"
+      );
+    });
+
+    test("preserves task state without copying interactive inputs", () => {
+      const root = createTranscriptRoot(
+        createQuoteableTranscriptMessage(
+          '<p id="first">Tasks</p><ul><li><input type="checkbox" checked disabled> done</li><li><input type="checkbox" disabled> pending</li><li><input type="checkbox" checked> interactive</li></ul><p id="last">End</p>'
+        )
+      );
+      const result = getTranscriptContextMenuMarkdown(select(root, "#first", "#last"));
+      expect(result?.text).toContain("*   [x] done");
+      expect(result?.text).toContain("*   [ ] pending");
+      expect(result?.text).toContain("*   interactive");
+      expect(result?.html).not.toContain("<input");
+    });
+
+    test.each([false, true])(
+      "copies one TeX source for selected rendered math (display=%s)",
+      (display) => {
+        const math =
+          '<span class="katex"><span class="katex-mathml"><math><semantics><mrow>x2</mrow><annotation encoding="application/x-tex">x^2</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span id="part">x2</span></span></span>';
+        const root = createTranscriptRoot(
+          createQuoteableTranscriptMessage(
+            display ? '<span class="katex-display">' + math + "</span>" : math
+          )
+        );
+        const result = getTranscriptContextMenuMarkdown(select(root, "#part"));
+        expect(result?.text).toBe(display ? "$$\nx^2\n$$" : "$x^2$");
+        expect(result?.html).not.toContain("x2");
+        expect(result?.html).not.toContain("<math");
+      }
+    );
+
+    test("retains sanitized disclosure structure", () => {
+      const root = createTranscriptRoot(
+        createQuoteableTranscriptMessage(
+          '<details open ontoggle="alert(1)"><summary id="first">More</summary><p id="last">Selected</p><p>Excluded</p></details>'
+        )
+      );
+      const result = getTranscriptContextMenuMarkdown(select(root, "#first", "#last"));
+      expect(result?.text).toBe(
+        '<details open=""><summary>More</summary><p>Selected</p></details>'
+      );
+      expect(result?.html).toBe(result?.text);
+    });
+
+    test("preserves the language of highlighted code", () => {
+      const root = createTranscriptRoot(
+        createQuoteableTranscriptMessage(
+          '<div class="code-block-container" data-code-language="typescript"><div class="line-number">1</div><div class="code-line"><span id="part">const x = 1;</span></div></div>'
+        )
+      );
+      const result = getTranscriptContextMenuMarkdown(select(root, "#part"));
+      expect(result?.text).toBe(["```typescript", "const x = 1;", "```"].join("\n"));
+      expect(result?.html).toBe('<pre><code class="language-typescript">const x = 1;</code></pre>');
+    });
+
     test("removes unsafe URLs, attributes, and active content", () => {
       const root = createTranscriptRoot(
         createQuoteableTranscriptMessage(

--- a/src/browser/utils/messages/transcriptContextMenu.ts
+++ b/src/browser/utils/messages/transcriptContextMenu.ts
@@ -339,6 +339,7 @@ const CLIPBOARD_TAGS = new Set([
   "table",
   "thead",
   "tbody",
+  "tfoot",
   "tr",
   "th",
   "td",
@@ -347,7 +348,7 @@ const CLIPBOARD_TAGS = new Set([
   "sub",
   "sup",
 ]);
-const CLIPBOARD_EXCLUDED_SELECTOR = `script, style, svg, img, iframe, object, .line-number, .sr-only, button, input, textarea, select, [hidden], [aria-hidden="true"], ${TRANSCRIPT_IGNORE_CONTEXT_MENU_SELECTOR}`;
+const CLIPBOARD_EXCLUDED_SELECTOR = `script, style, annotation, svg, img, iframe, object, .line-number, .sr-only, button, input, textarea, select, [hidden], [aria-hidden="true"], ${TRANSCRIPT_IGNORE_CONTEXT_MENU_SELECTOR}`;
 
 function isSafeClipboardHref(href: string): boolean {
   if (!href.trim() || href.includes("\\")) return false;
@@ -370,13 +371,43 @@ function isClipboardElementHidden(element: Element): boolean {
   );
 }
 
-function appendClipboardNodes(source: Node, destination: Node, range: Range): void {
+function hasSelectedOwnListText(item: Element, range: Range): boolean {
+  for (const child of item.childNodes) {
+    if (!range.intersectsNode(child)) continue;
+    if (child.nodeType === 3) {
+      const start = child === range.startContainer ? range.startOffset : 0;
+      const end = child === range.endContainer ? range.endOffset : child.textContent?.length;
+      if (child.textContent?.slice(start, end).trim()) return true;
+    } else if (child.nodeType === 1) {
+      const element = child as Element;
+      if (!element.matches("ul, ol, input") && hasSelectedOwnListText(element, range)) return true;
+    }
+  }
+  return false;
+}
+
+function appendClipboardNodes(
+  source: Node,
+  destination: Node,
+  range: Range,
+  preserveSpanningTable = false
+): void {
   const document = destination.ownerDocument!;
   for (const child of source.childNodes) {
     const isTaskMarker =
       child.nodeType === 1 &&
-      (child as Element).matches('li > input[type="checkbox"][disabled]:first-child');
-    if (!range.intersectsNode(child) && !isTaskMarker) {
+      (child as Element).matches('li > input[type="checkbox"][disabled]:first-child') &&
+      hasSelectedOwnListText(child.parentElement!, range);
+    const isTableStructure =
+      preserveSpanningTable &&
+      ["THEAD", "TBODY", "TFOOT", "TR", "TD", "TH"].includes(child.nodeName);
+    if (
+      source.nodeName === "DETAILS" &&
+      !(source as Element).hasAttribute("open") &&
+      child.nodeName !== "SUMMARY"
+    )
+      continue;
+    if (!range.intersectsNode(child) && !isTaskMarker && !isTableStructure) {
       // Empty cells retain column positions without copying unselected text.
       if (child.nodeName === "TH" || child.nodeName === "TD") {
         destination.appendChild(document.createElement(child.nodeName.toLowerCase()));
@@ -431,15 +462,26 @@ function appendClipboardNodes(source: Node, destination: Node, range: Range): vo
       destination.appendChild(pre);
       continue;
     }
-    const tag = element.tagName.toLowerCase();
+    // Streamdown renders Markdown bold as a styled span instead of a strong element.
+    const tag =
+      element.getAttribute("data-streamdown") === "strong"
+        ? "strong"
+        : element.tagName.toLowerCase();
     if (!CLIPBOARD_TAGS.has(tag)) {
-      appendClipboardNodes(element, destination, range);
+      appendClipboardNodes(element, destination, range, preserveSpanningTable);
       continue;
     }
     const copy = document.createElement(tag);
     if (tag === "a") {
       const href = element.getAttribute("href") ?? "";
       if (isSafeClipboardHref(href)) copy.setAttribute("href", href);
+    }
+    if (tag === "td" || tag === "th") {
+      const cell = element as HTMLTableCellElement;
+      if (/^\d+$/.test(element.getAttribute("colspan") ?? ""))
+        copy.setAttribute("colspan", String(cell.colSpan));
+      if (/^\d+$/.test(element.getAttribute("rowspan") ?? ""))
+        copy.setAttribute("rowspan", String(cell.rowSpan));
     }
     if (tag === "details" && element.hasAttribute("open")) copy.setAttribute("open", "");
     if (tag === "code") {
@@ -455,7 +497,11 @@ function appendClipboardNodes(source: Node, destination: Node, range: Range): vo
       );
       copy.setAttribute("start", String(list.start + Math.max(0, firstSelected)));
     }
-    appendClipboardNodes(element, copy, range);
+    // Keep empty spanning-table structure so partial selections retain cell positions.
+    const keepTableStructure =
+      preserveSpanningTable ||
+      (tag === "table" && element.querySelector("[rowspan], [colspan]") !== null);
+    appendClipboardNodes(element, copy, range, keepTableStructure);
     destination.appendChild(copy);
   }
 }
@@ -483,8 +529,19 @@ export function getTranscriptContextMenuMarkdown(
   )!;
   const container = options.transcriptRoot.ownerDocument.createElement("div");
   // Walk the original range so partial selections retain their formatting and list positions.
-  appendClipboardNodes(quoteRoot, container, range);
+  let selectedList = getEventTargetElement(range.startContainer)?.closest("ul, ol");
+  while (selectedList && !selectedList.contains(range.endContainer)) {
+    selectedList = selectedList.parentElement?.closest("ul, ol");
+  }
+  // A nested-item selection forms its own list, without empty unselected parent tasks.
+  const copyRoot = selectedList?.parentElement?.matches("li")
+    ? selectedList.parentElement
+    : quoteRoot;
+  appendClipboardNodes(copyRoot, container, range);
   const markdown = new TurndownService({ headingStyle: "atx", codeBlockStyle: "fenced" });
+  // Preserve literal HTML and entities as text when the copied Markdown is parsed again.
+  markdown.escape = (text) =>
+    TurndownService.prototype.escape(text).replace(/&/g, "&amp;").replace(/</g, "\\<");
   markdown.addRule("selectedMathAndTasks", {
     filter: (node) =>
       node.hasAttribute("data-clipboard-math") || node.hasAttribute("data-clipboard-task"),
@@ -492,10 +549,17 @@ export function getTranscriptContextMenuMarkdown(
       node.getAttribute("data-clipboard-math") ?? node.textContent?.trimEnd() ?? "",
   });
   markdown.addRule("disclosure", {
-    filter: ["details", "sub", "sup"],
+    filter: ["details", "summary"],
+    replacement: (content, node) => {
+      const tag = node.nodeName.toLowerCase();
+      const open = tag === "details" && node.hasAttribute("open") ? " open" : "";
+      return "\n\n<" + tag + open + ">\n\n" + content.trim() + "\n\n</" + tag + ">\n\n";
+    },
+  });
+  markdown.addRule("scripts", {
+    filter: ["sub", "sup"],
     // SECURITY AUDIT: This node contains only the sanitized clipboard elements and attributes.
-    replacement: (_content, node) =>
-      node.nodeName === "DETAILS" ? "\n\n" + node.outerHTML + "\n\n" : node.outerHTML,
+    replacement: (_content, node) => node.outerHTML,
   });
   markdown.addRule("safeLink", {
     filter: (node) => node.nodeName === "A" && node.hasAttribute("href"),
@@ -511,6 +575,8 @@ export function getTranscriptContextMenuMarkdown(
   markdown.addRule("table", {
     filter: "table",
     replacement: (_content, node) => {
+      // GFM cannot represent spans. Keep sanitized HTML instead of inventing a different table layout.
+      if (node.querySelector("[rowspan], [colspan]")) return "\n\n" + node.outerHTML + "\n\n";
       const rows = Array.from(node.querySelectorAll<HTMLTableRowElement>("tr"), (row) =>
         Array.from(row.cells, (cell) =>
           markdown.turndown(cell).replace(/\|/g, "\\|").replace(/\n/g, "<br>")

--- a/src/browser/utils/messages/transcriptContextMenu.ts
+++ b/src/browser/utils/messages/transcriptContextMenu.ts
@@ -314,6 +314,10 @@ export function getTranscriptContextMenuText(
 
 // Copy only semantic formatting. Transcript content can contain untrusted repository text.
 const CLIPBOARD_TAGS = new Set([
+  "div",
+  "dl",
+  "dt",
+  "dd",
   "p",
   "br",
   "strong",
@@ -520,7 +524,7 @@ export function getTranscriptContextMenuMarkdown(
   if (
     !target ||
     !options.transcriptRoot.contains(target) ||
-    (excludedTarget && !excludedTarget.matches('.katex-html[aria-hidden="true"]'))
+    (excludedTarget && !excludedTarget.closest(".katex"))
   ) {
     return null;
   }
@@ -543,6 +547,10 @@ export function getTranscriptContextMenuMarkdown(
     ? selectedList.parentElement
     : quoteRoot;
   appendClipboardNodes(copyRoot, container, range);
+  // Drop redundant outer wrappers, but retain boundaries between adjacent raw HTML blocks.
+  while (container.childNodes.length === 1 && container.firstElementChild?.tagName === "DIV") {
+    container.replaceChildren(...container.firstElementChild.childNodes);
+  }
   const markdown = new TurndownService({ headingStyle: "atx", codeBlockStyle: "fenced" });
   // Preserve literal HTML and entities as text when the copied Markdown is parsed again.
   markdown.escape = (text) =>
@@ -603,8 +611,11 @@ export function getTranscriptContextMenuMarkdown(
       );
       const width = Math.max(0, ...rows.map((row) => row.length));
       if (!width) return "";
-      if (!node.querySelector("tr th")) rows.unshift(Array<string>(width).fill(""));
       const firstRow = node.querySelector("tr");
+      // Row headers do not turn the first data record into a column header.
+      if (!firstRow || !Array.from(firstRow.cells).every((cell) => cell.tagName === "TH")) {
+        rows.unshift(Array<string>(width).fill(""));
+      }
       rows.splice(
         1,
         0,

--- a/src/browser/utils/messages/transcriptContextMenu.ts
+++ b/src/browser/utils/messages/transcriptContextMenu.ts
@@ -415,7 +415,8 @@ function appendClipboardNodes(
   source: Node,
   destination: Node,
   range: Range,
-  preserveSpanningTable = false
+  preserveSpanningTable = false,
+  collectFootnotes = true
 ): void {
   const document = destination.ownerDocument!;
   for (const child of source.childNodes) {
@@ -492,7 +493,7 @@ function appendClipboardNodes(
       for (const line of element.querySelectorAll(".code-line")) {
         if (!range.intersectsNode(line) || isClipboardElementHidden(line)) continue;
         const selectedLine = document.createElement("div");
-        appendClipboardNodes(line, selectedLine, range);
+        appendClipboardNodes(line, selectedLine, range, false, collectFootnotes);
         lines.push(selectedLine.textContent ?? "");
       }
       code.textContent = lines.join("\n");
@@ -511,17 +512,23 @@ function appendClipboardNodes(
       !CLIPBOARD_TAGS.has(tag) ||
       (tag === "details" && (!summary || !range.intersectsNode(summary)))
     ) {
-      appendClipboardNodes(element, destination, range, preserveSpanningTable);
+      appendClipboardNodes(element, destination, range, preserveSpanningTable, collectFootnotes);
       continue;
     }
     const copy = document.createElement(tag);
     // Carry selected footnote candidates until both sides of each relationship are known.
-    if ((tag === "li" && element.id) || element.hasAttribute("data-footnote-ref")) {
+    if (
+      collectFootnotes &&
+      ((tag === "li" && element.id) || element.hasAttribute("data-footnote-ref"))
+    ) {
+      // Generated backlinks and trailing whitespace do not belong to the definition selection.
       const contents = document.createRange();
       contents.selectNodeContents(element);
-      const fullySelected =
-        range.compareBoundaryPoints(range.START_TO_START, contents) <= 0 &&
-        range.compareBoundaryPoints(range.END_TO_END, contents) >= 0;
+      const fullCopy = document.createElement("div");
+      const selectedCopy = document.createElement("div");
+      appendClipboardNodes(element, fullCopy, contents, false, false);
+      appendClipboardNodes(element, selectedCopy, range, false, false);
+      const fullySelected = fullCopy.textContent?.trim() === selectedCopy.textContent?.trim();
       if (tag === "li" && fullySelected) copy.setAttribute("data-clipboard-source-id", element.id);
       if (tag === "a")
         copy.setAttribute(
@@ -553,7 +560,7 @@ function appendClipboardNodes(
     const keepTableStructure =
       preserveSpanningTable ||
       (tag === "table" && element.querySelector("[rowspan], [colspan]") !== null);
-    appendClipboardNodes(element, copy, range, keepTableStructure);
+    appendClipboardNodes(element, copy, range, keepTableStructure, collectFootnotes);
     // Range intersection includes empty boundary nodes. Keep only selected content or required structure.
     if (!copy.hasChildNodes() && !["br", "hr", "td", "th"].includes(tag)) continue;
     if (tag === "li" && source.nodeName === "OL" && destination.nodeName === "OL") {

--- a/src/browser/utils/messages/transcriptContextMenu.ts
+++ b/src/browser/utils/messages/transcriptContextMenu.ts
@@ -398,9 +398,11 @@ function appendClipboardNodes(
       child.nodeType === 1 &&
       (child as Element).matches('li > input[type="checkbox"][disabled]:first-child') &&
       hasSelectedOwnListText(child.parentElement!, range);
+    // Empty cells retain column positions and alignment without copying unselected text.
     const isTableStructure =
-      preserveSpanningTable &&
-      ["THEAD", "TBODY", "TFOOT", "TR", "TD", "TH"].includes(child.nodeName);
+      child.nodeName === "TD" ||
+      child.nodeName === "TH" ||
+      (preserveSpanningTable && ["THEAD", "TBODY", "TFOOT", "TR"].includes(child.nodeName));
     if (
       source.nodeName === "DETAILS" &&
       !(source as Element).hasAttribute("open") &&
@@ -408,10 +410,6 @@ function appendClipboardNodes(
     )
       continue;
     if (!range.intersectsNode(child) && !isTaskMarker && !isTableStructure) {
-      // Empty cells retain column positions without copying unselected text.
-      if (child.nodeName === "TH" || child.nodeName === "TD") {
-        destination.appendChild(document.createElement(child.nodeName.toLowerCase()));
-      }
       continue;
     }
     if (child.nodeType === 3) {
@@ -467,7 +465,12 @@ function appendClipboardNodes(
       element.getAttribute("data-streamdown") === "strong"
         ? "strong"
         : element.tagName.toLowerCase();
-    if (!CLIPBOARD_TAGS.has(tag)) {
+    const summary = tag === "details" ? element.querySelector(":scope > summary") : null;
+    // Body-only selections must not create a browser-generated disclosure label.
+    if (
+      !CLIPBOARD_TAGS.has(tag) ||
+      (tag === "details" && (!summary || !range.intersectsNode(summary)))
+    ) {
       appendClipboardNodes(element, destination, range, preserveSpanningTable);
       continue;
     }
@@ -478,6 +481,8 @@ function appendClipboardNodes(
     }
     if (tag === "td" || tag === "th") {
       const cell = element as HTMLTableCellElement;
+      const alignment = cell.getAttribute("align") ?? cell.style.textAlign;
+      if (["left", "center", "right"].includes(alignment)) copy.setAttribute("align", alignment);
       if (/^\d+$/.test(element.getAttribute("colspan") ?? ""))
         copy.setAttribute("colspan", String(cell.colSpan));
       if (/^\d+$/.test(element.getAttribute("rowspan") ?? ""))
@@ -576,7 +581,21 @@ export function getTranscriptContextMenuMarkdown(
     filter: "table",
     replacement: (_content, node) => {
       // GFM cannot represent spans. Keep sanitized HTML instead of inventing a different table layout.
-      if (node.querySelector("[rowspan], [colspan]")) return "\n\n" + node.outerHTML + "\n\n";
+      if (node.querySelector("[rowspan], [colspan]")) {
+        // Blank lines let Markdown parse cell content inside the span-preserving HTML.
+        const serialize = (element: Element): string => {
+          const tag = element.tagName.toLowerCase();
+          const attributes = Array.from(
+            element.attributes,
+            (attribute) => " " + attribute.name + '="' + attribute.value + '"'
+          ).join("");
+          const content = element.matches("td, th")
+            ? markdown.turndown(element as HTMLElement)
+            : Array.from(element.children, serialize).join("\n\n");
+          return "<" + tag + attributes + ">\n\n" + content + "\n\n</" + tag + ">";
+        };
+        return "\n\n" + serialize(node) + "\n\n";
+      }
       const rows = Array.from(node.querySelectorAll<HTMLTableRowElement>("tr"), (row) =>
         Array.from(row.cells, (cell) =>
           markdown.turndown(cell).replace(/\|/g, "\\|").replace(/\n/g, "<br>")
@@ -585,7 +604,21 @@ export function getTranscriptContextMenuMarkdown(
       const width = Math.max(0, ...rows.map((row) => row.length));
       if (!width) return "";
       if (!node.querySelector("tr th")) rows.unshift(Array<string>(width).fill(""));
-      rows.splice(1, 0, Array<string>(width).fill("---"));
+      const firstRow = node.querySelector("tr");
+      rows.splice(
+        1,
+        0,
+        Array.from({ length: width }, (_, index) => {
+          const alignment = firstRow?.cells[index]?.getAttribute("align");
+          return alignment === "left"
+            ? ":---"
+            : alignment === "right"
+              ? "---:"
+              : alignment === "center"
+                ? ":---:"
+                : "---";
+        })
+      );
       return (
         "\n\n" +
         rows

--- a/src/browser/utils/messages/transcriptContextMenu.ts
+++ b/src/browser/utils/messages/transcriptContextMenu.ts
@@ -407,7 +407,7 @@ function appendClipboardNodes(source: Node, destination: Node, range: Range): vo
         const math = document.createElement("span");
         math.textContent = element.closest(".katex-display")
           ? "$$\n" + tex + "\n$$"
-          : "$" + tex + "$";
+          : "$$" + tex + "$$";
         math.setAttribute("data-clipboard-math", math.textContent);
         destination.appendChild(math);
         continue;

--- a/src/browser/utils/messages/transcriptContextMenu.ts
+++ b/src/browser/utils/messages/transcriptContextMenu.ts
@@ -730,10 +730,15 @@ export function getTranscriptContextMenuMarkdown(
   // Blank lines let Markdown parse content inside structures that GFM cannot represent.
   const serializeStructuredHtml = (element: Element): string => {
     const tag = element.tagName.toLowerCase();
-    const attributes = Array.from(
-      element.attributes,
-      (attribute) => " " + attribute.name + '="' + attribute.value + '"'
-    ).join("");
+    const attributes = Array.from(element.attributes, (attribute) => {
+      // SECURITY AUDIT: Safe URL schemes can still contain quotes or HTML delimiters.
+      const value = attribute.value
+        .replace(/&/g, "&amp;")
+        .replace(/"/g, "&quot;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+      return " " + attribute.name + '="' + value + '"';
+    }).join("");
     const content = element.matches("td, th, li, dt, dd")
       ? markdown.turndown(element as HTMLElement)
       : Array.from(element.children, serializeStructuredHtml).join("\n\n");

--- a/src/browser/utils/messages/transcriptContextMenu.ts
+++ b/src/browser/utils/messages/transcriptContextMenu.ts
@@ -419,7 +419,8 @@ function appendClipboardNodes(
     if (child.nodeType === 3) {
       const start = child === range.startContainer ? range.startOffset : 0;
       const end = child === range.endContainer ? range.endOffset : child.textContent?.length;
-      destination.appendChild(document.createTextNode((child.textContent ?? "").slice(start, end)));
+      const selectedText = (child.textContent ?? "").slice(start, end);
+      if (selectedText) destination.appendChild(document.createTextNode(selectedText));
       continue;
     }
     if (child.nodeType !== 1) continue;
@@ -499,18 +500,29 @@ function appendClipboardNodes(
       );
       if (languageClass) copy.className = languageClass;
     }
-    if (tag === "ol") {
-      const list = element as HTMLOListElement;
-      const firstSelected = Array.from(list.children).findIndex((item) =>
-        range.intersectsNode(item)
-      );
-      copy.setAttribute("start", String(list.start + Math.max(0, firstSelected)));
-    }
     // Keep empty spanning-table structure so partial selections retain cell positions.
     const keepTableStructure =
       preserveSpanningTable ||
       (tag === "table" && element.querySelector("[rowspan], [colspan]") !== null);
     appendClipboardNodes(element, copy, range, keepTableStructure);
+    // Range intersection includes empty boundary nodes. Keep only selected content or required structure.
+    if (!copy.hasChildNodes() && !["br", "hr", "td", "th"].includes(tag)) continue;
+    if (tag === "li" && source.nodeName === "OL" && destination.nodeName === "OL") {
+      const listCopy = destination as HTMLOListElement;
+      if (!listCopy.children.length) {
+        let number = (source as HTMLOListElement).start;
+        for (const item of (source as Element).children) {
+          if (item.tagName !== "LI") continue;
+          if (/^[+-]?\d+$/.test(item.getAttribute("value") ?? ""))
+            number = (item as HTMLLIElement).value;
+          if (item === element) break;
+          number++;
+        }
+        listCopy.setAttribute("start", String(number));
+      } else if (/^[+-]?\d+$/.test(element.getAttribute("value") ?? "")) {
+        copy.setAttribute("value", String((element as HTMLLIElement).value));
+      }
+    }
     destination.appendChild(copy);
   }
 }
@@ -585,24 +597,32 @@ export function getTranscriptContextMenuMarkdown(
     filter: ["s", "del"],
     replacement: (content) => `~~${content}~~`,
   });
+  // Blank lines let Markdown parse content inside structures that GFM cannot represent.
+  const serializeStructuredHtml = (element: Element): string => {
+    const tag = element.tagName.toLowerCase();
+    const attributes = Array.from(
+      element.attributes,
+      (attribute) => " " + attribute.name + '="' + attribute.value + '"'
+    ).join("");
+    const content = element.matches("td, th, li")
+      ? markdown.turndown(element as HTMLElement)
+      : Array.from(element.children, serializeStructuredHtml).join("\n\n");
+    return "<" + tag + attributes + ">\n\n" + content + "\n\n</" + tag + ">";
+  };
+
+  markdown.addRule("numberedList", {
+    filter: (node) =>
+      node.nodeName === "OL" &&
+      (node.querySelector(":scope > li[value]") !== null ||
+        !/^\d{1,9}$/.test(node.getAttribute("start") ?? "1")),
+    replacement: (_content, node) => "\n\n" + serializeStructuredHtml(node) + "\n\n",
+  });
   markdown.addRule("table", {
     filter: "table",
     replacement: (_content, node) => {
       // GFM cannot represent spans. Keep sanitized HTML instead of inventing a different table layout.
       if (node.querySelector("[rowspan], [colspan]")) {
-        // Blank lines let Markdown parse cell content inside the span-preserving HTML.
-        const serialize = (element: Element): string => {
-          const tag = element.tagName.toLowerCase();
-          const attributes = Array.from(
-            element.attributes,
-            (attribute) => " " + attribute.name + '="' + attribute.value + '"'
-          ).join("");
-          const content = element.matches("td, th")
-            ? markdown.turndown(element as HTMLElement)
-            : Array.from(element.children, serialize).join("\n\n");
-          return "<" + tag + attributes + ">\n\n" + content + "\n\n</" + tag + ">";
-        };
-        return "\n\n" + serialize(node) + "\n\n";
+        return "\n\n" + serializeStructuredHtml(node) + "\n\n";
       }
       const rows = Array.from(node.querySelectorAll<HTMLTableRowElement>("tr"), (row) =>
         Array.from(row.cells, (cell) =>

--- a/src/browser/utils/messages/transcriptContextMenu.ts
+++ b/src/browser/utils/messages/transcriptContextMenu.ts
@@ -342,8 +342,21 @@ const CLIPBOARD_TAGS = new Set([
   "tr",
   "th",
   "td",
+  "details",
+  "summary",
 ]);
 const CLIPBOARD_EXCLUDED_SELECTOR = `script, style, svg, img, iframe, object, .line-number, button, input, textarea, select, [hidden], [aria-hidden="true"], ${TRANSCRIPT_IGNORE_CONTEXT_MENU_SELECTOR}`;
+
+function isSafeClipboardHref(href: string): boolean {
+  if (!href.trim() || href.includes("\\")) return false;
+  try {
+    // Resolve relative paths only for protocol validation. Keep the original destination when copying.
+    const url = new URL(href, "https://clipboard.invalid/");
+    return ["http:", "https:", "mailto:"].includes(url.protocol);
+  } catch {
+    return false;
+  }
+}
 
 function appendClipboardNodes(source: Node, destination: Node, range: Range): void {
   const document = destination.ownerDocument!;
@@ -363,11 +376,33 @@ function appendClipboardNodes(source: Node, destination: Node, range: Range): vo
     }
     if (child.nodeType !== 1) continue;
     const element = child as Element;
+    if (element.matches('input[type="checkbox"][disabled]')) {
+      const marker = document.createElement("span");
+      marker.setAttribute("data-clipboard-task", "true");
+      marker.textContent = (element as HTMLInputElement).checked ? "[x] " : "[ ] ";
+      destination.appendChild(marker);
+      continue;
+    }
     if (element.matches(CLIPBOARD_EXCLUDED_SELECTOR)) continue;
+    if (element.matches(".katex")) {
+      const tex = element.querySelector('annotation[encoding="application/x-tex"]')?.textContent;
+      if (tex != null) {
+        // Rendered math has duplicate accessibility text. Treat each selected formula as one unit.
+        const math = document.createElement("span");
+        math.textContent = element.closest(".katex-display")
+          ? "$$\n" + tex + "\n$$"
+          : "$" + tex + "$";
+        math.setAttribute("data-clipboard-math", math.textContent);
+        destination.appendChild(math);
+        continue;
+      }
+    }
     // Highlighted code uses a grid, not semantic pre/code elements. Exclude its line numbers.
     if (element.matches(".code-block-container")) {
       const pre = document.createElement("pre");
       const code = document.createElement("code");
+      const language = element.getAttribute("data-code-language") ?? "";
+      if (/^[\w.+#-]+$/.test(language)) code.className = `language-${language}`;
       const lines: string[] = [];
       for (const line of element.querySelectorAll(".code-line")) {
         if (!range.intersectsNode(line)) continue;
@@ -388,7 +423,14 @@ function appendClipboardNodes(source: Node, destination: Node, range: Range): vo
     const copy = document.createElement(tag);
     if (tag === "a") {
       const href = element.getAttribute("href") ?? "";
-      if (/^(https?:|mailto:)/i.test(href)) copy.setAttribute("href", href);
+      if (isSafeClipboardHref(href)) copy.setAttribute("href", href);
+    }
+    if (tag === "details" && element.hasAttribute("open")) copy.setAttribute("open", "");
+    if (tag === "code") {
+      const languageClass = Array.from(element.classList).find((name) =>
+        /^language-[\w.+#-]+$/.test(name)
+      );
+      if (languageClass) copy.className = languageClass;
     }
     if (tag === "ol") {
       const list = element as HTMLOListElement;
@@ -407,10 +449,11 @@ export function getTranscriptContextMenuMarkdown(
   options: TranscriptContextMenuTextOptions
 ): FormattedClipboardContent | null {
   const target = getEventTargetElement(options.target);
+  const excludedTarget = target?.closest(CLIPBOARD_EXCLUDED_SELECTOR);
   if (
     !target ||
     !options.transcriptRoot.contains(target) ||
-    target.closest(CLIPBOARD_EXCLUDED_SELECTOR)
+    (excludedTarget && !excludedTarget.matches('.katex-html[aria-hidden="true"]'))
   ) {
     return null;
   }
@@ -426,6 +469,17 @@ export function getTranscriptContextMenuMarkdown(
   // Walk the original range so partial selections retain their formatting and list positions.
   appendClipboardNodes(quoteRoot, container, range);
   const markdown = new TurndownService({ headingStyle: "atx", codeBlockStyle: "fenced" });
+  markdown.addRule("selectedMathAndTasks", {
+    filter: (node) =>
+      node.hasAttribute("data-clipboard-math") || node.hasAttribute("data-clipboard-task"),
+    replacement: (_content, node) =>
+      node.getAttribute("data-clipboard-math") ?? node.textContent?.trimEnd() ?? "",
+  });
+  markdown.addRule("disclosure", {
+    filter: "details",
+    // SECURITY AUDIT: This node contains only the sanitized clipboard elements and attributes.
+    replacement: (_content, node) => "\n\n" + node.outerHTML + "\n\n",
+  });
   markdown.addRule("strikethrough", {
     filter: ["s", "del"],
     replacement: (content) => `~~${content}~~`,

--- a/src/browser/utils/messages/transcriptContextMenu.ts
+++ b/src/browser/utils/messages/transcriptContextMenu.ts
@@ -620,8 +620,12 @@ export function getTranscriptContextMenuMarkdown(
   markdown.addRule("table", {
     filter: "table",
     replacement: (_content, node) => {
-      // GFM cannot represent spans. Keep sanitized HTML instead of inventing a different table layout.
-      if (node.querySelector("[rowspan], [colspan]")) {
+      // GFM cannot represent spans or block content inside cells. Preserve their HTML structure.
+      if (
+        node.querySelector(
+          "[rowspan], [colspan], :is(td, th) :is(pre, p, div, ul, ol, dl, blockquote, h1, h2, h3, h4, h5, h6, details, table, hr)"
+        )
+      ) {
         return "\n\n" + serializeStructuredHtml(node) + "\n\n";
       }
       const rows = Array.from(node.querySelectorAll<HTMLTableRowElement>("tr"), (row) =>

--- a/src/browser/utils/messages/transcriptContextMenu.ts
+++ b/src/browser/utils/messages/transcriptContextMenu.ts
@@ -1,3 +1,5 @@
+import TurndownService from "turndown";
+import type { FormattedClipboardContent } from "@/browser/utils/clipboard";
 import {
   TRANSCRIPT_IGNORE_CONTEXT_MENU_SELECTOR,
   TRANSCRIPT_MESSAGE_SELECTOR,
@@ -308,6 +310,156 @@ export function getTranscriptContextMenuText(
   }
 
   return getHoveredTranscriptText(options.transcriptRoot, options.target);
+}
+
+// Copy only semantic formatting. Transcript content can contain untrusted repository text.
+const CLIPBOARD_TAGS = new Set([
+  "p",
+  "br",
+  "strong",
+  "b",
+  "em",
+  "i",
+  "s",
+  "del",
+  "blockquote",
+  "pre",
+  "code",
+  "ul",
+  "ol",
+  "li",
+  "a",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "hr",
+  "table",
+  "thead",
+  "tbody",
+  "tr",
+  "th",
+  "td",
+]);
+const CLIPBOARD_EXCLUDED_SELECTOR = `script, style, svg, img, iframe, object, .line-number, button, input, textarea, select, [hidden], [aria-hidden="true"], ${TRANSCRIPT_IGNORE_CONTEXT_MENU_SELECTOR}`;
+
+function appendClipboardNodes(source: Node, destination: Node, range: Range): void {
+  const document = destination.ownerDocument!;
+  for (const child of source.childNodes) {
+    if (!range.intersectsNode(child)) {
+      // Empty cells retain column positions without copying unselected text.
+      if (child.nodeName === "TH" || child.nodeName === "TD") {
+        destination.appendChild(document.createElement(child.nodeName.toLowerCase()));
+      }
+      continue;
+    }
+    if (child.nodeType === 3) {
+      const start = child === range.startContainer ? range.startOffset : 0;
+      const end = child === range.endContainer ? range.endOffset : child.textContent?.length;
+      destination.appendChild(document.createTextNode((child.textContent ?? "").slice(start, end)));
+      continue;
+    }
+    if (child.nodeType !== 1) continue;
+    const element = child as Element;
+    if (element.matches(CLIPBOARD_EXCLUDED_SELECTOR)) continue;
+    // Highlighted code uses a grid, not semantic pre/code elements. Exclude its line numbers.
+    if (element.matches(".code-block-container")) {
+      const pre = document.createElement("pre");
+      const code = document.createElement("code");
+      const lines: string[] = [];
+      for (const line of element.querySelectorAll(".code-line")) {
+        if (!range.intersectsNode(line)) continue;
+        const selectedLine = document.createElement("div");
+        appendClipboardNodes(line, selectedLine, range);
+        lines.push(selectedLine.textContent ?? "");
+      }
+      code.textContent = lines.join("\n");
+      pre.appendChild(code);
+      destination.appendChild(pre);
+      continue;
+    }
+    const tag = element.tagName.toLowerCase();
+    if (!CLIPBOARD_TAGS.has(tag)) {
+      appendClipboardNodes(element, destination, range);
+      continue;
+    }
+    const copy = document.createElement(tag);
+    if (tag === "a") {
+      const href = element.getAttribute("href") ?? "";
+      if (/^(https?:|mailto:)/i.test(href)) copy.setAttribute("href", href);
+    }
+    if (tag === "ol") {
+      const list = element as HTMLOListElement;
+      const firstSelected = Array.from(list.children).findIndex((item) =>
+        range.intersectsNode(item)
+      );
+      copy.setAttribute("start", String(list.start + Math.max(0, firstSelected)));
+    }
+    appendClipboardNodes(element, copy, range);
+    destination.appendChild(copy);
+  }
+}
+
+/** Return only the selected chat text, with Markdown and safe rich-text formatting. */
+export function getTranscriptContextMenuMarkdown(
+  options: TranscriptContextMenuTextOptions
+): FormattedClipboardContent | null {
+  const target = getEventTargetElement(options.target);
+  if (
+    !target ||
+    !options.transcriptRoot.contains(target) ||
+    target.closest(CLIPBOARD_EXCLUDED_SELECTOR)
+  ) {
+    return null;
+  }
+  if (!getSelectedTranscriptText(options.transcriptRoot, options.selection, options.target)) {
+    return null;
+  }
+
+  const range = options.selection!.getRangeAt(0);
+  const quoteRoot = getEventTargetElement(range.startContainer)!.closest(
+    TRANSCRIPT_QUOTE_ROOT_SELECTOR
+  )!;
+  const container = options.transcriptRoot.ownerDocument.createElement("div");
+  // Walk the original range so partial selections retain their formatting and list positions.
+  appendClipboardNodes(quoteRoot, container, range);
+  const markdown = new TurndownService({ headingStyle: "atx", codeBlockStyle: "fenced" });
+  markdown.addRule("strikethrough", {
+    filter: ["s", "del"],
+    replacement: (content) => `~~${content}~~`,
+  });
+  markdown.addRule("table", {
+    filter: "table",
+    replacement: (_content, node) => {
+      const rows = Array.from(node.querySelectorAll<HTMLTableRowElement>("tr"), (row) =>
+        Array.from(row.cells, (cell) =>
+          markdown.turndown(cell).replace(/\|/g, "\\|").replace(/\n/g, "<br>")
+        )
+      );
+      const width = Math.max(0, ...rows.map((row) => row.length));
+      if (!width) return "";
+      if (!node.querySelector("tr th")) rows.unshift(Array<string>(width).fill(""));
+      rows.splice(1, 0, Array<string>(width).fill("---"));
+      return (
+        "\n\n" +
+        rows
+          .map(
+            (row) =>
+              "| " +
+              Array.from({ length: width }, (_, index) => row[index] ?? "").join(" | ") +
+              " |"
+          )
+          .join("\n") +
+        "\n\n"
+      );
+    },
+  });
+  const text = markdown.turndown(container);
+  if (!text.trim()) return null;
+  // SECURITY AUDIT: Serialize only allowlisted elements and attributes, never the original selection HTML.
+  return { text, html: container.innerHTML };
 }
 
 /**

--- a/src/browser/utils/messages/transcriptContextMenu.ts
+++ b/src/browser/utils/messages/transcriptContextMenu.ts
@@ -5,6 +5,7 @@ import {
   TRANSCRIPT_MESSAGE_SELECTOR,
   TRANSCRIPT_QUOTE_ROOT_SELECTOR,
   TRANSCRIPT_QUOTE_TEXT_ATTRIBUTE,
+  transcriptMermaidSources,
 } from "./transcriptQuoteAttributes";
 
 // Preserve native link context-menu actions (open/copy link, etc.) by treating
@@ -118,14 +119,15 @@ function selectionIntersectsIgnoredChrome(quoteRoot: Element, selectionRange: Ra
 function getSelectedTranscriptText(
   transcriptRoot: HTMLElement,
   selection: Selection | null,
-  target: EventTarget | null
+  target: EventTarget | null,
+  allowDiagrams = false
 ): string | null {
   if (!selection || selection.rangeCount === 0) {
     return null;
   }
 
   const selectedText = normalizeTranscriptText(selection.toString());
-  if (!hasNonWhitespaceTranscriptText(selectedText)) {
+  if (selection.isCollapsed || (!allowDiagrams && !hasNonWhitespaceTranscriptText(selectedText))) {
     return null;
   }
 
@@ -191,6 +193,14 @@ function getSelectedTranscriptText(
     return null;
   }
 
+  if (allowDiagrams && !hasNonWhitespaceTranscriptText(selectedText)) {
+    return Array.from(startQuoteRoot.querySelectorAll(".mermaid-container")).some(
+      (element) =>
+        transcriptMermaidSources.has(element) && hasSelectedContents(selectedRange, element)
+    )
+      ? "mermaid"
+      : null;
+  }
   return selectedText;
 }
 
@@ -390,6 +400,17 @@ function hasSelectedOwnListText(item: Element, range: Range): boolean {
   return false;
 }
 
+function hasSelectedContents(range: Range, element: Element): boolean {
+  if (!range.intersectsNode(element)) return false;
+  const intersection = element.ownerDocument.createRange();
+  intersection.selectNodeContents(element);
+  if (range.compareBoundaryPoints(range.START_TO_START, intersection) > 0)
+    intersection.setStart(range.startContainer, range.startOffset);
+  if (range.compareBoundaryPoints(range.END_TO_END, intersection) < 0)
+    intersection.setEnd(range.endContainer, range.endOffset);
+  return !intersection.collapsed;
+}
+
 function appendClipboardNodes(
   source: Node,
   destination: Node,
@@ -433,7 +454,21 @@ function appendClipboardNodes(
       destination.appendChild(marker);
       continue;
     }
-    if (element.matches(CLIPBOARD_EXCLUDED_SELECTOR)) continue;
+    const chart = transcriptMermaidSources.get(element);
+    if (chart != null && hasSelectedContents(range, element)) {
+      const pre = document.createElement("pre");
+      const code = document.createElement("code");
+      code.className = "language-mermaid";
+      code.textContent = chart;
+      pre.appendChild(code);
+      destination.appendChild(pre);
+      continue;
+    }
+    if (
+      element.matches(CLIPBOARD_EXCLUDED_SELECTOR) ||
+      element.hasAttribute("data-footnote-backref")
+    )
+      continue;
     if (element.matches(".katex")) {
       const tex = element.querySelector('annotation[encoding="application/x-tex"]')?.textContent;
       if (tex != null) {
@@ -480,6 +515,20 @@ function appendClipboardNodes(
       continue;
     }
     const copy = document.createElement(tag);
+    // Carry selected footnote candidates until both sides of each relationship are known.
+    if ((tag === "li" && element.id) || element.hasAttribute("data-footnote-ref")) {
+      const contents = document.createRange();
+      contents.selectNodeContents(element);
+      const fullySelected =
+        range.compareBoundaryPoints(range.START_TO_START, contents) <= 0 &&
+        range.compareBoundaryPoints(range.END_TO_END, contents) >= 0;
+      if (tag === "li" && fullySelected) copy.setAttribute("data-clipboard-source-id", element.id);
+      if (tag === "a")
+        copy.setAttribute(
+          "data-clipboard-footnote-candidate",
+          fullySelected ? "complete" : "partial"
+        );
+    }
     if (tag === "a") {
       const href = element.getAttribute("href") ?? "";
       if (isSafeClipboardHref(href)) copy.setAttribute("href", href);
@@ -527,20 +576,65 @@ function appendClipboardNodes(
   }
 }
 
+function restoreSelectedFootnotes(container: HTMLElement): void {
+  const definitions = new Map(
+    Array.from(container.querySelectorAll("[data-clipboard-source-id]"), (element) => [
+      element.getAttribute("data-clipboard-source-id")!,
+      element,
+    ])
+  );
+  let referenceNumber = 0;
+  for (const reference of container.querySelectorAll("[data-clipboard-footnote-candidate]")) {
+    const href = reference.getAttribute("href") ?? "";
+    const definition = href.startsWith("#") ? definitions.get(href.slice(1)) : undefined;
+    // Partial selections retain visible numbers, without unresolved navigation targets.
+    if (!definition || reference.getAttribute("data-clipboard-footnote-candidate") !== "complete") {
+      reference.replaceWith(...reference.childNodes);
+      continue;
+    }
+    referenceNumber++;
+    const label =
+      definition.getAttribute("data-clipboard-footnote-definition") ?? String(referenceNumber);
+    definition.setAttribute("data-clipboard-footnote-definition", label);
+    definition.id = "clipboard-fn-" + label;
+    reference.id = "clipboard-fnref-" + referenceNumber;
+    reference.setAttribute("href", "#" + definition.id);
+    reference.setAttribute("data-clipboard-footnote-ref", label);
+    const backlink = container.ownerDocument.createElement("a");
+    backlink.setAttribute("href", "#" + reference.id);
+    backlink.setAttribute("data-clipboard-footnote-backref", "");
+    backlink.textContent = "Back to reference";
+    definition.appendChild(backlink);
+  }
+  for (const element of container.querySelectorAll(
+    "[data-clipboard-source-id], [data-clipboard-footnote-candidate]"
+  )) {
+    element.removeAttribute("data-clipboard-source-id");
+    element.removeAttribute("data-clipboard-footnote-candidate");
+  }
+}
+
 /** Return only the selected chat text, with Markdown and safe rich-text formatting. */
 export function getTranscriptContextMenuMarkdown(
   options: TranscriptContextMenuTextOptions
 ): FormattedClipboardContent | null {
   const target = getEventTargetElement(options.target);
   const excludedTarget = target?.closest(CLIPBOARD_EXCLUDED_SELECTOR);
+  const diagramTarget = target?.closest(".mermaid-container");
+  // Permit diagram graphics, but never controls or links inside the diagram.
+  const trustedDiagramTarget =
+    diagramTarget &&
+    excludedTarget?.tagName.toLowerCase() === "svg" &&
+    transcriptMermaidSources.has(diagramTarget) &&
+    !target?.closest(INTERACTIVE_SELECTOR);
   if (
     !target ||
     !options.transcriptRoot.contains(target) ||
-    (excludedTarget && !excludedTarget.closest(".katex"))
+    (excludedTarget && !excludedTarget.closest(".katex") && !trustedDiagramTarget)
   ) {
     return null;
   }
-  if (!getSelectedTranscriptText(options.transcriptRoot, options.selection, options.target)) {
+  if (!getSelectedTranscriptText(options.transcriptRoot, options.selection, options.target, true)) {
     return null;
   }
 
@@ -563,10 +657,34 @@ export function getTranscriptContextMenuMarkdown(
   while (container.childNodes.length === 1 && container.firstElementChild?.tagName === "DIV") {
     container.replaceChildren(...container.firstElementChild.childNodes);
   }
+  restoreSelectedFootnotes(container);
   const markdown = new TurndownService({ headingStyle: "atx", codeBlockStyle: "fenced" });
   // Preserve literal HTML and entities as text when the copied Markdown is parsed again.
   markdown.escape = (text) =>
     TurndownService.prototype.escape(text).replace(/&/g, "&amp;").replace(/</g, "\\<");
+  markdown.addRule("footnoteReference", {
+    filter: (node) =>
+      node.nodeName === "SUP" && node.querySelector("[data-clipboard-footnote-ref]") !== null,
+    replacement: (_content, node) =>
+      "[^" +
+      node
+        .querySelector("[data-clipboard-footnote-ref]")!
+        .getAttribute("data-clipboard-footnote-ref") +
+      "]",
+  });
+  markdown.addRule("footnoteDefinition", {
+    filter: (node) => node.hasAttribute("data-clipboard-footnote-definition"),
+    replacement: (content, node) =>
+      "\n\n[^" +
+      node.getAttribute("data-clipboard-footnote-definition") +
+      "]: " +
+      content.trim().replace(/\n/g, "\n    ") +
+      "\n\n",
+  });
+  markdown.addRule("footnoteBacklink", {
+    filter: (node) => node.hasAttribute("data-clipboard-footnote-backref"),
+    replacement: () => "",
+  });
   markdown.addRule("selectedMathAndTasks", {
     filter: (node) =>
       node.hasAttribute("data-clipboard-math") || node.hasAttribute("data-clipboard-task"),
@@ -582,12 +700,17 @@ export function getTranscriptContextMenuMarkdown(
     },
   });
   markdown.addRule("scripts", {
-    filter: ["sub", "sup"],
+    filter: (node) =>
+      ["SUB", "SUP"].includes(node.nodeName) &&
+      !node.querySelector("[data-clipboard-footnote-ref]"),
     // SECURITY AUDIT: This node contains only the sanitized clipboard elements and attributes.
     replacement: (_content, node) => node.outerHTML,
   });
   markdown.addRule("safeLink", {
-    filter: (node) => node.nodeName === "A" && node.hasAttribute("href"),
+    filter: (node) =>
+      node.nodeName === "A" &&
+      node.hasAttribute("href") &&
+      !node.hasAttribute("data-clipboard-footnote-backref"),
     replacement: (content, node) => {
       const href = (node.getAttribute("href") ?? "").replace(/[<>\s]/g, encodeURIComponent);
       return "[" + content + "](<" + href + ">)";
@@ -604,12 +727,16 @@ export function getTranscriptContextMenuMarkdown(
       element.attributes,
       (attribute) => " " + attribute.name + '="' + attribute.value + '"'
     ).join("");
-    const content = element.matches("td, th, li")
+    const content = element.matches("td, th, li, dt, dd")
       ? markdown.turndown(element as HTMLElement)
       : Array.from(element.children, serializeStructuredHtml).join("\n\n");
     return "<" + tag + attributes + ">\n\n" + content + "\n\n</" + tag + ">";
   };
 
+  markdown.addRule("definitionList", {
+    filter: "dl",
+    replacement: (_content, node) => "\n\n" + serializeStructuredHtml(node) + "\n\n",
+  });
   markdown.addRule("numberedList", {
     filter: (node) =>
       node.nodeName === "OL" &&
@@ -670,6 +797,11 @@ export function getTranscriptContextMenuMarkdown(
   });
   const text = markdown.turndown(container);
   if (!text.trim()) return null;
+  for (const element of container.querySelectorAll("*")) {
+    for (const attribute of Array.from(element.attributes)) {
+      if (attribute.name.startsWith("data-clipboard-")) element.removeAttribute(attribute.name);
+    }
+  }
   // SECURITY AUDIT: Serialize only allowlisted elements and attributes, never the original selection HTML.
   return { text, html: container.innerHTML };
 }

--- a/src/browser/utils/messages/transcriptContextMenu.ts
+++ b/src/browser/utils/messages/transcriptContextMenu.ts
@@ -344,8 +344,10 @@ const CLIPBOARD_TAGS = new Set([
   "td",
   "details",
   "summary",
+  "sub",
+  "sup",
 ]);
-const CLIPBOARD_EXCLUDED_SELECTOR = `script, style, svg, img, iframe, object, .line-number, button, input, textarea, select, [hidden], [aria-hidden="true"], ${TRANSCRIPT_IGNORE_CONTEXT_MENU_SELECTOR}`;
+const CLIPBOARD_EXCLUDED_SELECTOR = `script, style, svg, img, iframe, object, .line-number, .sr-only, button, input, textarea, select, [hidden], [aria-hidden="true"], ${TRANSCRIPT_IGNORE_CONTEXT_MENU_SELECTOR}`;
 
 function isSafeClipboardHref(href: string): boolean {
   if (!href.trim() || href.includes("\\")) return false;
@@ -358,10 +360,23 @@ function isSafeClipboardHref(href: string): boolean {
   }
 }
 
+function isClipboardElementHidden(element: Element): boolean {
+  const style = element.ownerDocument.defaultView!.getComputedStyle(element);
+  return (
+    style.display === "none" ||
+    style.visibility === "hidden" ||
+    style.visibility === "collapse" ||
+    style.opacity === "0"
+  );
+}
+
 function appendClipboardNodes(source: Node, destination: Node, range: Range): void {
   const document = destination.ownerDocument!;
   for (const child of source.childNodes) {
-    if (!range.intersectsNode(child)) {
+    const isTaskMarker =
+      child.nodeType === 1 &&
+      (child as Element).matches('li > input[type="checkbox"][disabled]:first-child');
+    if (!range.intersectsNode(child) && !isTaskMarker) {
       // Empty cells retain column positions without copying unselected text.
       if (child.nodeName === "TH" || child.nodeName === "TD") {
         destination.appendChild(document.createElement(child.nodeName.toLowerCase()));
@@ -376,6 +391,7 @@ function appendClipboardNodes(source: Node, destination: Node, range: Range): vo
     }
     if (child.nodeType !== 1) continue;
     const element = child as Element;
+    if (isClipboardElementHidden(element)) continue;
     if (element.matches('input[type="checkbox"][disabled]')) {
       const marker = document.createElement("span");
       marker.setAttribute("data-clipboard-task", "true");
@@ -405,7 +421,7 @@ function appendClipboardNodes(source: Node, destination: Node, range: Range): vo
       if (/^[\w.+#-]+$/.test(language)) code.className = `language-${language}`;
       const lines: string[] = [];
       for (const line of element.querySelectorAll(".code-line")) {
-        if (!range.intersectsNode(line)) continue;
+        if (!range.intersectsNode(line) || isClipboardElementHidden(line)) continue;
         const selectedLine = document.createElement("div");
         appendClipboardNodes(line, selectedLine, range);
         lines.push(selectedLine.textContent ?? "");
@@ -476,9 +492,17 @@ export function getTranscriptContextMenuMarkdown(
       node.getAttribute("data-clipboard-math") ?? node.textContent?.trimEnd() ?? "",
   });
   markdown.addRule("disclosure", {
-    filter: "details",
+    filter: ["details", "sub", "sup"],
     // SECURITY AUDIT: This node contains only the sanitized clipboard elements and attributes.
-    replacement: (_content, node) => "\n\n" + node.outerHTML + "\n\n",
+    replacement: (_content, node) =>
+      node.nodeName === "DETAILS" ? "\n\n" + node.outerHTML + "\n\n" : node.outerHTML,
+  });
+  markdown.addRule("safeLink", {
+    filter: (node) => node.nodeName === "A" && node.hasAttribute("href"),
+    replacement: (content, node) => {
+      const href = (node.getAttribute("href") ?? "").replace(/[<>\s]/g, encodeURIComponent);
+      return "[" + content + "](<" + href + ">)";
+    },
   });
   markdown.addRule("strikethrough", {
     filter: ["s", "del"],

--- a/src/browser/utils/messages/transcriptQuoteAttributes.ts
+++ b/src/browser/utils/messages/transcriptQuoteAttributes.ts
@@ -1,3 +1,6 @@
+// Only renderer refs register chart sources. Raw HTML cannot forge this metadata.
+export const transcriptMermaidSources = new WeakMap<Element, string>();
+
 export const TRANSCRIPT_MESSAGE_SELECTOR = "[data-transcript-message]";
 export const TRANSCRIPT_QUOTE_ROOT_SELECTOR = "[data-transcript-quote-root]";
 export const TRANSCRIPT_IGNORE_CONTEXT_MENU_SELECTOR = "[data-transcript-ignore-context-menu]";

--- a/src/browser/utils/ui/keybinds.test.ts
+++ b/src/browser/utils/ui/keybinds.test.ts
@@ -15,6 +15,17 @@ function createEvent(overrides: Partial<KeyboardEvent> = {}): KeyboardEvent {
   } as KeyboardEvent;
 }
 
+describe("COPY_MARKDOWN keybind", () => {
+  test("accepts M without modifiers and rejects modified keys", () => {
+    expect(matchesKeybind(createEvent({ key: "m" }), KEYBINDS.COPY_MARKDOWN)).toBe(true);
+    for (const modifier of ["shiftKey", "ctrlKey", "metaKey", "altKey"]) {
+      expect(
+        matchesKeybind(createEvent({ key: "M", [modifier]: true }), KEYBINDS.COPY_MARKDOWN)
+      ).toBe(false);
+    }
+  });
+});
+
 describe("isMac", () => {
   it("falls back to navigator.platform when Electron API is missing", () => {
     const originalWindow = globalThis.window;

--- a/src/browser/utils/ui/keybinds.ts
+++ b/src/browser/utils/ui/keybinds.ts
@@ -298,6 +298,9 @@ export function isKeybindDeprecated(keybind: Keybind): boolean {
  * We also like vim keybinds.
  */
 export const KEYBINDS = {
+  /** Copy selected transcript Markdown while its context menu is open. */
+  COPY_MARKDOWN: { key: "m" },
+
   /** Open agent picker (focuses search) */
   TOGGLE_AGENT: { key: "A", ctrl: true, shift: true },
 


### PR DESCRIPTION
## Summary

Add **Copy Markdown** to the chat context menu for selected text. Copy Markdown and sanitized rich HTML together for formatted paste.

## Background

Plain-text copying loses formatting when users paste chat text into Slack. The new action preserves selected formatting without copying the entire message.

## Implementation

- Preserve emphasis, links, lists, tables, and code blocks within one message body.
- Exclude code line numbers, controls, visually hidden text, and unsafe HTML attributes.
- Preserve subscript and superscript semantics. Encode link destinations for valid Markdown.
- Keep partial list numbering and table column positions.
- Retain relative links, task states, disclosure blocks, and fenced-code languages.
- Copy selected math as a complete TeX formula to avoid duplicated renderer text.
- Reconstruct selected Mermaid diagrams from renderer-owned source metadata.
- Preserve definition-list structure and complete footnote relationships. Partial selections omit broken footnote links.
- Preserve explicit list numbering and block content inside table cells.
- Strip arbitrary classes and inline styles from raw HTML. Preserve renderer-generated math styling.
- Display unsupported raw MathML as literal text. Preserve literal HTML when copied Markdown renders again.
- Keep table spans as sanitized HTML and preserve empty structure for partial selections.
- Support **M** while the menu is open. Hide the shortcut label on phone layouts.
- Use Markdown-only copying when rich clipboard APIs are unavailable or reject the write.

## Risks

Selection conversion depends on the rendered chat structure. Raw HTML no longer supports arbitrary CSS classes or inline styles. Semantic Markdown formatting remains supported. Spanning-table selections can include empty structural cells. Slack paste behavior still needs direct confirmation.

---

_Generated with `xum` • Model: `openai:gpt-6-astra` • Thinking: `medium` • Cost: `$182.77`_

<!-- mux-attribution: model=openai:gpt-6-astra thinking=medium costs=182.77 -->
