### PR TITLE
[workspace] 🤖 Fix deletion of parents with inactive descendants

### DIFF
--- a/src/browser/components/ArchivedWorkspaces/ArchivedWorkspaces.test.tsx
+++ b/src/browser/components/ArchivedWorkspaces/ArchivedWorkspaces.test.tsx
@@ -1,6 +1,6 @@
 import "../../../../tests/ui/dom";
 
-import { type ReactNode } from "react";
+import { type ComponentProps, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { installDom } from "../../../../tests/ui/dom";
@@ -13,7 +13,7 @@ import * as ForceDeleteModalModule from "@/browser/components/ForceDeleteModal/F
 import * as RuntimeBadgeModule from "@/browser/components/RuntimeBadge/RuntimeBadge";
 import * as SkeletonModule from "@/browser/components/Skeleton/Skeleton";
 import * as OptimisticBatchLRUModule from "@/browser/hooks/useOptimisticBatchLRU";
-import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
+import type { FrontendWorkspaceMetadata, WorkspaceRemoveResult } from "@/common/types/workspace";
 
 import { ArchivedWorkspaces } from "./ArchivedWorkspaces";
 
@@ -49,13 +49,18 @@ describe("ArchivedWorkspaces", () => {
   const deleteWorktreeMock = mock(() => Promise.resolve({ success: true }));
   const getSessionUsageBatchMock = mock(() => Promise.resolve({}));
   const unarchiveWorkspaceMock = mock(() => Promise.resolve({ success: true }));
-  const removeWorkspaceMock = mock((_workspaceId: string, _options?: { force?: boolean }) =>
-    Promise.resolve({ success: true })
+  const removeWorkspaceMock = mock(
+    (
+      _workspaceId: string,
+      _options?: { force?: boolean; acknowledgedDescendantIds?: string[] }
+    ): Promise<WorkspaceRemoveResult> => Promise.resolve({ success: true })
   );
+  let modalProps: ComponentProps<typeof ForceDeleteModalModule.ForceDeleteModal> | undefined;
   const setSelectedWorkspaceMock = mock(() => undefined);
   const onWorkspacesChangedMock = mock(() => undefined);
 
   beforeEach(() => {
+    modalProps = undefined;
     installTestDoubles();
     cleanupDom = installDom();
     deleteWorktreeMock.mockClear();
@@ -97,9 +102,10 @@ describe("ArchivedWorkspaces", () => {
     spyOn(TooltipModule, "TooltipContent").mockImplementation(((props: { children: ReactNode }) => (
       <>{props.children}</>
     )) as unknown as typeof TooltipModule.TooltipContent);
-    spyOn(ForceDeleteModalModule, "ForceDeleteModal").mockImplementation(
-      (() => null) as unknown as typeof ForceDeleteModalModule.ForceDeleteModal
-    );
+    spyOn(ForceDeleteModalModule, "ForceDeleteModal").mockImplementation((props) => {
+      modalProps = props;
+      return null;
+    });
     spyOn(RuntimeBadgeModule, "RuntimeBadge").mockImplementation((() => (
       <span data-testid="runtime-badge" />
     )) as unknown as typeof RuntimeBadgeModule.RuntimeBadge);
@@ -185,6 +191,68 @@ describe("ArchivedWorkspaces", () => {
     });
     expect(removeWorkspaceMock.mock.calls.map((call) => call[0])).toEqual([child.id, parent.id]);
     expect(removeWorkspaceMock.mock.calls.every((call) => call[1]?.force === true)).toBe(true);
+  });
+
+  test("Shift-click requires descendant confirmation and forwards retry results", async () => {
+    const workspace = createWorkspace({ id: "parent", name: "parent" });
+    const descendants = [{ workspaceId: "child", title: "Child", active: false }];
+    removeWorkspaceMock.mockResolvedValueOnce({
+      success: false,
+      error: "Confirm children",
+      descendants,
+    });
+    const view = render(
+      <ArchivedWorkspaces
+        projectPath={workspace.projectPath}
+        projectName={workspace.projectName}
+        workspaces={[workspace]}
+        onWorkspacesChanged={onWorkspacesChangedMock}
+      />
+    );
+    fireEvent.click(view.getByLabelText("Expand archived workspaces"));
+    fireEvent.click(await waitFor(() => view.getByLabelText("Delete workspace parent")), {
+      shiftKey: true,
+    });
+    await waitFor(() => expect(modalProps?.descendants).toEqual(descendants));
+    expect(removeWorkspaceMock).toHaveBeenCalledTimes(1);
+    expect(removeWorkspaceMock).toHaveBeenCalledWith(workspace.id);
+    expect(onWorkspacesChangedMock).not.toHaveBeenCalled();
+    if (!modalProps) throw new Error("Expected deletion confirmation");
+    const retryFailure = {
+      success: false,
+      error: "Child starts running",
+      descendants: [{ ...descendants[0], active: true }],
+    };
+    removeWorkspaceMock.mockResolvedValueOnce(retryFailure);
+    expect(await modalProps.onForceDelete(workspace.id, ["child"])).toEqual(retryFailure);
+    expect(removeWorkspaceMock).toHaveBeenLastCalledWith(workspace.id, {
+      force: true,
+      acknowledgedDescendantIds: ["child"],
+    });
+    expect(onWorkspacesChangedMock).not.toHaveBeenCalled();
+    expect(await modalProps.onForceDelete(workspace.id, ["child"])).toEqual({ success: true });
+    expect(onWorkspacesChangedMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("Shift-click still forces deletion without descendants", async () => {
+    const workspace = createWorkspace({ id: "parent", name: "parent" });
+    removeWorkspaceMock.mockResolvedValueOnce({ success: false, error: "Dirty checkout" });
+    const view = render(
+      <ArchivedWorkspaces
+        projectPath={workspace.projectPath}
+        projectName={workspace.projectName}
+        workspaces={[workspace]}
+        onWorkspacesChanged={onWorkspacesChangedMock}
+      />
+    );
+    fireEvent.click(view.getByLabelText("Expand archived workspaces"));
+    fireEvent.click(await waitFor(() => view.getByLabelText("Delete workspace parent")), {
+      shiftKey: true,
+    });
+    await waitFor(() => expect(onWorkspacesChangedMock).toHaveBeenCalledTimes(1));
+    expect(removeWorkspaceMock).toHaveBeenNthCalledWith(1, workspace.id);
+    expect(removeWorkspaceMock).toHaveBeenNthCalledWith(2, workspace.id, { force: true });
+    expect(modalProps).toBeUndefined();
   });
 
   test("shows delete worktree for archived worktree workspaces and calls the API", async () => {

--- a/src/browser/components/ArchivedWorkspaces/ArchivedWorkspaces.tsx
+++ b/src/browser/components/ArchivedWorkspaces/ArchivedWorkspaces.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { cn } from "@/common/lib/utils";
 import { getArchivedWorkspacesExpandedKey } from "@/common/constants/storage";
 import { isWorktreeRuntime } from "@/common/types/runtime";
-import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
+import type {
+  FrontendWorkspaceMetadata,
+  WorkspaceRemovalDescendant,
+} from "@/common/types/workspace";
 import { getErrorMessage } from "@/common/utils/errors";
 import { useAPI } from "@/browser/contexts/API";
 import { useWorkspaceContext } from "@/browser/contexts/WorkspaceContext";
@@ -316,6 +319,7 @@ export const ArchivedWorkspaces: React.FC<ArchivedWorkspacesProps> = ({
   const [forceDeleteModal, setForceDeleteModal] = React.useState<{
     workspaceId: string;
     error: string;
+    descendants?: WorkspaceRemovalDescendant[];
   } | null>(null);
   const deleteWorktreeError = usePopoverError();
   const unarchiveError = usePopoverError();
@@ -720,7 +724,8 @@ export const ArchivedWorkspaces: React.FC<ArchivedWorkspacesProps> = ({
       }
 
       // Shift-click: skip force-delete confirmation, auto-force immediately.
-      if (options?.bypassForceConfirm) {
+      // Descendant deletion always requires an explicit scope confirmation, including Shift-click.
+      if (options?.bypassForceConfirm && !result.descendants?.length) {
         const forced = await removeWorkspace(workspaceId, { force: true });
         if (forced.success) {
           onWorkspacesChanged?.();
@@ -731,6 +736,7 @@ export const ArchivedWorkspaces: React.FC<ArchivedWorkspacesProps> = ({
         setForceDeleteModal({
           workspaceId,
           error: forced.error ?? result.error ?? "Failed to remove workspace",
+          descendants: forced.descendants,
         });
         return;
       }
@@ -738,6 +744,7 @@ export const ArchivedWorkspaces: React.FC<ArchivedWorkspacesProps> = ({
       setForceDeleteModal({
         workspaceId,
         error: result.error ?? "Failed to remove workspace",
+        descendants: result.descendants,
       });
     } finally {
       setProcessingIds((prev) => {
@@ -759,19 +766,23 @@ export const ArchivedWorkspaces: React.FC<ArchivedWorkspacesProps> = ({
     <>
       {/* Bulk operation progress modal */}
 
-      <ForceDeleteModal
-        isOpen={forceDeleteModal !== null}
-        workspaceId={forceDeleteModal?.workspaceId ?? ""}
-        error={forceDeleteModal?.error ?? ""}
-        onClose={() => setForceDeleteModal(null)}
-        onForceDelete={async (workspaceId) => {
-          const result = await removeWorkspace(workspaceId, { force: true });
-          if (!result.success) {
-            throw new Error(result.error ?? "Force delete failed");
-          }
-          onWorkspacesChanged?.();
-        }}
-      />
+      {forceDeleteModal && (
+        <ForceDeleteModal
+          isOpen
+          workspaceId={forceDeleteModal.workspaceId}
+          error={forceDeleteModal.error}
+          descendants={forceDeleteModal.descendants}
+          onClose={() => setForceDeleteModal(null)}
+          onForceDelete={async (workspaceId, acknowledgedDescendantIds) => {
+            const result = await removeWorkspace(workspaceId, {
+              force: true,
+              acknowledgedDescendantIds,
+            });
+            if (result.success) onWorkspacesChanged?.();
+            return result;
+          }}
+        />
+      )}
       <PopoverError
         error={unarchiveError.error}
         prefix="Failed to restore workspace"

--- a/src/browser/components/ForceDeleteModal/ForceDeleteModal.stories.tsx
+++ b/src/browser/components/ForceDeleteModal/ForceDeleteModal.stories.tsx
@@ -1,0 +1,176 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, mocked, userEvent, waitFor, within } from "storybook/test";
+import { useState, type ComponentProps } from "react";
+import { ForceDeleteModal } from "./ForceDeleteModal";
+
+const descendants = [
+  { workspaceId: "child-review", title: "Review child", active: false },
+  { workspaceId: "child-build", title: "Build child", active: false },
+];
+
+const meta = {
+  title: "Components/ForceDeleteModal",
+  component: ForceDeleteModal,
+  args: {
+    isOpen: true,
+    workspaceId: "parent",
+    error: "Descendant confirmation required",
+    descendants,
+    onClose: fn(),
+    onForceDelete: fn<ComponentProps<typeof ForceDeleteModal>["onForceDelete"]>(() =>
+      Promise.resolve({ success: true })
+    ),
+  },
+  render: function StatefulDialog(args) {
+    const [open, setOpen] = useState(true);
+    return (
+      <ForceDeleteModal
+        {...args}
+        isOpen={open}
+        onClose={() => {
+          args.onClose();
+          setOpen(false);
+        }}
+      />
+    );
+  },
+} satisfies Meta<typeof ForceDeleteModal>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ExplicitScope: Story = {
+  play: async ({ canvasElement, args }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    const dialog = await page.findByRole("dialog");
+    const scope = within(dialog).getByRole("region", { name: "Descendant workspaces" });
+    await expect(within(scope).getAllByRole("listitem")).toHaveLength(2);
+    await expect(args.onForceDelete).not.toHaveBeenCalled();
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Delete Workspace and Descendants" })
+    );
+    await waitFor(() =>
+      expect(args.onForceDelete).toHaveBeenCalledWith("parent", ["child-review", "child-build"])
+    );
+    await waitFor(() => expect(page.queryByRole("dialog")).not.toBeInTheDocument());
+    await expect(args.onClose).toHaveBeenCalledTimes(1);
+  },
+};
+
+export const ActiveDescendantBlocksShortcut: Story = {
+  args: { descendants: [{ ...descendants[0], active: true }] },
+  play: async ({ canvasElement, args }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    const dialog = await page.findByRole("dialog");
+    await expect(within(dialog).getAllByRole("button")).toHaveLength(1);
+    dialog.focus();
+    await userEvent.keyboard("y");
+    await expect(args.onForceDelete).not.toHaveBeenCalled();
+    await expect(args.onClose).not.toHaveBeenCalled();
+    await userEvent.click(within(dialog).getByRole("button", { name: "Close" }));
+    await waitFor(() => expect(page.queryByRole("dialog")).not.toBeInTheDocument());
+  },
+};
+
+export const RetryRefreshesScope: Story = {
+  beforeEach: ({ args }) => {
+    mocked(args.onForceDelete)
+      .mockResolvedValueOnce({
+        success: false,
+        error: "New descendants need confirmation",
+        descendants: [descendants[1]],
+      })
+      .mockResolvedValue({ success: true });
+  },
+  play: async ({ canvasElement, args }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    const dialog = await page.findByRole("dialog");
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Delete Workspace and Descendants" })
+    );
+    await expect(await page.findByText("New descendants need confirmation")).toBeVisible();
+    await expect(args.onClose).not.toHaveBeenCalled();
+    await expect(within(dialog).getAllByRole("listitem")).toHaveLength(1);
+    await expect(page.queryByText(descendants[0].title)).not.toBeInTheDocument();
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Delete Workspace and Descendants" })
+    );
+    await expect(args.onForceDelete).toHaveBeenNthCalledWith(1, "parent", [
+      "child-review",
+      "child-build",
+    ]);
+    await expect(args.onForceDelete).toHaveBeenNthCalledWith(2, "parent", ["child-build"]);
+    await waitFor(() => expect(page.queryByRole("dialog")).not.toBeInTheDocument());
+  },
+};
+
+export const RetryBecomesBlocked: Story = {
+  beforeEach: ({ args }) => {
+    mocked(args.onForceDelete).mockResolvedValue({
+      success: false,
+      error: "Child starts running",
+      descendants: [{ ...descendants[0], active: true }],
+    });
+  },
+  play: async ({ canvasElement, args }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    const dialog = await page.findByRole("dialog");
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Delete Workspace and Descendants" })
+    );
+    await expect(await page.findByText("Child starts running")).toBeVisible();
+    await expect(within(dialog).getAllByRole("button")).toHaveLength(1);
+    dialog.focus();
+    await userEvent.keyboard("y");
+    await expect(args.onForceDelete).toHaveBeenCalledTimes(1);
+    await expect(args.onClose).not.toHaveBeenCalled();
+  },
+};
+
+export const RejectedRetryRemainsVisible: Story = {
+  beforeEach: ({ args }) => {
+    mocked(args.onForceDelete).mockRejectedValue(new Error("Transport unavailable"));
+  },
+  play: async ({ canvasElement, args }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    const dialog = await page.findByRole("dialog");
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Delete Workspace and Descendants" })
+    );
+    await expect(await page.findByText("Transport unavailable")).toBeVisible();
+    await expect(within(dialog).getAllByRole("listitem")).toHaveLength(2);
+    await expect(
+      within(dialog).getByRole("button", { name: "Delete Workspace and Descendants" })
+    ).toBeEnabled();
+    await expect(args.onClose).not.toHaveBeenCalled();
+  },
+};
+
+export const Phone: Story = {
+  globals: { viewport: { value: "phone390", isRotated: false } },
+  parameters: { pixel: { matrix: { viewports: ["phone"] } } },
+  args: {
+    descendants: [
+      {
+        workspaceId: "child-" + "long-id-".repeat(16),
+        title: "A long descendant title that must wrap inside the deletion dialog",
+        active: false,
+      },
+    ],
+  },
+  play: async ({ canvasElement, parameters, globals }) => {
+    await expect(parameters).toMatchObject({ pixel: { matrix: { viewports: ["phone"] } } });
+    await expect(globals).toMatchObject({ viewport: { value: "phone390" } });
+    const dialog = await within(canvasElement.ownerDocument.body).findByRole("dialog");
+    if (window.innerWidth <= 390) {
+      await expect(dialog.getBoundingClientRect().left).toBeGreaterThanOrEqual(0);
+      await expect(dialog.getBoundingClientRect().right).toBeLessThanOrEqual(window.innerWidth);
+      await expect(dialog.scrollWidth).toBeLessThanOrEqual(dialog.clientWidth);
+      const button = within(dialog).getByRole("button", {
+        name: "Delete Workspace and Descendants",
+      });
+      await expect(button).toBeVisible();
+      await expect(button.getBoundingClientRect().right).toBeLessThanOrEqual(window.innerWidth);
+      await expect(within(button).getByText("Y")).not.toBeVisible();
+    }
+  },
+};

--- a/src/browser/components/ForceDeleteModal/ForceDeleteModal.tsx
+++ b/src/browser/components/ForceDeleteModal/ForceDeleteModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -16,70 +16,73 @@ import {
 import { Button } from "@/browser/components/Button/Button";
 import { stopKeyboardPropagation } from "@/browser/utils/events";
 import { isEditableElement, KEYBINDS, matchesKeybind } from "@/browser/utils/ui/keybinds";
+import { getErrorMessage } from "@/common/utils/errors";
+import type { WorkspaceRemovalDescendant, WorkspaceRemoveResult } from "@/common/types/workspace";
 
 interface ForceDeleteModalProps {
   isOpen: boolean;
   workspaceId: string;
   error: string;
+  descendants?: WorkspaceRemovalDescendant[];
   onClose: () => void;
-  onForceDelete: (workspaceId: string) => Promise<void>;
+  onForceDelete: (
+    workspaceId: string,
+    acknowledgedDescendantIds?: string[]
+  ) => Promise<WorkspaceRemoveResult>;
 }
 
-export const ForceDeleteModal: React.FC<ForceDeleteModalProps> = ({
-  isOpen,
-  workspaceId,
-  error,
-  onClose,
-  onForceDelete,
-}) => {
+export const ForceDeleteModal: React.FC<ForceDeleteModalProps> = (props) => {
   const [isDeleting, setIsDeleting] = useState(false);
+  const [failure, setFailure] = useState<WorkspaceRemoveResult | null>(null);
+  const error = failure?.error ?? props.error;
+  const descendants = failure ? (failure.descendants ?? []) : (props.descendants ?? []);
+  const hasDescendants = descendants.length > 0;
+  const hasActiveDescendants = descendants.some((descendant) => descendant.active);
 
-  const handleForceDelete = useCallback(() => {
+  const performForceDelete = async () => {
     setIsDeleting(true);
-    void (async () => {
-      try {
-        await onForceDelete(workspaceId);
-        onClose();
-      } catch (err) {
-        console.error("Force delete failed:", err);
-      } finally {
-        setIsDeleting(false);
+    try {
+      // Force alone does not authorize child deletion. Send only the scope shown in this dialog.
+      const result = await props.onForceDelete(
+        props.workspaceId,
+        hasDescendants ? descendants.map((descendant) => descendant.workspaceId) : undefined
+      );
+      if (result.success) {
+        props.onClose();
+      } else {
+        setFailure(result);
       }
-    })();
-  }, [onForceDelete, workspaceId, onClose]);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
 
-  const handleOpenChange = useCallback(
-    (open: boolean) => {
-      if (!open && !isDeleting) {
-        onClose();
-      }
-    },
-    [isDeleting, onClose]
-  );
+  const handleForceDelete = () => {
+    if (isDeleting || hasActiveDescendants) return;
+    performForceDelete().catch((err: unknown) => {
+      setFailure({ success: false, error: getErrorMessage(err), descendants });
+    });
+  };
 
-  const handleDialogKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (isEditableElement(e.target)) return;
+  const handleOpenChange = (open: boolean) => {
+    if (!open && !isDeleting) props.onClose();
+  };
 
-      // Block all global shortcuts while dialog is active.
-      // Radix handles Escape in capture phase (via onEscapeKeyDown) before this fires.
-      stopKeyboardPropagation(e);
-
-      if (isDeleting) return;
-
-      if (matchesKeybind(e, KEYBINDS.CONFIRM_DIALOG_YES)) {
-        e.preventDefault();
-        handleForceDelete();
-      } else if (matchesKeybind(e, KEYBINDS.CONFIRM_DIALOG_NO)) {
-        e.preventDefault();
-        onClose();
-      }
-    },
-    [isDeleting, handleForceDelete, onClose]
-  );
+  const handleDialogKeyDown = (e: React.KeyboardEvent) => {
+    if (isEditableElement(e.target)) return;
+    stopKeyboardPropagation(e);
+    if (isDeleting) return;
+    if (matchesKeybind(e, KEYBINDS.CONFIRM_DIALOG_YES)) {
+      e.preventDefault();
+      return handleForceDelete();
+    } else if (matchesKeybind(e, KEYBINDS.CONFIRM_DIALOG_NO)) {
+      e.preventDefault();
+      props.onClose();
+    }
+  };
 
   return (
-    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+    <Dialog open={props.isOpen} onOpenChange={handleOpenChange}>
       <DialogContent
         maxWidth="600px"
         maxHeight="90vh"
@@ -87,44 +90,77 @@ export const ForceDeleteModal: React.FC<ForceDeleteModalProps> = ({
         onKeyDown={handleDialogKeyDown}
       >
         <DialogHeader>
-          <DialogTitle>Force Delete Workspace?</DialogTitle>
-          <DialogDescription>The workspace could not be removed normally</DialogDescription>
+          <DialogTitle>
+            {hasActiveDescendants
+              ? "Cannot Delete Workspace"
+              : hasDescendants
+                ? "Delete Workspace and Descendants?"
+                : "Force Delete Workspace?"}
+          </DialogTitle>
+          <DialogDescription>
+            {hasActiveDescendants
+              ? "Stop the active descendants before deleting this workspace."
+              : "The workspace could not be removed normally."}
+          </DialogDescription>
         </DialogHeader>
         <ErrorSection>
-          <ErrorLabel>Git Error</ErrorLabel>
+          <ErrorLabel>Deletion Error</ErrorLabel>
           <ErrorCodeBlock>{error}</ErrorCodeBlock>
         </ErrorSection>
 
-        <WarningBox>
-          <WarningTitle>This action cannot be undone</WarningTitle>
-          <WarningText>
-            Force deleting will permanently remove the workspace and its local branch, and{" "}
-            {error.includes("unpushed commits:")
-              ? "discard the unpushed commits shown above"
-              : "may discard uncommitted work or lose data"}
-            . This action cannot be undone.
-          </WarningText>
-        </WarningBox>
+        {hasDescendants && (
+          <section aria-label="Descendant workspaces" className="min-w-0 space-y-2 text-sm">
+            <p>Deletion includes these descendants, deepest-first:</p>
+            <ul className="max-h-48 space-y-2 overflow-y-auto">
+              {descendants.map((descendant) => (
+                <li key={descendant.workspaceId} className="min-w-0 break-words">
+                  <span>{descendant.title}</span>
+                  <span className="text-muted block text-xs break-all">
+                    {descendant.workspaceId} — {descendant.active ? "Active" : "Inactive"}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
 
-        <DialogFooter className="justify-center">
-          <Button variant="secondary" onClick={onClose} disabled={isDeleting}>
-            Cancel
-            <span
-              aria-hidden="true"
-              className="ml-2 inline-flex items-center rounded border border-current/25 px-1.5 py-0.5 font-mono text-[10px] leading-none opacity-60"
-            >
+        {!hasActiveDescendants && (
+          <WarningBox>
+            <WarningTitle>This action cannot be undone</WarningTitle>
+            <WarningText>
+              {hasDescendants
+                ? "Deletion permanently removes this workspace and the listed descendants, including their histories and local branches. Uncommitted work can be lost."
+                : error.includes("unpushed commits:")
+                  ? "Force deletion permanently removes this workspace and its local branch, including the unpushed commits shown above."
+                  : "Force deletion permanently removes this workspace and its local branch. Uncommitted work and other data can be lost."}
+            </WarningText>
+          </WarningBox>
+        )}
+
+        <DialogFooter className="flex-wrap justify-center">
+          <Button variant="secondary" onClick={props.onClose} disabled={isDeleting}>
+            {hasActiveDescendants ? "Close" : "Cancel"}
+            <span aria-hidden="true" className="ml-2 hidden font-mono text-xs sm:inline">
               N
             </span>
           </Button>
-          <Button variant="destructive" onClick={handleForceDelete} disabled={isDeleting}>
-            {isDeleting ? "Deleting..." : "Force Delete"}
-            <span
-              aria-hidden="true"
-              className="ml-2 inline-flex items-center rounded border border-current/25 px-1.5 py-0.5 font-mono text-[10px] leading-none opacity-60"
+          {!hasActiveDescendants && (
+            <Button
+              variant="destructive"
+              className="h-auto whitespace-normal"
+              onClick={handleForceDelete}
+              disabled={isDeleting}
             >
-              Y
-            </span>
-          </Button>
+              {isDeleting
+                ? "Deleting..."
+                : hasDescendants
+                  ? "Delete Workspace and Descendants"
+                  : "Force Delete"}
+              <span aria-hidden="true" className="ml-2 hidden font-mono text-xs sm:inline">
+                Y
+              </span>
+            </Button>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/browser/contexts/ProjectContext.test.tsx
+++ b/src/browser/contexts/ProjectContext.test.tsx
@@ -423,120 +423,139 @@ describe("ProjectContext", () => {
     });
   });
 
-  test("refreshProjects ignores stale responses (race condition)", async () => {
-    let staleResolver: ((value: Array<[string, ProjectConfig]>) => void) | null = null;
-    const stalePromise = new Promise<Array<[string, ProjectConfig]>>((resolve) => {
-      staleResolver = resolve;
-    });
-
-    let latestResolver: ((value: Array<[string, ProjectConfig]>) => void) | null = null;
-    const latestPromise = new Promise<Array<[string, ProjectConfig]>>((resolve) => {
-      latestResolver = resolve;
-    });
-
-    let listCallCount = 0;
-    createMockAPI({
-      list: () => {
-        listCallCount += 1;
-
-        // Mount refresh (stale)
-        if (listCallCount === 1) {
-          return stalePromise;
-        }
-
-        // Manual refresh (latest)
-        if (listCallCount === 2) {
-          return latestPromise;
-        }
-
-        return Promise.resolve([]);
-      },
-      remove: () => Promise.resolve({ success: true as const, data: undefined }),
-      listBranches: () => Promise.resolve({ branches: ["main"], recommendedTrunk: "main" }),
-      secrets: {
-        get: () => Promise.resolve([]),
-        update: () => Promise.resolve({ success: true as const, data: undefined }),
-      },
-    });
-
+  test("coalesces callers and awaits invalidations during each pending request", async () => {
+    const first = Promise.withResolvers<Array<[string, ProjectConfig]>>();
+    const second = Promise.withResolvers<Array<[string, ProjectConfig]>>();
+    const third = Promise.withResolvers<Array<[string, ProjectConfig]>>();
+    const projectsApi = createMockAPI({ list: () => first.promise });
+    projectsApi.list
+      .mockImplementationOnce(() => first.promise)
+      .mockImplementationOnce(() => second.promise)
+      .mockImplementationOnce(() => third.promise);
     const ctx = await setup();
-
-    // Resolve the manual refresh first.
-    await act(async () => {
-      const refreshPromise = ctx().refreshProjects();
-      latestResolver!([["/new", { workspaces: [] }]]);
-      await refreshPromise;
-    });
-
-    await waitFor(() => {
-      expect(ctx().userProjects.has("/new")).toBe(true);
-    });
-
-    // Now resolve the stale mount refresh; it should be ignored.
+    await waitFor(() => expect(projectsApi.list).toHaveBeenCalledTimes(1));
+    const completed = mock(() => undefined);
+    const callers = Array.from({ length: 20 }, () => ctx().refreshProjects().then(completed));
+    expect(projectsApi.list).toHaveBeenCalledTimes(1);
     act(() => {
-      staleResolver!([["/stale", { workspaces: [] }]]);
+      first.resolve([["/old", { workspaces: [] }]]);
     });
-
-    await waitFor(() => {
-      expect(ctx().userProjects.has("/new")).toBe(true);
+    await waitFor(() => expect(projectsApi.list).toHaveBeenCalledTimes(2));
+    expect(completed).not.toHaveBeenCalled();
+    const later = ctx().refreshProjects().then(completed);
+    expect(projectsApi.list).toHaveBeenCalledTimes(2);
+    act(() => {
+      second.resolve([["/intermediate", { workspaces: [] }]]);
     });
-    expect(ctx().userProjects.has("/stale")).toBe(false);
+    await waitFor(() => expect(projectsApi.list).toHaveBeenCalledTimes(3));
+    expect(completed).not.toHaveBeenCalled();
+    await act(async () => {
+      third.resolve([["/final", { workspaces: [] }]]);
+      await Promise.all([...callers, later]);
+    });
+    expect(completed).toHaveBeenCalledTimes(21);
+    expect([...ctx().userProjects.keys()]).toEqual(["/final"]);
+    expect(projectsApi.list).toHaveBeenCalledTimes(3);
+    expect(ctx().loading).toBe(false);
   });
 
-  test("refreshProjects applies older success if a newer overlapping refresh fails", async () => {
-    let olderResolver: ((value: Array<[string, ProjectConfig]>) => void) | null = null;
-    const olderPromise = new Promise<Array<[string, ProjectConfig]>>((resolve) => {
-      olderResolver = resolve;
-    });
-
-    let newerRejecter: ((error: unknown) => void) | null = null;
-    const newerPromise = new Promise<Array<[string, ProjectConfig]>>((_, reject) => {
-      newerRejecter = reject;
-    });
-
-    let listCallCount = 0;
-    createMockAPI({
-      list: () => {
-        listCallCount += 1;
-
-        // Mount refresh (older)
-        if (listCallCount === 1) {
-          return olderPromise;
-        }
-
-        // Manual refresh (newer, but fails)
-        if (listCallCount === 2) {
-          return newerPromise;
-        }
-
-        return Promise.resolve([]);
-      },
-      remove: () => Promise.resolve({ success: true as const, data: undefined }),
-      listBranches: () => Promise.resolve({ branches: ["main"], recommendedTrunk: "main" }),
-      secrets: {
-        get: () => Promise.resolve([]),
-        update: () => Promise.resolve({ success: true as const, data: undefined }),
-      },
-    });
-
+  test("preserves older success after a trailing error and permits retry", async () => {
+    const first = Promise.withResolvers<Array<[string, ProjectConfig]>>();
+    const second = Promise.withResolvers<Array<[string, ProjectConfig]>>();
+    const projectsApi = createMockAPI({ list: () => first.promise });
+    projectsApi.list
+      .mockImplementationOnce(() => first.promise)
+      .mockImplementationOnce(() => second.promise)
+      .mockResolvedValue([["/retry", { workspaces: [] }]]);
     const ctx = await setup();
-
-    // Trigger a newer refresh, but reject it while the mount refresh is still in-flight.
-    await act(async () => {
-      const refreshPromise = ctx().refreshProjects();
-      newerRejecter!(new Error("boom"));
-      await refreshPromise;
-    });
-
-    // Now resolve the mount refresh; it should populate the list.
+    const trailing = ctx().refreshProjects();
     act(() => {
-      olderResolver!([["/older", { workspaces: [] }]]);
+      first.resolve([["/older", { workspaces: [] }]]);
     });
-
-    await waitFor(() => {
-      expect(ctx().userProjects.has("/older")).toBe(true);
+    await waitFor(() => expect(projectsApi.list).toHaveBeenCalledTimes(2));
+    await act(async () => {
+      second.reject(new Error("trailing failure"));
+      await trailing;
     });
+    expect([...ctx().userProjects.keys()]).toEqual(["/older"]);
+    expect(ctx().loaded).toBe(true);
+    expect(ctx().loadError).toBe("trailing failure");
+    await act(async () => {
+      await ctx().refreshProjects();
+    });
+    expect([...ctx().userProjects.keys()]).toEqual(["/retry"]);
+    expect(ctx().loadError).toBeNull();
   });
+
+  test("runs a queued refresh after an initial error", async () => {
+    const first = Promise.withResolvers<Array<[string, ProjectConfig]>>();
+    const projectsApi = createMockAPI({ list: () => first.promise });
+    projectsApi.list
+      .mockImplementationOnce(() => first.promise)
+      .mockResolvedValue([["/recovered", { workspaces: [] }]]);
+    const ctx = await setup();
+    const trailing = ctx().refreshProjects();
+    await act(async () => {
+      first.reject(new Error("initial failure"));
+      await trailing;
+    });
+    expect(projectsApi.list).toHaveBeenCalledTimes(2);
+    expect([...ctx().userProjects.keys()]).toEqual(["/recovered"]);
+    expect(ctx().loaded).toBe(true);
+    expect(ctx().loadError).toBeNull();
+  });
+
+  test.each(["success", "error"])(
+    "ignores old client %s and refreshes the replacement client",
+    async (outcome) => {
+      const oldRequest = Promise.withResolvers<Array<[string, ProjectConfig]>>();
+      const newRequest = Promise.withResolvers<Array<[string, ProjectConfig]>>();
+      const oldApi = createMockAPI({ list: () => oldRequest.promise });
+      const oldClient = currentClientMock as APIClient;
+      const newList = mock(() => newRequest.promise);
+      const newClient = { ...oldClient, projects: { ...oldClient.projects, list: newList } };
+      let context: ProjectContextModule.ProjectContext | null = null;
+      function Capture() {
+        context = useProjectContext();
+        return null;
+      }
+      const tree = (client: APIClient) => (
+        <APIProvider client={client}>
+          <ProjectProvider>
+            <Capture />
+          </ProjectProvider>
+        </APIProvider>
+      );
+      const view = render(tree(oldClient));
+      const ctx = () => context!;
+      await waitFor(() => expect(oldApi.list).toHaveBeenCalledTimes(1));
+      const oldRefresh = ctx().refreshProjects;
+      const waiting = oldRefresh();
+      view.rerender(tree(newClient));
+      await oldRefresh();
+      expect(oldApi.list).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(newList).toHaveBeenCalledTimes(1));
+      expect(ctx().userProjects.size).toBe(0);
+      expect(ctx().loading).toBe(true);
+      await act(async () => {
+        newRequest.resolve([["/new-client", { workspaces: [] }]]);
+        await newRequest.promise;
+      });
+      await waitFor(() => expect(ctx().loading).toBe(false));
+      expect([...ctx().userProjects.keys()]).toEqual(["/new-client"]);
+      // The new client finishes before the old transport settles.
+      await act(async () => {
+        if (outcome === "success") oldRequest.resolve([["/wrong-client", { workspaces: [] }]]);
+        else oldRequest.reject(new Error("old client failure"));
+        await waiting;
+      });
+      expect(oldApi.list).toHaveBeenCalledTimes(1);
+      expect(newList).toHaveBeenCalledTimes(1);
+      expect([...ctx().userProjects.keys()]).toEqual(["/new-client"]);
+      expect(ctx().loading).toBe(false);
+      expect(ctx().loadError).toBeNull();
+    }
+  );
 
   test("getBranchesForProject sanitizes malformed branch data", async () => {
     createMockAPI({

--- a/src/browser/contexts/ProjectContext.tsx
+++ b/src/browser/contexts/ProjectContext.tsx
@@ -170,51 +170,54 @@ export function ProjectProvider(props: { children: ReactNode }) {
   });
   const workspaceModalProjectRef = useRef<string | null>(null);
 
-  // Used to guard against refreshProjects() races.
-  //
-  // Example: the initial refresh (on mount) can start before a workspace fork, then
-  // resolve after a fork-triggered refresh. Without this guard, the stale response
-  // could overwrite the newer project list and make the forked workspace disappear
-  // from the sidebar again.
-  const projectsRefreshSeqRef = useRef(0);
-  const latestAppliedProjectsRefreshSeqRef = useRef(0);
+  const projectsRefreshRef = useRef<{
+    api: typeof api;
+    pending: boolean;
+    promise: Promise<void> | null;
+  }>({ api, pending: false, promise: null });
 
-  const refreshProjects = useCallback(async () => {
+  const refreshProjects = useCallback((): Promise<void> => {
+    const refresh = projectsRefreshRef.current;
+    if (refresh.api !== api) return Promise.resolve();
     if (!api) {
       setLoaded(false);
       setLoadError("API not connected");
-      return;
+      return Promise.resolve();
     }
 
-    const refreshSeq = projectsRefreshSeqRef.current + 1;
-    projectsRefreshSeqRef.current = refreshSeq;
-
-    try {
-      const projectsList = await api.projects.list();
-
-      // Ignore out-of-date refreshes so an older response can't clobber a newer success.
-      if (refreshSeq < latestAppliedProjectsRefreshSeqRef.current) {
-        return;
+    // Cascade events share one request. Later invalidations require a trailing request.
+    refresh.pending = true;
+    refresh.promise ??= Promise.resolve().then(async () => {
+      try {
+        while (refresh.pending && refresh.api) {
+          refresh.pending = false;
+          const requestApi = refresh.api;
+          try {
+            const projectsList = await requestApi.projects.list();
+            if (refresh !== projectsRefreshRef.current || !refresh.api) continue;
+            setAllProjectsInternal(new Map(projectsList));
+            setLoaded(true);
+            setLoadError(null);
+          } catch (error) {
+            if (refresh !== projectsRefreshRef.current || !refresh.api) continue;
+            // Keep successful data when a later refresh fails.
+            console.error("Failed to load projects:", error);
+            setLoadError(getErrorMessage(error));
+          }
+        }
+      } finally {
+        refresh.promise = null;
       }
-
-      latestAppliedProjectsRefreshSeqRef.current = refreshSeq;
-      setAllProjectsInternal(new Map(projectsList));
-      setLoaded(true);
-      setLoadError(null);
-    } catch (error) {
-      // Ignore out-of-date refreshes so an older error can't clobber a newer success.
-      if (refreshSeq < latestAppliedProjectsRefreshSeqRef.current) {
-        return;
-      }
-
-      // Keep the previous project list on error so scoped user preferences are not pruned.
-      console.error("Failed to load projects:", error);
-      setLoadError(getErrorMessage(error));
-    }
+    });
+    // All callers await the trailing request, not only the response already in flight.
+    return refresh.promise;
   }, [api]);
 
   useEffect(() => {
     let cancelled = false;
+    // A disconnected transport must not block the replacement client.
+    const refresh: typeof projectsRefreshRef.current = { api, pending: false, promise: null };
+    projectsRefreshRef.current = refresh;
     setLoading(true);
 
     const initialRefresh = async () => {
@@ -234,8 +237,10 @@ export function ProjectProvider(props: { children: ReactNode }) {
 
     return () => {
       cancelled = true;
+      refresh.api = null;
+      refresh.pending = false;
     };
-  }, [refreshProjects]);
+  }, [api, refreshProjects]);
 
   useEffect(() => {
     const onConfigChanged = api?.config?.onConfigChanged;

--- a/src/browser/contexts/WorkspaceContext.test.tsx
+++ b/src/browser/contexts/WorkspaceContext.test.tsx
@@ -279,6 +279,58 @@ describe("WorkspaceContext", () => {
     expect(workspaceApi.onMetadata).toHaveBeenCalled();
   });
 
+  test("deletion metadata waits for one config notification to refresh projects", async () => {
+    const workspaces = Array.from({ length: 5 }, (_, index) =>
+      createProjectWorkspaceMetadata("child-" + index, "/alpha")
+    );
+    const deletions = workspaces.map(() => Promise.withResolvers<void>());
+    const configChanged = Promise.withResolvers<void>();
+    const { projects } = createMockAPI({
+      workspace: {
+        list: () => Promise.resolve(workspaces),
+        onMetadata: () =>
+          Promise.resolve(
+            (async function* () {
+              for (const [index, workspace] of workspaces.entries()) {
+                await deletions[index].promise;
+                yield { workspaceId: workspace.id, metadata: null };
+              }
+            })() as unknown as Awaited<ReturnType<APIClient["workspace"]["onMetadata"]>>
+          ),
+      },
+    });
+    currentClientMock = {
+      ...currentClientMock,
+      config: {
+        onConfigChanged: () =>
+          Promise.resolve(
+            (async function* () {
+              await configChanged.promise;
+              yield undefined;
+            })() as unknown as Awaited<ReturnType<APIClient["config"]["onConfigChanged"]>>
+          ),
+      },
+    };
+    const contexts = await setupWithProjectContext();
+    await waitFor(() => expect(contexts.workspace().workspaceMetadata.size).toBe(5));
+    await waitFor(() => expect(contexts.project().loading).toBe(false));
+    await act(async () => {
+      await contexts.project().refreshProjects();
+    });
+    const initialRequests = projects.list.mock.calls.length;
+    for (const [index, deletion] of deletions.entries()) {
+      act(() => {
+        deletion.resolve();
+      });
+      await waitFor(() => expect(contexts.workspace().workspaceMetadata.size).toBe(4 - index));
+      expect(projects.list).toHaveBeenCalledTimes(initialRequests);
+    }
+    act(() => {
+      configChanged.resolve();
+    });
+    await waitFor(() => expect(projects.list).toHaveBeenCalledTimes(initialRequests + 1));
+  });
+
   test("switches selection to parent when selected child workspace is deleted", async () => {
     const parentId = "ws-parent";
     const childId = "ws-child";
@@ -583,59 +635,6 @@ describe("WorkspaceContext", () => {
     expect(ctx().workspaceMetadata.has(childId)).toBe(false);
     // Parent should still be selected
     expect(ctx().selectedWorkspace?.workspaceId).toBe(parentId);
-  });
-
-  test("refreshes projects when metadata delete event is received", async () => {
-    const workspaceId = "ws-delete-refresh";
-
-    const workspaces: FrontendWorkspaceMetadata[] = [
-      createWorkspaceMetadata({
-        id: workspaceId,
-        projectPath: "/alpha",
-        projectName: "alpha",
-        name: "main",
-        namedWorkspacePath: "/alpha-main",
-      }),
-    ];
-
-    let emitDelete:
-      | ((event: { workspaceId: string; metadata: FrontendWorkspaceMetadata | null }) => void)
-      | null = null;
-
-    const { projects: projectsApi } = createMockAPI({
-      workspace: {
-        list: () => Promise.resolve(workspaces),
-        onMetadata: () =>
-          Promise.resolve(
-            (async function* () {
-              const event = await new Promise<{
-                workspaceId: string;
-                metadata: FrontendWorkspaceMetadata | null;
-              }>((resolve) => {
-                emitDelete = resolve;
-              });
-              yield event;
-            })() as unknown as Awaited<ReturnType<APIClient["workspace"]["onMetadata"]>>
-          ),
-      },
-      projects: {
-        list: () => Promise.resolve([]),
-      },
-    });
-
-    await setup();
-
-    await waitFor(() => expect(emitDelete).toBeTruthy());
-    await waitFor(() => expect(projectsApi.list).toHaveBeenCalled());
-    const callsBeforeDelete = projectsApi.list.mock.calls.length;
-
-    act(() => {
-      emitDelete?.({ workspaceId, metadata: null });
-    });
-
-    await waitFor(() => {
-      expect(projectsApi.list.mock.calls.length).toBeGreaterThan(callsBeforeDelete);
-    });
   });
 
   test("seeds model + thinking localStorage from backend metadata", async () => {

--- a/src/browser/contexts/WorkspaceContext.test.tsx
+++ b/src/browser/contexts/WorkspaceContext.test.tsx
@@ -917,6 +917,23 @@ describe("WorkspaceContext", () => {
     expect(result.error).toBe("Failed");
   });
 
+  test("removeWorkspace forwards descendant consent and preserves blockers", async () => {
+    const { workspace: workspaceApi } = createMockAPI();
+    const ctx = await setup();
+    const failure = {
+      success: false,
+      error: "A descendant is active",
+      descendants: [{ workspaceId: "child", title: "Reviewer", active: true }],
+    };
+    workspaceApi.remove.mockResolvedValue(failure);
+    const options = { force: true, acknowledgedDescendantIds: ["child"] };
+
+    const result = await ctx().removeWorkspace("parent", options);
+
+    expect(workspaceApi.remove).toHaveBeenCalledWith({ workspaceId: "parent", options });
+    expect(result).toEqual(failure);
+  });
+
   describe("archiveWorkspace", () => {
     test("succeeds even when persisted layout is invalid JSON shape", async () => {
       const workspaceId = "ws-archive-invalid-layout";

--- a/src/browser/contexts/WorkspaceContext.tsx
+++ b/src/browser/contexts/WorkspaceContext.tsx
@@ -1354,16 +1354,9 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
               ? wasInActiveMap // was active, now archived
               : !wasInActiveMap && meta !== null; // was absent (archived), now active (unarchived)
 
-            // Also reload when:
-            // 1. Workspace is deleted in another session
-            // 2. New workspace appears (e.g., from fork)
-            // 3. Workspace transitions from initializing to ready (init completed)
-            if (
-              meta === null ||
-              isNewWorkspace ||
-              (wasInitializing && isNowReady) ||
-              archiveStateChanged
-            ) {
+            // Config notifications refresh deleted workspace lists once after a cascade.
+            // Keep metadata refreshes for new workspaces and completed initialization.
+            if (isNewWorkspace || (wasInitializing && isNowReady) || archiveStateChanged) {
               void refreshProjects();
             }
 

--- a/src/browser/contexts/WorkspaceContext.tsx
+++ b/src/browser/contexts/WorkspaceContext.tsx
@@ -11,7 +11,7 @@ import {
   type SetStateAction,
 } from "react";
 import { useLocation } from "react-router-dom";
-import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
+import type { FrontendWorkspaceMetadata, WorkspaceRemoveResult } from "@/common/types/workspace";
 import type { ArchivePreflightResult, ArchiveWorkspaceResult } from "@/common/orpc/schemas/api";
 import type { OpenAIReasoningMode, ThinkingLevel } from "@/common/types/thinking";
 import type { WorkspaceSelection } from "@/browser/components/ProjectSidebar/ProjectSidebar";
@@ -462,8 +462,8 @@ export interface WorkspaceContext extends WorkspaceMetadataContextValue {
   }>;
   removeWorkspace: (
     workspaceId: string,
-    options?: { force?: boolean }
-  ) => Promise<{ success: boolean; error?: string }>;
+    options?: Parameters<APIClient["workspace"]["remove"]>[0]["options"]
+  ) => Promise<WorkspaceRemoveResult>;
   updateWorkspaceTitle: (
     workspaceId: string,
     newTitle: string
@@ -1480,8 +1480,8 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
   const removeWorkspace = useCallback(
     async (
       workspaceId: string,
-      options?: { force?: boolean }
-    ): Promise<{ success: boolean; error?: string }> => {
+      options?: Parameters<APIClient["workspace"]["remove"]>[0]["options"]
+    ): Promise<WorkspaceRemoveResult> => {
       if (!api) return { success: false, error: "API not connected" };
 
       // Capture state before the async operation.
@@ -1523,7 +1523,7 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
           return { success: true };
         } else {
           console.error("Failed to remove workspace:", result.error);
-          return { success: false, error: result.error };
+          return result;
         }
       } catch (error) {
         const errorMessage = getErrorMessage(error);

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -84,6 +84,7 @@ import { BashToolResultSchema, FileTreeNodeSchema } from "./tools";
 import { WorkspaceStatsSnapshotSchema } from "./workspaceStats";
 import {
   FrontendWorkspaceMetadataSchema,
+  WorkspaceRemoveResultSchema,
   GitStatusSchema,
   ProjectRefSchema,
   WorkspaceActivitySnapshotSchema,
@@ -1383,9 +1384,14 @@ export const workspace = {
   remove: {
     input: z.object({
       workspaceId: z.string(),
-      options: z.object({ force: z.boolean().optional() }).optional(),
+      options: z
+        .object({
+          force: z.boolean().optional(),
+          acknowledgedDescendantIds: z.array(z.string()).optional(),
+        })
+        .optional(),
     }),
-    output: z.object({ success: z.boolean(), error: z.string().optional() }),
+    output: WorkspaceRemoveResultSchema,
   },
   rename: {
     input: z.object({ workspaceId: z.string(), newName: z.string() }),

--- a/src/common/orpc/schemas/workspace.ts
+++ b/src/common/orpc/schemas/workspace.ts
@@ -393,3 +393,14 @@ export const GitStatusSchema = z.object({
   incomingAdditions: z.number(),
   incomingDeletions: z.number(),
 });
+
+export const WorkspaceRemovalDescendantSchema = z.object({
+  workspaceId: z.string(),
+  title: z.string(),
+  active: z.boolean(),
+});
+export const WorkspaceRemoveResultSchema = z.object({
+  success: z.boolean(),
+  error: z.string().optional(),
+  descendants: z.array(WorkspaceRemovalDescendantSchema).optional(),
+});

--- a/src/common/types/workspace.ts
+++ b/src/common/types/workspace.ts
@@ -28,6 +28,11 @@ import type {
   WorkspaceMetadataSchema,
 } from "../orpc/schemas";
 
+import type {
+  WorkspaceRemoveResultSchema,
+  WorkspaceRemovalDescendantSchema,
+} from "../orpc/schemas/workspace";
+
 export type WorkspaceMetadata = z.infer<typeof WorkspaceMetadataSchema>;
 
 export type ProjectRef = z.infer<typeof ProjectRefSchema>;
@@ -45,3 +50,6 @@ export type GitStatus = z.infer<typeof GitStatusSchema>;
 export type FrontendWorkspaceMetadata = z.infer<typeof FrontendWorkspaceMetadataSchema>;
 
 export type WorkspaceActivitySnapshot = z.infer<typeof WorkspaceActivitySnapshotSchema>;
+
+export type WorkspaceRemoveResult = z.infer<typeof WorkspaceRemoveResultSchema>;
+export type WorkspaceRemovalDescendant = z.infer<typeof WorkspaceRemovalDescendantSchema>;

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -589,6 +589,64 @@ describe("Config", () => {
     });
   });
 
+  describe("deferred change notifications", () => {
+    it("flushes slow sequential edits and unrelated edits once", async () => {
+      let notifications = 0;
+      const unsubscribe = config.onConfigChanged(() => {
+        notifications += 1;
+      });
+      const paused = Promise.withResolvers<void>();
+      const resume = Promise.withResolvers<void>();
+      const operation = config.withDeferredChangeNotifications(async () => {
+        await config.setUpdateChannel("npm");
+        paused.resolve();
+        await resume.promise;
+        await config.setUpdateChannel("nightly");
+        return "complete";
+      });
+      await paused.promise;
+      expect(notifications).toBe(0);
+      await config.editConfig((value) => value);
+      expect(notifications).toBe(0);
+      resume.resolve();
+      expect(await operation).toBe("complete");
+      expect(notifications).toBe(1);
+      expect(config.getUpdateChannel()).toBe("nightly");
+      await config.setUpdateChannel("npm");
+      expect(notifications).toBe(2);
+      unsubscribe();
+    });
+
+    it("flushes nested partial failures only after the outer scope ends", async () => {
+      let notifications = 0;
+      const unsubscribe = config.onConfigChanged(() => {
+        notifications += 1;
+      });
+      const failure = await config
+        .withDeferredChangeNotifications(async () => {
+          await config.setUpdateChannel("npm");
+          const nestedFailure = await config
+            .withDeferredChangeNotifications(async () => {
+              await config.setUpdateChannel("nightly");
+              throw new Error("nested failure");
+            })
+            .catch((error: unknown) => error);
+          expect(nestedFailure).toEqual(new Error("nested failure"));
+          expect(notifications).toBe(0);
+          throw new Error("outer failure");
+        })
+        .catch((error: unknown) => error);
+      expect(failure).toEqual(new Error("outer failure"));
+      expect(notifications).toBe(1);
+      expect(config.getUpdateChannel()).toBe("nightly");
+      await config.withDeferredChangeNotifications(() => Promise.resolve());
+      expect(notifications).toBe(1);
+      await config.setUpdateChannel("npm");
+      expect(notifications).toBe(2);
+      unsubscribe();
+    });
+  });
+
   describe("editConfig", () => {
     it("serializes concurrent edits so no update is lost", async () => {
       // Regression: editConfig used to be a non-serialized read-modify-write

--- a/src/node/config/index.ts
+++ b/src/node/config/index.ts
@@ -1036,7 +1036,29 @@ export class Config {
     };
   }
 
+  private deferredChangeNotificationDepth = 0;
+  private changeNotificationPending = false;
+
+  /** Flush config changes once after the outermost operation, including partial failures. */
+  async withDeferredChangeNotifications<T>(operation: () => Promise<T>): Promise<T> {
+    this.deferredChangeNotificationDepth += 1;
+    try {
+      return await operation();
+    } finally {
+      this.deferredChangeNotificationDepth -= 1;
+      if (this.deferredChangeNotificationDepth === 0 && this.changeNotificationPending) {
+        this.changeNotificationPending = false;
+        this.notifyConfigChanged();
+      }
+    }
+  }
+
   private notifyConfigChanged(): void {
+    // The signal has no payload. A batch also includes unrelated edits during its lifetime.
+    if (this.deferredChangeNotificationDepth > 0) {
+      this.changeNotificationPending = true;
+      return;
+    }
     this.emitter.emit("configChanged");
   }
 

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -13161,7 +13161,15 @@ describe("TaskService", () => {
     expect((await removeScope([child])).success).toBe(false);
     expect((await removeScope([child, grandchild, "unrelated"])).success).toBe(false);
     expect(remove).not.toHaveBeenCalled();
-    expect(await removeScope([child, grandchild])).toEqual(Err("runtime failure"));
+    expect(
+      taskService.listWorkspaceRemovalDescendants(parent).map((entry) => entry.workspaceId)
+    ).toEqual([grandchild, child]);
+    const failure = await removeScope([child, grandchild]);
+    expect(failure.success).toBe(false);
+    if (!failure.success) {
+      expect(failure.error).toContain(child);
+      expect(failure.error).toContain("runtime failure");
+    }
     expect(
       taskService.listWorkspaceRemovalDescendants(parent).map((entry) => entry.workspaceId)
     ).toEqual([child]);

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -13110,6 +13110,68 @@ describe("TaskService", () => {
     );
   });
 
+  test("acknowledged removal preflights activity and scope and retries deepest-first", async () => {
+    const config = await createTestConfig(rootDir);
+    const projectPath = path.join(rootDir, "repo");
+    const parent = "ack-parent";
+    const child = "ack-child";
+    const grandchild = "ack-grandchild";
+    const workspaces = [
+      projectWorkspace(projectPath, "parent", parent),
+      projectWorkspace(projectPath, "child", child, {
+        parentWorkspaceId: parent,
+        taskStatus: "reported",
+      }),
+      projectWorkspace(projectPath, "grandchild", grandchild, {
+        parentWorkspaceId: child,
+        taskStatus: "running",
+        taskIsolation: "none",
+      }),
+    ];
+    await saveWorkspaces(config, projectPath, workspaces, testTaskSettings());
+    let fail = true;
+    const remove = mock(async (workspaceId: string): Promise<Result<void>> => {
+      if (workspaceId === child && fail) return Err("runtime failure");
+      await removeWorkspaceFromTestConfig(config, workspaceId);
+      return Ok(undefined);
+    });
+    const { workspaceService } = createWorkspaceServiceMocks({ remove });
+    let streaming = false;
+    const { aiService } = createAIServiceMocks(config, {
+      isStreaming: mock((id: string) => streaming && id === grandchild),
+    });
+    const { taskService } = createTaskServiceHarness(config, { workspaceService, aiService });
+    const removeScope = (ids: string[]) =>
+      taskService.withTaskTreeLifecycleLock(parent, () =>
+        taskService.removeAcknowledgedDescendantsWhileTaskTreeLocked(parent, ids)
+      );
+    expect(taskService.listWorkspaceRemovalDescendants(parent)).toContainEqual({
+      workspaceId: grandchild,
+      title: "grandchild",
+      active: true,
+    });
+    expect((await removeScope([child, grandchild])).success).toBe(false);
+    expect(remove).not.toHaveBeenCalled();
+    workspaces[2].taskStatus = "reported";
+    await saveWorkspaces(config, projectPath, workspaces, testTaskSettings());
+    streaming = true;
+    expect((await removeScope([child, grandchild])).success).toBe(false);
+    expect(remove).not.toHaveBeenCalled();
+    streaming = false;
+    expect((await removeScope([child])).success).toBe(false);
+    expect((await removeScope([child, grandchild, "unrelated"])).success).toBe(false);
+    expect(remove).not.toHaveBeenCalled();
+    expect(await removeScope([child, grandchild])).toEqual(Err("runtime failure"));
+    expect(
+      taskService.listWorkspaceRemovalDescendants(parent).map((entry) => entry.workspaceId)
+    ).toEqual([child]);
+    expect(config.findWorkspace(parent)).not.toBeNull();
+    fail = false;
+    expect(await removeScope([child, grandchild])).toEqual(Ok(undefined));
+    expect(remove.mock.calls.map((call) => call[0])).toEqual([grandchild, child, child]);
+    expect(await removeScope([child, grandchild])).toEqual(Ok(undefined));
+  });
+
   test("removeInactiveDescendantAgentTask enforces scope, leaf order, and idempotency", async () => {
     const config = await createTestConfig(rootDir);
     const projectPath = path.join(rootDir, "repo");

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -107,7 +107,11 @@ import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import { SCRATCH_PROJECT_CONFIG_KEY, SCRATCH_PROJECT_NAME } from "@/common/constants/scratch";
 import { DEFAULT_RUNTIME_CONFIG } from "@/common/constants/workspace";
 import { runtimeModeSupportsSharedTaskWorkspace, type RuntimeConfig } from "@/common/types/runtime";
-import type { ProjectRef, WorkspaceMetadata } from "@/common/types/workspace";
+import type {
+  ProjectRef,
+  WorkspaceMetadata,
+  WorkspaceRemovalDescendant,
+} from "@/common/types/workspace";
 import { getRuntimeType } from "@/node/runtime/initHook";
 import { AgentIdSchema } from "@/common/orpc/schemas";
 import { SendMessageOptionsSchema, ToolPolicySchema } from "@/common/orpc/schemas/stream";
@@ -9163,88 +9167,154 @@ export class TaskService implements AgentTaskIntegration {
     assert(ownerWorkspaceId.length > 0, "removeInactiveDescendantAgentTask requires owner");
     assert(taskId.length > 0, "removeInactiveDescendantAgentTask requires taskId");
 
-    return await this.withTaskTreeLifecycleLock(taskId, async () => {
-      const config = this.config.loadConfigOrDefault();
-      const entry = findWorkspaceEntry(config, taskId);
-      if (entry == null) {
-        const wasOwned =
-          (await this.hasRemovedAgentTaskTombstone(ownerWorkspaceId, taskId)) ||
-          (await this.filterDescendantAgentTaskIds(ownerWorkspaceId, [taskId])).includes(taskId);
-        return Ok(
-          wasOwned
-            ? { status: "already_removed", action: "remove", taskId, workspaceId: taskId }
-            : { status: "invalid_scope", action: "remove", taskId }
-        );
-      }
+    return await this.withTaskTreeLifecycleLock(taskId, () =>
+      this.removeInactiveDescendantAgentTaskWhileTaskTreeLocked(ownerWorkspaceId, taskId)
+    );
+  }
 
-      const index = this.buildAgentTaskIndex(config);
-      if (!this.isDescendantAgentTaskUsingParentById(index.parentById, ownerWorkspaceId, taskId)) {
-        return Ok({ status: "invalid_scope", action: "remove", taskId });
-      }
+  private async removeInactiveDescendantAgentTaskWhileTaskTreeLocked(
+    ownerWorkspaceId: string,
+    taskId: string
+  ): Promise<Result<WorkspaceLifecycleResult, string>> {
+    const config = this.config.loadConfigOrDefault();
+    const entry = findWorkspaceEntry(config, taskId);
+    if (entry == null) {
+      const wasOwned =
+        (await this.hasRemovedAgentTaskTombstone(ownerWorkspaceId, taskId)) ||
+        (await this.filterDescendantAgentTaskIds(ownerWorkspaceId, [taskId])).includes(taskId);
+      return Ok(
+        wasOwned
+          ? { status: "already_removed", action: "remove", taskId, workspaceId: taskId }
+          : { status: "invalid_scope", action: "remove", taskId }
+      );
+    }
 
-      const displayName = coerceNonEmptyString(entry.workspace.title) ?? entry.workspace.name;
-      const target = {
-        taskId,
-        workspaceId: taskId,
-        ...(displayName != null ? { displayName } : {}),
-      };
-      const descendantTaskIds = this.listDescendantAgentTasks(taskId).map((task) => task.taskId);
-      if (descendantTaskIds.length > 0) {
-        return Ok({
-          status: "error",
-          action: "remove",
-          ...target,
-          descendantTaskIds,
-          error: "Cannot remove a sub-agent while descendant sub-agents remain.",
-        });
-      }
+    const index = this.buildAgentTaskIndex(config);
+    if (!this.isDescendantAgentTaskUsingParentById(index.parentById, ownerWorkspaceId, taskId)) {
+      return Ok({ status: "invalid_scope", action: "remove", taskId });
+    }
 
-      if (
-        this.isActiveAgentTaskEntry({ ...entry.workspace, projectPath: entry.projectPath }) ||
-        this.aiService.isStreaming(taskId)
-      ) {
-        return Ok({
-          status: "active",
-          action: "remove",
-          ...target,
-          activeTaskIds: [taskId],
-          note: "Stop the sub-agent before removing it.",
-        });
-      }
-
-      return await this.gitPatchArtifactService.withOperationLock(taskId, async () => {
-        // The task can become inactive before its background format-patch job finishes. Wait for the
-        // in-process job, then refuse removal if a restart left a durable pending marker behind; the
-        // child worktree is the source needed to recover that artifact.
-        await this.gitPatchArtifactService.waitForGeneration(taskId);
-        const parentWorkspaceId = entry.workspace.parentWorkspaceId;
-        if (parentWorkspaceId) {
-          const patchArtifact = await readSubagentGitPatchArtifact(
-            path.join(this.config.sessionsDir, parentWorkspaceId),
-            taskId
-          );
-          if (patchArtifact?.status === "pending") {
-            return Ok({
-              status: "error",
-              action: "remove",
-              ...target,
-              error: "Cannot remove the sub-agent while its git patch artifact is still pending.",
-            });
-          }
-        }
-
-        const tombstoneResult = await this.persistRemovedAgentTaskTombstones(taskId);
-        if (!tombstoneResult.success) {
-          return Ok({ status: "error", action: "remove", ...target, error: tombstoneResult.error });
-        }
-        const result = await this.workspaceService.removeWhileTaskTreeLocked(taskId, true);
-        return Ok(
-          result.success
-            ? { status: "removed", action: "remove", ...target }
-            : { status: "error", action: "remove", ...target, error: result.error }
-        );
+    const displayName = coerceNonEmptyString(entry.workspace.title) ?? entry.workspace.name;
+    const target = {
+      taskId,
+      workspaceId: taskId,
+      ...(displayName != null ? { displayName } : {}),
+    };
+    const descendantTaskIds = this.listDescendantAgentTasks(taskId).map((task) => task.taskId);
+    if (descendantTaskIds.length > 0) {
+      return Ok({
+        status: "error",
+        action: "remove",
+        ...target,
+        descendantTaskIds,
+        error: "Cannot remove a sub-agent while descendant sub-agents remain.",
       });
+    }
+
+    if (
+      this.isActiveAgentTaskEntry({ ...entry.workspace, projectPath: entry.projectPath }) ||
+      this.aiService.isStreaming(taskId)
+    ) {
+      return Ok({
+        status: "active",
+        action: "remove",
+        ...target,
+        activeTaskIds: [taskId],
+        note: "Stop the sub-agent before removing it.",
+      });
+    }
+
+    return await this.gitPatchArtifactService.withOperationLock(taskId, async () => {
+      // The task can become inactive before its background format-patch job finishes. Wait for the
+      // in-process job, then refuse removal if a restart left a durable pending marker behind; the
+      // child worktree is the source needed to recover that artifact.
+      await this.gitPatchArtifactService.waitForGeneration(taskId);
+      const parentWorkspaceId = entry.workspace.parentWorkspaceId;
+      if (parentWorkspaceId) {
+        const patchArtifact = await readSubagentGitPatchArtifact(
+          path.join(this.config.sessionsDir, parentWorkspaceId),
+          taskId
+        );
+        if (patchArtifact?.status === "pending") {
+          return Ok({
+            status: "error",
+            action: "remove",
+            ...target,
+            error: "Cannot remove the sub-agent while its git patch artifact is still pending.",
+          });
+        }
+      }
+
+      const tombstoneResult = await this.persistRemovedAgentTaskTombstones(taskId);
+      if (!tombstoneResult.success) {
+        return Ok({ status: "error", action: "remove", ...target, error: tombstoneResult.error });
+      }
+      const result = await this.workspaceService.removeWhileTaskTreeLocked(taskId, true);
+      return Ok(
+        result.success
+          ? { status: "removed", action: "remove", ...target }
+          : { status: "error", action: "remove", ...target, error: result.error }
+      );
     });
+  }
+
+  listWorkspaceRemovalDescendants(workspaceId: string): WorkspaceRemovalDescendant[] {
+    const index = this.buildAgentTaskIndex(this.config.loadConfigOrDefault());
+    return this.listDescendantAgentTaskIdsFromIndex(index, workspaceId).map((taskId) => {
+      const entry = index.byId.get(taskId)!;
+      return {
+        workspaceId: taskId,
+        title: coerceNonEmptyString(entry.title) ?? entry.name ?? taskId,
+        active: this.isActiveAgentTaskEntry(entry) || this.aiService.isStreaming(taskId),
+      };
+    });
+  }
+
+  async removeAcknowledgedDescendantsWhileTaskTreeLocked(
+    workspaceId: string,
+    acknowledgedIds: string[]
+  ): Promise<Result<void>> {
+    const descendants = this.listWorkspaceRemovalDescendants(workspaceId);
+    const acknowledged = new Set(acknowledgedIds);
+    const current = new Set(descendants.map((descendant) => descendant.workspaceId));
+    if (descendants.some((descendant) => !acknowledged.has(descendant.workspaceId))) {
+      return Err("The descendant scope changed. Confirm the current descendants before removal.");
+    }
+    for (const taskId of acknowledged) {
+      // Only a durable removal record permits an absent ID during a partial retry.
+      if (
+        !current.has(taskId) &&
+        (this.config.findWorkspace(taskId) != null ||
+          !(await this.hasRemovedAgentTaskTombstone(workspaceId, taskId)))
+      ) {
+        return Err("The acknowledged descendant scope does not match this workspace.");
+      }
+    }
+    // Check the full scope before removal. Force does not grant consent to stop children.
+    if (descendants.some((descendant) => descendant.active)) {
+      return Err("Stop active descendant sub-agents before removing this workspace.");
+    }
+    const index = this.buildAgentTaskIndex(this.config.loadConfigOrDefault());
+    descendants.sort(
+      (a, b) =>
+        this.getTaskDepthFromParentById(index.parentById, b.workspaceId) -
+        this.getTaskDepthFromParentById(index.parentById, a.workspaceId)
+    );
+    for (const descendant of descendants) {
+      const result = await this.removeInactiveDescendantAgentTaskWhileTaskTreeLocked(
+        workspaceId,
+        descendant.workspaceId
+      );
+      if (!result.success) return Err(result.error);
+      if (result.data.status !== "removed" && result.data.status !== "already_removed") {
+        return Err(
+          "error" in result.data
+            ? (result.data.error ?? "Descendant removal failed.")
+            : "Descendant removal failed."
+        );
+      }
+    }
+    return Ok(undefined);
   }
 
   private removedAgentTaskTombstonePath(ownerWorkspaceId: string, taskId: string): string {

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -9260,7 +9260,13 @@ export class TaskService implements AgentTaskIntegration {
 
   listWorkspaceRemovalDescendants(workspaceId: string): WorkspaceRemovalDescendant[] {
     const index = this.buildAgentTaskIndex(this.config.loadConfigOrDefault());
-    return this.listDescendantAgentTaskIdsFromIndex(index, workspaceId).map((taskId) => {
+    const taskIds = this.listDescendantAgentTaskIdsFromIndex(index, workspaceId);
+    taskIds.sort(
+      (a, b) =>
+        this.getTaskDepthFromParentById(index.parentById, b) -
+        this.getTaskDepthFromParentById(index.parentById, a)
+    );
+    return taskIds.map((taskId) => {
       const entry = index.byId.get(taskId)!;
       return {
         workspaceId: taskId,
@@ -9294,24 +9300,24 @@ export class TaskService implements AgentTaskIntegration {
     if (descendants.some((descendant) => descendant.active)) {
       return Err("Stop active descendant sub-agents before removing this workspace.");
     }
-    const index = this.buildAgentTaskIndex(this.config.loadConfigOrDefault());
-    descendants.sort(
-      (a, b) =>
-        this.getTaskDepthFromParentById(index.parentById, b.workspaceId) -
-        this.getTaskDepthFromParentById(index.parentById, a.workspaceId)
-    );
     for (const descendant of descendants) {
-      const result = await this.removeInactiveDescendantAgentTaskWhileTaskTreeLocked(
-        workspaceId,
-        descendant.workspaceId
-      );
-      if (!result.success) return Err(result.error);
-      if (result.data.status !== "removed" && result.data.status !== "already_removed") {
-        return Err(
-          "error" in result.data
-            ? (result.data.error ?? "Descendant removal failed.")
-            : "Descendant removal failed."
+      const failure = (error: string) =>
+        Err(`Cannot remove ${descendant.title} (${descendant.workspaceId}): ${error}`);
+      try {
+        const result = await this.removeInactiveDescendantAgentTaskWhileTaskTreeLocked(
+          workspaceId,
+          descendant.workspaceId
         );
+        if (!result.success) return failure(result.error);
+        if (result.data.status !== "removed" && result.data.status !== "already_removed") {
+          return failure(
+            "error" in result.data
+              ? (result.data.error ?? "Descendant removal failed.")
+              : "Descendant removal failed."
+          );
+        }
+      } catch (error) {
+        return failure(getErrorMessage(error));
       }
     }
     return Ok(undefined);

--- a/src/node/services/taskWorkspaceSeam.testUtils.ts
+++ b/src/node/services/taskWorkspaceSeam.testUtils.ts
@@ -69,6 +69,8 @@ export function makeAgentTaskIntegrationFake(
     withTaskTreeLifecycleLock: <T>(_workspaceId: string, operation: () => Promise<T>): Promise<T> =>
       operation(),
     hasDescendantAgentTasks: () => false,
+    listWorkspaceRemovalDescendants: () => [],
+    removeAcknowledgedDescendantsWhileTaskTreeLocked: () => Promise.resolve(Ok(undefined)),
     hasActiveDescendantAgentTasksForWorkspace: () => false,
     hasActiveTopLevelWorkflowRunsForWorkspace: () => Promise.resolve(false),
     getAgentTaskStatus: () => undefined,

--- a/src/node/services/taskWorkspaceSeam.ts
+++ b/src/node/services/taskWorkspaceSeam.ts
@@ -13,7 +13,11 @@ import type {
 import type { Result } from "@/common/types/result";
 import type { StreamErrorRecoveryOutcome } from "@/node/services/agentSession";
 import type { RuntimeConfig } from "@/common/types/runtime";
-import type { FrontendWorkspaceMetadata, WorkspaceMetadata } from "@/common/types/workspace";
+import type {
+  FrontendWorkspaceMetadata,
+  WorkspaceMetadata,
+  WorkspaceRemovalDescendant,
+} from "@/common/types/workspace";
 import type { AgentAiSettingsLayerValues } from "@/common/types/agentAiSettings";
 import type {
   OpenAIReasoningMode,
@@ -535,6 +539,11 @@ export type WorkspaceHost = WorkspaceTurnHost &
 export interface AgentTaskIntegration {
   withTaskTreeLifecycleLock<T>(workspaceId: string, operation: () => Promise<T>): Promise<T>;
   hasDescendantAgentTasks(workspaceId: string): boolean;
+  listWorkspaceRemovalDescendants(workspaceId: string): WorkspaceRemovalDescendant[];
+  removeAcknowledgedDescendantsWhileTaskTreeLocked(
+    workspaceId: string,
+    acknowledgedIds: string[]
+  ): Promise<Result<void>>;
   hasActiveDescendantAgentTasksForWorkspace(workspaceId: string): boolean;
   hasActiveTopLevelWorkflowRunsForWorkspace(workspaceId: string): Promise<boolean>;
   getAgentTaskStatus(workspaceId: string): AgentTaskStatus | null | undefined;

--- a/src/node/services/workspaceOperations.ts
+++ b/src/node/services/workspaceOperations.ts
@@ -205,10 +205,12 @@ export async function removeWorkspace(
   context: ORPCContext,
   input: z.infer<typeof schemas.workspace.remove.input>
 ) {
-  const result = await context.workspaceService.remove(input.workspaceId, input.options?.force);
+  const result = await context.workspaceService.remove(input.workspaceId, input.options?.force, {
+    acknowledgedDescendantIds: input.options?.acknowledgedDescendantIds,
+  });
   return result.success
     ? { success: true as const }
-    : { success: false as const, error: result.error };
+    : { success: false as const, error: result.error, descendants: result.descendants };
 }
 
 export async function forkWorkspace(context: ORPCContext, input: ForkWorkspaceInput) {

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -13508,6 +13508,74 @@ describe("WorkspaceService assertPricedModelForBudgetedGoal", () => {
 });
 
 describe("WorkspaceService remove lifecycle coordination", () => {
+  test("acknowledged removal keeps the parent last and returns forced failure scope", async () => {
+    const workspaceService = createWorkspaceServiceForTest({
+      config: { findWorkspace: mock(() => null) },
+    });
+    const descendants = [{ workspaceId: "child", title: "Child", active: true }];
+    const order: string[] = [];
+    let locked = false;
+    let blocked = true;
+    const removeDescendants = mock(() => {
+      expect(locked).toBe(true);
+      order.push("descendants");
+      return Promise.resolve(blocked ? Err("active child") : Ok(undefined));
+    });
+    workspaceService.setAgentTaskIntegration(
+      makeAgentTaskIntegrationFake({
+        withTaskTreeLifecycleLock: async <T>(
+          _id: string,
+          operation: () => Promise<T>
+        ): Promise<T> => {
+          expect(locked).toBe(false);
+          locked = true;
+          try {
+            return await operation();
+          } finally {
+            locked = false;
+          }
+        },
+        listWorkspaceRemovalDescendants: () => descendants,
+        removeAcknowledgedDescendantsWhileTaskTreeLocked: removeDescendants,
+      })
+    );
+    const removeParent = spyOn(
+      workspaceService as unknown as {
+        removeUnlocked(id: string, force: boolean): Promise<Result<void>>;
+      },
+      "removeUnlocked"
+    ).mockImplementation(() => {
+      expect(locked).toBe(true);
+      order.push("parent");
+      return Promise.resolve(Err("parent failure"));
+    });
+    expect(
+      await workspaceService.remove("parent", true, { acknowledgedDescendantIds: ["child"] })
+    ).toEqual({
+      success: false,
+      error: "active child",
+      descendants,
+    });
+    expect(removeParent).not.toHaveBeenCalled();
+    blocked = false;
+    expect(
+      await workspaceService.remove("parent", true, { acknowledgedDescendantIds: ["child"] })
+    ).toEqual({
+      success: false,
+      error: "parent failure",
+      descendants,
+    });
+    expect(order).toEqual(["descendants", "descendants", "parent"]);
+    removeDescendants.mockClear();
+    expect(await workspaceService.remove("parent", true)).toEqual({
+      success: false,
+      error: "parent failure",
+      descendants,
+    });
+    expect(removeDescendants).not.toHaveBeenCalled();
+    removeParent.mockRestore();
+  });
+
   test("checks descendant tasks while holding the task-tree lifecycle lock", async () => {
     const workspaceId = "parent-remove-lifecycle";
     const workspaceService = createWorkspaceServiceForTest({

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -13509,17 +13509,24 @@ describe("WorkspaceService assertPricedModelForBudgetedGoal", () => {
 
 describe("WorkspaceService remove lifecycle coordination", () => {
   test("acknowledged removal keeps the parent last and returns forced failure scope", async () => {
-    const workspaceService = createWorkspaceServiceForTest({
-      config: { findWorkspace: mock(() => null) },
+    const { config, historyService, cleanup } = await createTestHistoryService();
+    const workspaceService = createWorkspaceServiceForTest({ config, historyService });
+    let notifications = 0;
+    const unsubscribe = config.onConfigChanged(() => {
+      notifications += 1;
     });
     const descendants = [{ workspaceId: "child", title: "Child", active: true }];
     const order: string[] = [];
     let locked = false;
     let blocked = true;
-    const removeDescendants = mock(() => {
+    const removeDescendants = mock(async () => {
       expect(locked).toBe(true);
+      const before = notifications;
       order.push("descendants");
-      return Promise.resolve(blocked ? Err("active child") : Ok(undefined));
+      await config.editConfig((value) => value);
+      await config.editConfig((value) => value);
+      expect(notifications).toBe(before);
+      return blocked ? Err("active child") : Ok(undefined);
     });
     workspaceService.setAgentTaskIntegration(
       makeAgentTaskIntegrationFake({
@@ -13544,10 +13551,11 @@ describe("WorkspaceService remove lifecycle coordination", () => {
         removeUnlocked(id: string, force: boolean): Promise<Result<void>>;
       },
       "removeUnlocked"
-    ).mockImplementation(() => {
+    ).mockImplementation(async () => {
       expect(locked).toBe(true);
       order.push("parent");
-      return Promise.resolve(Err("parent failure"));
+      await config.editConfig((value) => value);
+      return Err("parent failure");
     });
     expect(
       await workspaceService.remove("parent", true, { acknowledgedDescendantIds: ["child"] })
@@ -13566,6 +13574,7 @@ describe("WorkspaceService remove lifecycle coordination", () => {
       descendants,
     });
     expect(order).toEqual(["descendants", "descendants", "parent"]);
+    expect(notifications).toBe(2);
     removeDescendants.mockClear();
     expect(await workspaceService.remove("parent", true)).toEqual({
       success: false,
@@ -13573,7 +13582,10 @@ describe("WorkspaceService remove lifecycle coordination", () => {
       descendants,
     });
     expect(removeDescendants).not.toHaveBeenCalled();
+    expect(notifications).toBe(3);
+    unsubscribe();
     removeParent.mockRestore();
+    await cleanup();
   });
 
   test("checks descendant tasks while holding the task-tree lifecycle lock", async () => {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -5741,30 +5741,37 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
     options?: { beforeRemove?: () => Promise<boolean>; acknowledgedDescendantIds?: string[] }
   ): Promise<Result<void> & { descendants?: WorkspaceRemovalDescendant[] }> {
     return await this.withTaskTreeLifecycleLock(workspaceId, async () => {
-      if (options?.beforeRemove != null && !(await options.beforeRemove())) {
-        return Ok(undefined);
-      }
-      const failure = (error: string) => {
-        const descendants = this.agentTaskIntegration?.listWorkspaceRemovalDescendants(workspaceId);
-        return { ...Err(error), ...(descendants?.length ? { descendants } : {}) };
-      };
-      try {
-        if (options?.acknowledgedDescendantIds != null) {
-          if (this.agentTaskIntegration == null) {
-            return failure("Task lifecycle service is unavailable.");
-          }
-          const descendantsResult =
-            await this.agentTaskIntegration.removeAcknowledgedDescendantsWhileTaskTreeLocked(
-              workspaceId,
-              options.acknowledgedDescendantIds
-            );
-          if (!descendantsResult.success) return failure(descendantsResult.error);
+      const operation = async () => {
+        if (options?.beforeRemove != null && !(await options.beforeRemove())) {
+          return Ok(undefined);
         }
-        const result = await this.removeUnlocked(workspaceId, force);
-        return result.success ? result : failure(result.error);
-      } catch (error) {
-        return failure(getErrorMessage(error));
-      }
+        const failure = (error: string) => {
+          const descendants =
+            this.agentTaskIntegration?.listWorkspaceRemovalDescendants(workspaceId);
+          return { ...Err(error), ...(descendants?.length ? { descendants } : {}) };
+        };
+        try {
+          if (options?.acknowledgedDescendantIds != null) {
+            if (this.agentTaskIntegration == null) {
+              return failure("Task lifecycle service is unavailable.");
+            }
+            const descendantsResult =
+              await this.agentTaskIntegration.removeAcknowledgedDescendantsWhileTaskTreeLocked(
+                workspaceId,
+                options.acknowledgedDescendantIds
+              );
+            if (!descendantsResult.success) return failure(descendantsResult.error);
+          }
+          const result = await this.removeUnlocked(workspaceId, force);
+          return result.success ? result : failure(result.error);
+        } catch (error) {
+          return failure(getErrorMessage(error));
+        }
+      };
+      // Defer the project-list refresh until the complete descendant cascade ends.
+      return options?.acknowledgedDescendantIds != null
+        ? await this.config.withDeferredChangeNotifications(operation)
+        : await operation();
     });
   }
 

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -184,6 +184,7 @@ import type {
   ProjectRef,
   WorkspaceActivitySnapshot,
   WorkspaceMetadata,
+  WorkspaceRemovalDescendant,
 } from "@/common/types/workspace";
 import { isDynamicToolPart } from "@/common/types/toolParts";
 import { buildAskUserQuestionSummary } from "@/common/utils/tools/askUserQuestionSummary";
@@ -5737,13 +5738,33 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
   async remove(
     workspaceId: string,
     force = false,
-    options?: { beforeRemove?: () => Promise<boolean> }
-  ): Promise<Result<void>> {
+    options?: { beforeRemove?: () => Promise<boolean>; acknowledgedDescendantIds?: string[] }
+  ): Promise<Result<void> & { descendants?: WorkspaceRemovalDescendant[] }> {
     return await this.withTaskTreeLifecycleLock(workspaceId, async () => {
       if (options?.beforeRemove != null && !(await options.beforeRemove())) {
         return Ok(undefined);
       }
-      return await this.removeUnlocked(workspaceId, force);
+      const failure = (error: string) => {
+        const descendants = this.agentTaskIntegration?.listWorkspaceRemovalDescendants(workspaceId);
+        return { ...Err(error), ...(descendants?.length ? { descendants } : {}) };
+      };
+      try {
+        if (options?.acknowledgedDescendantIds != null) {
+          if (this.agentTaskIntegration == null) {
+            return failure("Task lifecycle service is unavailable.");
+          }
+          const descendantsResult =
+            await this.agentTaskIntegration.removeAcknowledgedDescendantsWhileTaskTreeLocked(
+              workspaceId,
+              options.acknowledgedDescendantIds
+            );
+          if (!descendantsResult.success) return failure(descendantsResult.error);
+        }
+        const result = await this.removeUnlocked(workspaceId, force);
+        return result.success ? result : failure(result.error);
+      } catch (error) {
+        return failure(getErrorMessage(error));
+      }
     });
   }
 


### PR DESCRIPTION
## Summary

Add explicit confirmation to delete a workspace and its inactive sub-agent descendants. Show deletion failures in the dialog.

## Background

Completed sub-agents can block deletion of an archived parent. The previous Force Delete button repeated the same blocked request.

## Implementation

- List descendants and require consent for the displayed scope.
- Reject active descendants and newly added descendants before deletion.
- Remove descendants deepest-first, then remove the parent.
- Preserve shared-checkout and pending-patch protections.
- Show retry errors and refresh the remaining deletion scope.
- Batch config notifications across the complete deletion operation, including partial failures.
- Keep archive behavior unchanged.

## Risks

Deletion is irreversible. A runtime failure can leave partial progress, so retries validate the remaining descendants.

## Testing

No personal-deployment testing.

---

_Generated with `xum` • Model: `openai:gpt-6-astra` • Thinking: `medium` • Cost: `$16.24`_

<!-- mux-attribution: model=openai:gpt-6-astra thinking=medium costs=16.24 -->


