### PR TITLE
🤖 release: v0.28.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coder/xum",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "desktopName": "xum.desktop",
   "description": "xum - coding agent multiplexer",
   "author": "Coder",

--- a/packages/mux-compat/package.json
+++ b/packages/mux-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mux",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "description": "Compatibility package forwarding the legacy mux command to @coder/xum",
   "bin": {
     "mux": "bin/mux.js"
@@ -10,7 +10,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@coder/xum": "0.28.4"
+    "@coder/xum": "0.28.5"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Version bump for the v0.28.5 patch release. Headline changes since v0.28.4: remote server connections in the desktop app (#4101), self-updating `xum server` under a restart supervisor (#4083, #4127), first-class GPT-6 Astra and Astra Pro support including Codex OAuth routing (#4064, #4094, #4106, #4124), token-budget context window rollovers (#4097), the workspace remembering model and mode on send (#3968), in-place plugin updates (#4164), the optional flat sidebar chat list (#3994), and copying selected chat text as Markdown (#4170). It also carries a long run of streaming, compaction, and task-lifecycle fixes (reconnect streaming #4123, message edits during active streams #4153, Codex OAuth prompt-cache routing #4159, compaction/history fencing #4133 through #4148, task lock ordering #4161) plus the Effect Wave 4 runtime refactors and deslop passes 1 through 3.

## Implementation

Bumped with `node ./scripts/set-package-version.js 0.28.5` so the root `package.json` and the legacy `packages/mux-compat` forwarding package stay version-locked. `src/common/compat/productIdentity.test.ts` passes locally (8/8).

After this PR merges, the `v0.28.5` tag will be applied to the squash commit and the GitHub Release published to trigger the desktop/npm/docker pipelines.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$1.64`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=1.64 -->

