### PR TITLE
🤖 feat: keep sent messages visible in the transcript until the backend acknowledges them

### DIFF
--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -1110,7 +1110,8 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
       hasRenderableMessages: deferredMessages.length > 0,
       // Any mounted barrier (including waiting-on-monitor) counts: a cleared
       // transcript with an armed monitor must not flash placeholders under it.
-      shouldShowStreamingBarrier: shouldMountStreamingBarrier,
+      // A pending send is a live tail row for the same reason.
+      shouldShowStreamingBarrier: shouldMountStreamingBarrier || pendingSend !== null,
     });
   const showEmptyTranscriptPlaceholder =
     deferredMessages.length === 0 &&

--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -1733,6 +1733,7 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
                       workspaceName={workspaceName}
                       revealDecorations={revealDecorations}
                       isStreamStarting={isStreamStarting}
+                      hasPendingSend={pendingSend !== null}
                       isTranscriptCaughtUp={isTranscriptCaughtUp}
                       runtimeConfig={runtimeConfig}
                       isPreStreamAgentTask={isPreStreamAgentTask}
@@ -1815,6 +1816,7 @@ interface ChatInputPaneProps {
   preStreamAgentTaskStatus: "queued" | "starting";
   isCompacting: boolean;
   isStreamStarting: boolean;
+  hasPendingSend: boolean;
   isTranscriptCaughtUp: boolean;
   shouldShowPinnedTodoList: boolean;
   shouldShowReviewsBanner: boolean;
@@ -1998,6 +2000,7 @@ const ChatInputPane: React.FC<ChatInputPaneProps> = (props) => {
         }
         isTranscriptCaughtUp={props.isTranscriptCaughtUp}
         isStreamStarting={props.isStreamStarting}
+        hasPendingSend={props.hasPendingSend}
         isCompacting={props.isCompacting}
         editingMessage={props.editingMessage}
         onCancelEdit={props.onCancelEdit}

--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -69,6 +69,7 @@ import type { RuntimeConfig } from "@/common/types/runtime";
 import { getRuntimeTypeForTelemetry } from "@/common/telemetry";
 import { useAIViewKeybinds } from "@/browser/hooks/useAIViewKeybinds";
 import { QueuedMessage } from "@/browser/features/Messages/QueuedMessage";
+import { PendingSendMessage } from "@/browser/features/Messages/PendingSendMessage";
 import { CompactionWarning } from "../CompactionWarning/CompactionWarning";
 import { ContextSwitchWarning as ContextSwitchWarningBanner } from "../ContextSwitchWarning/ContextSwitchWarning";
 import {
@@ -466,6 +467,7 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
     hasOlderHistory,
     loadingOlderHistory,
     activeBashMonitorCount,
+    pendingSend,
   } = workspaceState;
   const shouldShowPinnedTodoList = workspaceState.todos.length > 0;
   const shouldShowReviewsBanner = reviews.reviews.length > 0;
@@ -1113,9 +1115,13 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
   const showEmptyTranscriptPlaceholder =
     deferredMessages.length === 0 &&
     !showTranscriptHydrationPlaceholder &&
-    !shouldMountStreamingBarrier;
+    !shouldMountStreamingBarrier &&
+    pendingSend === null;
   const showRetryBarrier =
-    !isHydratingTranscript && !shouldShowStreamingBarrier && hasInterruptedStream;
+    !isHydratingTranscript &&
+    !shouldShowStreamingBarrier &&
+    hasInterruptedStream &&
+    pendingSend === null;
   const isAutoRetryActive =
     workspaceState.autoRetryStatus?.type === "auto-retry-scheduled" ||
     workspaceState.autoRetryStatus?.type === "auto-retry-starting";
@@ -1170,6 +1176,14 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
     lastRetryCandidateMessage != null &&
     interruptedBarrierMessageIds.has(lastRetryCandidateMessage.id);
   const transcriptTailItems: TranscriptTailStackItem[] = [];
+  if (pendingSend) {
+    transcriptTailItems.push(
+      createTranscriptTailStackItem({
+        key: "pending-send",
+        node: <PendingSendMessage message={pendingSend} />,
+      })
+    );
+  }
   if (shouldMountRetryBarrier) {
     transcriptTailItems.push(
       createTranscriptTailStackItem({

--- a/src/browser/components/PinnedTodoList/PinnedTodoList.test.tsx
+++ b/src/browser/components/PinnedTodoList/PinnedTodoList.test.tsx
@@ -31,6 +31,7 @@ function buildWorkspaceState(workspaceId: string, state: MockWorkspaceState): Wo
     name: workspaceId,
     messages: [],
     queuedMessage: null,
+    pendingSend: null,
     canInterrupt: false,
     isCompacting: false,
     isStreamStarting: false,

--- a/src/browser/features/ChatInput/ChatInput.stories.tsx
+++ b/src/browser/features/ChatInput/ChatInput.stories.tsx
@@ -284,6 +284,78 @@ export const FocusedComposer: AppStory = {
   },
 };
 
+export const SendingMessage: AppStory = {
+  render: () => (
+    <AppWithMocks
+      setup={() => {
+        collapseLeftSidebar();
+        const workspaceId = "ws-sending-message";
+        setWorkspaceInput(
+          workspaceId,
+          "Please double-check the retry path before we ship the connection fix."
+        );
+        return setupSimpleChatStory({
+          workspaceId,
+          messages: [
+            createUserMessage("msg-1", "Can you look at the reconnect logic?", {
+              historySequence: 1,
+              timestamp: STABLE_TIMESTAMP - 120_000,
+            }),
+            createAssistantMessage("msg-2", "Sure, I found the handler that owns reconnects.", {
+              historySequence: 2,
+              timestamp: STABLE_TIMESTAMP - 60_000,
+            }),
+          ],
+          // Never resolves: the send stays in flight so the pending row remains visible.
+          onSendMessage: () => new Promise(() => undefined),
+        });
+      }}
+    />
+  ),
+  parameters: {
+    ...appMeta.parameters,
+    pixel: {
+      matrix: { themes: ["dark"], viewports: ["phone", "laptop"] },
+    },
+    docs: {
+      description: {
+        story:
+          "A sent message stays visible in the transcript tail with a sending indicator until the backend acknowledges it; the composer is disabled meanwhile.",
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const storyRoot = document.getElementById("storybook-root") ?? canvasElement;
+    await waitForChatInputAutofocusDone(storyRoot);
+
+    const sendButton = await within(storyRoot).findByLabelText("Send message");
+    await userEvent.click(sendButton);
+
+    await waitFor(() => {
+      const row = storyRoot.querySelector<HTMLElement>('[data-component="PendingSendMessage"]');
+      const status = storyRoot.querySelector<HTMLElement>('[data-component="PendingSendStatus"]');
+      if (!row || !status) {
+        throw new Error("Pending send row not rendered");
+      }
+      if (!row.textContent?.includes("Please double-check the retry path")) {
+        throw new Error("Pending send row does not show the sent text");
+      }
+      if (row.scrollWidth > row.clientWidth) {
+        throw new Error(
+          `Pending send row overflows horizontally (${row.scrollWidth}px > ${row.clientWidth}px)`
+        );
+      }
+      const textarea = storyRoot.querySelector<HTMLTextAreaElement>(
+        'textarea[aria-label="Message Claude"]'
+      );
+      if (!textarea?.disabled) {
+        throw new Error("Composer should be disabled while the send is in flight");
+      }
+    });
+    blurActiveElement();
+  },
+};
+
 export const ThinkingSelectorOpen: AppStory = {
   tags: ["thinking-selector"],
   globals: {

--- a/src/browser/features/ChatInput/ChatInput.stories.tsx
+++ b/src/browser/features/ChatInput/ChatInput.stories.tsx
@@ -285,6 +285,9 @@ export const FocusedComposer: AppStory = {
 };
 
 export const SendingMessage: AppStory = {
+  globals: {
+    viewport: { value: "mobile1", isRotated: false },
+  },
   render: () => (
     <AppWithMocks
       setup={() => {

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -2158,7 +2158,8 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         }
 
         // Keep the message visible in the transcript tail until the backend echoes it back;
-        // otherwise it vanishes for the whole round-trip on a slow connection.
+        // otherwise it vanishes for the whole round-trip on a slow connection. A successful
+        // response must not clear it: the acknowledgement event can land a frame later.
         pendingSendId = `pending-send-${Date.now()}`;
         store.beginPendingSend(props.workspaceId, {
           id: pendingSendId,
@@ -2181,6 +2182,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           // Show error using enhanced toast
           setToast(createErrorToast(result.error));
           // Restore draft on error so user can try again
+          store.clearPendingSend(props.workspaceId, pendingSendId);
           setOptimisticallyDismissedEditId(null);
           setDraft(preSendDraft);
           setDraftReviews(preSendReviews);
@@ -2234,13 +2236,13 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           })
         );
         // Restore draft on error
+        if (pendingSendId !== null) {
+          store.clearPendingSend(props.workspaceId, pendingSendId);
+        }
         setOptimisticallyDismissedEditId(null);
         setDraft(preSendDraft);
         setDraftReviews(preSendReviews);
       } finally {
-        if (pendingSendId !== null) {
-          store.clearPendingSend(props.workspaceId, pendingSendId);
-        }
         setSendingCount((c) => c - 1);
         setHideReviewsDuringSend(false);
       }

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -766,11 +766,11 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   // Creation sends also pass through the async resolution phase guarded by
   // sendingCount, so include it alongside the creation-specific flag.
   const isSendInFlight = variant === "creation" ? creationState.isSending || isSending : isSending;
-  // Stream startup lets follow-ups queue behind a slow turn, but never before the current
-  // send has been acknowledged: a second send would replace the pending row.
+  // Stream startup lets follow-ups queue behind a slow turn, but never while a send is still
+  // unacknowledged: a second send would replace the pending row.
   const sendInFlightBlocksInput =
     variant === "workspace"
-      ? isSendInFlight && (!isStreamStarting || hasPendingSend)
+      ? (isSendInFlight && !isStreamStarting) || hasPendingSend
       : isSendInFlight;
 
   // Coder workspace state - config is owned by selectedRuntime.coder, this hook manages async data
@@ -2163,7 +2163,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         pendingSendId = `pending-send-${Date.now()}`;
         store.beginPendingSend(props.workspaceId, {
           id: pendingSendId,
-          content: messageText,
+          // Staged files only exist in the persisted text as the attachment notice.
+          content: appendStagedNoticeToUserMessage
+            ? appendStagedAttachmentNotice(messageText, sendAttachments)
+            : messageText,
           fileParts: sendFileParts,
           reviews: reviewsData,
         });
@@ -2187,6 +2190,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           setDraft(preSendDraft);
           setDraftReviews(preSendReviews);
         } else {
+          store.markPendingSendAccepted(props.workspaceId, pendingSendId);
           // Track telemetry for successful message send
           telemetry.messageSent(
             props.workspaceId,

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -2043,6 +2043,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       const preSendDraft = { ...getDraft(), attachments: sendAttachments };
       const preSendReviews = draftReviews;
       const editMessageForSend = editingMessageForUi;
+      let pendingSendId: string | null = null;
 
       try {
         // Prepare file parts if any
@@ -2151,6 +2152,16 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           inputRef.current.style.height = "";
         }
 
+        // Keep the message visible in the transcript tail until the backend echoes it back;
+        // otherwise it vanishes for the whole round-trip on a slow connection.
+        pendingSendId = `pending-send-${Date.now()}`;
+        store.beginPendingSend(props.workspaceId, {
+          id: pendingSendId,
+          content: messageText,
+          fileParts: sendFileParts,
+          reviews: reviewsData,
+        });
+
         props.onMessageSendStarted?.(overrides?.queueDispatchMode ?? "tool-end");
 
         const result = await api.workspace.sendMessage({
@@ -2222,6 +2233,9 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         setDraft(preSendDraft);
         setDraftReviews(preSendReviews);
       } finally {
+        if (pendingSendId !== null) {
+          store.clearPendingSend(props.workspaceId, pendingSendId);
+        }
         setSendingCount((c) => c - 1);
         setHideReviewsDuringSend(false);
       }

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -289,6 +289,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const isTranscriptCaughtUp =
     variant === "workspace" ? (props.isTranscriptCaughtUp ?? false) : false;
   const isStreamStarting = variant === "workspace" ? (props.isStreamStarting ?? false) : false;
+  const hasPendingSend = variant === "workspace" ? (props.hasPendingSend ?? false) : false;
   const isCompacting = variant === "workspace" ? (props.isCompacting ?? false) : false;
   const [isMobileTouch, setIsMobileTouch] = useState(
     () =>
@@ -765,8 +766,12 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   // Creation sends also pass through the async resolution phase guarded by
   // sendingCount, so include it alongside the creation-specific flag.
   const isSendInFlight = variant === "creation" ? creationState.isSending || isSending : isSending;
+  // Stream startup lets follow-ups queue behind a slow turn, but never before the current
+  // send has been acknowledged: a second send would replace the pending row.
   const sendInFlightBlocksInput =
-    variant === "workspace" ? isSendInFlight && !isStreamStarting : isSendInFlight;
+    variant === "workspace"
+      ? isSendInFlight && (!isStreamStarting || hasPendingSend)
+      : isSendInFlight;
 
   // Coder workspace state - config is owned by selectedRuntime.coder, this hook manages async data
   const currentRuntime = creationState.selectedRuntime;

--- a/src/browser/features/ChatInput/types.ts
+++ b/src/browser/features/ChatInput/types.ts
@@ -42,6 +42,8 @@ export interface ChatInputWorkspaceVariant {
   isTranscriptCaughtUp?: boolean;
   isCompacting?: boolean;
   isStreamStarting?: boolean;
+  /** A send is still waiting for the backend to acknowledge it (pending transcript row). */
+  hasPendingSend?: boolean;
   editingMessage?: EditingMessageState;
   onCancelEdit?: () => void;
   onEditLastUserMessage?: () => void;

--- a/src/browser/features/ChatInput/useCreationWorkspace.test.tsx
+++ b/src/browser/features/ChatInput/useCreationWorkspace.test.tsx
@@ -1129,7 +1129,9 @@ describe("useCreationWorkspace", () => {
     // barrier is cleared once staging fails.
     expect(onWorkspaceCreated.mock.calls.length).toBe(1);
     expect(onWorkspaceCreated.mock.calls[0][1]).toMatchObject({ markPendingInitialSend: true });
-    expect(clearPendingInitialSendSpy.mock.calls).toContainEqual([TEST_WORKSPACE_ID]);
+    expect(clearPendingInitialSendSpy.mock.calls.map(([workspaceId]) => workspaceId)).toContain(
+      TEST_WORKSPACE_ID
+    );
     clearPendingInitialSendSpy.mockRestore();
 
     const pendingScopeId = getPendingScopeId(TEST_PROJECT_PATH);

--- a/src/browser/features/ChatInput/useCreationWorkspace.test.tsx
+++ b/src/browser/features/ChatInput/useCreationWorkspace.test.tsx
@@ -861,6 +861,8 @@ describe("useCreationWorkspace", () => {
       trunkBranch: "dev",
     });
     const onWorkspaceCreated = mock((metadata: FrontendWorkspaceMetadata) => metadata);
+    const beginPendingSendSpy = spyOn(workspaceStore, "beginPendingSend");
+    const markPendingSendAcceptedSpy = spyOn(workspaceStore, "markPendingSendAccepted");
 
     const getHook = renderUseCreationWorkspace({
       projectPath: TEST_PROJECT_PATH,
@@ -879,6 +881,16 @@ describe("useCreationWorkspace", () => {
     });
 
     expect(handleSendResult).toEqual({ success: true });
+
+    // The initial message is shown as pending in the new workspace and marked accepted on success.
+    expect(beginPendingSendSpy.mock.calls.length).toBe(1);
+    expect(beginPendingSendSpy.mock.calls[0][0]).toBe(TEST_WORKSPACE_ID);
+    expect(beginPendingSendSpy.mock.calls[0][1]).toMatchObject({ content: "launch workspace" });
+    expect(markPendingSendAcceptedSpy.mock.calls).toEqual([
+      [TEST_WORKSPACE_ID, beginPendingSendSpy.mock.calls[0][1].id],
+    ]);
+    beginPendingSendSpy.mockRestore();
+    markPendingSendAcceptedSpy.mockRestore();
 
     // workspace.create should be called with the generated name
     expect(workspaceApi.create.mock.calls.length).toBe(1);

--- a/src/browser/features/ChatInput/useCreationWorkspace.ts
+++ b/src/browser/features/ChatInput/useCreationWorkspace.ts
@@ -702,13 +702,23 @@ export function useCreationWorkspace({
             : null;
 
         // Runtime startup can take minutes; keep the initial message visible in the new
-        // transcript until the backend echoes it. Staged files join the persisted row later.
+        // transcript until the backend echoes it. Files awaiting staging show as display-only
+        // parts until the staged notice replaces them below.
         const pendingSendId = `pending-send-${Date.now()}`;
+        const pendingDisplayText = overrideRawCommand ?? messageText;
         if (initialSlashCommand == null) {
+          const displayFileParts: FilePart[] = [
+            ...(fileParts ?? []),
+            ...pendingFilesToStage.map((file) => ({
+              mediaType: file.mediaType,
+              url: `data:${file.mediaType};base64,${file.dataBase64}`,
+              filename: file.filename,
+            })),
+          ];
           workspaceStore.beginPendingSend(metadata.id, {
             id: pendingSendId,
-            content: overrideRawCommand ?? messageText,
-            fileParts: fileParts && fileParts.length > 0 ? fileParts : undefined,
+            content: pendingDisplayText,
+            fileParts: displayFileParts.length > 0 ? displayFileParts : undefined,
           });
         }
 
@@ -728,6 +738,14 @@ export function useCreationWorkspace({
             ? await stagePendingFiles(api, metadata.id, pendingFilesToStage)
             : { staged: [], failures: [] };
         const stagingFailed = stagingOutcome.failures.length > 0;
+
+        if (stagingOutcome.staged.length > 0 && !stagingFailed) {
+          workspaceStore.updatePendingSend(metadata.id, {
+            id: pendingSendId,
+            content: appendStagedAttachmentNotice(pendingDisplayText, stagingOutcome.staged),
+            fileParts: fileParts && fileParts.length > 0 ? fileParts : undefined,
+          });
+        }
 
         if (stagingFailed) {
           workspaceStore.clearPendingInitialSendState(metadata.id);

--- a/src/browser/features/ChatInput/useCreationWorkspace.ts
+++ b/src/browser/features/ChatInput/useCreationWorkspace.ts
@@ -690,6 +690,28 @@ export function useCreationWorkspace({
           markPendingInitialSend: initialSlashCommand == null,
         });
 
+        // SendMessageOptions.muxMetadata is a black box (z.any); the creation
+        // caller only ever passes XumMessageMetadata built in ChatInput.
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const overrideMuxMetadata: MuxMessageMetadata | undefined = optionsOverride?.muxMetadata;
+        const overrideRawCommand =
+          overrideMuxMetadata &&
+          "rawCommand" in overrideMuxMetadata &&
+          typeof overrideMuxMetadata.rawCommand === "string"
+            ? overrideMuxMetadata.rawCommand
+            : null;
+
+        // Runtime startup can take minutes; keep the initial message visible in the new
+        // transcript until the backend echoes it. Staged files join the persisted row later.
+        const pendingSendId = `pending-send-${Date.now()}`;
+        if (initialSlashCommand == null) {
+          workspaceStore.beginPendingSend(metadata.id, {
+            id: pendingSendId,
+            content: overrideRawCommand ?? messageText,
+            fileParts: fileParts && fileParts.length > 0 ? fileParts : undefined,
+          });
+        }
+
         if (typeof draftId === "string" && draftId.trim().length > 0 && promoteWorkspaceDraft) {
           // UI-only: show the created workspace in-place where the draft was rendered.
           promoteWorkspaceDraft(projectPath, draftId, metadata);
@@ -706,17 +728,6 @@ export function useCreationWorkspace({
             ? await stagePendingFiles(api, metadata.id, pendingFilesToStage)
             : { staged: [], failures: [] };
         const stagingFailed = stagingOutcome.failures.length > 0;
-
-        // SendMessageOptions.muxMetadata is a black box (z.any); the creation
-        // caller only ever passes XumMessageMetadata built in ChatInput.
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const overrideMuxMetadata: MuxMessageMetadata | undefined = optionsOverride?.muxMetadata;
-        const overrideRawCommand =
-          overrideMuxMetadata &&
-          "rawCommand" in overrideMuxMetadata &&
-          typeof overrideMuxMetadata.rawCommand === "string"
-            ? overrideMuxMetadata.rawCommand
-            : null;
 
         if (stagingFailed) {
           workspaceStore.clearPendingInitialSendState(metadata.id);
@@ -859,6 +870,7 @@ export function useCreationWorkspace({
           return { success: false, error: sendResult.error };
         }
 
+        workspaceStore.markPendingSendAccepted(metadata.id, pendingSendId);
         return { success: true };
       } catch (err) {
         if (createdWorkspaceId) {

--- a/src/browser/features/ChatInput/useCreationWorkspace.ts
+++ b/src/browser/features/ChatInput/useCreationWorkspace.ts
@@ -503,6 +503,7 @@ export function useCreationWorkspace({
       );
 
       let createdWorkspaceId: string | null = null;
+      let pendingSendId: string | null = null;
 
       try {
         // Wait for identity generation to complete (blocks if still in progress)
@@ -704,7 +705,7 @@ export function useCreationWorkspace({
         // Runtime startup can take minutes; keep the initial message visible in the new
         // transcript until the backend echoes it. Files awaiting staging show as display-only
         // parts until the staged notice replaces them below.
-        const pendingSendId = `pending-send-${Date.now()}`;
+        pendingSendId = `pending-send-${Date.now()}`;
         const pendingDisplayText = overrideRawCommand ?? messageText;
         if (initialSlashCommand == null) {
           const displayFileParts: FilePart[] = [
@@ -748,7 +749,7 @@ export function useCreationWorkspace({
         }
 
         if (stagingFailed) {
-          workspaceStore.clearPendingInitialSendState(metadata.id);
+          workspaceStore.clearPendingInitialSendState(metadata.id, pendingSendId);
           // Fail closed: a partial notice would misrepresent the workspace
           // contents. Transfer the draft (staged results kept, failed files
           // still pending) so the user can retry from the workspace composer.
@@ -801,7 +802,7 @@ export function useCreationWorkspace({
           setIsSending(false);
 
           if (commandResult.inputDisposition !== "consume") {
-            workspaceStore.clearPendingInitialSendState(metadata.id);
+            workspaceStore.clearPendingInitialSendState(metadata.id, pendingSendId);
             return { success: false };
           }
 
@@ -865,7 +866,7 @@ export function useCreationWorkspace({
 
         if (!sendResult.success) {
           if (createdWorkspaceId) {
-            workspaceStore.clearPendingInitialSendState(createdWorkspaceId);
+            workspaceStore.clearPendingInitialSendState(createdWorkspaceId, pendingSendId);
           }
           if (stagingOutcome.staged.length > 0) {
             // The creation draft was already cleared; without a transferred
@@ -892,7 +893,7 @@ export function useCreationWorkspace({
         return { success: true };
       } catch (err) {
         if (createdWorkspaceId) {
-          workspaceStore.clearPendingInitialSendState(createdWorkspaceId);
+          workspaceStore.clearPendingInitialSendState(createdWorkspaceId, pendingSendId);
         }
         const errorMessage = getErrorMessage(err);
         setToast({

--- a/src/browser/features/ChatInput/useCreationWorkspace.ts
+++ b/src/browser/features/ChatInput/useCreationWorkspace.ts
@@ -703,23 +703,19 @@ export function useCreationWorkspace({
             : null;
 
         // Runtime startup can take minutes; keep the initial message visible in the new
-        // transcript until the backend echoes it. Files awaiting staging show as display-only
-        // parts until the staged notice replaces them below.
+        // transcript until the backend echoes it. Files awaiting staging show as inert chips
+        // until the staged notice replaces them below.
         pendingSendId = `pending-send-${Date.now()}`;
         const pendingDisplayText = overrideRawCommand ?? messageText;
         if (initialSlashCommand == null) {
-          const displayFileParts: FilePart[] = [
-            ...(fileParts ?? []),
-            ...pendingFilesToStage.map((file) => ({
-              mediaType: file.mediaType,
-              url: `data:${file.mediaType};base64,${file.dataBase64}`,
-              filename: file.filename,
-            })),
-          ];
           workspaceStore.beginPendingSend(metadata.id, {
             id: pendingSendId,
             content: pendingDisplayText,
-            fileParts: displayFileParts.length > 0 ? displayFileParts : undefined,
+            fileParts: fileParts && fileParts.length > 0 ? fileParts : undefined,
+            stagingFilenames:
+              pendingFilesToStage.length > 0
+                ? pendingFilesToStage.map((file) => file.filename)
+                : undefined,
           });
         }
 

--- a/src/browser/features/Messages/PendingSendMessage.tsx
+++ b/src/browser/features/Messages/PendingSendMessage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Loader2 } from "lucide-react";
+import { FileText, Loader2 } from "lucide-react";
 import type { PendingSendMessage as PendingSendMessageData } from "@/common/types/message";
 import { UserMessageContent } from "@/browser/features/Messages/UserMessageContent";
 
@@ -9,6 +9,7 @@ interface PendingSendMessageProps {
 
 // Mirror the sent user bubble so the row stays in place when the persisted message replaces it.
 export const PendingSendMessage: React.FC<PendingSendMessageProps> = (props) => {
+  const stagingFilenames = props.message.stagingFilenames ?? [];
   return (
     <div
       className="mt-4 mb-1 ml-auto flex w-fit max-w-full flex-col"
@@ -21,6 +22,20 @@ export const PendingSendMessage: React.FC<PendingSendMessageProps> = (props) => 
           fileParts={props.message.fileParts}
           variant="sent"
         />
+        {stagingFilenames.length > 0 && (
+          // Inert on purpose: file bytes never reach the renderer as an openable URL.
+          <div className="mt-3 flex flex-wrap gap-3">
+            {stagingFilenames.map((filename) => (
+              <span
+                key={filename}
+                className="flex max-w-80 items-center gap-2 rounded-xl border border-[var(--color-attachment-border)] px-3 py-2 text-sm text-[var(--color-subtle)] opacity-70"
+              >
+                <FileText className="h-4 w-4 shrink-0" />
+                <span className="truncate">{filename}</span>
+              </span>
+            ))}
+          </div>
+        )}
       </div>
       <div
         role="status"

--- a/src/browser/features/Messages/PendingSendMessage.tsx
+++ b/src/browser/features/Messages/PendingSendMessage.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { Loader2 } from "lucide-react";
+import type { PendingSendMessage as PendingSendMessageData } from "@/common/types/message";
+import { UserMessageContent } from "@/browser/features/Messages/UserMessageContent";
+
+interface PendingSendMessageProps {
+  message: PendingSendMessageData;
+}
+
+// Mirror the sent user bubble so the row stays in place when the persisted message replaces it.
+export const PendingSendMessage: React.FC<PendingSendMessageProps> = (props) => {
+  return (
+    <div
+      className="mt-4 mb-1 ml-auto flex w-fit max-w-full flex-col"
+      data-component="PendingSendMessage"
+    >
+      <div className="rounded-lg border border-[var(--color-user-border)] bg-[var(--color-user-surface)] px-3 py-2 shadow-sm">
+        <UserMessageContent
+          content={props.message.content}
+          reviews={props.message.reviews}
+          fileParts={props.message.fileParts}
+          variant="sent"
+        />
+      </div>
+      <div
+        role="status"
+        className="text-muted mt-2 ml-auto flex items-center gap-1.5 text-[11px]"
+        data-component="PendingSendStatus"
+      >
+        <Loader2 aria-hidden="true" className="size-3 shrink-0 animate-spin" />
+        <span>Sending...</span>
+      </div>
+    </div>
+  );
+};

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.test.tsx
@@ -41,6 +41,7 @@ function buildState(workspaceId: string, input: SeedInput): WorkspaceState {
     name: workspaceId,
     messages: [],
     queuedMessage: null,
+    pendingSend: null,
     canInterrupt: input.canInterrupt ?? false,
     isCompacting: false,
     isStreamStarting: input.isStarting ?? false,

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -5386,6 +5386,71 @@ describe("WorkspaceStore", () => {
       expect(store.getWorkspaceState(workspaceId).pendingSend).toEqual(pendingSend);
     });
 
+    it("retires an accepted send that a replayed queue snapshot already holds", async () => {
+      const workspaceId = "pending-send-replay-queued-snapshot";
+      let attempt = 0;
+      mockChatStreamFor(workspaceId, async function* (signal) {
+        attempt += 1;
+        yield createUserMessageEvent("user-1", "earlier", 1, 1);
+        if (attempt === 2) {
+          // The reconnect replay already shows the in-flight send sitting in the queue.
+          yield {
+            type: "queued-message-changed",
+            workspaceId,
+            hasQueuedMessages: true,
+            queuedMessages: ["hello"],
+            displayText: "hello",
+          };
+        }
+        yield fullCaughtUpEvent(1, "user-1");
+        await waitForAbortSignal(signal);
+      });
+      createAndAddWorkspace(store, workspaceId);
+      expect(await waitUntil(() => store.getWorkspaceState(workspaceId).isTranscriptCaughtUp)).toBe(
+        true
+      );
+
+      store.beginPendingSend(workspaceId, pendingSend);
+      await resubscribe(workspaceId, `${workspaceId}-other`);
+      expect(store.getWorkspaceState(workspaceId).queuedMessage?.content).toBe("hello");
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toEqual(pendingSend);
+
+      store.markPendingSendAccepted(workspaceId, pendingSend.id);
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toBeNull();
+    });
+
+    it("does not treat paginated older rows as the pending send's echo", async () => {
+      const workspaceId = "pending-send-paginated-rows";
+      let attempt = 0;
+      mockChatStreamFor(workspaceId, async function* (signal) {
+        attempt += 1;
+        yield createHistoryMessageEvent("msg-newer", 5);
+        if (attempt === 2) {
+          yield createHistoryMessageEvent("msg-older", 3);
+        }
+        yield { type: "caught-up", hasOlderHistory: attempt === 1, replay: "full" };
+        await waitForAbortSignal(signal);
+      });
+      mockHistoryLoadMore.mockResolvedValueOnce({
+        messages: [createHistoryMessageEvent("msg-older", 3)],
+        nextCursor: null,
+        hasOlder: false,
+      });
+      createAndAddWorkspace(store, workspaceId);
+      expect(await waitUntil(() => store.getWorkspaceState(workspaceId).isTranscriptCaughtUp)).toBe(
+        true
+      );
+
+      store.beginPendingSend(workspaceId, pendingSend);
+      await store.loadOlderHistory(workspaceId);
+      expect(
+        store.getWorkspaceState(workspaceId).muxMessages.some((m) => m.id === "msg-older")
+      ).toBe(true);
+      await resubscribe(workspaceId, `${workspaceId}-other`);
+
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toEqual(pendingSend);
+    });
+
     it("keeps a pending row begun before the first replay of an empty new workspace", async () => {
       const workspaceId = "pending-send-new-workspace";
       const replay = gate();

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -4990,6 +4990,35 @@ describe("WorkspaceStore", () => {
       expect(store.getWorkspaceState(workspaceId).pendingSend).toEqual(pendingSend);
     });
 
+    it("clears an attachment-only pending row when the queue grows by a file", async () => {
+      const workspaceId = "pending-send-queued-file-only";
+      const queue = gate();
+      await createCaughtUpWorkspace(workspaceId, async function* (signal) {
+        await queue.opened;
+        yield {
+          type: "queued-message-changed",
+          workspaceId,
+          hasQueuedMessages: true,
+          queuedMessages: [],
+          displayText: "",
+          fileParts: [{ url: "data:image/png;base64,AA==", mediaType: "image/png" }],
+        };
+        await waitForAbortSignal(signal);
+      });
+
+      store.beginPendingSend(workspaceId, {
+        id: "pending-file",
+        content: "",
+        fileParts: [{ url: "data:image/png;base64,AA==", mediaType: "image/png" }],
+      });
+      queue.release();
+
+      expect(
+        await waitUntil(() => store.getWorkspaceState(workspaceId).queuedMessage !== null)
+      ).toBe(true);
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toBeNull();
+    });
+
     it("retires the pending row when the compaction turn that took it over is abandoned", async () => {
       const workspaceId = "pending-send-compaction-abandoned";
       const compaction = gate();
@@ -5001,7 +5030,17 @@ describe("WorkspaceStore", () => {
           id: "compaction-1",
           role: "user",
           parts: [{ type: "text", text: "Summarize" }],
-          metadata: { historySequence: 1, timestamp: 1, synthetic: true, uiVisible: true },
+          metadata: {
+            historySequence: 1,
+            timestamp: 1,
+            synthetic: true,
+            uiVisible: true,
+            muxMetadata: {
+              type: "compaction-request",
+              rawCommand: "/compact",
+              parsed: { model: TEST_MODEL, followUpContent: { text: "hello" } },
+            },
+          },
         };
         yield compactionRequest;
         await abort.opened;

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -5234,7 +5234,7 @@ describe("WorkspaceStore", () => {
       const replay = gate();
       mockChatStreamFor(workspaceId, async function* (signal) {
         await replay.opened;
-        yield createUserMessageEvent("user-old", "long ago", 1, Date.now() - 3_600_000);
+        yield createUserMessageEvent("user-old", "long ago", 1, 1);
         yield { type: "caught-up", replay: "full" };
         await waitForAbortSignal(signal);
       });
@@ -5253,7 +5253,7 @@ describe("WorkspaceStore", () => {
       const replay = gate();
       mockChatStreamFor(workspaceId, async function* (signal) {
         await replay.opened;
-        yield createUserMessageEvent("user-old", "long ago", 1, Date.now() - 3_600_000);
+        yield createUserMessageEvent("user-old", "long ago", 1, 1);
         yield { type: "caught-up", replay: "full" };
         await waitForAbortSignal(signal);
       });
@@ -5270,13 +5270,13 @@ describe("WorkspaceStore", () => {
       expect(store.getWorkspaceState(workspaceId).pendingSend).toBeNull();
     });
 
-    it("retires a row begun before catch-up when the replay holds its fresh echo", async () => {
-      const workspaceId = "pending-send-hydration-fresh-echo";
+    it("keeps a row begun before catch-up until the request result even if the replay holds it", async () => {
+      const workspaceId = "pending-send-hydration-echo-in-replay";
       const replay = gate();
       mockChatStreamFor(workspaceId, async function* (signal) {
         await replay.opened;
-        yield createUserMessageEvent("user-old", "long ago", 1, Date.now() - 3_600_000);
-        yield createUserMessageEvent("user-new", "hello", 2, Date.now() + 5);
+        yield createUserMessageEvent("user-old", "long ago", 1, 1);
+        yield createUserMessageEvent("user-new", "hello", 2, 2);
         yield { type: "caught-up", replay: "full" };
         await waitForAbortSignal(signal);
       });
@@ -5287,6 +5287,9 @@ describe("WorkspaceStore", () => {
       expect(await waitUntil(() => store.getWorkspaceState(workspaceId).isTranscriptCaughtUp)).toBe(
         true
       );
+      // Replayed rows cannot be told apart from the echo without a baseline; the result decides.
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toEqual(pendingSend);
+      store.markPendingSendAccepted(workspaceId, pendingSend.id);
       expect(store.getWorkspaceState(workspaceId).pendingSend).toBeNull();
     });
 

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -4779,11 +4779,21 @@ describe("WorkspaceStore", () => {
   describe("pending send", () => {
     const pendingSend = { id: "pending-1", content: "hello" };
 
+    function gate(): { release: () => void; opened: Promise<void> } {
+      let release!: () => void;
+      const opened = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      return { release, opened };
+    }
+
     async function createCaughtUpWorkspace(
       workspaceId: string,
-      liveEvents: (signal: AbortSignal | undefined) => AsyncIterable<WorkspaceChatMessage>
+      liveEvents: (signal: AbortSignal | undefined) => AsyncIterable<WorkspaceChatMessage>,
+      history: WorkspaceChatMessage[] = []
     ): Promise<void> {
       mockChatStreamFor(workspaceId, async function* (signal) {
+        yield* history;
         yield { type: "caught-up", hasOlderHistory: false };
         yield* liveEvents(signal);
       });
@@ -4812,18 +4822,15 @@ describe("WorkspaceStore", () => {
 
     it("clears the pending row when the backend echoes a user message", async () => {
       const workspaceId = "pending-send-user-echo";
-      let releaseEcho!: () => void;
-      const echoGate = new Promise<void>((resolve) => {
-        releaseEcho = resolve;
-      });
+      const echo = gate();
       await createCaughtUpWorkspace(workspaceId, async function* (signal) {
-        await echoGate;
+        await echo.opened;
         yield createUserMessageEvent("user-1", "hello", 1, 1);
         await waitForAbortSignal(signal);
       });
 
       store.beginPendingSend(workspaceId, pendingSend);
-      releaseEcho();
+      echo.release();
 
       expect(await waitUntil(() => store.getWorkspaceState(workspaceId).pendingSend === null)).toBe(
         true
@@ -4833,14 +4840,37 @@ describe("WorkspaceStore", () => {
       );
     });
 
+    it("keeps the pending row across a synthetic user row such as an auto-compaction request", async () => {
+      const workspaceId = "pending-send-synthetic";
+      const echo = gate();
+      await createCaughtUpWorkspace(workspaceId, async function* (signal) {
+        await echo.opened;
+        yield {
+          type: "message",
+          id: "compaction-1",
+          role: "user",
+          parts: [{ type: "text", text: "Summarize" }],
+          metadata: { historySequence: 1, timestamp: 1, synthetic: true, uiVisible: true },
+        };
+        await waitForAbortSignal(signal);
+      });
+
+      store.beginPendingSend(workspaceId, pendingSend);
+      echo.release();
+
+      expect(
+        await waitUntil(() =>
+          store.getWorkspaceState(workspaceId).muxMessages.some((m) => m.id === "compaction-1")
+        )
+      ).toBe(true);
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toEqual(pendingSend);
+    });
+
     it("clears the pending row when the send lands in the backend queue", async () => {
       const workspaceId = "pending-send-queued";
-      let releaseQueue!: () => void;
-      const queueGate = new Promise<void>((resolve) => {
-        releaseQueue = resolve;
-      });
+      const queue = gate();
       await createCaughtUpWorkspace(workspaceId, async function* (signal) {
-        await queueGate;
+        await queue.opened;
         yield {
           type: "queued-message-changed",
           workspaceId,
@@ -4852,7 +4882,7 @@ describe("WorkspaceStore", () => {
       });
 
       store.beginPendingSend(workspaceId, pendingSend);
-      releaseQueue();
+      queue.release();
 
       expect(
         await waitUntil(() => store.getWorkspaceState(workspaceId).queuedMessage !== null)
@@ -4860,27 +4890,126 @@ describe("WorkspaceStore", () => {
       expect(store.getWorkspaceState(workspaceId).pendingSend).toBeNull();
     });
 
-    it("clears the pending row when a replay catches up", async () => {
-      const workspaceId = "pending-send-caught-up";
-      let releaseCaughtUp!: () => void;
-      const caughtUpGate = new Promise<void>((resolve) => {
-        releaseCaughtUp = resolve;
-      });
-      mockChatStreamFor(workspaceId, async function* (signal) {
-        await caughtUpGate;
-        yield { type: "caught-up", hasOlderHistory: false };
+    it("acceptance alone keeps the row until the backend acknowledges it", async () => {
+      const workspaceId = "pending-send-accepted-live";
+      const echo = gate();
+      await createCaughtUpWorkspace(workspaceId, async function* (signal) {
+        await echo.opened;
+        yield createUserMessageEvent("user-1", "hello", 1, 1);
         await waitForAbortSignal(signal);
       });
-      createAndAddWorkspace(store, workspaceId);
 
       store.beginPendingSend(workspaceId, pendingSend);
+      store.markPendingSendAccepted(workspaceId, pendingSend.id);
       expect(store.getWorkspaceState(workspaceId).pendingSend).toEqual(pendingSend);
-      releaseCaughtUp();
 
+      echo.release();
+      expect(await waitUntil(() => store.getWorkspaceState(workspaceId).pendingSend === null)).toBe(
+        true
+      );
+    });
+
+    // Resubscribe by switching away and back; the second attempt replays since the cursor.
+    async function resubscribe(workspaceId: string, otherWorkspaceId: string): Promise<void> {
+      createAndAddWorkspace(store, otherWorkspaceId);
+      expect(
+        await waitUntil(() => store.getWorkspaceState(workspaceId).isTranscriptCaughtUp === false)
+      ).toBe(true);
+      store.setActiveWorkspaceId(workspaceId);
       expect(await waitUntil(() => store.getWorkspaceState(workspaceId).isTranscriptCaughtUp)).toBe(
         true
       );
+    }
+
+    function mockReplayAttempts(
+      workspaceId: string,
+      secondAttempt: () => WorkspaceChatMessage[]
+    ): void {
+      let attempt = 0;
+      mockChatStreamFor(workspaceId, async function* (signal) {
+        attempt += 1;
+        if (attempt === 1) {
+          yield createUserMessageEvent("user-1", "earlier", 1, 1);
+          yield fullCaughtUpEvent(1, "user-1");
+        } else {
+          yield* secondAttempt();
+        }
+        await waitForAbortSignal(signal);
+      });
+    }
+
+    it("keeps an unaccepted pending row through a replay that lacks its echo", async () => {
+      const workspaceId = "pending-send-replay-preflight";
+      mockReplayAttempts(workspaceId, () => [
+        createUserMessageEvent("user-1", "earlier", 1, 1),
+        sinceCaughtUpEvent(1, "user-1"),
+      ]);
+      createAndAddWorkspace(store, workspaceId);
+      expect(await waitUntil(() => store.getWorkspaceState(workspaceId).isTranscriptCaughtUp)).toBe(
+        true
+      );
+
+      store.beginPendingSend(workspaceId, pendingSend);
+      await resubscribe(workspaceId, `${workspaceId}-other`);
+
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toEqual(pendingSend);
+    });
+
+    it("clears an accepted pending row when a replay catches up", async () => {
+      const workspaceId = "pending-send-replay-accepted";
+      mockReplayAttempts(workspaceId, () => [
+        createUserMessageEvent("user-1", "earlier", 1, 1),
+        sinceCaughtUpEvent(1, "user-1"),
+      ]);
+      createAndAddWorkspace(store, workspaceId);
+      expect(await waitUntil(() => store.getWorkspaceState(workspaceId).isTranscriptCaughtUp)).toBe(
+        true
+      );
+
+      store.beginPendingSend(workspaceId, pendingSend);
+      store.markPendingSendAccepted(workspaceId, pendingSend.id);
+      await resubscribe(workspaceId, `${workspaceId}-other`);
+
       expect(store.getWorkspaceState(workspaceId).pendingSend).toBeNull();
+    });
+
+    it("clears the pending row when a replay shows an echo that was not there before", async () => {
+      const workspaceId = "pending-send-replay-new-echo";
+      mockReplayAttempts(workspaceId, () => [
+        createUserMessageEvent("user-1", "earlier", 1, 1),
+        createUserMessageEvent("user-2", "hello", 2, 2),
+        sinceCaughtUpEvent(2, "user-2"),
+      ]);
+      createAndAddWorkspace(store, workspaceId);
+      expect(await waitUntil(() => store.getWorkspaceState(workspaceId).isTranscriptCaughtUp)).toBe(
+        true
+      );
+
+      store.beginPendingSend(workspaceId, pendingSend);
+      await resubscribe(workspaceId, `${workspaceId}-other`);
+
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toBeNull();
+      expect(store.getWorkspaceState(workspaceId).muxMessages.some((m) => m.id === "user-2")).toBe(
+        true
+      );
+    });
+
+    it("keeps a pending row begun before the first replay of an empty new workspace", async () => {
+      const workspaceId = "pending-send-new-workspace";
+      const replay = gate();
+      mockChatStreamFor(workspaceId, async function* (signal) {
+        await replay.opened;
+        yield { type: "caught-up", replay: "full" };
+        await waitForAbortSignal(signal);
+      });
+      createAndAddWorkspace(store, workspaceId);
+      store.beginPendingSend(workspaceId, pendingSend);
+
+      replay.release();
+      expect(await waitUntil(() => store.getWorkspaceState(workspaceId).isTranscriptCaughtUp)).toBe(
+        true
+      );
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toEqual(pendingSend);
     });
   });
 

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -4909,6 +4909,127 @@ describe("WorkspaceStore", () => {
       );
     });
 
+    it("does not treat a drained queue entry's echo as the pending send's acknowledgement", async () => {
+      const workspaceId = "pending-send-queue-drain";
+      const drain = gate();
+      const echo = gate();
+      await createCaughtUpWorkspace(workspaceId, async function* (signal) {
+        yield {
+          type: "queued-message-changed",
+          workspaceId,
+          hasQueuedMessages: true,
+          queuedMessages: ["earlier follow-up"],
+          displayText: "earlier follow-up",
+        };
+        await drain.opened;
+        // The active turn ends: the queued follow-up dispatches and echoes its own user row.
+        yield {
+          type: "queued-message-changed",
+          workspaceId,
+          hasQueuedMessages: false,
+          queuedMessages: [],
+          displayText: "",
+        };
+        yield createUserMessageEvent("follow-up-1", "earlier follow-up", 2, 2);
+        await echo.opened;
+        yield createUserMessageEvent("user-2", "hello", 3, 3);
+        await waitForAbortSignal(signal);
+      });
+      expect(
+        await waitUntil(() => store.getWorkspaceState(workspaceId).queuedMessage !== null)
+      ).toBe(true);
+
+      store.beginPendingSend(workspaceId, pendingSend);
+      drain.release();
+      expect(
+        await waitUntil(() =>
+          store.getWorkspaceState(workspaceId).muxMessages.some((m) => m.id === "follow-up-1")
+        )
+      ).toBe(true);
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toEqual(pendingSend);
+
+      echo.release();
+      expect(await waitUntil(() => store.getWorkspaceState(workspaceId).pendingSend === null)).toBe(
+        true
+      );
+    });
+
+    it("keeps the pending row when a queue update only shrinks", async () => {
+      const workspaceId = "pending-send-queue-partial-drain";
+      const drain = gate();
+      await createCaughtUpWorkspace(workspaceId, async function* (signal) {
+        yield {
+          type: "queued-message-changed",
+          workspaceId,
+          hasQueuedMessages: true,
+          queuedMessages: ["first", "second"],
+          displayText: "first\nsecond",
+        };
+        await drain.opened;
+        yield {
+          type: "queued-message-changed",
+          workspaceId,
+          hasQueuedMessages: true,
+          queuedMessages: ["second"],
+          displayText: "second",
+        };
+        await waitForAbortSignal(signal);
+      });
+      expect(
+        await waitUntil(() => store.getWorkspaceState(workspaceId).queuedMessage !== null)
+      ).toBe(true);
+
+      store.beginPendingSend(workspaceId, pendingSend);
+      drain.release();
+      expect(
+        await waitUntil(
+          () => store.getWorkspaceState(workspaceId).queuedMessage?.content === "second"
+        )
+      ).toBe(true);
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toEqual(pendingSend);
+    });
+
+    it("retires the pending row when the compaction turn that took it over is abandoned", async () => {
+      const workspaceId = "pending-send-compaction-abandoned";
+      const compaction = gate();
+      const abort = gate();
+      await createCaughtUpWorkspace(workspaceId, async function* (signal) {
+        await compaction.opened;
+        const compactionRequest: WorkspaceChatMessage = {
+          type: "message",
+          id: "compaction-1",
+          role: "user",
+          parts: [{ type: "text", text: "Summarize" }],
+          metadata: { historySequence: 1, timestamp: 1, synthetic: true, uiVisible: true },
+        };
+        yield compactionRequest;
+        await abort.opened;
+        const streamAbort: WorkspaceChatMessage = {
+          type: "stream-abort",
+          workspaceId,
+          messageId: "compaction-stream",
+          abortReason: "user",
+          metadata: {},
+        };
+        yield streamAbort;
+        await waitForAbortSignal(signal);
+      });
+
+      store.beginPendingSend(workspaceId, pendingSend);
+      compaction.release();
+      expect(
+        await waitUntil(() =>
+          store.getWorkspaceState(workspaceId).muxMessages.some((m) => m.id === "compaction-1")
+        )
+      ).toBe(true);
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toEqual(pendingSend);
+
+      abort.release();
+      expect(await waitUntil(() => store.getWorkspaceState(workspaceId).pendingSend === null)).toBe(
+        true
+      );
+    });
+
     // Resubscribe by switching away and back; the second attempt replays since the cursor.
     async function resubscribe(workspaceId: string, otherWorkspaceId: string): Promise<void> {
       createAndAddWorkspace(store, otherWorkspaceId);

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -4914,15 +4914,16 @@ describe("WorkspaceStore", () => {
       const drain = gate();
       const echo = gate();
       await createCaughtUpWorkspace(workspaceId, async function* (signal) {
+        // One queued entry batching two plain follow-ups: it dispatches as a single user row.
         yield {
           type: "queued-message-changed",
           workspaceId,
           hasQueuedMessages: true,
-          queuedMessages: ["earlier follow-up"],
-          displayText: "earlier follow-up",
+          queuedMessages: ["earlier follow-up", "and another"],
+          displayText: "earlier follow-up\nand another",
         };
         await drain.opened;
-        // The active turn ends: the queued follow-up dispatches and echoes its own user row.
+        // The active turn ends: the queued entry dispatches and echoes its own user row.
         yield {
           type: "queued-message-changed",
           workspaceId,
@@ -4930,7 +4931,7 @@ describe("WorkspaceStore", () => {
           queuedMessages: [],
           displayText: "",
         };
-        yield createUserMessageEvent("follow-up-1", "earlier follow-up", 2, 2);
+        yield createUserMessageEvent("follow-up-1", "earlier follow-up\n\nand another", 2, 2);
         await echo.opened;
         yield createUserMessageEvent("user-2", "hello", 3, 3);
         await waitForAbortSignal(signal);

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -5198,6 +5198,87 @@ describe("WorkspaceStore", () => {
       );
     });
 
+    it("keeps a row begun before catch-up when the replay only holds older user rows", async () => {
+      const workspaceId = "pending-send-hydration-old-rows";
+      const replay = gate();
+      mockChatStreamFor(workspaceId, async function* (signal) {
+        await replay.opened;
+        yield createUserMessageEvent("user-old", "long ago", 1, Date.now() - 3_600_000);
+        yield { type: "caught-up", replay: "full" };
+        await waitForAbortSignal(signal);
+      });
+      createAndAddWorkspace(store, workspaceId);
+      store.beginPendingSend(workspaceId, pendingSend);
+
+      replay.release();
+      expect(await waitUntil(() => store.getWorkspaceState(workspaceId).isTranscriptCaughtUp)).toBe(
+        true
+      );
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toEqual(pendingSend);
+    });
+
+    it("retires a row begun before catch-up when the replay holds its fresh echo", async () => {
+      const workspaceId = "pending-send-hydration-fresh-echo";
+      const replay = gate();
+      mockChatStreamFor(workspaceId, async function* (signal) {
+        await replay.opened;
+        yield createUserMessageEvent("user-old", "long ago", 1, Date.now() - 3_600_000);
+        yield createUserMessageEvent("user-new", "hello", 2, Date.now() + 5);
+        yield { type: "caught-up", replay: "full" };
+        await waitForAbortSignal(signal);
+      });
+      createAndAddWorkspace(store, workspaceId);
+      store.beginPendingSend(workspaceId, pendingSend);
+
+      replay.release();
+      expect(await waitUntil(() => store.getWorkspaceState(workspaceId).isTranscriptCaughtUp)).toBe(
+        true
+      );
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toBeNull();
+    });
+
+    it("forgets a queue shrink that restored the draft instead of dispatching", async () => {
+      const workspaceId = "pending-send-queue-restore";
+      const restore = gate();
+      const echo = gate();
+      await createCaughtUpWorkspace(workspaceId, async function* (signal) {
+        yield {
+          type: "queued-message-changed",
+          workspaceId,
+          hasQueuedMessages: true,
+          queuedMessages: ["queued draft"],
+          displayText: "queued draft",
+        };
+        await restore.opened;
+        // Editing the queued message clears the queue and hands the text back to the composer.
+        yield {
+          type: "queued-message-changed",
+          workspaceId,
+          hasQueuedMessages: false,
+          queuedMessages: [],
+          displayText: "",
+        };
+        yield { type: "restore-to-input", workspaceId, text: "queued draft" };
+        await echo.opened;
+        yield createUserMessageEvent("user-2", "hello", 2, 2);
+        await waitForAbortSignal(signal);
+      });
+      expect(
+        await waitUntil(() => store.getWorkspaceState(workspaceId).queuedMessage !== null)
+      ).toBe(true);
+
+      restore.release();
+      expect(
+        await waitUntil(() => store.getWorkspaceState(workspaceId).queuedMessage === null)
+      ).toBe(true);
+      store.beginPendingSend(workspaceId, pendingSend);
+      echo.release();
+
+      expect(await waitUntil(() => store.getWorkspaceState(workspaceId).pendingSend === null)).toBe(
+        true
+      );
+    });
+
     it("keeps a pending row begun before the first replay of an empty new workspace", async () => {
       const workspaceId = "pending-send-new-workspace";
       const replay = gate();

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -4955,6 +4955,49 @@ describe("WorkspaceStore", () => {
       );
     });
 
+    it("does not treat the echo of an entry dispatched before the send began as its acknowledgement", async () => {
+      const workspaceId = "pending-send-queue-drain-before-begin";
+      const echo = gate();
+      const own = gate();
+      await createCaughtUpWorkspace(workspaceId, async function* (signal) {
+        yield {
+          type: "queued-message-changed",
+          workspaceId,
+          hasQueuedMessages: true,
+          queuedMessages: ["earlier follow-up"],
+          displayText: "earlier follow-up",
+        };
+        // Dispatch happens before the user sends; the dispatched row arrives only afterwards.
+        yield {
+          type: "queued-message-changed",
+          workspaceId,
+          hasQueuedMessages: false,
+          queuedMessages: [],
+          displayText: "",
+        };
+        await echo.opened;
+        yield createUserMessageEvent("follow-up-1", "earlier follow-up", 2, 2);
+        await own.opened;
+        yield createUserMessageEvent("user-2", "hello", 3, 3);
+        await waitForAbortSignal(signal);
+      });
+      await tick(20);
+
+      store.beginPendingSend(workspaceId, pendingSend);
+      echo.release();
+      expect(
+        await waitUntil(() =>
+          store.getWorkspaceState(workspaceId).muxMessages.some((m) => m.id === "follow-up-1")
+        )
+      ).toBe(true);
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toEqual(pendingSend);
+
+      own.release();
+      expect(await waitUntil(() => store.getWorkspaceState(workspaceId).pendingSend === null)).toBe(
+        true
+      );
+    });
+
     it("keeps the pending row when a queue update only shrinks", async () => {
       const workspaceId = "pending-send-queue-partial-drain";
       const drain = gate();

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -4859,6 +4859,33 @@ describe("WorkspaceStore", () => {
       ).toBe(true);
       expect(store.getWorkspaceState(workspaceId).pendingSend).toBeNull();
     });
+
+    it("keeps the pending row when a queue update does not contain the sent text", async () => {
+      const workspaceId = "pending-send-queued-other";
+      let releaseQueue!: () => void;
+      const queueGate = new Promise<void>((resolve) => {
+        releaseQueue = resolve;
+      });
+      await createCaughtUpWorkspace(workspaceId, async function* (signal) {
+        await queueGate;
+        yield {
+          type: "queued-message-changed",
+          workspaceId,
+          hasQueuedMessages: true,
+          queuedMessages: ["earlier follow-up"],
+          displayText: "earlier follow-up",
+        };
+        await waitForAbortSignal(signal);
+      });
+
+      store.beginPendingSend(workspaceId, pendingSend);
+      releaseQueue();
+
+      expect(
+        await waitUntil(() => store.getWorkspaceState(workspaceId).queuedMessage !== null)
+      ).toBe(true);
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toEqual(pendingSend);
+    });
   });
 
   describe("bash-output events", () => {

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -5335,6 +5335,57 @@ describe("WorkspaceStore", () => {
       );
     });
 
+    it("keeps the pending row when a full replay first delivers an owed dispatch echo", async () => {
+      const workspaceId = "pending-send-replay-owed-dispatch";
+      let attempt = 0;
+      mockChatStreamFor(workspaceId, async function* (signal) {
+        attempt += 1;
+        if (attempt === 1) {
+          yield createUserMessageEvent("user-1", "earlier", 1, 1);
+          yield {
+            type: "queued-message-changed",
+            workspaceId,
+            hasQueuedMessages: true,
+            queuedMessages: ["queued follow-up"],
+            displayText: "queued follow-up",
+          };
+          // No cursor: the next subscription falls back to a full replay and its reset.
+          yield { type: "caught-up", replay: "full" };
+          await tick(20);
+          // The entry dispatches, but its echo only shows up in the replay after reconnecting.
+          yield {
+            type: "queued-message-changed",
+            workspaceId,
+            hasQueuedMessages: false,
+            queuedMessages: [],
+            displayText: "",
+          };
+        } else {
+          yield createUserMessageEvent("user-1", "earlier", 1, 1);
+          yield createUserMessageEvent("follow-up-1", "queued follow-up", 2, 2);
+          yield { type: "caught-up", replay: "full" };
+        }
+        await waitForAbortSignal(signal);
+      });
+      createAndAddWorkspace(store, workspaceId);
+      expect(
+        await waitUntil(
+          () =>
+            store.getWorkspaceState(workspaceId).queuedMessage === null &&
+            store.getWorkspaceState(workspaceId).isTranscriptCaughtUp
+        )
+      ).toBe(true);
+
+      store.beginPendingSend(workspaceId, pendingSend);
+      await resubscribe(workspaceId, `${workspaceId}-other`);
+      expect(attempt).toBe(2);
+
+      expect(
+        store.getWorkspaceState(workspaceId).muxMessages.some((m) => m.id === "follow-up-1")
+      ).toBe(true);
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toEqual(pendingSend);
+    });
+
     it("keeps a pending row begun before the first replay of an empty new workspace", async () => {
       const workspaceId = "pending-send-new-workspace";
       const replay = gate();

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -4776,6 +4776,91 @@ describe("WorkspaceStore", () => {
     ).toBe(true);
   });
 
+  describe("pending send", () => {
+    const pendingSend = { id: "pending-1", content: "hello" };
+
+    async function createCaughtUpWorkspace(
+      workspaceId: string,
+      liveEvents: (signal: AbortSignal | undefined) => AsyncIterable<WorkspaceChatMessage>
+    ): Promise<void> {
+      mockChatStreamFor(workspaceId, async function* (signal) {
+        yield { type: "caught-up", hasOlderHistory: false };
+        yield* liveEvents(signal);
+      });
+      createAndAddWorkspace(store, workspaceId);
+      expect(await waitUntil(() => store.getWorkspaceState(workspaceId).isTranscriptCaughtUp)).toBe(
+        true
+      );
+    }
+
+    it("exposes the pending row until it is cleared by id", async () => {
+      const workspaceId = "pending-send-clear";
+      await createCaughtUpWorkspace(workspaceId, async function* (signal) {
+        await waitForAbortSignal(signal);
+        yield* [];
+      });
+
+      store.beginPendingSend(workspaceId, pendingSend);
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toEqual(pendingSend);
+
+      store.clearPendingSend(workspaceId, "other-send");
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toEqual(pendingSend);
+
+      store.clearPendingSend(workspaceId, pendingSend.id);
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toBeNull();
+    });
+
+    it("clears the pending row when the backend echoes a user message", async () => {
+      const workspaceId = "pending-send-user-echo";
+      let releaseEcho!: () => void;
+      const echoGate = new Promise<void>((resolve) => {
+        releaseEcho = resolve;
+      });
+      await createCaughtUpWorkspace(workspaceId, async function* (signal) {
+        await echoGate;
+        yield createUserMessageEvent("user-1", "hello", 1, 1);
+        await waitForAbortSignal(signal);
+      });
+
+      store.beginPendingSend(workspaceId, pendingSend);
+      releaseEcho();
+
+      expect(await waitUntil(() => store.getWorkspaceState(workspaceId).pendingSend === null)).toBe(
+        true
+      );
+      expect(store.getWorkspaceState(workspaceId).messages.some((m) => m.id === "user-1")).toBe(
+        true
+      );
+    });
+
+    it("clears the pending row when the send lands in the backend queue", async () => {
+      const workspaceId = "pending-send-queued";
+      let releaseQueue!: () => void;
+      const queueGate = new Promise<void>((resolve) => {
+        releaseQueue = resolve;
+      });
+      await createCaughtUpWorkspace(workspaceId, async function* (signal) {
+        await queueGate;
+        yield {
+          type: "queued-message-changed",
+          workspaceId,
+          hasQueuedMessages: true,
+          queuedMessages: ["hello"],
+          displayText: "hello",
+        };
+        await waitForAbortSignal(signal);
+      });
+
+      store.beginPendingSend(workspaceId, pendingSend);
+      releaseQueue();
+
+      expect(
+        await waitUntil(() => store.getWorkspaceState(workspaceId).queuedMessage !== null)
+      ).toBe(true);
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toBeNull();
+    });
+  });
+
   describe("bash-output events", () => {
     it("retains live output when bash tool result has no output", async () => {
       const workspaceId = "bash-output-workspace-1";

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -5419,6 +5419,36 @@ describe("WorkspaceStore", () => {
       expect(store.getWorkspaceState(workspaceId).pendingSend).toBeNull();
     });
 
+    it("retires an accepted send that replaced a same-size queue entry during a disconnect", async () => {
+      const workspaceId = "pending-send-replay-queue-replaced";
+      let attempt = 0;
+      mockChatStreamFor(workspaceId, async function* (signal) {
+        attempt += 1;
+        yield createUserMessageEvent("user-1", "earlier", 1, 1);
+        yield {
+          type: "queued-message-changed",
+          workspaceId,
+          hasQueuedMessages: true,
+          queuedMessages: [attempt === 1 ? "earlier follow-up" : "hello"],
+          displayText: attempt === 1 ? "earlier follow-up" : "hello",
+        };
+        yield fullCaughtUpEvent(1, "user-1");
+        await waitForAbortSignal(signal);
+      });
+      createAndAddWorkspace(store, workspaceId);
+      expect(
+        await waitUntil(() => store.getWorkspaceState(workspaceId).queuedMessage !== null)
+      ).toBe(true);
+
+      store.beginPendingSend(workspaceId, pendingSend);
+      await resubscribe(workspaceId, `${workspaceId}-other`);
+      expect(store.getWorkspaceState(workspaceId).queuedMessage?.content).toBe("hello");
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toEqual(pendingSend);
+
+      store.markPendingSendAccepted(workspaceId, pendingSend.id);
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toBeNull();
+    });
+
     it("does not treat paginated older rows as the pending send's echo", async () => {
       const workspaceId = "pending-send-paginated-rows";
       let attempt = 0;

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -4866,6 +4866,37 @@ describe("WorkspaceStore", () => {
       expect(store.getWorkspaceState(workspaceId).pendingSend).toEqual(pendingSend);
     });
 
+    it("keeps the pending row across an agent-initiated user turn", async () => {
+      const workspaceId = "pending-send-agent-initiated";
+      const turn = gate();
+      await createCaughtUpWorkspace(workspaceId, async function* (signal) {
+        await turn.opened;
+        const agentTurn: WorkspaceChatMessage = {
+          type: "message",
+          id: "agent-turn-1",
+          role: "user",
+          parts: [{ type: "text", text: "Continue with the next goal step" }],
+          metadata: {
+            historySequence: 1,
+            timestamp: 1,
+            retrySendOptions: { agentInitiated: true },
+          },
+        };
+        yield agentTurn;
+        await waitForAbortSignal(signal);
+      });
+
+      store.beginPendingSend(workspaceId, pendingSend);
+      turn.release();
+
+      expect(
+        await waitUntil(() =>
+          store.getWorkspaceState(workspaceId).muxMessages.some((m) => m.id === "agent-turn-1")
+        )
+      ).toBe(true);
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toEqual(pendingSend);
+    });
+
     it("clears the pending row when the send lands in the backend queue", async () => {
       const workspaceId = "pending-send-queued";
       const queue = gate();

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -5217,6 +5217,28 @@ describe("WorkspaceStore", () => {
       expect(store.getWorkspaceState(workspaceId).pendingSend).toEqual(pendingSend);
     });
 
+    it("retires an accepted row begun before catch-up once the transcript is caught up", async () => {
+      const workspaceId = "pending-send-hydration-accepted";
+      const replay = gate();
+      mockChatStreamFor(workspaceId, async function* (signal) {
+        await replay.opened;
+        yield createUserMessageEvent("user-old", "long ago", 1, Date.now() - 3_600_000);
+        yield { type: "caught-up", replay: "full" };
+        await waitForAbortSignal(signal);
+      });
+      createAndAddWorkspace(store, workspaceId);
+      store.beginPendingSend(workspaceId, pendingSend);
+
+      replay.release();
+      expect(await waitUntil(() => store.getWorkspaceState(workspaceId).isTranscriptCaughtUp)).toBe(
+        true
+      );
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toEqual(pendingSend);
+
+      store.markPendingSendAccepted(workspaceId, pendingSend.id);
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toBeNull();
+    });
+
     it("retires a row begun before catch-up when the replay holds its fresh echo", async () => {
       const workspaceId = "pending-send-hydration-fresh-echo";
       const replay = gate();

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -4860,31 +4860,27 @@ describe("WorkspaceStore", () => {
       expect(store.getWorkspaceState(workspaceId).pendingSend).toBeNull();
     });
 
-    it("keeps the pending row when a queue update does not contain the sent text", async () => {
-      const workspaceId = "pending-send-queued-other";
-      let releaseQueue!: () => void;
-      const queueGate = new Promise<void>((resolve) => {
-        releaseQueue = resolve;
+    it("clears the pending row when a replay catches up", async () => {
+      const workspaceId = "pending-send-caught-up";
+      let releaseCaughtUp!: () => void;
+      const caughtUpGate = new Promise<void>((resolve) => {
+        releaseCaughtUp = resolve;
       });
-      await createCaughtUpWorkspace(workspaceId, async function* (signal) {
-        await queueGate;
-        yield {
-          type: "queued-message-changed",
-          workspaceId,
-          hasQueuedMessages: true,
-          queuedMessages: ["earlier follow-up"],
-          displayText: "earlier follow-up",
-        };
+      mockChatStreamFor(workspaceId, async function* (signal) {
+        await caughtUpGate;
+        yield { type: "caught-up", hasOlderHistory: false };
         await waitForAbortSignal(signal);
       });
+      createAndAddWorkspace(store, workspaceId);
 
       store.beginPendingSend(workspaceId, pendingSend);
-      releaseQueue();
-
-      expect(
-        await waitUntil(() => store.getWorkspaceState(workspaceId).queuedMessage !== null)
-      ).toBe(true);
       expect(store.getWorkspaceState(workspaceId).pendingSend).toEqual(pendingSend);
+      releaseCaughtUp();
+
+      expect(await waitUntil(() => store.getWorkspaceState(workspaceId).isTranscriptCaughtUp)).toBe(
+        true
+      );
+      expect(store.getWorkspaceState(workspaceId).pendingSend).toBeNull();
     });
   });
 

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -370,8 +370,6 @@ interface PendingSendState {
   knownUserEchoIds: Set<string> | null;
   /** The send request succeeded, so any later replay is guaranteed to contain its echo. */
   accepted: boolean;
-  /** Queue entries dispatched since the send began; each echoes a user row that is not this send. */
-  drainedEchoesExpected: number;
   /** A synthetic user row (pre-send compaction) took the turn; the echo follows that turn. */
   deferredBehindSyntheticTurn: boolean;
 }
@@ -390,6 +388,8 @@ interface WorkspaceChatTransientState {
   queuedMessage: QueuedMessage | null;
   /** Visible queue payload size from the last queue update, to tell drains from new enqueues. */
   queuedMessageCount: number;
+  /** Dispatched queue entries whose user rows have not arrived yet; they are not send echoes. */
+  queueDispatchesAwaitingEcho: number;
   pendingSend: PendingSendState | null;
   liveBashOutput: Map<string, LiveBashOutputInternal>;
   liveAdvisorOutput: Map<string, AdvisorLiveOutputState>;
@@ -503,6 +503,7 @@ function createInitialChatTransientState(): WorkspaceChatTransientState {
     replayingHistory: false,
     queuedMessage: null,
     queuedMessageCount: 0,
+    queueDispatchesAwaitingEcho: 0,
     pendingSend: null,
     liveBashOutput: new Map(),
     liveAdvisorOutput: new Map(),
@@ -1195,13 +1196,16 @@ export class WorkspaceStore {
       // Attachment-only entries add no text, so size the queue by every visible payload kind.
       const nextCount =
         data.queuedMessages.length + (data.fileParts?.length ?? 0) + (data.reviews?.length ?? 0);
-      if (pending && transient.caughtUp && !transient.replayingHistory) {
-        if (nextCount > transient.queuedMessageCount || (pending.accepted && queuedMessage)) {
+      if (transient.caughtUp && !transient.replayingHistory) {
+        if (nextCount < transient.queuedMessageCount) {
+          // One dispatched entry per shrink, however many batched strings it carried.
+          transient.queueDispatchesAwaitingEcho += 1;
+        } else if (
+          pending &&
+          (nextCount > transient.queuedMessageCount || (pending.accepted && queuedMessage))
+        ) {
           // The send landed in the backend queue; the queued card takes over from the pending row.
           transient.pendingSend = null;
-        } else if (nextCount < transient.queuedMessageCount) {
-          // One dispatched entry per shrink, however many batched strings it carried.
-          pending.drainedEchoesExpected += 1;
         }
       }
       transient.queuedMessageCount = nextCount;
@@ -4060,11 +4064,9 @@ export class WorkspaceStore {
     this.states.bump(workspaceId);
   }
 
-  clearPendingInitialSendState(workspaceId: string): void {
-    const transient = this.chatTransientState.get(workspaceId);
-    if (transient?.pendingSend) {
-      transient.pendingSend = null;
-      this.states.bump(workspaceId);
+  clearPendingInitialSendState(workspaceId: string, pendingSendId?: string | null): void {
+    if (pendingSendId != null) {
+      this.clearPendingSend(workspaceId, pendingSendId);
     }
 
     const aggregator = this.aggregators.get(workspaceId);
@@ -4099,7 +4101,6 @@ export class WorkspaceStore {
           )
         : null,
       accepted: false,
-      drainedEchoesExpected: 0,
       deferredBehindSyntheticTurn: false,
     };
     this.states.bump(workspaceId);
@@ -4166,18 +4167,14 @@ export class WorkspaceStore {
     transient: WorkspaceChatTransientState,
     echo: MuxMessage
   ): void {
-    const pending = transient.pendingSend;
-    if (!pending) {
-      return;
-    }
     if (echo.metadata?.synthetic === true) {
-      if (echo.metadata.muxMetadata?.type === "compaction-request") {
-        pending.deferredBehindSyntheticTurn = true;
+      if (transient.pendingSend && echo.metadata.muxMetadata?.type === "compaction-request") {
+        transient.pendingSend.deferredBehindSyntheticTurn = true;
       }
       return;
     }
-    if (pending.drainedEchoesExpected > 0) {
-      pending.drainedEchoesExpected -= 1;
+    if (transient.queueDispatchesAwaitingEcho > 0) {
+      transient.queueDispatchesAwaitingEcho -= 1;
       return;
     }
     transient.pendingSend = null;
@@ -5022,8 +5019,8 @@ export const workspaceStore = {
    */
   markPendingInitialSend: (workspaceId: string, pendingStreamModel: string | null) =>
     getStoreInstance().markPendingInitialSend(workspaceId, pendingStreamModel),
-  clearPendingInitialSendState: (workspaceId: string) =>
-    getStoreInstance().clearPendingInitialSendState(workspaceId),
+  clearPendingInitialSendState: (workspaceId: string, pendingSendId?: string | null) =>
+    getStoreInstance().clearPendingInitialSendState(workspaceId, pendingSendId),
   beginPendingSend: (workspaceId: string, message: PendingSendMessage) =>
     getStoreInstance().beginPendingSend(workspaceId, message),
   updatePendingSend: (workspaceId: string, message: PendingSendMessage) =>

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -373,6 +373,8 @@ interface PendingSendState {
   knownUserEchoIds: Set<string> | null;
   /** The send request succeeded, so any later replay is guaranteed to contain its echo. */
   accepted: boolean;
+  /** Visible queue payload size when the send began; growth by acceptance means it was queued. */
+  queueSizeAtBegin: number;
   /** A synthetic user row (pre-send compaction) took the turn; the echo follows that turn. */
   deferredBehindSyntheticTurn: boolean;
 }
@@ -2703,6 +2705,15 @@ export class WorkspaceStore {
           mode: "append",
           skipDerivedState: true,
         });
+        // Older rows predate any pending send; never let a later replay mistake them for its echo.
+        const known = this.chatTransientState.get(workspaceId)?.pendingSend?.knownUserEchoIds;
+        if (known) {
+          for (const message of historicalMessages) {
+            if (isUserEcho(message)) {
+              known.add(message.id);
+            }
+          }
+        }
         this.consumerManager.scheduleCalculation(workspaceId, aggregator);
       }
 
@@ -4122,6 +4133,7 @@ export class WorkspaceStore {
           )
         : null,
       accepted: false,
+      queueSizeAtBegin: transient.queuedMessageCount,
       deferredBehindSyntheticTurn: false,
     };
     this.states.bump(workspaceId);
@@ -4153,9 +4165,14 @@ export class WorkspaceStore {
     }
 
     pending.accepted = true;
+    // A queue that grew since the send began (for example through a replayed snapshot) holds it.
+    const queuedSinceBegin =
+      transient.queuedMessage !== null && transient.queuedMessageCount > pending.queueSizeAtBegin;
     if (
       transient.caughtUp &&
-      (pending.knownUserEchoIds === null || this.settleUnseenUserEchoes(transient, aggregator))
+      (pending.knownUserEchoIds === null ||
+        queuedSinceBegin ||
+        this.settleUnseenUserEchoes(transient, aggregator))
     ) {
       transient.pendingSend = null;
       this.states.bump(workspaceId);

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -364,6 +364,19 @@ export interface WorkflowToolLiveRunState {
   run?: WorkflowRunRecord;
 }
 
+interface PendingSendState {
+  message: PendingSendMessage;
+  /** User echoes already in the transcript when the send began; null when begun before catch-up. */
+  knownUserEchoIds: Set<string> | null;
+  /** The send request succeeded, so any later replay is guaranteed to contain its echo. */
+  accepted: boolean;
+}
+
+/** A persisted user turn the backend emits in response to a send; synthetic rows are not echoes. */
+function isUserEcho(message: MuxMessage): boolean {
+  return message.role === "user" && message.metadata?.synthetic !== true;
+}
+
 interface WorkspaceChatTransientState {
   caughtUp: boolean;
   isHydratingTranscript: boolean;
@@ -371,7 +384,7 @@ interface WorkspaceChatTransientState {
   pendingStreamEvents: WorkspaceChatMessage[];
   replayingHistory: boolean;
   queuedMessage: QueuedMessage | null;
-  pendingSend: PendingSendMessage | null;
+  pendingSend: PendingSendState | null;
   liveBashOutput: Map<string, LiveBashOutputInternal>;
   liveAdvisorOutput: Map<string, AdvisorLiveOutputState>;
   liveAdvisorReasoning: Map<string, AdvisorLiveReasoningState>;
@@ -2314,7 +2327,7 @@ export class WorkspaceStore {
         name: metadata?.name ?? workspaceId, // Fall back to ID if metadata missing
         messages: displayedMessages,
         queuedMessage: transient.queuedMessage,
-        pendingSend: transient.pendingSend,
+        pendingSend: transient.pendingSend?.message ?? null,
         canInterrupt,
         isCompacting: aggregator.isCompacting(),
         isStreamStarting,
@@ -3767,6 +3780,8 @@ export class WorkspaceStore {
     if (previousTransient?.isHydratingTranscript) {
       nextTransient.isHydratingTranscript = true;
     }
+    // A send begun before the first replay (new workspace) is retired by the replay itself.
+    nextTransient.pendingSend = previousTransient?.pendingSend ?? null;
 
     this.chatTransientState.set(workspaceId, nextTransient);
 
@@ -4028,6 +4043,12 @@ export class WorkspaceStore {
   }
 
   clearPendingInitialSendState(workspaceId: string): void {
+    const transient = this.chatTransientState.get(workspaceId);
+    if (transient?.pendingSend) {
+      transient.pendingSend = null;
+      this.states.bump(workspaceId);
+    }
+
     const aggregator = this.aggregators.get(workspaceId);
     if (aggregator?.getPendingStreamStartTime() == null) {
       return;
@@ -4039,28 +4060,58 @@ export class WorkspaceStore {
 
   /**
    * Show the composer content in the transcript tail while the send request is in flight.
-   * Cleared when the backend echoes a user message or queues it, when replay catches up, or
-   * via clearPendingSend after a failed send.
+   * Retired by the backend acknowledgement (a user echo or a queue update), by a replay that
+   * must contain the echo, or by clearPendingSend after a failed send.
    */
   beginPendingSend(workspaceId: string, message: PendingSendMessage): void {
     const transient = this.chatTransientState.get(workspaceId);
-    if (!transient) {
+    const aggregator = this.aggregators.get(workspaceId);
+    if (!transient || !aggregator) {
       return;
     }
 
-    transient.pendingSend = message;
+    transient.pendingSend = {
+      message,
+      knownUserEchoIds: transient.caughtUp
+        ? new Set(
+            aggregator
+              .getAllMessages()
+              .filter(isUserEcho)
+              .map((echo) => echo.id)
+          )
+        : null,
+      accepted: false,
+    };
     this.states.bump(workspaceId);
+  }
+
+  /** Record that the backend accepted the send, so the next replay is known to contain its echo. */
+  markPendingSendAccepted(workspaceId: string, id: string): void {
+    const pending = this.chatTransientState.get(workspaceId)?.pendingSend;
+    if (pending?.message.id === id) {
+      pending.accepted = true;
+    }
   }
 
   /** Remove the pending send row; a mismatched id means a newer send already replaced it. */
   clearPendingSend(workspaceId: string, id: string): void {
     const transient = this.chatTransientState.get(workspaceId);
-    if (transient?.pendingSend?.id !== id) {
+    if (transient?.pendingSend?.message.id !== id) {
       return;
     }
 
     transient.pendingSend = null;
     this.states.bump(workspaceId);
+  }
+
+  private hasUnseenUserEcho(
+    aggregator: StreamingMessageAggregator,
+    pending: PendingSendState
+  ): boolean {
+    const known = pending.knownUserEchoIds;
+    return aggregator
+      .getAllMessages()
+      .some((message) => isUserEcho(message) && !known?.has(message.id));
   }
 
   /**
@@ -4534,8 +4585,15 @@ export class WorkspaceStore {
       // Mark as caught up
       transient.caughtUp = true;
       transient.isHydratingTranscript = false;
-      // Replayed history is authoritative: a send acknowledged while disconnected is in it now.
-      transient.pendingSend = null;
+      // An accepted send is in the replayed history; an unaccepted one is only retired when
+      // the replay shows its echo, so a reconnect during preflight keeps the row.
+      const pendingSend = transient.pendingSend;
+      if (
+        pendingSend &&
+        (pendingSend.accepted || this.hasUnseenUserEcho(aggregator, pendingSend))
+      ) {
+        transient.pendingSend = null;
+      }
       this.lastUserPromptStore.bump(workspaceId);
       this.states.bump(workspaceId);
       this.checkAndBumpRecencyIfChanged(); // Messages loaded, update recency
@@ -4792,7 +4850,7 @@ export class WorkspaceStore {
         // Process live events immediately (after history loaded)
         applyWorkspaceChatEventToAggregator(aggregator, data);
 
-        if (data.role === "user") {
+        if (isUserEcho(data)) {
           // The backend echoed the send; the persisted row replaces the pending one.
           transient.pendingSend = null;
         }
@@ -4885,6 +4943,10 @@ export const workspaceStore = {
     getStoreInstance().markPendingInitialSend(workspaceId, pendingStreamModel),
   clearPendingInitialSendState: (workspaceId: string) =>
     getStoreInstance().clearPendingInitialSendState(workspaceId),
+  beginPendingSend: (workspaceId: string, message: PendingSendMessage) =>
+    getStoreInstance().beginPendingSend(workspaceId, message),
+  markPendingSendAccepted: (workspaceId: string, id: string) =>
+    getStoreInstance().markPendingSendAccepted(workspaceId, id),
   /**
    * Set the active workspace for onChat subscription management.
    * Exposed for test helpers that bypass React routing effects.

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -1170,11 +1170,7 @@ export class WorkspaceStore {
       aggregator.setActiveQueuedFollowUp(data.hasQueuedMessages ?? queuedMessage !== null);
       const transient = this.assertChatTransientState(workspaceId);
       transient.queuedMessage = queuedMessage;
-      if (
-        queuedMessage &&
-        transient.pendingSend &&
-        queuedMessage.content.includes(transient.pendingSend.content)
-      ) {
+      if (queuedMessage) {
         // The send landed in the backend queue; the queued card takes over from the pending row.
         transient.pendingSend = null;
       }
@@ -4043,7 +4039,8 @@ export class WorkspaceStore {
 
   /**
    * Show the composer content in the transcript tail while the send request is in flight.
-   * Cleared when the backend echoes a user message or queues it, or via clearPendingSend.
+   * Cleared when the backend echoes a user message or queues it, when replay catches up, or
+   * via clearPendingSend after a failed send.
    */
   beginPendingSend(workspaceId: string, message: PendingSendMessage): void {
     const transient = this.chatTransientState.get(workspaceId);
@@ -4537,6 +4534,8 @@ export class WorkspaceStore {
       // Mark as caught up
       transient.caughtUp = true;
       transient.isHydratingTranscript = false;
+      // Replayed history is authoritative: a send acknowledged while disconnected is in it now.
+      transient.pendingSend = null;
       this.lastUserPromptStore.bump(workspaceId);
       this.states.bump(workspaceId);
       this.checkAndBumpRecencyIfChanged(); // Messages loaded, update recency

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -103,7 +103,7 @@ import {
   getPinnedTodoExpandedKey,
 } from "@/common/constants/storage";
 import { DEFAULT_AUTO_COMPACTION_THRESHOLD_PERCENT } from "@/common/constants/ui";
-import { APPROX_CHARS_PER_TOKEN, PENDING_SEND_ECHO_CLOCK_SKEW_MS } from "@/constants/streaming";
+import { APPROX_CHARS_PER_TOKEN } from "@/constants/streaming";
 import { trackStreamCompleted } from "@/common/telemetry";
 import { isWorkflowRunEmittingToolName } from "@/common/utils/workflowRunMessages";
 import { isProviderConfigFixableError } from "@/common/utils/messages/retryEligibility";
@@ -368,7 +368,7 @@ interface PendingSendState {
   message: PendingSendMessage;
   /** User echoes already in the transcript when the send began; null when begun before catch-up. */
   knownUserEchoIds: Set<string> | null;
-  /** Wall clock at begin; with no baseline, only rows persisted after it can be the echo. */
+  /** Wall clock at begin; with no baseline, only rows persisted at or after it can be the echo. */
   beganAtMs: number;
   /** The send request succeeded, so any later replay is guaranteed to contain its echo. */
   accepted: boolean;
@@ -4132,7 +4132,8 @@ export class WorkspaceStore {
   /**
    * Record that the backend accepted the send, so the next replay is known to contain its echo.
    * A direct send's echo always precedes the response, so an echo displayed by now retires the
-   * row; a row still standing belongs to a queued send whose queue update is in flight.
+   * row; a row still standing belongs to a queued send whose queue update is in flight. Without a
+   * baseline the echo cannot be told apart by id, so a caught-up transcript is trusted instead.
    */
   markPendingSendAccepted(workspaceId: string, id: string): void {
     const transient = this.chatTransientState.get(workspaceId);
@@ -4143,7 +4144,10 @@ export class WorkspaceStore {
     }
 
     pending.accepted = true;
-    if (transient.caughtUp && this.hasUnseenUserEcho(aggregator, pending)) {
+    if (
+      transient.caughtUp &&
+      (pending.knownUserEchoIds === null || this.hasUnseenUserEcho(aggregator, pending))
+    ) {
       transient.pendingSend = null;
       this.states.bump(workspaceId);
     }
@@ -4165,13 +4169,12 @@ export class WorkspaceStore {
     pending: PendingSendState
   ): boolean {
     const known = pending.knownUserEchoIds;
-    const earliestEchoMs = pending.beganAtMs - PENDING_SEND_ECHO_CLOCK_SKEW_MS;
     return aggregator
       .getAllMessages()
       .some(
         (message) =>
           isUserEcho(message) &&
-          (known ? !known.has(message.id) : (message.metadata?.timestamp ?? 0) >= earliestEchoMs)
+          (known ? !known.has(message.id) : (message.metadata?.timestamp ?? 0) >= pending.beganAtMs)
       );
   }
 

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -103,7 +103,7 @@ import {
   getPinnedTodoExpandedKey,
 } from "@/common/constants/storage";
 import { DEFAULT_AUTO_COMPACTION_THRESHOLD_PERCENT } from "@/common/constants/ui";
-import { APPROX_CHARS_PER_TOKEN } from "@/constants/streaming";
+import { APPROX_CHARS_PER_TOKEN, PENDING_SEND_ECHO_CLOCK_SKEW_MS } from "@/constants/streaming";
 import { trackStreamCompleted } from "@/common/telemetry";
 import { isWorkflowRunEmittingToolName } from "@/common/utils/workflowRunMessages";
 import { isProviderConfigFixableError } from "@/common/utils/messages/retryEligibility";
@@ -368,6 +368,8 @@ interface PendingSendState {
   message: PendingSendMessage;
   /** User echoes already in the transcript when the send began; null when begun before catch-up. */
   knownUserEchoIds: Set<string> | null;
+  /** Wall clock at begin; with no baseline, only rows persisted after it can be the echo. */
+  beganAtMs: number;
   /** The send request succeeded, so any later replay is guaranteed to contain its echo. */
   accepted: boolean;
   /** A synthetic user row (pre-send compaction) took the turn; the echo follows that turn. */
@@ -918,6 +920,8 @@ export class WorkspaceStore {
     ) => void
   > = {
     "stream-start": (workspaceId, aggregator, data) => {
+      // Every dispatched entry echoes before its stream starts, so nothing is still owed.
+      this.assertChatTransientState(workspaceId).queueDispatchesAwaitingEcho = 0;
       applyWorkspaceChatEventToAggregator(aggregator, data);
       if (this.onModelUsed) {
         this.onModelUsed((data as { model: string }).model);
@@ -1211,8 +1215,11 @@ export class WorkspaceStore {
       transient.queuedMessageCount = nextCount;
       this.states.bump(workspaceId);
     },
-    "restore-to-input": (_workspaceId, _aggregator, data) => {
+    "restore-to-input": (workspaceId, _aggregator, data) => {
       if (!isRestoreToInput(data)) return;
+
+      // The queue was cleared, not dispatched; the shrink that preceded this owes no echo.
+      this.assertChatTransientState(workspaceId).queueDispatchesAwaitingEcho = 0;
 
       // Use UPDATE_CHAT_INPUT event with mode="replace"
       window.dispatchEvent(
@@ -4069,8 +4076,12 @@ export class WorkspaceStore {
       this.clearPendingSend(workspaceId, pendingSendId);
     }
 
+    // Only the optimistic barrier belongs to the creation send; an echoed later send owns it after.
     const aggregator = this.aggregators.get(workspaceId);
-    if (aggregator?.getPendingStreamStartTime() == null) {
+    if (
+      aggregator?.getPendingStreamStartTime() == null ||
+      !aggregator.isOptimisticPendingStreamStart()
+    ) {
       return;
     }
 
@@ -4100,6 +4111,7 @@ export class WorkspaceStore {
               .map((echo) => echo.id)
           )
         : null,
+      beganAtMs: Date.now(),
       accepted: false,
       deferredBehindSyntheticTurn: false,
     };
@@ -4153,9 +4165,14 @@ export class WorkspaceStore {
     pending: PendingSendState
   ): boolean {
     const known = pending.knownUserEchoIds;
+    const earliestEchoMs = pending.beganAtMs - PENDING_SEND_ECHO_CLOCK_SKEW_MS;
     return aggregator
       .getAllMessages()
-      .some((message) => isUserEcho(message) && !known?.has(message.id));
+      .some(
+        (message) =>
+          isUserEcho(message) &&
+          (known ? !known.has(message.id) : (message.metadata?.timestamp ?? 0) >= earliestEchoMs)
+      );
   }
 
   /**

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -376,9 +376,16 @@ interface PendingSendState {
   deferredBehindSyntheticTurn: boolean;
 }
 
-/** A persisted user turn the backend emits in response to a send; synthetic rows are not echoes. */
+/**
+ * A persisted user turn the backend emits in response to a send. Synthetic rows and
+ * agent-initiated turns (hidden queue entries) are not echoes.
+ */
 function isUserEcho(message: MuxMessage): boolean {
-  return message.role === "user" && message.metadata?.synthetic !== true;
+  return (
+    message.role === "user" &&
+    message.metadata?.synthetic !== true &&
+    message.metadata?.retrySendOptions?.agentInitiated !== true
+  );
 }
 
 interface WorkspaceChatTransientState {
@@ -4180,15 +4187,19 @@ export class WorkspaceStore {
 
   /**
    * A live user row arrived. A synthetic pre-send compaction request defers the echo behind its
-   * turn, drained queue entries echo their own rows, and other synthetic rows (monitor wakes,
-   * continuations) are unrelated; anything else is this send's echo.
+   * turn, drained queue entries echo their own rows, and other non-echo rows (monitor wakes,
+   * continuations, agent-initiated turns) are unrelated; anything else is this send's echo.
    */
   private acknowledgePendingSendEcho(
     transient: WorkspaceChatTransientState,
     echo: MuxMessage
   ): void {
-    if (echo.metadata?.synthetic === true) {
-      if (transient.pendingSend && echo.metadata.muxMetadata?.type === "compaction-request") {
+    if (!isUserEcho(echo)) {
+      if (
+        transient.pendingSend &&
+        echo.metadata?.synthetic === true &&
+        echo.metadata.muxMetadata?.type === "compaction-request"
+      ) {
         transient.pendingSend.deferredBehindSyntheticTurn = true;
       }
       return;

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -366,10 +366,11 @@ export interface WorkflowToolLiveRunState {
 
 interface PendingSendState {
   message: PendingSendMessage;
-  /** User echoes already in the transcript when the send began; null when begun before catch-up. */
+  /**
+   * User echoes already in the transcript when the send began; null when begun before catch-up,
+   * in which case only the request result can tell the echo apart from replayed history.
+   */
   knownUserEchoIds: Set<string> | null;
-  /** Wall clock at begin; with no baseline, only rows persisted at or after it can be the echo. */
-  beganAtMs: number;
   /** The send request succeeded, so any later replay is guaranteed to contain its echo. */
   accepted: boolean;
   /** A synthetic user row (pre-send compaction) took the turn; the echo follows that turn. */
@@ -4118,7 +4119,6 @@ export class WorkspaceStore {
               .map((echo) => echo.id)
           )
         : null,
-      beganAtMs: Date.now(),
       accepted: false,
       deferredBehindSyntheticTurn: false,
     };
@@ -4176,13 +4176,12 @@ export class WorkspaceStore {
     pending: PendingSendState
   ): boolean {
     const known = pending.knownUserEchoIds;
+    if (!known) {
+      return false;
+    }
     return aggregator
       .getAllMessages()
-      .some(
-        (message) =>
-          isUserEcho(message) &&
-          (known ? !known.has(message.id) : (message.metadata?.timestamp ?? 0) >= pending.beganAtMs)
-      );
+      .some((message) => isUserEcho(message) && !known.has(message.id));
   }
 
   /**

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -370,6 +370,10 @@ interface PendingSendState {
   knownUserEchoIds: Set<string> | null;
   /** The send request succeeded, so any later replay is guaranteed to contain its echo. */
   accepted: boolean;
+  /** Queue entries dispatched since the send began; each echoes a user row that is not this send. */
+  drainedEchoesExpected: number;
+  /** A synthetic user row (pre-send compaction) took the turn; the echo follows that turn. */
+  deferredBehindSyntheticTurn: boolean;
 }
 
 /** A persisted user turn the backend emits in response to a send; synthetic rows are not echoes. */
@@ -384,6 +388,8 @@ interface WorkspaceChatTransientState {
   pendingStreamEvents: WorkspaceChatMessage[];
   replayingHistory: boolean;
   queuedMessage: QueuedMessage | null;
+  /** Visible queue entries from the last queue update, to tell drains from new enqueues. */
+  queuedMessageCount: number;
   pendingSend: PendingSendState | null;
   liveBashOutput: Map<string, LiveBashOutputInternal>;
   liveAdvisorOutput: Map<string, AdvisorLiveOutputState>;
@@ -496,6 +502,7 @@ function createInitialChatTransientState(): WorkspaceChatTransientState {
     pendingStreamEvents: [],
     replayingHistory: false,
     queuedMessage: null,
+    queuedMessageCount: 0,
     pendingSend: null,
     liveBashOutput: new Map(),
     liveAdvisorOutput: new Map(),
@@ -1001,6 +1008,7 @@ export class WorkspaceStore {
       const streamAbortData = data as StreamAbortEvent;
       applyWorkspaceChatEventToAggregator(aggregator, streamAbortData);
       this.releaseStreamingMessageChannel(workspaceId);
+      this.retirePendingSendAfterAbandonedTurn(workspaceId);
 
       // Track stream interruption telemetry (get model from aggregator)
       const model = aggregator.getCurrentModel();
@@ -1183,10 +1191,17 @@ export class WorkspaceStore {
       aggregator.setActiveQueuedFollowUp(data.hasQueuedMessages ?? queuedMessage !== null);
       const transient = this.assertChatTransientState(workspaceId);
       transient.queuedMessage = queuedMessage;
-      if (queuedMessage) {
-        // The send landed in the backend queue; the queued card takes over from the pending row.
-        transient.pendingSend = null;
+      const pending = transient.pendingSend;
+      const nextCount = data.queuedMessages.length;
+      if (pending && transient.caughtUp && !transient.replayingHistory) {
+        if (nextCount > transient.queuedMessageCount || (pending.accepted && queuedMessage)) {
+          // The send landed in the backend queue; the queued card takes over from the pending row.
+          transient.pendingSend = null;
+        } else if (nextCount < transient.queuedMessageCount) {
+          pending.drainedEchoesExpected += transient.queuedMessageCount - nextCount;
+        }
       }
+      transient.queuedMessageCount = nextCount;
       this.states.bump(workspaceId);
     },
     "restore-to-input": (_workspaceId, _aggregator, data) => {
@@ -4081,15 +4096,40 @@ export class WorkspaceStore {
           )
         : null,
       accepted: false,
+      drainedEchoesExpected: 0,
+      deferredBehindSyntheticTurn: false,
     };
     this.states.bump(workspaceId);
   }
 
-  /** Record that the backend accepted the send, so the next replay is known to contain its echo. */
-  markPendingSendAccepted(workspaceId: string, id: string): void {
+  /** Replace the displayed content of an in-flight pending send (e.g. once files are staged). */
+  updatePendingSend(workspaceId: string, message: PendingSendMessage): void {
     const pending = this.chatTransientState.get(workspaceId)?.pendingSend;
-    if (pending?.message.id === id) {
-      pending.accepted = true;
+    if (pending?.message.id !== message.id) {
+      return;
+    }
+
+    pending.message = message;
+    this.states.bump(workspaceId);
+  }
+
+  /**
+   * Record that the backend accepted the send, so the next replay is known to contain its echo.
+   * A direct send's echo always precedes the response, so an echo displayed by now retires the
+   * row; a row still standing belongs to a queued send whose queue update is in flight.
+   */
+  markPendingSendAccepted(workspaceId: string, id: string): void {
+    const transient = this.chatTransientState.get(workspaceId);
+    const aggregator = this.aggregators.get(workspaceId);
+    const pending = transient?.pendingSend;
+    if (!transient || !aggregator || pending?.message.id !== id) {
+      return;
+    }
+
+    pending.accepted = true;
+    if (transient.caughtUp && this.hasUnseenUserEcho(aggregator, pending)) {
+      transient.pendingSend = null;
+      this.states.bump(workspaceId);
     }
   }
 
@@ -4112,6 +4152,41 @@ export class WorkspaceStore {
     return aggregator
       .getAllMessages()
       .some((message) => isUserEcho(message) && !known?.has(message.id));
+  }
+
+  /**
+   * A live user row arrived. Synthetic rows (pre-send compaction) defer the echo and drained
+   * queue entries echo their own rows; anything else is this send's echo.
+   */
+  private acknowledgePendingSendEcho(
+    transient: WorkspaceChatTransientState,
+    echo: MuxMessage
+  ): void {
+    const pending = transient.pendingSend;
+    if (!pending) {
+      return;
+    }
+    if (echo.metadata?.synthetic === true) {
+      pending.deferredBehindSyntheticTurn = true;
+      return;
+    }
+    if (pending.drainedEchoesExpected > 0) {
+      pending.drainedEchoesExpected -= 1;
+      return;
+    }
+    transient.pendingSend = null;
+  }
+
+  /** A turn that took over the send (pre-send compaction) ended without echoing it. */
+  private retirePendingSendAfterAbandonedTurn(workspaceId: string): void {
+    const transient = this.chatTransientState.get(workspaceId);
+    if (
+      transient?.pendingSend?.deferredBehindSyntheticTurn &&
+      transient.caughtUp &&
+      !transient.replayingHistory
+    ) {
+      transient.pendingSend = null;
+    }
   }
 
   /**
@@ -4711,6 +4786,7 @@ export class WorkspaceStore {
       this.cancelPendingIdleBump(workspaceId);
       this.cancelPendingStreamingBump(workspaceId);
       this.releaseStreamingMessageChannel(workspaceId);
+      this.retirePendingSendAfterAbandonedTurn(workspaceId);
       this.states.bump(workspaceId);
       this.streamingStatsStore.bump(workspaceId);
       return;
@@ -4850,9 +4926,8 @@ export class WorkspaceStore {
         // Process live events immediately (after history loaded)
         applyWorkspaceChatEventToAggregator(aggregator, data);
 
-        if (isUserEcho(data)) {
-          // The backend echoed the send; the persisted row replaces the pending one.
-          transient.pendingSend = null;
+        if (data.role === "user") {
+          this.acknowledgePendingSendEcho(transient, data);
         }
 
         const muxMeta = data.metadata?.muxMetadata as { type?: string } | undefined;
@@ -4945,6 +5020,8 @@ export const workspaceStore = {
     getStoreInstance().clearPendingInitialSendState(workspaceId),
   beginPendingSend: (workspaceId: string, message: PendingSendMessage) =>
     getStoreInstance().beginPendingSend(workspaceId, message),
+  updatePendingSend: (workspaceId: string, message: PendingSendMessage) =>
+    getStoreInstance().updatePendingSend(workspaceId, message),
   markPendingSendAccepted: (workspaceId: string, id: string) =>
     getStoreInstance().markPendingSendAccepted(workspaceId, id),
   /**

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -3819,6 +3819,8 @@ export class WorkspaceStore {
     }
     // A send begun before the first replay (new workspace) is retired by the replay itself.
     nextTransient.pendingSend = previousTransient?.pendingSend ?? null;
+    // Dispatched entries still owe their echoes after the replay too.
+    nextTransient.queueDispatchesAwaitingEcho = previousTransient?.queueDispatchesAwaitingEcho ?? 0;
 
     this.chatTransientState.set(workspaceId, nextTransient);
 
@@ -4153,7 +4155,7 @@ export class WorkspaceStore {
     pending.accepted = true;
     if (
       transient.caughtUp &&
-      (pending.knownUserEchoIds === null || this.hasUnseenUserEcho(aggregator, pending))
+      (pending.knownUserEchoIds === null || this.settleUnseenUserEchoes(transient, aggregator))
     ) {
       transient.pendingSend = null;
       this.states.bump(workspaceId);
@@ -4171,17 +4173,28 @@ export class WorkspaceStore {
     this.states.bump(workspaceId);
   }
 
-  private hasUnseenUserEcho(
-    aggregator: StreamingMessageAggregator,
-    pending: PendingSendState
+  /**
+   * Whether an echo the pending send did not know about is displayed. Echoes still owed by
+   * dispatched queue entries are not this send's; they are consumed and remembered so a later
+   * replay cannot count them again.
+   */
+  private settleUnseenUserEchoes(
+    transient: WorkspaceChatTransientState,
+    aggregator: StreamingMessageAggregator
   ): boolean {
-    const known = pending.knownUserEchoIds;
+    const known = transient.pendingSend?.knownUserEchoIds;
     if (!known) {
       return false;
     }
-    return aggregator
+    const unseen = aggregator
       .getAllMessages()
-      .some((message) => isUserEcho(message) && !known.has(message.id));
+      .filter((message) => isUserEcho(message) && !known.has(message.id));
+    const owed = unseen.splice(0, Math.min(unseen.length, transient.queueDispatchesAwaitingEcho));
+    transient.queueDispatchesAwaitingEcho -= owed.length;
+    for (const echo of owed) {
+      known.add(echo.id);
+    }
+    return unseen.length > 0;
   }
 
   /**
@@ -4205,6 +4218,7 @@ export class WorkspaceStore {
     }
     if (transient.queueDispatchesAwaitingEcho > 0) {
       transient.queueDispatchesAwaitingEcho -= 1;
+      transient.pendingSend?.knownUserEchoIds?.add(echo.id);
       return;
     }
     transient.pendingSend = null;
@@ -4698,7 +4712,7 @@ export class WorkspaceStore {
       const pendingSend = transient.pendingSend;
       if (
         pendingSend &&
-        (pendingSend.accepted || this.hasUnseenUserEcho(aggregator, pendingSend))
+        (pendingSend.accepted || this.settleUnseenUserEchoes(transient, aggregator))
       ) {
         transient.pendingSend = null;
       }

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -1170,7 +1170,11 @@ export class WorkspaceStore {
       aggregator.setActiveQueuedFollowUp(data.hasQueuedMessages ?? queuedMessage !== null);
       const transient = this.assertChatTransientState(workspaceId);
       transient.queuedMessage = queuedMessage;
-      if (queuedMessage) {
+      if (
+        queuedMessage &&
+        transient.pendingSend &&
+        queuedMessage.content.includes(transient.pendingSend.content)
+      ) {
         // The send landed in the backend queue; the queued card takes over from the pending row.
         transient.pendingSend = null;
       }

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -388,7 +388,7 @@ interface WorkspaceChatTransientState {
   pendingStreamEvents: WorkspaceChatMessage[];
   replayingHistory: boolean;
   queuedMessage: QueuedMessage | null;
-  /** Visible queue strings from the last queue update, to tell drains from new enqueues. */
+  /** Visible queue payload size from the last queue update, to tell drains from new enqueues. */
   queuedMessageCount: number;
   pendingSend: PendingSendState | null;
   liveBashOutput: Map<string, LiveBashOutputInternal>;
@@ -1192,7 +1192,9 @@ export class WorkspaceStore {
       const transient = this.assertChatTransientState(workspaceId);
       transient.queuedMessage = queuedMessage;
       const pending = transient.pendingSend;
-      const nextCount = data.queuedMessages.length;
+      // Attachment-only entries add no text, so size the queue by every visible payload kind.
+      const nextCount =
+        data.queuedMessages.length + (data.fileParts?.length ?? 0) + (data.reviews?.length ?? 0);
       if (pending && transient.caughtUp && !transient.replayingHistory) {
         if (nextCount > transient.queuedMessageCount || (pending.accepted && queuedMessage)) {
           // The send landed in the backend queue; the queued card takes over from the pending row.
@@ -4156,8 +4158,9 @@ export class WorkspaceStore {
   }
 
   /**
-   * A live user row arrived. Synthetic rows (pre-send compaction) defer the echo and drained
-   * queue entries echo their own rows; anything else is this send's echo.
+   * A live user row arrived. A synthetic pre-send compaction request defers the echo behind its
+   * turn, drained queue entries echo their own rows, and other synthetic rows (monitor wakes,
+   * continuations) are unrelated; anything else is this send's echo.
    */
   private acknowledgePendingSendEcho(
     transient: WorkspaceChatTransientState,
@@ -4168,7 +4171,9 @@ export class WorkspaceStore {
       return;
     }
     if (echo.metadata?.synthetic === true) {
-      pending.deferredBehindSyntheticTurn = true;
+      if (echo.metadata.muxMetadata?.type === "compaction-request") {
+        pending.deferredBehindSyntheticTurn = true;
+      }
       return;
     }
     if (pending.drainedEchoesExpected > 0) {

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -1,6 +1,11 @@
 import assert from "@/common/utils/assert";
 import { stripStagedAttachmentNotice } from "@/browser/features/ChatInput/stagedAttachments";
-import type { MuxMessage, DisplayedMessage, QueuedMessage } from "@/common/types/message";
+import type {
+  MuxMessage,
+  DisplayedMessage,
+  PendingSendMessage,
+  QueuedMessage,
+} from "@/common/types/message";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import { isGoalPendingPersistence, type GoalSnapshot } from "@/common/types/goal";
 import type {
@@ -187,6 +192,7 @@ export interface WorkspaceState {
   name: string; // User-facing workspace name (e.g., "feature-branch")
   messages: DisplayedMessage[];
   queuedMessage: QueuedMessage | null;
+  pendingSend: PendingSendMessage | null;
   canInterrupt: boolean;
   isCompacting: boolean;
   isStreamStarting: boolean;
@@ -365,6 +371,7 @@ interface WorkspaceChatTransientState {
   pendingStreamEvents: WorkspaceChatMessage[];
   replayingHistory: boolean;
   queuedMessage: QueuedMessage | null;
+  pendingSend: PendingSendMessage | null;
   liveBashOutput: Map<string, LiveBashOutputInternal>;
   liveAdvisorOutput: Map<string, AdvisorLiveOutputState>;
   liveAdvisorReasoning: Map<string, AdvisorLiveReasoningState>;
@@ -476,6 +483,7 @@ function createInitialChatTransientState(): WorkspaceChatTransientState {
     pendingStreamEvents: [],
     replayingHistory: false,
     queuedMessage: null,
+    pendingSend: null,
     liveBashOutput: new Map(),
     liveAdvisorOutput: new Map(),
     liveAdvisorReasoning: new Map(),
@@ -1160,7 +1168,12 @@ export class WorkspaceStore {
       // Mirror the queue signal onto active streams so response notifications follow
       // user-visible terminal turns instead of every intermediate handoff.
       aggregator.setActiveQueuedFollowUp(data.hasQueuedMessages ?? queuedMessage !== null);
-      this.assertChatTransientState(workspaceId).queuedMessage = queuedMessage;
+      const transient = this.assertChatTransientState(workspaceId);
+      transient.queuedMessage = queuedMessage;
+      if (queuedMessage) {
+        // The send landed in the backend queue; the queued card takes over from the pending row.
+        transient.pendingSend = null;
+      }
       this.states.bump(workspaceId);
     },
     "restore-to-input": (_workspaceId, _aggregator, data) => {
@@ -2301,6 +2314,7 @@ export class WorkspaceStore {
         name: metadata?.name ?? workspaceId, // Fall back to ID if metadata missing
         messages: displayedMessages,
         queuedMessage: transient.queuedMessage,
+        pendingSend: transient.pendingSend,
         canInterrupt,
         isCompacting: aggregator.isCompacting(),
         isStreamStarting,
@@ -4024,6 +4038,31 @@ export class WorkspaceStore {
   }
 
   /**
+   * Show the composer content in the transcript tail while the send request is in flight.
+   * Cleared when the backend echoes a user message or queues it, or via clearPendingSend.
+   */
+  beginPendingSend(workspaceId: string, message: PendingSendMessage): void {
+    const transient = this.chatTransientState.get(workspaceId);
+    if (!transient) {
+      return;
+    }
+
+    transient.pendingSend = message;
+    this.states.bump(workspaceId);
+  }
+
+  /** Remove the pending send row; a mismatched id means a newer send already replaced it. */
+  clearPendingSend(workspaceId: string, id: string): void {
+    const transient = this.chatTransientState.get(workspaceId);
+    if (transient?.pendingSend?.id !== id) {
+      return;
+    }
+
+    transient.pendingSend = null;
+    this.states.bump(workspaceId);
+  }
+
+  /**
    * Remove a workspace and clean up subscriptions.
    */
   removeWorkspace(workspaceId: string): void {
@@ -4749,6 +4788,11 @@ export class WorkspaceStore {
       } else {
         // Process live events immediately (after history loaded)
         applyWorkspaceChatEventToAggregator(aggregator, data);
+
+        if (data.role === "user") {
+          // The backend echoed the send; the persisted row replaces the pending one.
+          transient.pendingSend = null;
+        }
 
         const muxMeta = data.metadata?.muxMetadata as { type?: string } | undefined;
         const isCompactionBoundarySummary =

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -375,6 +375,8 @@ interface PendingSendState {
   accepted: boolean;
   /** Visible queue payload size when the send began; growth by acceptance means it was queued. */
   queueSizeAtBegin: number;
+  /** Queued card identity when the send began; a different card at equal size replaced it. */
+  queuedMessageIdAtBegin: string | null;
   /** A synthetic user row (pre-send compaction) took the turn; the echo follows that turn. */
   deferredBehindSyntheticTurn: boolean;
 }
@@ -4134,6 +4136,7 @@ export class WorkspaceStore {
         : null,
       accepted: false,
       queueSizeAtBegin: transient.queuedMessageCount,
+      queuedMessageIdAtBegin: transient.queuedMessage?.id ?? null,
       deferredBehindSyntheticTurn: false,
     };
     this.states.bump(workspaceId);
@@ -4165,9 +4168,14 @@ export class WorkspaceStore {
     }
 
     pending.accepted = true;
-    // A queue that grew since the send began (for example through a replayed snapshot) holds it.
+    // A queue that grew since the send began, or a same-size queue showing a different card
+    // (a replayed snapshot after a replacement), holds the accepted send.
+    const queued = transient.queuedMessage;
     const queuedSinceBegin =
-      transient.queuedMessage !== null && transient.queuedMessageCount > pending.queueSizeAtBegin;
+      queued !== null &&
+      (transient.queuedMessageCount > pending.queueSizeAtBegin ||
+        (transient.queuedMessageCount === pending.queueSizeAtBegin &&
+          queued.id !== pending.queuedMessageIdAtBegin));
     if (
       transient.caughtUp &&
       (pending.knownUserEchoIds === null ||

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -388,7 +388,7 @@ interface WorkspaceChatTransientState {
   pendingStreamEvents: WorkspaceChatMessage[];
   replayingHistory: boolean;
   queuedMessage: QueuedMessage | null;
-  /** Visible queue entries from the last queue update, to tell drains from new enqueues. */
+  /** Visible queue strings from the last queue update, to tell drains from new enqueues. */
   queuedMessageCount: number;
   pendingSend: PendingSendState | null;
   liveBashOutput: Map<string, LiveBashOutputInternal>;
@@ -1198,7 +1198,8 @@ export class WorkspaceStore {
           // The send landed in the backend queue; the queued card takes over from the pending row.
           transient.pendingSend = null;
         } else if (nextCount < transient.queuedMessageCount) {
-          pending.drainedEchoesExpected += transient.queuedMessageCount - nextCount;
+          // One dispatched entry per shrink, however many batched strings it carried.
+          pending.drainedEchoesExpected += 1;
         }
       }
       transient.queuedMessageCount = nextCount;

--- a/src/browser/stories/helpers/chatSetup.ts
+++ b/src/browser/stories/helpers/chatSetup.ts
@@ -17,6 +17,7 @@ import { createWorkspace, groupWorkspacesByProject } from "../mocks/workspaces";
 import { createStaticChatHandler, createStreamingChatHandler } from "../mocks/chatHandlers";
 import type { GitStatusFixture } from "../mocks/git";
 import { createMockORPCClient, type MockSessionUsage } from "@/browser/stories/mocks/orpc";
+import type { MockORPCClientOptions } from "@/browser/stories/mocks/orpc";
 import { collapseRightSidebar, selectWorkspace } from "./uiState";
 import { createGitStatusExecutor, type GitDiffFixture } from "./git";
 
@@ -68,6 +69,8 @@ export interface SimpleChatSetupOptions {
   >;
   /** Optional custom chat handler for emitting additional events (e.g., queued-message-changed) */
   onChat?: (workspaceId: string, emit: (msg: WorkspaceChatMessage) => void) => void;
+  /** Override for workspace.sendMessage (default: immediate success) */
+  onSendMessage?: MockORPCClientOptions["onSendMessage"];
   /** Idle compaction hours for context meter (null = disabled) */
   idleCompactionHours?: number | null;
   /** Route priority for routing-aware stories */
@@ -173,6 +176,7 @@ export function setupSimpleChatStory(opts: SimpleChatSetupOptions): APIClient {
     projects: groupWorkspacesByProject(workspaces),
     workspaces,
     onChat,
+    onSendMessage: opts.onSendMessage,
     executeBash,
     providersConfig: opts.providersConfig,
     agentAiDefaults: opts.agentAiDefaults,

--- a/src/browser/stories/mocks/orpc.ts
+++ b/src/browser/stories/mocks/orpc.ts
@@ -80,6 +80,7 @@ import {
 } from "@/common/config/schemas/userPreferences";
 import type { z } from "zod";
 import type { ProjectRemoveErrorSchema } from "@/common/orpc/schemas/errors";
+import type { SendMessageError } from "@/common/types/errors";
 import { isWorkspaceArchived } from "@/common/utils/archive";
 import { getProjectWorkspaceCounts } from "@/common/utils/projectRemoval";
 
@@ -220,6 +221,11 @@ export interface MockORPCClientOptions {
   onProjectRemove?: (
     projectPath: string
   ) => { success: true; data: undefined } | { success: false; error: ProjectRemoveError };
+  /** Override for workspace.sendMessage (default: immediate success) */
+  onSendMessage?: (input: {
+    workspaceId: string;
+    message: string;
+  }) => Promise<{ success: true; data: undefined } | { success: false; error: SendMessageError }>;
   /** Override for nameGeneration.generate result (default: success) */
   nameGenerationResult?: { success: false; error: NameGenerationError };
   /** Background processes per workspace */
@@ -391,6 +397,7 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
     providersList = [],
     serverAuthSessions: initialServerAuthSessions = [],
     onProjectRemove,
+    onSendMessage,
     nameGenerationResult,
     backgroundProcesses = new Map<string, MockBackgroundProcess[]>(),
     sessionUsage = new Map<string, MockSessionUsage>(),
@@ -1666,7 +1673,8 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
           data: { newWorkspaceId: input.workspaceId },
         }),
       fork: () => Promise.resolve({ success: false, error: "Not implemented in mock" }),
-      sendMessage: () => Promise.resolve({ success: true, data: undefined }),
+      sendMessage: (input: { workspaceId: string; message: string }) =>
+        onSendMessage ? onSendMessage(input) : Promise.resolve({ success: true, data: undefined }),
       resumeStream: () => Promise.resolve({ success: true, data: { started: true } }),
       setAutoRetryEnabled: () =>
         Promise.resolve({

--- a/src/browser/utils/commands/sources.test.ts
+++ b/src/browser/utils/commands/sources.test.ts
@@ -708,6 +708,7 @@ function makeWorkspaceState(goal: WorkspaceState["goal"]): WorkspaceState {
     name: "feat-x",
     messages: [],
     queuedMessage: null,
+    pendingSend: null,
     canInterrupt: false,
     isCompacting: false,
     isStreamStarting: false,

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -2008,6 +2008,10 @@ export class StreamingMessageAggregator {
     this.setPendingStreamStartTime(null);
   }
 
+  isOptimisticPendingStreamStart(): boolean {
+    return this.optimisticPendingStreamStart;
+  }
+
   resetForReplay(): void {
     const pendingStreamSnapshot =
       this.pendingStreamStartTime === null

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -1411,6 +1411,9 @@ export interface QueuedMessage {
   hasCompactionRequest?: boolean;
 }
 
+/** Composer content shown in the transcript tail until the backend acknowledges the send. */
+export type PendingSendMessage = Pick<QueuedMessage, "id" | "content" | "fileParts" | "reviews">;
+
 /** Keep every snapshot kind here so history scans and edits retain it with its user message. */
 export function isSyntheticSnapshotUserMessage(message: MuxMessage): boolean {
   return (

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -1412,7 +1412,10 @@ export interface QueuedMessage {
 }
 
 /** Composer content shown in the transcript tail until the backend acknowledges the send. */
-export type PendingSendMessage = Pick<QueuedMessage, "id" | "content" | "fileParts" | "reviews">;
+export type PendingSendMessage = Pick<QueuedMessage, "id" | "content" | "fileParts" | "reviews"> & {
+  /** Files still being staged into the workspace; shown as inert chips until the notice lands. */
+  stagingFilenames?: string[];
+};
 
 /** Keep every snapshot kind here so history scans and edits retain it with its user message. */
 export function isSyntheticSnapshotUserMessage(message: MuxMessage): boolean {

--- a/src/constants/streaming.ts
+++ b/src/constants/streaming.ts
@@ -6,12 +6,6 @@
 export const WORKSPACE_STREAMING_STATUS_TRANSITION_MS = 150;
 
 /**
- * A user row persisted at least this long before a send began cannot be that send's echo.
- * Absorbs client/server clock skew when a send begins before the transcript has caught up.
- */
-export const PENDING_SEND_ECHO_CLOCK_SKEW_MS = 30_000;
-
-/**
  * Average character-per-token estimate used to convert tokens-per-second (from
  * the streaming TPS calculator) into characters-per-second (consumed by the
  * smoothing engine to target the model's actual emission rate). 4 is the

--- a/src/constants/streaming.ts
+++ b/src/constants/streaming.ts
@@ -6,6 +6,12 @@
 export const WORKSPACE_STREAMING_STATUS_TRANSITION_MS = 150;
 
 /**
+ * A user row persisted at least this long before a send began cannot be that send's echo.
+ * Absorbs client/server clock skew when a send begins before the transcript has caught up.
+ */
+export const PENDING_SEND_ECHO_CLOCK_SKEW_MS = 30_000;
+
+/**
  * Average character-per-token estimate used to convert tokens-per-second (from
  * the streaming TPS calculator) into characters-per-second (consumed by the
  * smoothing engine to target the model's actual emission rate). 4 is the

--- a/tests/ui/chat/newChatStreamingFlash.test.ts
+++ b/tests/ui/chat/newChatStreamingFlash.test.ts
@@ -80,19 +80,21 @@ async function createCreationHarness(options?: {
   }
 }
 
-type WorkspaceSendMessageFn = TestEnvironment["orpc"]["workspace"]["sendMessage"];
+type WorkspaceServiceSendMessage = TestEnvironment["services"]["workspaceService"]["sendMessage"];
 
+// The oRPC router client builds a fresh proxy on every property access, so an override must land
+// on the service the router handler calls into; assigning onto `env.orpc.workspace` is discarded.
 function overrideWorkspaceSendMessage(
   env: TestEnvironment,
-  override: WorkspaceSendMessageFn
+  override: (original: WorkspaceServiceSendMessage) => WorkspaceServiceSendMessage
 ): () => void {
-  const workspaceApi = env.orpc.workspace as typeof env.orpc.workspace & {
-    sendMessage: WorkspaceSendMessageFn;
+  const service = env.services.workspaceService as typeof env.services.workspaceService & {
+    sendMessage: WorkspaceServiceSendMessage;
   };
-  const originalSendMessage = workspaceApi.sendMessage;
-  workspaceApi.sendMessage = override;
+  const originalSendMessage = service.sendMessage.bind(service) as WorkspaceServiceSendMessage;
+  service.sendMessage = override(originalSendMessage);
   return () => {
-    workspaceApi.sendMessage = originalSendMessage;
+    service.sendMessage = originalSendMessage;
   };
 }
 
@@ -128,13 +130,14 @@ describe("New chat streaming flash regression", () => {
     let restoreSendMessage: () => void = () => {};
     const app = await createCreationHarness({
       beforeRender: (env) => {
-        const originalSendMessage = env.orpc.workspace.sendMessage.bind(
-          env.orpc.workspace
-        ) as WorkspaceSendMessageFn;
-        restoreSendMessage = overrideWorkspaceSendMessage(env, (async (input) => {
-          await sendGate;
-          return originalSendMessage(input);
-        }) as WorkspaceSendMessageFn);
+        restoreSendMessage = overrideWorkspaceSendMessage(
+          env,
+          (original) =>
+            (async (...args) => {
+              await sendGate;
+              return original(...args);
+            }) as WorkspaceServiceSendMessage
+        );
       },
     });
 

--- a/tests/ui/chat/pendingSendMessage.test.ts
+++ b/tests/ui/chat/pendingSendMessage.test.ts
@@ -1,0 +1,162 @@
+import "../dom";
+
+jest.mock("lottie-react", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+import { waitFor } from "@testing-library/react";
+
+import { preloadTestModules, type TestEnvironment } from "../../ipc/setup";
+
+import { createAppHarness, type AppHarness } from "../harness";
+
+type WorkspaceServiceSendMessage = TestEnvironment["services"]["workspaceService"]["sendMessage"];
+
+// The oRPC router client builds a fresh proxy on every property access, so overrides must land on
+// the service the router handler calls into.
+function overrideServiceSendMessage(
+  env: TestEnvironment,
+  override: (original: WorkspaceServiceSendMessage) => WorkspaceServiceSendMessage
+): () => void {
+  const service = env.services.workspaceService as typeof env.services.workspaceService & {
+    sendMessage: WorkspaceServiceSendMessage;
+  };
+  const original = service.sendMessage.bind(service) as WorkspaceServiceSendMessage;
+  service.sendMessage = override(original);
+  return () => {
+    service.sendMessage = original;
+  };
+}
+
+function getPendingSendRow(container: HTMLElement): HTMLElement | null {
+  return container.querySelector<HTMLElement>('[data-component="PendingSendMessage"]');
+}
+
+function getComposerTextarea(container: HTMLElement): HTMLTextAreaElement {
+  const textarea = container
+    .querySelector('[data-testid="chat-composer-dock"]')
+    ?.querySelector<HTMLTextAreaElement>('textarea[aria-label="Message Claude"]');
+  if (!textarea) {
+    throw new Error("Composer textarea not found");
+  }
+  return textarea;
+}
+
+function getPersistedMessageBlocks(container: HTMLElement): Element[] {
+  return Array.from(container.querySelectorAll("[data-message-block]"));
+}
+
+async function expectPendingSendRow(app: AppHarness, text: string): Promise<void> {
+  await waitFor(
+    () => {
+      const row = getPendingSendRow(app.view.container);
+      if (!row) {
+        throw new Error("Pending send row not rendered");
+      }
+      expect(row.textContent).toContain(text);
+      expect(row.querySelector('[data-component="PendingSendStatus"]')?.textContent).toContain(
+        "Sending"
+      );
+      expect(getComposerTextarea(app.view.container).disabled).toBe(true);
+    },
+    { timeout: 10_000 }
+  );
+}
+
+describe("Optimistic pending send row", () => {
+  beforeAll(async () => {
+    await preloadTestModules();
+  });
+
+  test("shows the message in the transcript tail until the backend echoes it", async () => {
+    let releaseSend: () => void = () => {};
+    const sendGate = new Promise<void>((resolve) => {
+      releaseSend = resolve;
+    });
+    let restoreSendMessage: () => void = () => {};
+    const app = await createAppHarness({
+      branchPrefix: "pending-send",
+      beforeRenderEnvironment: (env) => {
+        restoreSendMessage = overrideServiceSendMessage(
+          env,
+          (original) =>
+            (async (...args) => {
+              await sendGate;
+              return original(...args);
+            }) as WorkspaceServiceSendMessage
+        );
+      },
+    });
+
+    try {
+      const text = "Hold this message until the server acknowledges it";
+      await app.chat.send(text);
+
+      await expectPendingSendRow(app, text);
+      // Nothing persisted yet, so the only copy of the text is the pending row.
+      expect(getPersistedMessageBlocks(app.view.container)).toHaveLength(0);
+
+      releaseSend();
+
+      await waitFor(
+        () => {
+          expect(getPendingSendRow(app.view.container)).toBeNull();
+          const blocks = getPersistedMessageBlocks(app.view.container);
+          expect(blocks.some((block) => block.textContent?.includes(text))).toBe(true);
+        },
+        { timeout: 10_000 }
+      );
+      await app.chat.expectStreamComplete();
+    } finally {
+      restoreSendMessage();
+      releaseSend();
+      await app.dispose();
+    }
+  }, 60_000);
+
+  test("returns the message to the composer when the send fails", async () => {
+    let releaseSend: () => void = () => {};
+    const sendGate = new Promise<void>((resolve) => {
+      releaseSend = resolve;
+    });
+    let restoreSendMessage: () => void = () => {};
+    const app = await createAppHarness({
+      branchPrefix: "pending-send-fail",
+      beforeRenderEnvironment: (env) => {
+        restoreSendMessage = overrideServiceSendMessage(
+          env,
+          () =>
+            (async () => {
+              await sendGate;
+              return { success: false, error: { type: "unknown", raw: "simulated outage" } };
+            }) as WorkspaceServiceSendMessage
+        );
+      },
+    });
+
+    try {
+      const text = "This send is going to fail";
+      await app.chat.send(text);
+
+      await expectPendingSendRow(app, text);
+
+      releaseSend();
+
+      await waitFor(
+        () => {
+          expect(getPendingSendRow(app.view.container)).toBeNull();
+          const textarea = getComposerTextarea(app.view.container);
+          expect(textarea.disabled).toBe(false);
+          expect(textarea.value).toBe(text);
+        },
+        { timeout: 10_000 }
+      );
+      expect(getPersistedMessageBlocks(app.view.container)).toHaveLength(0);
+    } finally {
+      restoreSendMessage();
+      releaseSend();
+      await app.dispose();
+    }
+  }, 60_000);
+});

--- a/tests/ui/chat/pendingSendMessage.test.ts
+++ b/tests/ui/chat/pendingSendMessage.test.ts
@@ -9,6 +9,8 @@ import { waitFor } from "@testing-library/react";
 
 import { preloadTestModules, type TestEnvironment } from "../../ipc/setup";
 
+import { workspaceStore } from "@/browser/stores/WorkspaceStore";
+
 import { createAppHarness, type AppHarness } from "../harness";
 
 type WorkspaceServiceSendMessage = TestEnvironment["services"]["workspaceService"]["sendMessage"];
@@ -159,4 +161,68 @@ describe("Optimistic pending send row", () => {
       await app.dispose();
     }
   }, 60_000);
+
+  test("keeps the composer locked while a send awaits the queue during stream startup", async () => {
+    let releaseSend: () => void = () => {};
+    const sendGate = new Promise<void>((resolve) => {
+      releaseSend = resolve;
+    });
+    let gateNextSend = false;
+    let restoreSendMessage: () => void = () => {};
+    const app = await createAppHarness({
+      branchPrefix: "pending-send-queue",
+      beforeRenderEnvironment: (env) => {
+        restoreSendMessage = overrideServiceSendMessage(
+          env,
+          (original) =>
+            (async (...args) => {
+              if (gateNextSend) {
+                gateNextSend = false;
+                await sendGate;
+              }
+              return original(...args);
+            }) as WorkspaceServiceSendMessage
+        );
+      },
+    });
+
+    try {
+      // Hold the first turn before stream-start so the composer is in its "starting" phase,
+      // which normally re-enables input for queued follow-ups.
+      await app.chat.send("[mock:wait-start] first turn");
+      await waitFor(
+        () => {
+          expect(workspaceStore.getWorkspaceSidebarState(app.workspaceId).isStarting).toBe(true);
+          expect(getComposerTextarea(app.view.container).disabled).toBe(false);
+        },
+        { timeout: 10_000 }
+      );
+
+      gateNextSend = true;
+      const text = "Follow-up that must stay locked until acknowledged";
+      await app.chat.send(text);
+      await expectPendingSendRow(app, text);
+
+      releaseSend();
+
+      await waitFor(
+        () => {
+          expect(getPendingSendRow(app.view.container)).toBeNull();
+          const queued = app.view.container.querySelector('[data-component="QueuedMessageBanner"]');
+          expect(queued?.textContent).toContain(text);
+          expect(getComposerTextarea(app.view.container).disabled).toBe(false);
+        },
+        { timeout: 10_000 }
+      );
+
+      app.env.services.aiService.releaseMockStreamStartGate(app.workspaceId);
+      await app.chat.expectTranscriptContains(`Mock response: ${text}`, 30_000);
+      await app.chat.expectStreamComplete();
+    } finally {
+      restoreSendMessage();
+      releaseSend();
+      app.env.services.aiService.releaseMockStreamStartGate(app.workspaceId);
+      await app.dispose();
+    }
+  }, 90_000);
 });


### PR DESCRIPTION
## Summary

A sent chat message now stays visible in the transcript tail, with a "Sending..." spinner beneath it, until the backend acknowledges it. The composer is locked meanwhile. If the send fails, the row disappears and the text returns to the composer.

## Background

On a slow or dying connection a sent message vanished for the whole round-trip: the composer clears immediately, but the transcript only shows the user message once the backend echoes it over `onChat`. Users saw nothing until either the echo arrived or a failure toast restored the draft.

## Implementation

- `WorkspaceStore` gains transient `pendingSend` state exposed on `WorkspaceState`, plus `beginPendingSend` / `updatePendingSend` / `markPendingSendAccepted` / `clearPendingSend(id)`. The row is retired only by evidence that the backend holds the send:
  - a live user echo that is neither synthetic nor agent-initiated and not owed to a queue entry dispatched earlier (shrinking queue updates record that debt; it is consumed by the next echo and reset on `stream-start` and `restore-to-input`);
  - a queue update that grows the visible queue (text plus file plus review payloads), or any queue update once the request has been accepted;
  - a replay catch-up when the send was accepted, or when the replay shows an echo the send did not know about (its baseline is the echo ids present at begin, extended by paginated history);
  - the request result: acceptance retires the row when the transcript already shows the echo or a queue that grew or was replaced since begin, and when the send began before catch-up (no baseline); failure retires it and restores the draft.
  A synthetic pre-send compaction request defers the echo; if that turn aborts or errors before echoing, the row is retired so compaction recovery stays available. A row begun before a workspace's first replay survives the replay reset.
- `ChatInput` begins the pending send right after clearing the input, marks it accepted on success, and clears it only on failure. A successful RPC response never retires the row directly: for queued sends the response and the queue event travel as separate WebSocket frames and the response can land first, which produced a one-frame gap during UAT. The pending content carries the staged-attachment notice like the persisted row.
- The composer stays disabled while a pending send exists, including the "stream starting" phase that otherwise re-enables input for queued follow-ups. Without this a second send could replace the pending row.
- The creation composer seeds the new workspace's pending row right after `onWorkspaceCreated` (files awaiting staging appear as inert chips, replaced by the staged notice once staging finishes), so a slow runtime start shows the message instead of only the starting barrier; the existing `clearPendingInitialSendState` failure paths retire that send's row only.
- `PendingSendMessage` mirrors the sent user bubble so the persisted row replaces it in place. It renders in the transcript tail stack ahead of the retry/streaming barriers; the hydration skeleton, empty-transcript placeholder, and retry barrier yield to it.
- Story mocks gain an `onSendMessage` override; new story `App/Chat/Input/SendingMessage` (Pixel: phone + laptop). `tests/ui/chat/newChatStreamingFlash.test.ts` now gates the send at the service so its delayed first send is real.

## Validation

- Remote UAT through Coder Agents over four rounds, driving real Chromium against a dev server behind a TCP delay proxy (1.5 s each way) and backend kills. Round 1 found the composer re-enabling during stream startup (fixed), round 2/3 found an intermittent one-frame gap at the pending -> Queued handoff (root cause above, fixed), round 4 passed with zero absent samples across nine handoff runs and zero enabled-control samples across 1,814 pending samples.
- `tests/ui/chat/pendingSendMessage.test.ts` gates `workspaceService.sendMessage` to cover the success handoff, the failure restore, and the composer lock while a send awaits the queue during stream startup (the last one fails without the lock).

## Risks

- `ChatInput` send path and `WorkspaceStore` event handling are on the hot path for every send. The pending row can only remain stale if a send succeeds and neither an echo, a queue update, nor a catch-up follows; the composer stays locked in that state. Every acknowledged send path exercised in UAT retired it.
- Pre-existing and out of scope: clicking Send while the "Reconnecting to server" overlay is shown is a silent no-op (draft preserved).

<details>
<summary>Decision log</summary>

- Render the pending row in the transcript tail (like the queued-agent prompt) rather than as a composer decoration, so it reads as the message it will become and hands off in place.
- Store-owned state instead of `ChatInput`-local state so the acknowledgement handlers in `WorkspaceStore` can retire it without prop drilling or effects.
- Single `pendingSend` slot: the composer lock guarantees at most one unacknowledged send per workspace.
- Tried and reverted: retiring the row only when the queue text contains the sent text. It did not remove the handoff gap (the cause was response/event ordering) and could strand a `/compact` send whose display text differs.
- Test harness note: overriding `env.orpc.workspace.sendMessage` is ineffective because the oRPC router client returns a fresh proxy per property access; both UI tests override the service method instead.

</details>

---

_Generated by Coder Agents (Claude) on behalf of @ibetitsmike._


