### PR TITLE
🤖 fix: normalize Codex security titles consistently across review gates

### DIFF
--- a/scripts/lib/codex_comments.jq
+++ b/scripts/lib/codex_comments.jq
@@ -49,8 +49,8 @@ def codex_comment_is_informational($bot):
         ) catch false) // false
       else
         ($body | test("Didn.t find any major issues|usage limits have been reached|create a Codex account"))
-        or ($body | test("^(### 🛡️ Codex Security Review · _[^_\n]+_\n+)?"
-          + "Security review completed\\. No security issues were found in this pull request\\."
+        # Normalization removes one known title; a second must remain blocking.
+        or ($body | test("^Security review completed\\. No security issues were found in this pull request\\."
           + "\n+\\*\\*Reviewed commit:\\*\\* `[0-9a-f]{7,40}`"
           + "\n+\\[View security finding report\\]\\(https://chatgpt\\.com/codex/cloud/tasks/[A-Za-z0-9_-]+\\)"
           + "\n+_Only the user who started this review can view the report in Codex\\._$"))

--- a/scripts/wait_pr_codex.sh
+++ b/scripts/wait_pr_codex.sh
@@ -460,13 +460,13 @@ CHECK_CODEX_STATUS_ONCE() {
   fi
 
   # Completed status/no-findings envelopes are neither approval nor a failed
-  # review. Reuse the CI classifier and keep waiting for the approval signal.
+  # review. Normalize titles like the CI classifier and keep waiting for approval.
   # Unfinished/unknown envelopes and account errors retain their blocking behavior.
   codex_response_count_comments=$(echo "$all_comments" | jq -r -L "$SCRIPT_DIR/lib" --arg bot "$BOT_LOGIN_GRAPHQL" --arg request_at "$request_at" '
     include "codex_comments";
     [.[] | select(.author.login == $bot and .createdAt > $request_at)
       | select(
-          ((.body | startswith("<!-- codex-pull-request-review-summary -->") or startswith("Security review completed."))
+          ((.body | codex_without_help | startswith("<!-- codex-pull-request-review-summary -->") or startswith("Security review completed."))
             and codex_comment_is_informational($bot)) | not
         )] | length
   ')


### PR DESCRIPTION
Titled Codex security no-findings cards now keep the review waiter polling for an explicit approval signal. The waiter uses the classifier's existing normalization before checking informational prefixes, and the classifier no longer accepts a second security title after normalization, so duplicate titles remain blocking.

Validation: reproduced both failures on `origin/main`, then passed all 12 existing offline regression groups with the fix. These cover findings, account errors, unknown cards, and authenticated, fresh approval signals. `make static-check`, Bash syntax, targeted ShellCheck, shfmt, and `git diff --check` pass.

---

_Generated with `xum` • Model: `GPT-6 (Codex)` • Thinking: `unavailable` • Cost: `$unavailable`_

<!-- mux-attribution: model=GPT-6 thinking=unavailable costs=unavailable -->
