### PR TITLE
🤖 refactor: qualify pending consumers and restart cleanup

### DIFF
--- a/src/node/services/compactionPendingState.consumers.test.ts
+++ b/src/node/services/compactionPendingState.consumers.test.ts
@@ -290,7 +290,7 @@ describe("inactive pending consumer contracts", () => {
     }
   );
 
-  it("keeps acknowledged carryover eligible until a foreign reset, while pending authority ends", async () => {
+  it("keeps acknowledged warmth only while its boundary remains current", async () => {
     const a = await publish("A");
     assert(a.result.success && a.result.data);
     const receipt = a.result.data;
@@ -305,10 +305,50 @@ describe("inactive pending consumer contracts", () => {
     const successor = await bytes();
     expect(await store.consume(receipt)).toBe(false);
     expect(await bytes()).toBe(successor);
-    expect(await store.isCurrent(receipt, "carryover", () => true)).toBe(true);
+    expect(await store.isCurrent(receipt, "carryover", () => true)).toBe(false);
     assert((await new HistoryService(h.config).clearHistory(workspaceId)).success);
     expect(await store.isCurrent(receipt, "carryover", () => true)).toBe(false);
   });
+
+  it.each(["history-only boundary", "future sidecar", "same-boundary owner"] as const)(
+    "refuses stale warmth after a foreign %s without deleting its bytes",
+    async (change) => {
+      const a = await publish("A");
+      assert(a.result.success && a.result.data);
+      expect(await store.consume(a.result.data)).toBe(true);
+      const journal = h.historyService.getContinuousCompactionJournal(workspaceId);
+      const generation = await journal.captureGeneration();
+      if (change === "history-only boundary") {
+        assert(
+          (
+            await new HistoryService(h.config).appendToHistory(
+              workspaceId,
+              createMuxMessage("B", "assistant", "B", {
+                compacted: "user",
+                compactionBoundary: true,
+                compactionEpoch: 2,
+              })
+            )
+          ).success
+        );
+      } else if (change === "future sidecar") {
+        await fs.writeFile(pendingPath, '{"version":9,"opaque":"future owner"}\n');
+      } else {
+        assert(
+          await restart().prepare({
+            boundaryMessageId: a.summary.id,
+            publication: { generation },
+            attachments: { diffs: [], loadedSkills: [], readFiles: ["/replacement.ts"] },
+            isCurrent: () => true,
+          })
+        );
+      }
+      expect(await journal.captureGeneration()).toBe(generation);
+      const before = await bytes().catch(() => undefined);
+      expect(await store.isCurrent(a.result.data, "carryover", () => true)).toBe(false);
+      expect(await bytes().catch(() => undefined)).toBe(before);
+    }
+  );
 
   it.each(["future", "legacy", "malformed"] as const)(
     "reset preserves %s bytes without trusting them as enrichment",
@@ -370,7 +410,7 @@ describe("inactive pending consumer contracts", () => {
     }
   });
 
-  it.each(["consume", "load", "discard", "restore"] as const)(
+  it.each(["consume", "load", "discard", "restore", "pending", "carryover"] as const)(
     "lost physical authority during %s cannot affect successor bytes",
     async (operation) => {
       const a = await publish("A");
@@ -397,7 +437,9 @@ describe("inactive pending consumer contracts", () => {
             ? store.consume(a.result.data)
             : operation === "load"
               ? store.load(() => true)
-              : store.discardAfterBoundary()
+              : operation === "pending" || operation === "carryover"
+                ? store.isCurrent(a.result.data, operation, () => true)
+                : store.discardAfterBoundary()
       ).catch((error: unknown) => error);
       try {
         await entered.promise;

--- a/src/node/services/compactionPendingState.consumers.test.ts
+++ b/src/node/services/compactionPendingState.consumers.test.ts
@@ -351,7 +351,7 @@ describe("inactive pending consumer contracts", () => {
   );
 
   it.each(["future", "legacy", "malformed"] as const)(
-    "reset preserves %s bytes without trusting them as enrichment",
+    "destructive reset handles %s bytes without trusting them as enrichment",
     async (kind) => {
       const raw =
         kind === "future"
@@ -362,9 +362,11 @@ describe("inactive pending consumer contracts", () => {
       await fs.writeFile(pendingPath, raw);
       assert((await new HistoryService(h.config).clearHistory(workspaceId)).success);
       await store.discardAfterBoundary();
-      expect(await bytes()).toBe(raw);
+      if (kind === "legacy")
+        expect(await bytes().catch((error: unknown) => error)).toMatchObject({ code: "ENOENT" });
+      else expect(await bytes()).toBe(raw);
       expect(await restart().load(() => true)).toBeUndefined();
-      if (kind !== "malformed") expect(await bytes()).toBe(raw);
+      if (kind === "future") expect(await bytes()).toBe(raw);
     }
   );
 

--- a/src/node/services/compactionPendingState.consumers.test.ts
+++ b/src/node/services/compactionPendingState.consumers.test.ts
@@ -1,0 +1,431 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as atomicWrite from "write-file-atomic";
+import { createMuxMessage, type MuxMessage } from "@/common/types/message";
+import { acquireProcessFileLock } from "@/node/utils/concurrency/fileLock";
+import { CompactionPendingState, type CompactionPendingReceipt } from "./compactionPendingState";
+import { HistoryService } from "./historyService";
+import { createTestHistoryService } from "./testHistoryService";
+import { historyWriteLockPath } from "./workspaceRemoval";
+
+type RollbackInput = Parameters<CompactionPendingState["rollbackHeartbeat"]>[0];
+
+describe("inactive pending consumer contracts", () => {
+  const workspaceId = "pending-consumers";
+  let h: Awaited<ReturnType<typeof createTestHistoryService>>;
+  let pendingPath: string;
+  let store: CompactionPendingState;
+
+  function restart(service = new HistoryService(h.config)) {
+    return new CompactionPendingState(
+      pendingPath,
+      service.getCompactionPendingHistory(workspaceId)
+    );
+  }
+
+  async function publish(name: string, heartbeat = false, target = store, accepted = true) {
+    const summary = createMuxMessage(name, "assistant", name, {
+      compacted: heartbeat ? "heartbeat" : "user",
+      compactionBoundary: true,
+      compactionEpoch: 1,
+      ...(heartbeat && {
+        muxMetadata: {
+          type: "compaction-summary",
+          pendingFollowUp: { text: "Resume", model: "openai:gpt-4o", agentId: "exec" },
+        },
+      }),
+    });
+    const result = await target.publishBoundary({
+      attachments: { diffs: [], loadedSkills: [], readFiles: [`/${name}.ts`] },
+      summaryMessage: summary,
+      tailCopies: [],
+      updateExisting: false,
+      publication: {
+        generation: await h.historyService
+          .getContinuousCompactionJournal(workspaceId)
+          .captureGeneration(),
+      },
+      isCurrent: () => true,
+      shouldPersist: () => accepted,
+      onCommitted: () => undefined,
+    });
+    return { summary, result };
+  }
+
+  function rollback(
+    summaryMessage: MuxMessage,
+    target = store,
+    overrides: Partial<RollbackInput> = {}
+  ) {
+    return target.rollbackHeartbeat({
+      summaryMessage,
+      isCurrent: () => true,
+      canRestorePrevious: () => true,
+      onCommitted: () => undefined,
+      onRestored: () => undefined,
+      ...overrides,
+    });
+  }
+
+  const bytes = () => fs.readFile(pendingPath, "utf8");
+  async function historyIds() {
+    const result = await h.historyService.getHistoryFromLatestBoundary(workspaceId);
+    assert(result.success);
+    return result.data.map((row) => row.id);
+  }
+
+  beforeEach(async () => {
+    h = await createTestHistoryService();
+    pendingPath = path.join(h.config.sessionsDir, workspaceId, "post-compaction.json");
+    assert(
+      (
+        await h.historyService.appendToHistory(
+          workspaceId,
+          createMuxMessage("seed", "user", "Context")
+        )
+      ).success
+    );
+    store = restart(h.historyService);
+  });
+
+  afterEach(async () => {
+    mock.restore();
+    await h.cleanup();
+  });
+
+  it("requires synchronous history and restoration receipt callbacks", () => {
+    const acceptCommit = (_callback: RollbackInput["onCommitted"]) => undefined;
+    const acceptRestoration = (_callback: RollbackInput["onRestored"]) => undefined;
+    acceptCommit(() => undefined);
+    acceptRestoration(() => undefined);
+    // @ts-expect-error History publication facts must precede lock release.
+    acceptCommit(async () => {
+      await Promise.resolve();
+    });
+    // @ts-expect-error Restored receipt ownership must precede lock release.
+    acceptRestoration(async () => {
+      await Promise.resolve();
+    });
+  });
+
+  it("does not grant warm carryover authority to an unpublished preparation", async () => {
+    const receipt = await store.prepare({
+      attachments: { diffs: [], loadedSkills: [], readFiles: ["/unpublished.ts"] },
+      boundaryMessageId: "unpublished",
+      publication: { generation: undefined },
+      isCurrent: () => true,
+    });
+    assert(receipt);
+    expect(await store.isCurrent(receipt, "pending", () => true)).toBe(false);
+    expect(await store.isCurrent(receipt, "carryover", () => true)).toBe(false);
+    expect(await historyIds()).toEqual(["seed"]);
+  });
+
+  it("cannot restore pending state when the real history cleanup fails before commit", async () => {
+    await publish("A");
+    const { summary } = await publish("B", true);
+    const before = await bytes();
+    const write = atomicWrite.default;
+    spyOn(atomicWrite, "default").mockImplementation(
+      new Proxy(write, {
+        async apply(target, _thisArg, args: Parameters<typeof write>) {
+          if (String(args[0]).includes(".follow-up-")) throw new Error("Disk full");
+          return target(...args);
+        },
+      })
+    );
+    let committed = false;
+    let restored = false;
+    const result = await rollback(summary, restart(), {
+      onCommitted: () => {
+        committed = true;
+      },
+      onRestored: () => {
+        restored = true;
+      },
+    });
+    expect(result.success).toBe(false);
+    expect(committed).toBe(false);
+    expect(restored).toBe(false);
+    expect(await bytes()).toBe(before);
+    expect(await historyIds()).toEqual(["B"]);
+  });
+
+  it("restores exact predecessor bytes after restart only through witnessed heartbeat cleanup", async () => {
+    assert((await publish("A")).result.success);
+    const previous = await bytes();
+    const { summary } = await publish("B", true);
+    const restarted = restart();
+    const receipt = await restarted.load(() => true);
+    assert(receipt);
+    const current = await bytes();
+    expect(await restarted.rollback(receipt, () => true)).toBe(false);
+    expect(await bytes()).toBe(current);
+    let committed = false;
+    let restored: CompactionPendingReceipt | undefined;
+    const result = await rollback(summary, restarted, {
+      onCommitted: () => {
+        committed = true;
+      },
+      onRestored: (receipt) => {
+        expect(committed).toBe(true);
+        restored = receipt;
+      },
+    });
+    assert(result.success);
+    expect(result.data).toEqual({ outcome: "applied", restored });
+    expect(restored?.attachments.readFiles).toEqual(["/A.ts"]);
+    expect(await bytes()).toBe(previous);
+    expect(await historyIds()).toEqual(["A"]);
+    expect((await restart().load(() => true))?.attachments.readFiles).toEqual(["/A.ts"]);
+  });
+
+  it.each(["follow-up", "sequence", "admission"] as const)(
+    "skipped %s cleanup cannot restore or consume bytes",
+    async (reason) => {
+      await publish("A");
+      const { summary } = await publish("B", true);
+      const before = await bytes();
+      const wrong = structuredClone(summary);
+      assert(wrong.metadata);
+      if (reason === "sequence") wrong.metadata.historySequence = 900;
+      if (reason === "follow-up")
+        wrong.metadata.muxMetadata = {
+          type: "compaction-summary",
+          pendingFollowUp: { text: "Changed", model: "openai:gpt-4o", agentId: "exec" },
+        };
+      const result = await rollback(wrong, restart(), {
+        isCurrent: () => reason !== "admission",
+        onCommitted: () => {
+          throw new Error("Skipped cleanup cannot commit");
+        },
+        onRestored: () => {
+          throw new Error("Skipped cleanup cannot restore");
+        },
+      });
+      expect(result).toEqual({ success: true, data: { outcome: "skipped" } });
+      expect(await bytes()).toBe(before);
+      expect(await historyIds()).toEqual(["B"]);
+    }
+  );
+
+  it.each(["generation", "boundary", "consumed", "local retirement"] as const)(
+    "refuses predecessor restoration with invalid %s proof",
+    async (reason) => {
+      const a = await publish("A");
+      assert(a.result.success && a.result.data);
+      const { summary } = await publish("B", true);
+      if (reason === "consumed") {
+        expect(await store.consume(a.result.data)).toBe(true);
+      } else if (reason !== "local retirement") {
+        const state = JSON.parse(await bytes()) as Record<string, unknown>;
+        if (reason === "generation") delete state.previousStateGeneration;
+        else state.previousStateBoundary = { kind: "identified", messageId: "unrelated" };
+        await fs.writeFile(pendingPath, JSON.stringify(state));
+      }
+      const result = await rollback(summary, restart(), {
+        canRestorePrevious: () => reason !== "local retirement",
+      });
+      expect(result).toEqual({ success: true, data: { outcome: "applied", restored: undefined } });
+      expect(await historyIds()).toEqual(["A"]);
+      expect(await restart().load(() => true)).toBeUndefined();
+      expect(await fs.stat(pendingPath).catch((error: unknown) => error)).toMatchObject({
+        code: "ENOENT",
+      });
+    }
+  );
+
+  it.each(["failed successor", "committed successor", "reset", "late error"] as const)(
+    "records exact cleanup before a delayed return and preserves %s",
+    async (scenario) => {
+      await publish("A");
+      const { summary } = await publish("B", true);
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const cleanup = h.historyService.cleanupCompactionFollowUp.bind(h.historyService);
+      spyOn(h.historyService, "cleanupCompactionFollowUp").mockImplementationOnce(
+        async (...args) => {
+          const result = await cleanup(...args);
+          entered.resolve();
+          await release.promise;
+          if (scenario === "late error") throw new Error("Lock disposal failed after commit");
+          return result;
+        }
+      );
+      let committed = false;
+      const operation = rollback(summary, store, {
+        onCommitted: () => {
+          committed = true;
+        },
+      });
+      try {
+        await entered.promise;
+        expect(committed).toBe(true);
+        expect(await historyIds()).toEqual(["A"]);
+        let successor: string | undefined;
+        if (scenario === "failed successor" || scenario === "committed successor") {
+          const accepted = scenario === "committed successor";
+          const c = await publish("C", false, restart(), accepted);
+          expect(c.result.success).toBe(accepted);
+          successor = await bytes();
+        }
+        if (scenario === "reset")
+          assert((await new HistoryService(h.config).clearHistory(workspaceId)).success);
+        release.resolve();
+        const result = await operation;
+        assert(result.success);
+        expect(result.data.outcome).toBe("applied");
+        if (successor) expect(await bytes()).toBe(successor);
+        expect((await restart().load(() => true))?.attachments.readFiles).toEqual(
+          scenario === "reset"
+            ? undefined
+            : [scenario === "committed successor" ? "/C.ts" : "/A.ts"]
+        );
+      } finally {
+        release.resolve();
+        await operation;
+      }
+    }
+  );
+
+  it("keeps acknowledged carryover eligible until a foreign reset, while pending authority ends", async () => {
+    const a = await publish("A");
+    assert(a.result.success && a.result.data);
+    const receipt = a.result.data;
+    expect(await store.isCurrent(receipt, "pending", () => true)).toBe(true);
+    expect(await store.consume(receipt)).toBe(true);
+    expect(await store.isCurrent(receipt, "pending", () => true)).toBe(false);
+    expect(await store.isCurrent(receipt, "carryover", () => true)).toBe(true);
+    expect(await store.isCurrent(receipt, "carryover", () => false)).toBe(false);
+    expect(await restart().isCurrent(receipt, "carryover", () => true)).toBe(false);
+    const b = await publish("B", false, restart());
+    assert(b.result.success);
+    const successor = await bytes();
+    expect(await store.consume(receipt)).toBe(false);
+    expect(await bytes()).toBe(successor);
+    expect(await store.isCurrent(receipt, "carryover", () => true)).toBe(true);
+    assert((await new HistoryService(h.config).clearHistory(workspaceId)).success);
+    expect(await store.isCurrent(receipt, "carryover", () => true)).toBe(false);
+  });
+
+  it.each(["future", "legacy", "malformed"] as const)(
+    "reset preserves %s bytes without trusting them as enrichment",
+    async (kind) => {
+      const raw =
+        kind === "future"
+          ? '{"version":9,"opaque":{"keep":true}}\n'
+          : kind === "legacy"
+            ? '{"version":1,"createdAt":1,"readFiles":["/old.ts"]}\n'
+            : "{malformed";
+      await fs.writeFile(pendingPath, raw);
+      assert((await new HistoryService(h.config).clearHistory(workspaceId)).success);
+      await store.discardAfterBoundary();
+      expect(await bytes()).toBe(raw);
+      expect(await restart().load(() => true)).toBeUndefined();
+      if (kind !== "malformed") expect(await bytes()).toBe(raw);
+    }
+  );
+
+  it("preserves future bytes through mandatory heartbeat cleanup without optional restoration", async () => {
+    await publish("A");
+    const { summary } = await publish("B", true);
+    const future = '{"version":9,"payload":"future owner"}\n';
+    await fs.writeFile(pendingPath, future);
+    const result = await rollback(summary, restart());
+    expect(result).toEqual({ success: true, data: { outcome: "applied", restored: undefined } });
+    expect(await historyIds()).toEqual(["A"]);
+    expect(await bytes()).toBe(future);
+  });
+
+  it("uses an immutable summary capture while its initial pending read is delayed", async () => {
+    await publish("A");
+    const { summary } = await publish("B", true);
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const read = fs.readFile;
+    let paused = false;
+    spyOn(fs, "readFile").mockImplementation((async (...args: Parameters<typeof fs.readFile>) => {
+      const contents = await read(...args);
+      if (args[0] === pendingPath && !paused) {
+        paused = true;
+        entered.resolve();
+        await release.promise;
+      }
+      return contents;
+    }) as typeof fs.readFile);
+    const operation = rollback(summary, restart());
+    try {
+      await entered.promise;
+      assert(summary.metadata);
+      summary.id = "replacement";
+      summary.metadata.historySequence = 999;
+      release.resolve();
+      expect((await operation).success).toBe(true);
+      expect(await historyIds()).toEqual(["A"]);
+    } finally {
+      release.resolve();
+      await operation;
+    }
+  });
+
+  it.each(["consume", "load", "discard", "restore"] as const)(
+    "lost physical authority during %s cannot affect successor bytes",
+    async (operation) => {
+      const a = await publish("A");
+      assert(a.result.success && a.result.data);
+      const heartbeat = operation === "restore" ? await publish("B", true) : undefined;
+      if (operation === "discard")
+        await h.historyService.getContinuousCompactionJournal(workspaceId).advanceGeneration();
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const read = fs.readFile;
+      let reads = 0;
+      spyOn(fs, "readFile").mockImplementation((async (...args: Parameters<typeof fs.readFile>) => {
+        const contents = await read(...args);
+        if (args[0] === pendingPath && ++reads === (operation === "restore" ? 2 : 1)) {
+          entered.resolve();
+          await release.promise;
+        }
+        return contents;
+      }) as typeof fs.readFile);
+      const task = (
+        heartbeat
+          ? rollback(heartbeat.summary)
+          : operation === "consume"
+            ? store.consume(a.result.data)
+            : operation === "load"
+              ? store.load(() => true)
+              : store.discardAfterBoundary()
+      ).catch((error: unknown) => error);
+      try {
+        await entered.promise;
+        const lockPath = historyWriteLockPath(h.config.rootDir, workspaceId);
+        const token = await fs.readFile(lockPath, "utf8");
+        await fs.writeFile(lockPath, token.split(":").slice(0, 2).join(":"));
+        await fs.utimes(lockPath, new Date(0), new Date(0));
+        await using successor = await acquireProcessFileLock({
+          lockPath,
+          timeoutMs: 1000,
+          label: "consumer successor",
+        });
+        const future = '{"version":9,"owner":"successor"}\n';
+        await fs.writeFile(pendingPath, future);
+        release.resolve();
+        const result = await task;
+        if (operation === "restore")
+          expect(result).toEqual({
+            success: true,
+            data: { outcome: "applied", restored: undefined },
+          });
+        else expect(result).toBeInstanceOf(Error);
+        expect(await bytes()).toBe(future);
+        await successor.assertStillOwned();
+      } finally {
+        release.resolve();
+        await task;
+      }
+    }
+  );
+});

--- a/src/node/services/compactionPendingState.destructiveCleanup.test.ts
+++ b/src/node/services/compactionPendingState.destructiveCleanup.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { createMuxMessage } from "@/common/types/message";
+import { acquireProcessFileLock } from "@/node/utils/concurrency/fileLock";
+import { CompactionPendingState } from "./compactionPendingState";
+import { HistoryService } from "./historyService";
+import { createTestHistoryService } from "./testHistoryService";
+import { historyWriteLockPath } from "./workspaceRemoval";
+
+describe("destructive compaction cleanup compatibility", () => {
+  const workspaceId = "destructive-legacy";
+  let h: Awaited<ReturnType<typeof createTestHistoryService>>;
+  let pendingPath: string;
+  let pending: CompactionPendingState;
+  const legacy = {
+    version: 1,
+    createdAt: 1,
+    diffs: [{ path: "/before.ts", diff: "+before", truncated: false }],
+    loadedSkills: [{ name: "before", scope: "project", body: "Previous instructions" }],
+    readFiles: ["/before.ts"],
+  };
+
+  beforeEach(async () => {
+    h = await createTestHistoryService();
+    assert(
+      (
+        await h.historyService.appendToHistory(
+          workspaceId,
+          createMuxMessage("before", "user", "Previous context")
+        )
+      ).success
+    );
+    pendingPath = path.join(h.config.sessionsDir, workspaceId, "post-compaction.json");
+    pending = new CompactionPendingState(
+      pendingPath,
+      h.historyService.getCompactionPendingHistory(workspaceId)
+    );
+  });
+
+  afterEach(async () => {
+    mock.restore();
+    await h.cleanup();
+  });
+
+  async function destroy() {
+    assert((await h.historyService.clearHistory(workspaceId)).success);
+  }
+
+  function foreignStore() {
+    return new CompactionPendingState(
+      pendingPath,
+      new HistoryService(h.config).getCompactionPendingHistory(workspaceId)
+    );
+  }
+
+  function successorBoundary() {
+    return createMuxMessage("after", "assistant", "New context", {
+      compacted: "user",
+      compactionBoundary: true,
+      compactionEpoch: 1,
+    });
+  }
+
+  async function publishSuccessor() {
+    return foreignStore().publishBoundary({
+      summaryMessage: successorBoundary(),
+      tailCopies: [],
+      updateExisting: false,
+      attachments: { diffs: [], loadedSkills: [], readFiles: ["/after.ts"] },
+      publication: {
+        generation: await h.historyService
+          .getContinuousCompactionJournal(workspaceId)
+          .captureGeneration(),
+      },
+      isCurrent: () => true,
+      shouldPersist: () => true,
+      onCommitted: () => undefined,
+    });
+  }
+
+  it.each([false, true])(
+    "explicit destruction removes legacy V1 bytes that a downgrade could reload (tagged=%s)",
+    async (tagged) => {
+      await fs.writeFile(
+        pendingPath,
+        JSON.stringify({ ...legacy, ...(tagged && { boundaryMessageId: "before" }) })
+      );
+      await destroy();
+      await pending.discardAfterBoundary();
+      expect(await fs.stat(pendingPath).catch((error: unknown) => error)).toMatchObject({
+        code: "ENOENT",
+      });
+    }
+  );
+
+  it("ordinary ambiguous loading preserves legacy bytes after a fence", async () => {
+    const raw = JSON.stringify(legacy);
+    await fs.writeFile(pendingPath, raw);
+    await destroy();
+    expect(await pending.load(() => true)).toBeUndefined();
+    expect(await foreignStore().load(() => true)).toBeUndefined();
+    expect(await fs.readFile(pendingPath, "utf8")).toBe(raw);
+  });
+
+  it("does not delete legacy bytes without a durable generation fence", async () => {
+    const raw = JSON.stringify(legacy);
+    await fs.writeFile(pendingPath, raw);
+    await pending.discardAfterBoundary();
+    expect(await fs.readFile(pendingPath, "utf8")).toBe(raw);
+  });
+
+  it.each([
+    { ...legacy, version: 9 },
+    { schema: "future", payload: legacy },
+  ])("explicit destruction preserves unknown schema bytes (%j)", async (future) => {
+    const raw = JSON.stringify(future);
+    await fs.writeFile(pendingPath, raw);
+    await destroy();
+    await pending.discardAfterBoundary();
+    expect(await fs.readFile(pendingPath, "utf8")).toBe(raw);
+  });
+
+  it.each([false, true])(
+    "late cleanup preserves a newer publication (additional generation=%s)",
+    async (additionalGeneration) => {
+      await fs.writeFile(pendingPath, JSON.stringify(legacy));
+      await destroy();
+      if (additionalGeneration)
+        await h.historyService.getContinuousCompactionJournal(workspaceId).advanceGeneration();
+      assert((await publishSuccessor()).success);
+      const raw = await fs.readFile(pendingPath, "utf8");
+      await pending.discardAfterBoundary();
+      expect(await fs.readFile(pendingPath, "utf8")).toBe(raw);
+      expect((await foreignStore().load(() => true))?.attachments.readFiles).toEqual(["/after.ts"]);
+    }
+  );
+
+  it.each(["queued", "reclaimed lease"] as const)(
+    "a successor survives cleanup with %s ownership",
+    async (scenario) => {
+      await fs.writeFile(pendingPath, JSON.stringify(legacy));
+      await destroy();
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const readFile = fs.readFile;
+      const held = spyOn(fs, "readFile").mockImplementation((async (
+        ...args: Parameters<typeof fs.readFile>
+      ) => {
+        const result = await readFile(...args);
+        if (args[0] === pendingPath) {
+          entered.resolve();
+          await release.promise;
+        }
+        return result;
+      }) as typeof fs.readFile);
+      const cleaning = pending.discardAfterBoundary().catch((error: unknown) => error);
+      let queued: ReturnType<typeof publishSuccessor> | undefined;
+      let lease: Awaited<ReturnType<typeof acquireProcessFileLock>> | undefined;
+      try {
+        await entered.promise;
+        held.mockRestore();
+        if (scenario === "queued") queued = publishSuccessor();
+        else {
+          const lockPath = historyWriteLockPath(h.config.rootDir, workspaceId);
+          const token = await fs.readFile(lockPath, "utf8");
+          await fs.writeFile(lockPath, token.split(":").slice(0, 2).join(":"));
+          await fs.utimes(lockPath, new Date(0), new Date(0));
+          lease = await acquireProcessFileLock({ lockPath, timeoutMs: 1000, label: "successor" });
+          const generation = await h.historyService
+            .getContinuousCompactionJournal(workspaceId)
+            .captureGenerationUnderHistoryLock();
+          // Simulate a foreign process writing only after it owns the reclaimed physical lease.
+          await fs.writeFile(
+            path.join(path.dirname(pendingPath), "chat.jsonl"),
+            JSON.stringify(successorBoundary()) + "\n"
+          );
+          await fs.writeFile(
+            pendingPath,
+            JSON.stringify({
+              ...legacy,
+              boundaryMessageId: "after",
+              writeId: "successor",
+              publicationGeneration: generation,
+              readFiles: ["/after.ts"],
+            })
+          );
+        }
+        release.resolve();
+        if (scenario === "reclaimed lease") expect(await cleaning).toBeInstanceOf(Error);
+        else expect(await cleaning).toBeUndefined();
+        await lease?.[Symbol.asyncDispose]();
+        lease = undefined;
+        if (queued) assert((await queued).success);
+        expect((await foreignStore().load(() => true))?.attachments.readFiles).toEqual([
+          "/after.ts",
+        ]);
+      } finally {
+        release.resolve();
+        await cleaning;
+        await lease?.[Symbol.asyncDispose]();
+        await queued;
+      }
+    }
+  );
+
+  it("reports legacy unlink failure and can retry the same fenced cleanup", async () => {
+    const raw = JSON.stringify(legacy);
+    await fs.writeFile(pendingPath, raw);
+    await destroy();
+    const unlink = fs.unlink;
+    const failure = spyOn(fs, "unlink").mockImplementation((file) => {
+      if (file === pendingPath)
+        return Promise.reject(Object.assign(new Error("Permission denied"), { code: "EACCES" }));
+      return unlink(file);
+    });
+    expect(await pending.discardAfterBoundary().catch((error: unknown) => error)).toMatchObject({
+      code: "EACCES",
+    });
+    failure.mockRestore();
+    expect(await fs.readFile(pendingPath, "utf8")).toBe(raw);
+    await pending.discardAfterBoundary();
+    expect(await fs.stat(pendingPath).catch((error: unknown) => error)).toMatchObject({
+      code: "ENOENT",
+    });
+  });
+});

--- a/src/node/services/compactionPendingState.publication.test.ts
+++ b/src/node/services/compactionPendingState.publication.test.ts
@@ -99,6 +99,7 @@ describe("inactive atomic pending/history publication", () => {
     });
     const foreign = new HistoryService(h.config).getCompactionPendingHistory(workspaceId);
     const second = new CompactionPendingState(pendingPath, {
+      ...foreign,
       withLock: (operation) => {
         attempted.resolve();
         return foreign.withLock(operation);

--- a/src/node/services/compactionPendingState.test.ts
+++ b/src/node/services/compactionPendingState.test.ts
@@ -688,7 +688,8 @@ describe("unactivated compaction pending-file protocol", () => {
         changed ? undefined : ["/legacy.ts"]
       );
       if (operation === "discard" && changed)
-        expect(JSON.parse(await bytes())).toMatchObject({ version: 1, boundaryMessageId: "a" });
+        expect(await bytes().catch((error: unknown) => error)).toMatchObject({ code: "ENOENT" });
+      else expect(JSON.parse(await bytes())).toMatchObject({ version: 1, boundaryMessageId: "a" });
     }
   );
 

--- a/src/node/services/compactionPendingState.test.ts
+++ b/src/node/services/compactionPendingState.test.ts
@@ -26,6 +26,7 @@ describe("unactivated compaction pending-file protocol", () => {
   function historyAdapter(history = h.historyService): CompactionPendingHistory {
     const adapter = history.getCompactionPendingHistory(workspaceId);
     return {
+      ...adapter,
       withLock: (operation) =>
         adapter.withLock((view) =>
           operation({ ...view, boundary: boundaryOverride ?? view.boundary })
@@ -687,7 +688,7 @@ describe("unactivated compaction pending-file protocol", () => {
         changed ? undefined : ["/legacy.ts"]
       );
       if (operation === "discard" && changed)
-        expect(await bytes().catch((error: unknown) => error)).toMatchObject({ code: "ENOENT" });
+        expect(JSON.parse(await bytes())).toMatchObject({ version: 1, boundaryMessageId: "a" });
     }
   );
 

--- a/src/node/services/compactionPendingState.ts
+++ b/src/node/services/compactionPendingState.ts
@@ -78,6 +78,12 @@ interface PendingPreparation {
 }
 
 export interface CompactionPendingHistory {
+  /** Owns its history locks; invoke outside withLock, then revalidate any pending receipt. */
+  cleanupHeartbeat(
+    summary: MuxMessage,
+    isCurrent: () => boolean,
+    onCommitted: () => undefined
+  ): Promise<Result<"applied" | "skipped">>;
   /**
    * Hold BOTH existing history locks throughout the callback, reject removed workspaces,
    * and provide a stable view without reacquiring history/journal queues inside the lock.
@@ -278,7 +284,9 @@ export class CompactionPendingState {
     {
       identity: string;
       generation: string | undefined;
+      boundaryMessageId?: string;
       prepared: boolean;
+      published: boolean;
       startingBoundary?: CompactionPendingBoundary;
     }
   >();
@@ -323,7 +331,9 @@ export class CompactionPendingState {
     this.receipts.set(receipt, {
       identity: identity(state),
       generation,
+      boundaryMessageId: state.boundaryMessageId,
       prepared,
+      published: !prepared,
       startingBoundary,
     });
     return receipt;
@@ -332,14 +342,18 @@ export class CompactionPendingState {
   load(isCurrent: () => boolean): Promise<CompactionPendingReceipt | undefined> {
     return this.enqueue(async (view) => {
       // Optional enrichment must not brick recovery when its sidecar is unreadable.
-      const raw = await this.readBytes().catch(() => undefined);
+      const raw = await this.readBytes(view.assertStillOwned).catch(() => undefined);
       if (!isCurrent()) return;
       const parsed = parseJson(raw);
       // A downgraded reader must leave newer schemas intact for the version that owns them.
       if (parsed !== undefined && record(parsed)?.version !== 1) return;
       const persisted = parseState(parsed);
       const state = eligibleState(persisted, view);
-      if (state) return this.receipt(state, view.generation);
+      if (state) {
+        await view.assertStillOwned();
+        if (isCurrent()) return this.receipt(state, view.generation);
+        return;
+      }
       // A live writer may still be between pending-file publication and boundary commit.
       // Missing boundary proof suppresses injection; it does not authorize deleting its file.
       // Preserve ambiguous legacy bytes too; fresh compaction must establish usable ownership.
@@ -350,7 +364,8 @@ export class CompactionPendingState {
             persisted.publicationGeneration !== (view.generation ?? null)))
       ) {
         // Attachments are already suppressed; inability to prune them must not block a request.
-        await fs.unlink(this.filePath).catch(() => undefined);
+        await view.assertStillOwned();
+        if (isCurrent()) await fs.unlink(this.filePath).catch(() => undefined);
       }
     });
   }
@@ -463,6 +478,8 @@ export class CompactionPendingState {
             () => {
               // The rename is the commit: observer/lock-disposal failures cannot undo it.
               committed = true;
+              const owner = receipt && this.receipts.get(receipt);
+              if (owner) owner.published = true;
               onCommitted(receipt);
             }
           );
@@ -485,19 +502,99 @@ export class CompactionPendingState {
   consume(receipt: CompactionPendingReceipt): Promise<boolean> {
     const expected = this.receipts.get(receipt);
     if (!expected) return Promise.resolve(false);
-    return this.enqueue(async () => {
-      const state = parseState(parseJson(await this.readBytes()));
+    return this.enqueue(async (view) => {
+      const state = parseState(parseJson(await this.readBytes(view.assertStillOwned)));
       if (!state) return false;
       if (identity(state) === expected.identity) {
+        await view.assertStillOwned();
         await fs.unlink(this.filePath);
         return true;
       }
       if (!state.previousState || identity(state.previousState) !== expected.identity) return false;
       // A may be consumed while B is provisional. Remove only A's fallback, durably, so
       // B's later rollback/restart cannot resurrect it. B retains its immutable write identity.
-      await publishCompactionFile(this.filePath, JSON.stringify(head(state)), () => true);
+      await publishCompactionFile(
+        this.filePath,
+        JSON.stringify(head(state)),
+        () => true,
+        undefined,
+        view.assertStillOwned
+      );
       return true;
     });
+  }
+
+  /** Acknowledgement removes the file, but warm skills/paths still require current provenance. */
+  isCurrent(
+    receipt: CompactionPendingReceipt,
+    scope: "pending" | "carryover",
+    isCurrent: () => boolean
+  ): Promise<boolean> {
+    const expected = this.receipts.get(receipt);
+    if (!expected) return Promise.resolve(false);
+    return this.enqueue(async (view) => {
+      if (expected.generation !== view.generation || view.boundary.kind === "unreadable-reset")
+        return false;
+      // A provisional file is not evidence that its attachments ever belonged to history.
+      if (scope === "carryover" && !expected.published) return false;
+      if (scope === "pending") {
+        const state = eligibleState(
+          parseState(parseJson(await this.readBytes(view.assertStillOwned))),
+          view
+        );
+        if (!state || identity(state) !== expected.identity) return false;
+      }
+      await view.assertStillOwned();
+      if (!isCurrent()) return false;
+      expected.published = true;
+      return true;
+    });
+  }
+
+  /**
+   * Restart receipts cannot authorize ordinary rollback. Only this composition witnesses
+   * exact heartbeat removal, then rechecks the captured file and persisted predecessor proof.
+   * Never hold the pending/history lock while calling the separately queued history cleanup.
+   */
+  async rollbackHeartbeat(input: {
+    summaryMessage: MuxMessage;
+    isCurrent: () => boolean;
+    canRestorePrevious: () => boolean;
+    onCommitted: () => undefined;
+    onRestored: (receipt: CompactionPendingReceipt) => undefined;
+  }): Promise<Result<{ outcome: "applied" | "skipped"; restored?: CompactionPendingReceipt }>> {
+    const summary = structuredClone(input.summaryMessage);
+    const { isCurrent, canRestorePrevious, onCommitted, onRestored } = input;
+    let committed = false;
+    let restored: CompactionPendingReceipt | undefined;
+    // Enrichment read failures must not prevent mandatory exact history cleanup.
+    const receipt = await this.load(isCurrent).catch(() => undefined);
+    try {
+      const result = await this.history.cleanupHeartbeat(summary, isCurrent, () => {
+        committed = true;
+        onCommitted();
+      });
+      if (!committed) return result.success ? Ok({ outcome: "skipped" }) : result;
+    } catch (error) {
+      if (!committed) return Err(`Failed to roll back heartbeat: ${getErrorMessage(error)}`);
+      log.warn("Heartbeat cleanup failed after history commit", error);
+    }
+    try {
+      if (receipt && this.receipts.get(receipt)?.boundaryMessageId === summary.id)
+        await this.enqueue((view) =>
+          this.rollbackUnderLock(view, receipt, canRestorePrevious, {
+            boundaryMessageId: summary.id,
+            onRestored: (previous) => {
+              restored = previous;
+              onRestored(previous);
+            },
+          })
+        );
+    } catch (error) {
+      // Cleanup is already committed. Optional restoration cannot turn it into a retry.
+      log.warn("Pending heartbeat restoration unavailable", error);
+    }
+    return Ok({ outcome: "applied", restored });
   }
 
   rollback(receipt: CompactionPendingReceipt, canRestorePrevious: () => boolean): Promise<boolean> {
@@ -508,12 +605,17 @@ export class CompactionPendingState {
   private async rollbackUnderLock(
     view: CompactionPendingHistoryView,
     receipt: CompactionPendingReceipt,
-    canRestorePrevious: () => boolean
+    canRestorePrevious: () => boolean,
+    cleanup?: {
+      boundaryMessageId: string;
+      onRestored: (receipt: CompactionPendingReceipt) => undefined;
+    }
   ): Promise<boolean> {
     const expected = this.receipts.get(receipt);
-    if (!expected?.prepared) return false;
+    if (!expected || (!expected.prepared && !cleanup)) return false;
     const state = parseState(parseJson(await this.readBytes(view.assertStillOwned)));
     if (!state || identity(state) !== expected.identity) return false;
+    if (cleanup && state.boundaryMessageId !== cleanup.boundaryMessageId) return false;
     if (isCurrentState(state, view)) return false;
     // Restoring a committed heartbeat also needs the caller's exact history rollback proof.
     // A generation change permits exact cleanup, never restoration of the prior context.
@@ -523,7 +625,10 @@ export class CompactionPendingState {
     if (
       previous &&
       expected.generation === view.generation &&
-      sameBoundary(expected.startingBoundary, view.boundary) &&
+      sameBoundary(
+        cleanup ? state.previousStateBoundary : expected.startingBoundary,
+        view.boundary
+      ) &&
       canRestorePrevious()
     ) {
       if (
@@ -531,7 +636,9 @@ export class CompactionPendingState {
           this.filePath,
           JSON.stringify(head(previous)),
           canRestorePrevious,
-          undefined,
+          () => {
+            cleanup?.onRestored(this.receipt(previous, view.generation));
+          },
           view.assertStillOwned
         )
       )
@@ -545,17 +652,14 @@ export class CompactionPendingState {
   /** Call only after the destructive boundary/generation change committed under the history lock. */
   discardAfterBoundary(): Promise<void> {
     return this.enqueue(async (view) => {
-      const raw = await this.readBytes();
+      const raw = await this.readBytes(view.assertStillOwned);
       if (raw === undefined) return;
       const state = parseState(parseJson(raw));
-      if (
-        state &&
-        (isCurrentState(state, view) ||
-          (state.boundaryMessageId !== undefined &&
-            state.publicationGeneration !== undefined &&
-            state.publicationGeneration === (view.generation ?? null)))
-      )
-        return;
+      // A reset may retire proven old V1 state, never bytes owned by a future reader or
+      // ambiguous legacy state. Their absence from enrichment is enough to honor the reset.
+      if (state?.publicationGeneration === undefined) return;
+      if (state.publicationGeneration === (view.generation ?? null)) return;
+      await view.assertStillOwned();
       await fs.unlink(this.filePath);
     });
   }

--- a/src/node/services/compactionPendingState.ts
+++ b/src/node/services/compactionPendingState.ts
@@ -535,13 +535,21 @@ export class CompactionPendingState {
     return this.enqueue(async (view) => {
       if (expected.generation !== view.generation || view.boundary.kind === "unreadable-reset")
         return false;
-      // A provisional file is not evidence that its attachments ever belonged to history.
-      if (scope === "carryover" && !expected.published) return false;
-      if (scope === "pending") {
-        const state = eligibleState(
-          parseState(parseJson(await this.readBytes(view.assertStillOwned))),
-          view
-        );
+      // An acknowledged file may be absent, but its boundary must still be current.
+      // A foreign compaction can replace that boundary without advancing the reset generation.
+      if (
+        scope === "carryover" &&
+        (!expected.published ||
+          (view.boundary.kind === "identified"
+            ? view.boundary.messageId !== expected.boundaryMessageId
+            : expected.boundaryMessageId !== undefined))
+      )
+        return false;
+      const raw = await this.readBytes(view.assertStillOwned);
+      // Existing bytes must prove this exact owner, including replacement writes at the same
+      // boundary. Future formats stay untouched and cannot authorize cached enrichment.
+      if (scope === "pending" || raw !== undefined) {
+        const state = eligibleState(parseState(parseJson(raw)), view);
         if (!state || identity(state) !== expected.identity) return false;
       }
       await view.assertStillOwned();

--- a/src/node/services/compactionPendingState.ts
+++ b/src/node/services/compactionPendingState.ts
@@ -663,9 +663,11 @@ export class CompactionPendingState {
       const raw = await this.readBytes(view.assertStillOwned);
       if (raw === undefined) return;
       const state = parseState(parseJson(raw));
-      // A reset may retire proven old V1 state, never bytes owned by a future reader or
-      // ambiguous legacy state. Their absence from enrichment is enough to honor the reset.
-      if (state?.publicationGeneration === undefined) return;
+      // Explicit destruction must remove compatible legacy V1 too: older readers do not
+      // honor the generation fence and would re-inject its attachments after a downgrade.
+      // Ordinary ambiguous loads still preserve it; unknown schemas remain untouched here.
+      if (!state || (state.publicationGeneration === undefined && view.generation === undefined))
+        return;
       if (state.publicationGeneration === (view.generation ?? null)) return;
       await view.assertStillOwned();
       await fs.unlink(this.filePath);

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -455,6 +455,14 @@ export class HistoryService {
   /** Inactive G1 adapter: pending-file I/O must finish before either history lock is released. */
   getCompactionPendingHistory(workspaceId: string): CompactionPendingHistory {
     return {
+      cleanupHeartbeat: (summary, isCurrent, onCommitted) =>
+        this.cleanupCompactionFollowUp(
+          workspaceId,
+          summary,
+          "rollback-heartbeat",
+          isCurrent,
+          onCommitted
+        ),
       withLock: (operation) =>
         this.fileLocks.withLock(workspaceId, () =>
           this.withCrossProcessWriteLock(workspaceId, async (assertStillOwned) => {


### PR DESCRIPTION
Adds inactive consumer contracts for pending compaction attachments. Captured receipts are qualified against current history before request injection or warm carryover, and a restarted store can restore a predecessor only after witnessing the exact heartbeat rollback commit.

The store checks receipt identity, publication generation, and physical history ownership under the existing transaction boundary. Acknowledged attachments remain warm only at their captured boundary; any existing sidecar must prove the exact write owner. Foreign same-generation compactions, history-only successors, and unsupported replacement formats cannot authorize stale enrichment.

Ordinary loading preserves ambiguous legacy files while suppressing unproven attachments. Explicit destructive cleanup also removes recognized legacy V1 after a durable generation fence: preceding versions do not understand that fence and would otherwise reload pre-reset attachments after a downgrade. Unknown future schemas and publications matching the current generation remain intact. Runtime consumers remain unchanged in this layer.

Validation of the combined five-layer replay: 2,321 tests and 18,866 assertions pass across 40 files on runtime `013d22c6d68c50be1370e1c4df6b1ccbe776f304` over lifecycle `29b43c63f53040d43feecf38a36f2ff14b53aa41`, based on pinned main `a0a2dab98da8efe7e659fb0cb8b9897f376d9641`. The final runtime candidate `b0abd1481d5dbfb025c484fbf5efc7fdaef73689` adds only a mechanical Error-type-guard correction to a diagnostic assertion; its 12 affected rollover controls and targeted ESLint pass, with production unchanged. This covers pending/history ownership, publication, rollback, partial recovery, all runtime compaction paths, token-budget and model-requested `new_context` rollover, `session_history`, and append provenance. Tests use real local storage with outbound provider traffic blocked. These are combined-phase results, not a separate test run at each intermediate layer. Canonical `make static-check` passes on the final runtime candidate; Nix formatting skips because Nix is unavailable. Final coordinated PR readiness remains pending.

Risk: low immediate runtime risk because activation is deferred. The substantive contract risk is stale attachment reuse or deletion across compaction/reset races; tests use real history and pending files with deterministic transaction barriers.

Integration: candidate `50db6ad4d5043c8e0f3245e097c383189ebf5bbe` replays this PR's complete owning interval onto `94de3b46d58149075b845ab995a88d471c9b7296` without conflicts or manual resolutions. Range-diff is unchanged, and source authors and complete commit messages are preserved. Main's strict partial-read option and newer history behavior remain in the prepared chain. Runtime activation remains owned by #4190.

---

_Generated with `xum` • Model: `unavailable` • Thinking: `unavailable` • Cost: `$unavailable`_

<!-- mux-attribution: model=unavailable thinking=unavailable costs=unavailable -->
