### PR TITLE
🤖 refactor: isolate local compaction preparation lifecycle

### DIFF
--- a/src/common/orpc/schemas/message.ts
+++ b/src/common/orpc/schemas/message.ts
@@ -196,6 +196,7 @@ export const MuxMessageSchema = z.object({
       compactionEpoch: CompactionEpochSchema,
       // Durable boundary marker for compaction summaries.
       compactionBoundary: z.boolean().optional(),
+      compactionPublicationId: z.string().min(1).optional().catch(undefined),
       contextBoundaryKind: z.literal(CONTEXT_BOUNDARY_KINDS.RESET).optional(),
       toolPolicy: z.any().optional(),
       disableWorkspaceAgents: z.boolean().optional(),

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -1046,6 +1046,8 @@ export interface MuxMetadata {
    * This lets downstream logic identify compaction boundaries without mutating history.
    */
   compactionBoundary?: boolean;
+  /** Exact composed publication occurrence, shared with the pending file writeId. */
+  compactionPublicationId?: string;
   /** Durable provider-context boundary kind. Existing compaction rows are also boundaries via compactionBoundary. */
   contextBoundaryKind?: PersistedContextBoundaryKind;
   toolPolicy?: ToolPolicy; // Tool policy active when this message was sent (user messages only)

--- a/src/node/services/agentPlugins/installService.test.ts
+++ b/src/node/services/agentPlugins/installService.test.ts
@@ -1696,6 +1696,8 @@ describe("AgentPluginInstallService", () => {
           { dir, maxBytes: 1024, maxFiles: 10_000, pollMs: 10 },
           async (signal) => {
             await fsPromises.writeFile(path.join(dir, "pack"), "x".repeat(8192));
+            // The watchdog can abort while filesystem work is still pending.
+            signal.throwIfAborted();
             await new Promise((_resolve, reject) => {
               signal.addEventListener("abort", () => reject(new Error("killed")), { once: true });
             });
@@ -1707,31 +1709,42 @@ describe("AgentPluginInstallService", () => {
     }
   });
 
-  test("withDiskQuotaWatchdog aborts on entry count independently of bytes", async () => {
-    // Empty files and directories consume inodes and allocation metadata
-    // without moving the byte total, so the in-flight watchdog must enforce
-    // maxFiles DURING checkout too — the post-clone count only runs after
-    // git returns. Directories must charge the count like files.
-    const dir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "quota-watchdog-files-"));
-    try {
-      await expect(
-        withDiskQuotaWatchdog(
-          { dir, maxBytes: 1024 * 1024, maxFiles: 8, pollMs: 10 },
-          async (signal) => {
-            for (let i = 0; i < 10; i += 1) {
-              await fsPromises.writeFile(path.join(dir, `empty-${i}`), "");
-              await fsPromises.mkdir(path.join(dir, `dir-${i}`));
+  test.each([false, true])(
+    "withDiskQuotaWatchdog aborts on entry count independently of bytes (during writes=%s)",
+    async (abortDuringWrites) => {
+      // Empty files and directories consume inodes and allocation metadata
+      // without moving the byte total, so the in-flight watchdog must enforce
+      // maxFiles DURING checkout too — the post-clone count only runs after
+      // git returns. Directories must charge the count like files.
+      const dir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "quota-watchdog-files-"));
+      try {
+        await expect(
+          withDiskQuotaWatchdog(
+            { dir, maxBytes: 1024 * 1024, maxFiles: 8, pollMs: 10 },
+            async (signal) => {
+              for (let i = 0; i < 10; i += 1) {
+                await fsPromises.writeFile(path.join(dir, `empty-${i}`), "");
+                await fsPromises.mkdir(path.join(dir, `dir-${i}`));
+                if (abortDuringWrites && i === 5 && !signal.aborted) {
+                  // Hold an in-flight checkout past the quota notification without relying on load.
+                  await new Promise<void>((resolve) => {
+                    signal.addEventListener("abort", () => resolve(), { once: true });
+                  });
+                }
+              }
+              // The watchdog can abort while filesystem work is still pending.
+              signal.throwIfAborted();
+              await new Promise((_resolve, reject) => {
+                signal.addEventListener("abort", () => reject(new Error("killed")), { once: true });
+              });
             }
-            await new Promise((_resolve, reject) => {
-              signal.addEventListener("abort", () => reject(new Error("killed")), { once: true });
-            });
-          }
-        )
-      ).rejects.toThrow(/too large to install/);
-    } finally {
-      await fsPromises.rm(dir, { recursive: true, force: true });
+          )
+        ).rejects.toThrow(/too large to install/);
+      } finally {
+        await fsPromises.rm(dir, { recursive: true, force: true });
+      }
     }
-  });
+  );
 
   test("stale staging reclamation ages trash by embedded stamp and spares owned dirs", async () => {
     const staging = stagingDir();

--- a/src/node/services/compactionPendingState.consumers.test.ts
+++ b/src/node/services/compactionPendingState.consumers.test.ts
@@ -237,6 +237,30 @@ describe("inactive pending consumer contracts", () => {
     }
   );
 
+  it("uses the same authenticated fallback receipt for admission and restored ownership", async () => {
+    const a = await publish("A");
+    assert(a.result.success && a.result.data);
+    const receipt = a.result.data;
+    const { summary } = await publish("B", true);
+    const admitted = new Set<CompactionPendingReceipt>();
+    let restored: CompactionPendingReceipt | undefined;
+    expect(
+      await rollback(summary, store, {
+        canRestorePrevious: (previous) => {
+          expect(store.isSameReceipt(receipt, previous)).toBe(true);
+          admitted.add(previous);
+          return true;
+        },
+        onRestored: (previous) => {
+          restored = previous;
+        },
+      })
+    ).toMatchObject({ success: true, data: { outcome: "applied" } });
+    expect(admitted.size).toBe(1);
+    expect(restored && admitted.has(restored)).toBe(true);
+    expect((await restart().load(() => true))?.attachments.readFiles).toEqual(["/A.ts"]);
+  });
+
   it.each(["failed successor", "committed successor", "reset", "late error"] as const)(
     "records exact cleanup before a delayed return and preserves %s",
     async (scenario) => {
@@ -412,12 +436,22 @@ describe("inactive pending consumer contracts", () => {
     }
   });
 
-  it.each(["consume", "load", "discard", "restore", "pending", "carryover"] as const)(
+  it.each([
+    "consume",
+    "load",
+    "discard",
+    "restore",
+    "restore-read-failure",
+    "observe",
+    "pending",
+    "carryover",
+  ] as const)(
     "lost physical authority during %s cannot affect successor bytes",
     async (operation) => {
       const a = await publish("A");
       assert(a.result.success && a.result.data);
-      const heartbeat = operation === "restore" ? await publish("B", true) : undefined;
+      const heartbeat = operation.startsWith("restore") ? await publish("B", true) : undefined;
+      const reconciled = mock(() => undefined);
       if (operation === "discard")
         await h.historyService.getContinuousCompactionJournal(workspaceId).advanceGeneration();
       const entered = Promise.withResolvers<void>();
@@ -426,22 +460,25 @@ describe("inactive pending consumer contracts", () => {
       let reads = 0;
       spyOn(fs, "readFile").mockImplementation((async (...args: Parameters<typeof fs.readFile>) => {
         const contents = await read(...args);
-        if (args[0] === pendingPath && ++reads === (operation === "restore" ? 2 : 1)) {
+        if (args[0] === pendingPath && ++reads === 1) {
           entered.resolve();
           await release.promise;
+          if (operation === "restore-read-failure") throw new Error("Read failed after lease loss");
         }
         return contents;
       }) as typeof fs.readFile);
       const task = (
         heartbeat
-          ? rollback(heartbeat.summary)
+          ? rollback(heartbeat.summary, store, { onReconciled: reconciled })
           : operation === "consume"
             ? store.consume(a.result.data)
             : operation === "load"
               ? store.load(() => true)
-              : operation === "pending" || operation === "carryover"
-                ? store.isCurrent(a.result.data, operation, () => true)
-                : store.discardAfterBoundary()
+              : operation === "observe"
+                ? store.observe([], () => true)
+                : operation === "pending" || operation === "carryover"
+                  ? store.isCurrent(a.result.data, operation, () => true)
+                  : store.discardAfterBoundary()
       ).catch((error: unknown) => error);
       try {
         await entered.promise;
@@ -458,17 +495,102 @@ describe("inactive pending consumer contracts", () => {
         await fs.writeFile(pendingPath, future);
         release.resolve();
         const result = await task;
-        if (operation === "restore")
+        if (operation.startsWith("restore"))
           expect(result).toEqual({
             success: true,
             data: { outcome: "applied", restored: undefined },
           });
         else expect(result).toBeInstanceOf(Error);
+        expect(reconciled).not.toHaveBeenCalled();
         expect(await bytes()).toBe(future);
         await successor.assertStillOwned();
       } finally {
         release.resolve();
         await task;
+      }
+    }
+  );
+  it("finishes locked reconciliation after admission changes at the history commit", async () => {
+    await publish("A");
+    const b = await publish("B", true);
+    let current = true;
+    const reconciled = mock(() => undefined);
+    const result = await rollback(b.summary, store, {
+      isCurrent: () => current,
+      onCommitted: () => {
+        current = false;
+      },
+      isRetired: () => true,
+      onReconciled: reconciled,
+    });
+    expect(result).toMatchObject({ success: true, data: { outcome: "applied" } });
+    expect(reconciled).toHaveBeenCalledTimes(1);
+    expect(await restart().load(() => true)).toBeUndefined();
+  });
+  it.each([false, true])(
+    "preserves a successor when the lease is reclaimed while staging retirement (checkpoint=%s)",
+    async (checkpoint) => {
+      await publish("A");
+      const b = await publish("B", true);
+      const unlink = fs.unlink;
+      spyOn(fs, "unlink").mockImplementation(async (file) => {
+        if (file === pendingPath) throw new Error("Unlink unavailable");
+        return unlink(file);
+      });
+      assert(b.result.success && b.result.data);
+      const receipt = b.result.data;
+      if (checkpoint)
+        expect(await store.consume(receipt).catch((error: unknown) => error)).toBeInstanceOf(Error);
+      const atomic = atomicWrite.default;
+      const future = '{"version":9,"owner":"successor"}\n';
+      let successor: Awaited<ReturnType<typeof acquireProcessFileLock>> | undefined;
+      spyOn(atomicWrite, "default").mockImplementation(
+        new Proxy(atomic, {
+          async apply(target, receiver, args: Parameters<typeof atomic>) {
+            const result = await Reflect.apply(target, receiver, args);
+            if (String(args[0]).startsWith(`${pendingPath}.continuous-`)) {
+              const lockPath = historyWriteLockPath(h.config.rootDir, workspaceId);
+              const token = await fs.readFile(lockPath, "utf8");
+              await fs.writeFile(lockPath, token.split(":").slice(0, 2).join(":"));
+              await fs.utimes(lockPath, new Date(0), new Date(0));
+              successor = await acquireProcessFileLock({
+                lockPath,
+                timeoutMs: 1000,
+                label: "retirement successor",
+              });
+              await fs.writeFile(pendingPath, future);
+            }
+            return result;
+          },
+        })
+      );
+      try {
+        const result = await rollback(b.summary, store, {
+          canRestorePrevious: () => false,
+          isRetiredBeforeRollback: checkpoint
+            ? (candidate) => store.isSameReceipt(candidate, receipt)
+            : undefined,
+        });
+        expect(result).toMatchObject(
+          checkpoint ? { success: false } : { success: true, data: { outcome: "applied" } }
+        );
+        if (checkpoint) {
+          const chat = await fs.readFile(
+            path.join(h.config.sessionsDir, workspaceId, "chat.jsonl"),
+            "utf8"
+          );
+          expect(
+            chat
+              .trim()
+              .split("\n")
+              .map((line) => (JSON.parse(line) as MuxMessage).id)
+          ).toContain("B");
+        }
+        assert(successor);
+        expect(await bytes()).toBe(future);
+        await successor.assertStillOwned();
+      } finally {
+        await successor?.[Symbol.asyncDispose]();
       }
     }
   );

--- a/src/node/services/compactionPendingState.test.ts
+++ b/src/node/services/compactionPendingState.test.ts
@@ -94,6 +94,39 @@ describe("unactivated compaction pending-file protocol", () => {
     await h.cleanup();
   });
 
+  it("qualifies only authenticated receipts for the same write and generation", async () => {
+    const a = await prepare("A");
+    await boundary("A");
+    const reloaded = await store.load(() => true);
+    const foreign = await restart().load(() => true);
+    assert(reloaded && foreign);
+    expect(store.isSameReceipt(a, reloaded)).toBe(true);
+    expect(store.isSameReceipt(a, foreign)).toBe(false);
+    expect(store.isSameReceipt(foreign, a)).toBe(false);
+    expect(store.isSameReceipt(a, structuredClone(a))).toBe(false);
+    expect(store.belongsToBoundary(structuredClone(a), "A")).toBe(false);
+    const replacement = await prepare("A");
+    expect(store.belongsToBoundary(a, "A")).toBe(true);
+    expect(store.belongsToBoundary(replacement, "A")).toBe(true);
+    expect(store.isSameReceipt(a, replacement)).toBe(false);
+    expect(await store.isCurrent(a, "pending", () => true)).toBe(false);
+  });
+
+  it("does not equate a reused boundary and write ID on opposite sides of a reset", async () => {
+    const before = await prepare("A");
+    await boundary("A");
+    const persisted = JSON.parse(await bytes()) as Record<string, unknown>;
+    assert((await h.historyService.clearHistory(workspaceId)).success);
+    await boundary("A");
+    persisted.publicationGeneration = await h.historyService
+      .getContinuousCompactionJournal(workspaceId)
+      .captureGeneration();
+    await fs.writeFile(filePath, JSON.stringify(persisted));
+    const after = await store.load(() => true);
+    assert(after);
+    expect(store.isSameReceipt(before, after)).toBe(false);
+  });
+
   it("loads old V1 files, sanitizes individual attachments, and consumes across reload", async () => {
     await fs.writeFile(
       filePath,

--- a/src/node/services/compactionPendingState.ts
+++ b/src/node/services/compactionPendingState.ts
@@ -401,40 +401,47 @@ export class CompactionPendingState {
   }
 
   /** Qualify disk and acknowledged memory against one locked history/sidecar observation. */
-  async observe(
+  observe(
     warmth: readonly CompactionPendingReceipt[],
     isCurrent: () => boolean,
-    noLocalOwnership = false
+    noLocalOwnership: () => boolean = () => false
   ): Promise<CompactionPendingObservation | undefined> {
-    // Ordinary sends with no local ownership need no history proof when the sidecar is
-    // absent. Probe every call so foreign publications are visible; uncertainty stays locked.
-    if (
-      noLocalOwnership &&
-      warmth.length === 0 &&
-      (await fs.stat(this.filePath).then(
-        () => false,
-        (error: NodeJS.ErrnoException) => error.code === "ENOENT"
-      ))
-    )
-      return;
-    return this.enqueue(async (view) => {
-      const raw = await this.readBytes(view.assertStillOwned).then(
-        (value) => ({ value, readable: true }),
-        () => ({ value: undefined, readable: false })
-      );
-      await view.assertStillOwned();
-      if (!isCurrent()) return;
-      return raw.readable
-        ? this.observation(view, raw.value, warmth)
-        : {
-            retention: this.retention(view),
-            readable: false,
-          };
+    return this.enqueueOperation(async () => {
+      // Earlier queued publications must settle before probing; a history-only publication
+      // can establish local ownership without creating a sidecar, so evaluate that fact now.
+      // Ordinary absent state still needs neither history locks nor a history scan.
+      if (
+        noLocalOwnership() &&
+        warmth.length === 0 &&
+        (await fs.stat(this.filePath).then(
+          () => false,
+          (error: NodeJS.ErrnoException) => error.code === "ENOENT"
+        ))
+      )
+        return;
+      return this.history.withLock(async (view) => {
+        const raw = await this.readBytes(view.assertStillOwned).then(
+          (value) => ({ value, readable: true }),
+          () => ({ value: undefined, readable: false })
+        );
+        await view.assertStillOwned();
+        if (!isCurrent()) return;
+        return raw.readable
+          ? this.observation(view, raw.value, warmth)
+          : {
+              retention: this.retention(view),
+              readable: false,
+            };
+      });
     });
   }
 
   private enqueue<T>(operation: (view: CompactionPendingHistoryView) => Promise<T>): Promise<T> {
-    const result = this.pending.then(() => this.history.withLock(operation));
+    return this.enqueueOperation(() => this.history.withLock(operation));
+  }
+
+  private enqueueOperation<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.pending.then(operation);
     this.pending = result.catch(() => undefined);
     return result;
   }

--- a/src/node/services/compactionPendingState.ts
+++ b/src/node/services/compactionPendingState.ts
@@ -267,7 +267,10 @@ function hasWarmthPublication(writeId: string | undefined, view: CompactionPendi
   );
 }
 
-function isCurrentState(state: PersistedState, view: CompactionPendingHistoryView): boolean {
+function isCurrentState(
+  state: PersistedState,
+  view: Pick<CompactionPendingHistoryView, "boundary" | "generation" | "boundaryPublicationId">
+): boolean {
   return (
     sameBoundary(
       state.boundaryMessageId
@@ -332,6 +335,12 @@ export class CompactionPendingState {
       published: boolean;
       startingBoundary?: CompactionPendingBoundary;
     }
+  >();
+
+  // Only held-lock committed publications can authorize later predecessor retirement.
+  private readonly predecessors = new WeakMap<
+    CompactionPendingRetention,
+    Pick<CompactionPendingRetention, "generation" | "boundary" | "boundaryPublicationId">
   >();
 
   constructor(
@@ -632,7 +641,14 @@ export class CompactionPendingState {
               input.summaryMessage.metadata = summaryMessage.metadata;
               const owner = receipt && this.receipts.get(receipt);
               if (owner) owner.published = true;
-              onCommitted(receipt, previous, this.retention(view));
+              const retention = this.retention(view);
+              if (!receipt)
+                this.predecessors.set(retention, {
+                  generation: retention.generation,
+                  boundary: structuredClone(retention.boundary),
+                  boundaryPublicationId: retention.boundaryPublicationId,
+                });
+              onCommitted(receipt, previous, retention);
             }
           );
           if (committed) return Ok(receipt);
@@ -649,6 +665,59 @@ export class CompactionPendingState {
       }
       return Err(`Failed to publish compaction pending boundary: ${getErrorMessage(error)}`);
     }
+  }
+
+  /** A known exact receipt may retain legacy authority; an inferred predecessor may not. */
+  isPredecessor(receipt: CompactionPendingReceipt, retention: CompactionPendingRetention): boolean {
+    const owner = this.receipts.get(receipt);
+    const expected = this.predecessors.get(retention);
+    return !!(
+      owner &&
+      expected &&
+      owner.generation === expected.generation &&
+      sameBoundary(
+        owner.boundaryMessageId
+          ? { kind: "identified", messageId: owner.boundaryMessageId }
+          : { kind: "none" },
+        expected.boundary
+      ) &&
+      (expected.boundaryPublicationId === undefined ||
+        owner.writeId === expected.boundaryPublicationId)
+    );
+  }
+
+  /** Recover retirement authority after unreadable preparations, without trusting local caches. */
+  consumePredecessor(
+    retentions: readonly CompactionPendingRetention[],
+    onObserved: (receipt: CompactionPendingReceipt, retention: CompactionPendingRetention) => void
+  ): Promise<boolean> {
+    const candidates = retentions.flatMap((retention) => {
+      const expected = this.predecessors.get(retention);
+      // An ambiguous legacy boundary cannot authorize newly inferred destructive work.
+      return expected?.boundary.kind === "identified" &&
+        expected.boundaryPublicationId !== undefined
+        ? [{ retention, expected }]
+        : [];
+    });
+    if (candidates.length === 0) return Promise.resolve(false);
+    return this.enqueue(async (view) => {
+      if (view.boundary.kind === "unreadable-reset") return false;
+      const state = parseState(parseJson(await this.readBytes(view.assertStillOwned)));
+      if (!state) return false;
+      for (const { retention, expected } of candidates) {
+        if (view.generation !== expected.generation) continue;
+        const candidate = [state, state.previousState].find(
+          (value) => value && isCurrentState(value, expected)
+        );
+        if (!candidate) continue;
+        await view.assertStillOwned();
+        const receipt = this.receipt(candidate, expected.generation);
+        // Preserve local retirement facts before fallible cleanup; this is never acknowledgment.
+        onObserved(receipt, retention);
+        return this.consumeUnderLock(view, receipt, state);
+      }
+      return false;
+    });
   }
 
   consume(receipt: CompactionPendingReceipt): Promise<boolean> {

--- a/src/node/services/compactionPendingState.ts
+++ b/src/node/services/compactionPendingState.ts
@@ -46,6 +46,10 @@ interface PersistedState extends CompactionPendingAttachments {
 
 export interface CompactionPendingHistoryView {
   generation: string | undefined;
+  /** Exact marked publication occurrence; legacy rows cannot authorize absent-file warmth. */
+  boundaryPublicationId?: string;
+  /** Rollbackable suffix + exposed base; undefined member is initial history, absent set is unproven. */
+  reachableBoundaryIds?: ReadonlySet<string | undefined>;
   /** Recheck physical lock ownership after awaited I/O before publishing or retiring bytes. */
   assertStillOwned(this: void): Promise<void>;
   /**
@@ -73,6 +77,7 @@ export interface CompactionPendingBoundaryWrite {
 interface PendingPreparation {
   attachments: CompactionPendingAttachments;
   boundaryMessageId: string;
+  writeId?: string;
   publication: ContinuousCompactionPublication;
   isCurrent: () => boolean;
 }
@@ -82,7 +87,12 @@ export interface CompactionPendingHistory {
   cleanupHeartbeat(
     summary: MuxMessage,
     isCurrent: () => boolean,
-    onCommitted: () => undefined
+    onCommitted: () => undefined,
+    reconcileUnderLock?: (
+      view: CompactionPendingHistoryView,
+      removedCurrentBoundary: boolean
+    ) => Promise<void>,
+    beforeRollback?: (restoredView: CompactionPendingHistoryView) => Promise<void>
   ): Promise<Result<"applied" | "skipped">>;
   /**
    * Hold BOTH existing history locks throughout the callback, reject removed workspaces,
@@ -96,6 +106,26 @@ export interface CompactionPendingHistory {
 export interface CompactionPendingReceipt {
   readonly attachments: CompactionPendingAttachments;
 }
+
+export type CompactionPendingRetention = Pick<
+  CompactionPendingHistoryView,
+  "generation" | "boundary" | "boundaryPublicationId" | "reachableBoundaryIds"
+>;
+
+export interface CompactionPendingObservation {
+  retention: CompactionPendingRetention;
+  readable: boolean;
+  pending?: CompactionPendingReceipt;
+  warmth?: CompactionPendingReceipt;
+}
+
+type CanRestorePrevious = (previous: CompactionPendingReceipt) => boolean;
+type IsRetired = (
+  receipt: CompactionPendingReceipt,
+  restoredContext: boolean,
+  retention: CompactionPendingRetention,
+  removed?: CompactionPendingReceipt
+) => boolean;
 
 function record(value: unknown): Record<string, unknown> | undefined {
   return value !== null && typeof value === "object" && !Array.isArray(value)
@@ -227,6 +257,16 @@ function sameBoundary(
   );
 }
 
+/** File absence needs a durable occurrence marker; legacy row IDs alone cannot prove warmth. */
+function hasWarmthPublication(writeId: string | undefined, view: CompactionPendingHistoryView) {
+  return (
+    view.boundary.kind === "none" ||
+    (view.boundary.kind === "identified" &&
+      view.boundaryPublicationId !== undefined &&
+      writeId === view.boundaryPublicationId)
+  );
+}
+
 function isCurrentState(state: PersistedState, view: CompactionPendingHistoryView): boolean {
   return (
     sameBoundary(
@@ -235,6 +275,8 @@ function isCurrentState(state: PersistedState, view: CompactionPendingHistoryVie
         : { kind: "none" },
       view.boundary
     ) &&
+    // A marked replacement cannot inherit a stale same-ID file, even if enrichment failed.
+    (view.boundaryPublicationId === undefined || state.writeId === view.boundaryPublicationId) &&
     // Untagged V1 files predate generation tracking; only proven initial history qualifies.
     (state.boundaryMessageId !== undefined || view.generation === undefined) &&
     // A destructive edit can preserve the boundary ID, so even tagged legacy state
@@ -285,6 +327,7 @@ export class CompactionPendingState {
       identity: string;
       generation: string | undefined;
       boundaryMessageId?: string;
+      writeId?: string;
       prepared: boolean;
       published: boolean;
       startingBoundary?: CompactionPendingBoundary;
@@ -295,6 +338,91 @@ export class CompactionPendingState {
     private readonly filePath: string,
     private readonly history: CompactionPendingHistory
   ) {}
+
+  /** Compare authenticated write identity, not receipt object identity or attachment content. */
+  isSameReceipt(left: CompactionPendingReceipt, right: CompactionPendingReceipt): boolean {
+    const a = this.receipts.get(left);
+    const b = this.receipts.get(right);
+    return !!a && !!b && a.identity === b.identity && a.generation === b.generation;
+  }
+
+  /** Identity only: callers still need isCurrent before admitting any cached attachments. */
+  belongsToBoundary(receipt: CompactionPendingReceipt, messageId: string): boolean {
+    return this.receipts.get(receipt)?.boundaryMessageId === messageId;
+  }
+
+  private retention(view: CompactionPendingHistoryView): CompactionPendingRetention {
+    return {
+      generation: view.generation,
+      boundary: view.boundary,
+      boundaryPublicationId: view.boundaryPublicationId,
+      reachableBoundaryIds: view.reachableBoundaryIds,
+    };
+  }
+
+  private observation(
+    view: CompactionPendingHistoryView,
+    raw: string | undefined,
+    warmth: readonly CompactionPendingReceipt[]
+  ): CompactionPendingObservation {
+    const state = eligibleState(parseState(parseJson(raw)), view);
+    return {
+      retention: this.retention(view),
+      readable: true,
+      pending: state && this.receipt(state, view.generation),
+      warmth:
+        raw === undefined
+          ? // Newer exact receipts supersede older acknowledged writes at a reused boundary ID.
+            warmth.findLast((receipt) => {
+              const owner = this.receipts.get(receipt);
+              return (
+                owner?.published &&
+                owner.generation === view.generation &&
+                hasWarmthPublication(owner.writeId, view) &&
+                sameBoundary(
+                  owner.boundaryMessageId
+                    ? { kind: "identified", messageId: owner.boundaryMessageId }
+                    : { kind: "none" },
+                  view.boundary
+                )
+              );
+            })
+          : undefined,
+    };
+  }
+
+  /** Qualify disk and acknowledged memory against one locked history/sidecar observation. */
+  async observe(
+    warmth: readonly CompactionPendingReceipt[],
+    isCurrent: () => boolean,
+    noLocalOwnership = false
+  ): Promise<CompactionPendingObservation | undefined> {
+    // Ordinary sends with no local ownership need no history proof when the sidecar is
+    // absent. Probe every call so foreign publications are visible; uncertainty stays locked.
+    if (
+      noLocalOwnership &&
+      warmth.length === 0 &&
+      (await fs.stat(this.filePath).then(
+        () => false,
+        (error: NodeJS.ErrnoException) => error.code === "ENOENT"
+      ))
+    )
+      return;
+    return this.enqueue(async (view) => {
+      const raw = await this.readBytes(view.assertStillOwned).then(
+        (value) => ({ value, readable: true }),
+        () => ({ value: undefined, readable: false })
+      );
+      await view.assertStillOwned();
+      if (!isCurrent()) return;
+      return raw.readable
+        ? this.observation(view, raw.value, warmth)
+        : {
+            retention: this.retention(view),
+            readable: false,
+          };
+    });
+  }
 
   private enqueue<T>(operation: (view: CompactionPendingHistoryView) => Promise<T>): Promise<T> {
     const result = this.pending.then(() => this.history.withLock(operation));
@@ -332,6 +460,7 @@ export class CompactionPendingState {
       identity: identity(state),
       generation,
       boundaryMessageId: state.boundaryMessageId,
+      writeId: state.writeId,
       prepared,
       published: !prepared,
       startingBoundary,
@@ -389,7 +518,8 @@ export class CompactionPendingState {
 
   private async prepareUnderLock(
     view: CompactionPendingHistoryView,
-    input: PendingPreparation
+    input: PendingPreparation,
+    onPrevious?: (receipt: CompactionPendingReceipt | undefined) => undefined
   ): Promise<CompactionPendingReceipt | undefined> {
     const { attachments: captured, publication, boundaryMessageId, isCurrent } = input;
     if (!boundaryMessageId.trim()) throw new Error("Pending state requires a boundary message ID");
@@ -400,14 +530,17 @@ export class CompactionPendingState {
     // Unsupported future schemas remain owned by their version, even after a new boundary.
     if (parsed !== undefined && record(parsed)?.version !== 1) return;
     const previous = eligibleState(parseState(parsed), view);
+    await view.assertStillOwned();
     if (!isCurrent()) return;
+    // Capture before optional staging can fail, from the same locked view as publication.
+    onPrevious?.(previous && this.receipt(previous, view.generation));
     const startingBoundary = structuredClone(view.boundary);
     const state = parseState({
       ...captured,
       version: 1,
       createdAt: Date.now(),
       boundaryMessageId,
-      writeId: randomUUID(),
+      writeId: input.writeId ?? randomUUID(),
       publicationGeneration: publication.generation ?? null,
       previousState: previous && head(previous),
       previousStateGeneration: previous ? (view.generation ?? null) : undefined,
@@ -438,20 +571,36 @@ export class CompactionPendingState {
     input: CompactionPendingBoundaryWrite & {
       attachments: CompactionPendingAttachments;
       isCurrent: () => boolean;
-      /** Synchronous lifecycle state only. Events and goal observers run after this returns. */
-      onCommitted: (receipt: CompactionPendingReceipt | undefined) => undefined;
+      /**
+       * Synchronous lifecycle state only. Previous is the exact eligible starting predecessor,
+       * including when optional enrichment fails; it is not admission proof after this commit.
+       */
+      onCommitted: (
+        receipt: CompactionPendingReceipt | undefined,
+        previous: CompactionPendingReceipt | undefined,
+        retention: CompactionPendingRetention
+      ) => undefined;
     }
   ): Promise<Result<CompactionPendingReceipt | undefined>> {
-    const { summaryMessage, tailCopies, updateExisting, isCurrent, shouldPersist, onCommitted } =
-      input;
+    const { tailCopies, updateExisting, isCurrent, shouldPersist, onCommitted } = input;
+    // Check before copying: one caller object cannot own both appended row receipts.
+    if (!updateExisting && tailCopies.includes(input.summaryMessage))
+      return Err("Compaction summary cannot also be a tail copy");
+    // Allocate before optional enrichment; history-only commits need occurrence identity too.
+    // Caller metadata changes only with the synchronous history receipt, never while staging.
+    const summaryMessage = structuredClone(input.summaryMessage);
+    const writeId = randomUUID();
+    summaryMessage.metadata = { ...summaryMessage.metadata, compactionPublicationId: writeId };
     const publication = structuredClone(input.publication);
     const preparation = {
       attachments: structuredClone(input.attachments),
       boundaryMessageId: summaryMessage.id,
+      writeId,
       publication,
       isCurrent,
     };
     let receipt: CompactionPendingReceipt | undefined;
+    let previous: CompactionPendingReceipt | undefined;
     let committed = false;
     try {
       return await this.enqueue(async (view) => {
@@ -460,7 +609,9 @@ export class CompactionPendingState {
         if (view.boundary.kind === "identified" && view.boundary.messageId === summaryMessage.id)
           return Err("Compaction publication requires a new boundary ID");
         try {
-          receipt = await this.prepareUnderLock(view, preparation);
+          receipt = await this.prepareUnderLock(view, preparation, (captured) => {
+            previous = captured;
+          });
         } catch (error) {
           // Enrichment failures cannot brick mandatory history. The history writer rechecks
           // physical ownership, publication and admission independently before committing.
@@ -478,9 +629,10 @@ export class CompactionPendingState {
             () => {
               // The rename is the commit: observer/lock-disposal failures cannot undo it.
               committed = true;
+              input.summaryMessage.metadata = summaryMessage.metadata;
               const owner = receipt && this.receipts.get(receipt);
               if (owner) owner.published = true;
-              onCommitted(receipt);
+              onCommitted(receipt, previous, this.retention(view));
             }
           );
           if (committed) return Ok(receipt);
@@ -500,28 +652,36 @@ export class CompactionPendingState {
   }
 
   consume(receipt: CompactionPendingReceipt): Promise<boolean> {
-    const expected = this.receipts.get(receipt);
-    if (!expected) return Promise.resolve(false);
+    if (!this.receipts.has(receipt)) return Promise.resolve(false);
     return this.enqueue(async (view) => {
       const state = parseState(parseJson(await this.readBytes(view.assertStillOwned)));
-      if (!state) return false;
-      if (identity(state) === expected.identity) {
-        await view.assertStillOwned();
-        await fs.unlink(this.filePath);
-        return true;
-      }
-      if (!state.previousState || identity(state.previousState) !== expected.identity) return false;
-      // A may be consumed while B is provisional. Remove only A's fallback, durably, so
-      // B's later rollback/restart cannot resurrect it. B retains its immutable write identity.
-      await publishCompactionFile(
-        this.filePath,
-        JSON.stringify(head(state)),
-        () => true,
-        undefined,
-        view.assertStillOwned
-      );
-      return true;
+      return state ? this.consumeUnderLock(view, receipt, state) : false;
     });
+  }
+
+  private async consumeUnderLock(
+    view: CompactionPendingHistoryView,
+    receipt: CompactionPendingReceipt,
+    state: PersistedState
+  ): Promise<boolean> {
+    const expected = this.receipts.get(receipt);
+    if (!expected) return false;
+    if (identity(state) === expected.identity) {
+      await view.assertStillOwned();
+      await fs.unlink(this.filePath);
+      return true;
+    }
+    if (!state.previousState || identity(state.previousState) !== expected.identity) return false;
+    // A may be consumed while B is provisional. Remove only A's fallback, durably, so
+    // B's later rollback/restart cannot resurrect it. B retains its immutable write identity.
+    await publishCompactionFile(
+      this.filePath,
+      JSON.stringify(head(state)),
+      () => true,
+      undefined,
+      view.assertStillOwned
+    );
+    return true;
   }
 
   /** Acknowledgement removes the file, but warm skills/paths still require current provenance. */
@@ -546,6 +706,12 @@ export class CompactionPendingState {
       )
         return false;
       const raw = await this.readBytes(view.assertStillOwned);
+      if (
+        raw === undefined &&
+        scope === "carryover" &&
+        !hasWarmthPublication(expected.writeId, view)
+      )
+        return false;
       // Existing bytes must prove this exact owner, including replacement writes at the same
       // boundary. Future formats stay untouched and cannot authorize cached enrichment.
       if (scope === "pending" || raw !== undefined) {
@@ -560,52 +726,154 @@ export class CompactionPendingState {
   }
 
   /**
-   * Restart receipts cannot authorize ordinary rollback. Only this composition witnesses
-   * exact heartbeat removal, then rechecks the captured file and persisted predecessor proof.
-   * Never hold the pending/history lock while calling the separately queued history cleanup.
+   * Exact history removal and pending reconciliation share one lease. A failed earlier
+   * sidecar read cannot hide a now-eligible predecessor or authorize a foreign successor.
    */
   async rollbackHeartbeat(input: {
     summaryMessage: MuxMessage;
     isCurrent: () => boolean;
-    canRestorePrevious: () => boolean;
+    canRestorePrevious: CanRestorePrevious;
     onCommitted: () => undefined;
     onRestored: (receipt: CompactionPendingReceipt) => undefined;
+    warmth?: readonly CompactionPendingReceipt[];
+    isRetired?: IsRetired;
+    /** Pure consumed-ownership decision; preparation must not mark a rollback committed. */
+    isRetiredBeforeRollback?: IsRetired;
+    onReconciled?: (
+      observation: CompactionPendingObservation,
+      removedCurrentBoundary: boolean
+    ) => undefined;
   }): Promise<Result<{ outcome: "applied" | "skipped"; restored?: CompactionPendingReceipt }>> {
     const summary = structuredClone(input.summaryMessage);
-    const { isCurrent, canRestorePrevious, onCommitted, onRestored } = input;
+    const { isCurrent, canRestorePrevious, onCommitted, onRestored, isRetiredBeforeRollback } =
+      input;
     let committed = false;
     let restored: CompactionPendingReceipt | undefined;
-    // Enrichment read failures must not prevent mandatory exact history cleanup.
-    const receipt = await this.load(isCurrent).catch(() => undefined);
     try {
-      const result = await this.history.cleanupHeartbeat(summary, isCurrent, () => {
-        committed = true;
-        onCommitted();
-      });
+      const result = await this.history.cleanupHeartbeat(
+        summary,
+        isCurrent,
+        () => {
+          committed = true;
+          onCommitted();
+        },
+        async (view, removedCurrentBoundary) => {
+          // This obligation survives an admission change after the synchronous history commit.
+          let raw: string | undefined;
+          try {
+            raw = await this.readBytes(view.assertStillOwned);
+          } catch {
+            await view.assertStillOwned();
+            input.onReconciled?.(
+              { retention: this.retention(view), readable: false },
+              removedCurrentBoundary
+            );
+            return;
+          }
+          await view.assertStillOwned();
+          const state = parseState(parseJson(raw));
+          let removed: CompactionPendingReceipt | undefined;
+          if (
+            removedCurrentBoundary &&
+            state?.boundaryMessageId === summary.id &&
+            (summary.metadata?.compactionPublicationId === undefined ||
+              state.writeId === summary.metadata.compactionPublicationId)
+          ) {
+            const previous = eligiblePrevious(state, view);
+            const receipt = this.receipt(state, view.generation);
+            removed = receipt;
+            const changed = await this.rollbackUnderLock(
+              view,
+              receipt,
+              (candidate) =>
+                !input.isRetired?.(candidate, true, this.retention(view), removed) &&
+                canRestorePrevious(candidate),
+              {
+                boundaryMessageId: summary.id,
+                onRestored: (candidate) => {
+                  restored = candidate;
+                  onRestored(candidate);
+                },
+              },
+              state
+            );
+            if (changed) raw = restored && previous ? JSON.stringify(head(previous)) : undefined;
+          }
+          let observation = this.observation(view, raw, input.warmth ?? []);
+          if (
+            observation.pending &&
+            input.isRetired?.(
+              observation.pending,
+              removedCurrentBoundary,
+              this.retention(view),
+              removed
+            )
+          ) {
+            const observedState = parseState(parseJson(raw));
+            if (
+              observedState &&
+              (await this.consumeUnderLock(view, observation.pending, observedState))
+            ) {
+              const expected = this.receipts.get(observation.pending)!;
+              raw =
+                identity(observedState) === expected.identity
+                  ? undefined
+                  : JSON.stringify(head(observedState));
+              observation = this.observation(view, raw, input.warmth ?? []);
+            }
+          }
+          await view.assertStillOwned();
+          if (restored && observation.pending && this.isSameReceipt(restored, observation.pending))
+            observation.pending = restored;
+          input.onReconciled?.(observation, removedCurrentBoundary);
+        },
+        isRetiredBeforeRollback &&
+          (async (view) => {
+            const state = parseState(parseJson(await this.readBytes(view.assertStillOwned)));
+            await view.assertStillOwned();
+            if (!state) return;
+            const removed =
+              state.boundaryMessageId === summary.id &&
+              (summary.metadata?.compactionPublicationId === undefined ||
+                state.writeId === summary.metadata.compactionPublicationId)
+                ? this.receipt(state, view.generation)
+                : undefined;
+            const predecessor = eligibleState(state, view);
+            const receipt =
+              removed && isRetiredBeforeRollback(removed, false, this.retention(view), removed)
+                ? removed
+                : predecessor && this.receipt(predecessor, view.generation);
+            if (
+              !receipt ||
+              !isRetiredBeforeRollback(receipt, receipt !== removed, this.retention(view), removed)
+            )
+              return;
+            try {
+              if (!(await this.consumeUnderLock(view, receipt, state)))
+                throw new Error("Pending retirement changed");
+            } catch (error) {
+              // Empty only an exact retired head; a retired fallback cannot erase active B.
+              const expected = this.receipts.get(receipt)!;
+              if (
+                identity(state) !== expected.identity ||
+                !(await this.emptyRetiredHead(view, expected.identity))
+              )
+                throw error;
+            }
+          })
+      );
       if (!committed) return result.success ? Ok({ outcome: "skipped" }) : result;
     } catch (error) {
       if (!committed) return Err(`Failed to roll back heartbeat: ${getErrorMessage(error)}`);
       log.warn("Heartbeat cleanup failed after history commit", error);
     }
-    try {
-      if (receipt && this.receipts.get(receipt)?.boundaryMessageId === summary.id)
-        await this.enqueue((view) =>
-          this.rollbackUnderLock(view, receipt, canRestorePrevious, {
-            boundaryMessageId: summary.id,
-            onRestored: (previous) => {
-              restored = previous;
-              onRestored(previous);
-            },
-          })
-        );
-    } catch (error) {
-      // Cleanup is already committed. Optional restoration cannot turn it into a retry.
-      log.warn("Pending heartbeat restoration unavailable", error);
-    }
     return Ok({ outcome: "applied", restored });
   }
 
-  rollback(receipt: CompactionPendingReceipt, canRestorePrevious: () => boolean): Promise<boolean> {
+  rollback(
+    receipt: CompactionPendingReceipt,
+    canRestorePrevious: CanRestorePrevious
+  ): Promise<boolean> {
     if (!this.receipts.get(receipt)?.prepared) return Promise.resolve(false);
     return this.enqueue((view) => this.rollbackUnderLock(view, receipt, canRestorePrevious));
   }
@@ -613,15 +881,17 @@ export class CompactionPendingState {
   private async rollbackUnderLock(
     view: CompactionPendingHistoryView,
     receipt: CompactionPendingReceipt,
-    canRestorePrevious: () => boolean,
+    canRestorePrevious: CanRestorePrevious,
     cleanup?: {
       boundaryMessageId: string;
       onRestored: (receipt: CompactionPendingReceipt) => undefined;
-    }
+    },
+    observedState?: PersistedState
   ): Promise<boolean> {
     const expected = this.receipts.get(receipt);
     if (!expected || (!expected.prepared && !cleanup)) return false;
-    const state = parseState(parseJson(await this.readBytes(view.assertStillOwned)));
+    const state =
+      observedState ?? parseState(parseJson(await this.readBytes(view.assertStillOwned)));
     if (!state || identity(state) !== expected.identity) return false;
     if (cleanup && state.boundaryMessageId !== cleanup.boundaryMessageId) return false;
     if (isCurrentState(state, view)) return false;
@@ -633,28 +903,56 @@ export class CompactionPendingState {
     if (
       previous &&
       expected.generation === view.generation &&
-      sameBoundary(
-        cleanup ? state.previousStateBoundary : expected.startingBoundary,
-        view.boundary
-      ) &&
-      canRestorePrevious()
+      sameBoundary(cleanup ? state.previousStateBoundary : expected.startingBoundary, view.boundary)
     ) {
+      // One exact fallback receipt qualifies local retirement facts across every recheck.
+      await view.assertStillOwned();
+      const previousReceipt = this.receipt(previous, view.generation);
+      const canRestore = () => canRestorePrevious(previousReceipt);
       if (
-        await publishCompactionFile(
+        canRestore() &&
+        (await publishCompactionFile(
           this.filePath,
           JSON.stringify(head(previous)),
-          canRestorePrevious,
+          canRestore,
           () => {
-            cleanup?.onRestored(this.receipt(previous, view.generation));
+            cleanup?.onRestored(previousReceipt);
           },
           view.assertStillOwned
-        )
+        ))
       )
         return true;
     }
     await view.assertStillOwned();
-    await fs.unlink(this.filePath);
+    try {
+      await fs.unlink(this.filePath);
+    } catch (error) {
+      // Preparation rollback remains retryable with its original receipt. Only committed
+      // heartbeat cleanup has irrevocably retired this head and may replace its contents.
+      if (!cleanup) throw error;
+      try {
+        await this.emptyRetiredHead(view, expected.identity);
+      } catch (replacementError) {
+        log.warn("Pending rollback retirement remains unavailable", replacementError);
+      }
+      // History may already be committed. Preserve the cleanup error instead of reporting
+      // fictitious file absence; if both operations fail, retirement remains process-local.
+      throw error;
+    }
     return true;
+  }
+
+  /** Only a consumed head or a committed rollback can authorize dropping its payload/fallback. */
+  private async emptyRetiredHead(view: CompactionPendingHistoryView, expectedIdentity: string) {
+    const current = parseState(parseJson(await this.readBytes(view.assertStillOwned)));
+    if (!current || identity(current) !== expectedIdentity) return false;
+    return publishCompactionFile(
+      this.filePath,
+      JSON.stringify({ ...head(current), diffs: [], loadedSkills: [], readFiles: [] }),
+      () => true,
+      undefined,
+      view.assertStillOwned
+    );
   }
 
   /** Call only after the destructive boundary/generation change committed under the history lock. */

--- a/src/node/services/compactionPreparationLifecycle.test.ts
+++ b/src/node/services/compactionPreparationLifecycle.test.ts
@@ -1,0 +1,1517 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import assert from "node:assert/strict";
+import * as syncFs from "node:fs";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as atomicWrite from "write-file-atomic";
+import { createMuxMessage } from "@/common/types/message";
+import { CompactionPendingState } from "./compactionPendingState";
+import { CompactionPreparationLifecycle } from "./compactionPreparationLifecycle";
+import { HistoryService } from "./historyService";
+import { createTestHistoryService } from "./testHistoryService";
+
+type BoundaryInput = Parameters<CompactionPreparationLifecycle["publish"]>[1];
+
+describe("inactive local compaction preparation lifecycle", () => {
+  const workspaceId = "local-preparation";
+  let h: Awaited<ReturnType<typeof createTestHistoryService>>;
+  let pendingPath: string;
+  let store: CompactionPendingState;
+  let lifecycle: CompactionPreparationLifecycle;
+
+  function restart() {
+    return new CompactionPendingState(
+      pendingPath,
+      new HistoryService(h.config).getCompactionPendingHistory(workspaceId)
+    );
+  }
+
+  async function input(name: string, heartbeat = false): Promise<BoundaryInput> {
+    return {
+      attachments: {
+        diffs: [{ path: `/${name}.ts`, diff: `+${name}`, truncated: false }],
+        loadedSkills: [],
+        readFiles: [`/${name}.ts`],
+      },
+      summaryMessage: createMuxMessage(name, "assistant", name, {
+        compacted: heartbeat ? "heartbeat" : "user",
+        compactionBoundary: true,
+        compactionEpoch: 1,
+        ...(heartbeat && {
+          muxMetadata: {
+            type: "compaction-summary",
+            pendingFollowUp: { text: "Resume", model: "openai:gpt-4o", agentId: "exec" },
+          },
+        }),
+      }),
+      tailCopies: [],
+      updateExisting: false,
+      publication: {
+        generation: await h.historyService
+          .getContinuousCompactionJournal(workspaceId)
+          .captureGeneration(),
+      },
+      shouldPersist: () => true,
+    };
+  }
+
+  async function publish(name: string, heartbeat = false, target = lifecycle, accepted = true) {
+    const preparation = target.begin(() => true);
+    const prepared = await input(name, heartbeat);
+    prepared.shouldPersist = () => accepted;
+    return target.publish(preparation, prepared);
+  }
+
+  const bytes = () => fs.readFile(pendingPath, "utf8");
+  async function historyIds() {
+    const result = await h.historyService.getHistoryFromLatestBoundary(workspaceId);
+    assert(result.success);
+    return result.data.map((row) => row.id);
+  }
+
+  beforeEach(async () => {
+    h = await createTestHistoryService();
+    pendingPath = path.join(h.config.sessionsDir, workspaceId, "post-compaction.json");
+    assert(
+      (
+        await h.historyService.appendToHistory(
+          workspaceId,
+          createMuxMessage("seed", "user", "Context")
+        )
+      ).success
+    );
+    store = new CompactionPendingState(
+      pendingPath,
+      h.historyService.getCompactionPendingHistory(workspaceId)
+    );
+    lifecycle = new CompactionPreparationLifecycle(store);
+  });
+
+  afterEach(async () => {
+    mock.restore();
+    await h.cleanup();
+  });
+
+  it("avoids history scans for absent state and observes a later foreign publication", async () => {
+    const adapter = h.historyService.getCompactionPendingHistory(workspaceId);
+    const locked = spyOn(adapter, "withLock");
+    const target = new CompactionPreparationLifecycle(
+      new CompactionPendingState(pendingPath, adapter)
+    );
+    expect(await target.capture("pending")).toBeUndefined();
+    expect(await target.capture("carryover")).toBeUndefined();
+    expect(locked).not.toHaveBeenCalled();
+    assert((await publish("A", false, new CompactionPreparationLifecycle(restart()))).success);
+    const delivered = await target.capture("pending");
+    assert(delivered);
+    expect(delivered.readFiles).toEqual(["/A.ts"]);
+    expect(locked).toHaveBeenCalledTimes(1);
+    await target.consume(delivered, "ack");
+    const beforeWarmth = locked.mock.calls.length;
+    expect((await target.capture("carryover"))?.readFiles).toEqual(["/A.ts"]);
+    expect(locked.mock.calls.length).toBe(beforeWarmth + 1);
+  });
+
+  it.each(["error", "directory"] as const)(
+    "qualifies ambiguous sidecar presence through history (%s)",
+    async (presence) => {
+      const adapter = h.historyService.getCompactionPendingHistory(workspaceId);
+      const locked = spyOn(adapter, "withLock");
+      const target = new CompactionPreparationLifecycle(
+        new CompactionPendingState(pendingPath, adapter)
+      );
+      if (presence === "directory") await fs.mkdir(pendingPath);
+      else {
+        const stat = fs.stat;
+        spyOn(fs, "stat").mockImplementation((async (...args: Parameters<typeof fs.stat>) => {
+          if (args[0] === pendingPath)
+            throw Object.assign(new Error("Probe unavailable"), { code: "EACCES" });
+          return stat(...args);
+        }) as typeof fs.stat);
+      }
+      expect(await target.capture("pending")).toBeUndefined();
+      expect(locked).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it("qualifies a local history-only token even when its pending file is absent", async () => {
+    const adapter = h.historyService.getCompactionPendingHistory(workspaceId);
+    const locked = spyOn(adapter, "withLock");
+    const target = new CompactionPreparationLifecycle(
+      new CompactionPendingState(pendingPath, adapter)
+    );
+    const rename = syncFs.renameSync;
+    spyOn(syncFs, "renameSync").mockImplementation((from, to) => {
+      if (to === pendingPath) throw new Error("Optional write unavailable");
+      rename(from, to);
+    });
+    assert((await publish("B", true, target)).success);
+    const beforeCapture = locked.mock.calls.length;
+    expect((await target.capture("pending"))?.readFiles).toEqual([]);
+    expect(locked.mock.calls.length).toBe(beforeCapture + 1);
+  });
+
+  it("claims preparation before awaits, rejects superseded/reused handles, and does not revive them", async () => {
+    const a = lifecycle.begin(() => true);
+    const b = lifecycle.begin(() => true);
+    const prepared = await input("B");
+    prepared.shouldPersist = () => false;
+    expect(a.isCurrent()).toBe(false);
+    expect((await lifecycle.publish(a, await input("A"))).success).toBe(false);
+    expect((await lifecycle.publish(b, prepared)).success).toBe(false);
+    expect(a.isCurrent()).toBe(false);
+    expect(b.isCurrent()).toBe(false);
+    expect((await lifecycle.publish(b, await input("B"))).success).toBe(false);
+    expect((await lifecycle.publish({ isCurrent: () => true }, await input("fake"))).success).toBe(
+      false
+    );
+    expect(await historyIds()).toEqual(["seed"]);
+    expect(await lifecycle.capture("pending")).toBeUndefined();
+  });
+
+  it("captures rows and attachments before queued I/O without mutating caller snapshots", async () => {
+    const prepared = await input("A");
+    prepared.tailCopies = [createMuxMessage("tail", "user", "Tail")];
+    const operation = lifecycle.publish(
+      lifecycle.begin(() => true),
+      prepared
+    );
+    prepared.attachments.readFiles.push("/changed.ts");
+    prepared.summaryMessage.parts = [{ type: "text", text: "Changed" }];
+    prepared.tailCopies[0].parts = [{ type: "text", text: "Changed tail" }];
+    const result = await operation;
+    assert(result.success);
+    expect(result.data.summaryMessage.parts).toMatchObject([{ type: "text", text: "A" }]);
+    expect(result.data.tailCopies[0].parts).toMatchObject([{ type: "text", text: "Tail" }]);
+    expect(result.data.summaryMessage.metadata?.historySequence).toBe(1);
+    expect(result.data.tailCopies[0].metadata?.historySequence).toBe(2);
+    expect(prepared.summaryMessage.metadata?.historySequence).toBeUndefined();
+    expect(prepared.tailCopies[0].metadata?.historySequence).toBeUndefined();
+    const snapshot = await lifecycle.capture("pending");
+    assert(snapshot);
+    snapshot.readFiles.push("/mutated-capture.ts");
+    expect((await lifecycle.capture("pending"))?.readFiles).toEqual(["/A.ts"]);
+    expect((await restart().load(() => true))?.attachments.readFiles).toEqual(["/A.ts"]);
+  });
+
+  it.each(["before", "after"] as const)(
+    "retains committed A when its promise returns %s B fails",
+    async (order) => {
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const atomic = store.publishBoundary.bind(store);
+      spyOn(store, "publishBoundary").mockImplementationOnce(async (request) => {
+        const result = await atomic(request);
+        entered.resolve();
+        await release.promise;
+        return result;
+      });
+      const a = publish("A", true);
+      try {
+        await entered.promise;
+        expect(await historyIds()).toEqual(["A"]);
+        if (order === "before") {
+          release.resolve();
+          expect((await a).success).toBe(true);
+        }
+        expect((await publish("B", true, lifecycle, false)).success).toBe(false);
+        expect((await lifecycle.capture("pending"))?.readFiles).toEqual(["/A.ts"]);
+        release.resolve();
+        expect((await a).success).toBe(true);
+        expect((await lifecycle.capture("pending"))?.readFiles).toEqual(["/A.ts"]);
+        expect((await restart().load(() => true))?.attachments.readFiles).toEqual(["/A.ts"]);
+      } finally {
+        release.resolve();
+        await a;
+      }
+    }
+  );
+
+  it("never revives A after its exact history rollback commits but returns late", async () => {
+    await publish("prior");
+    const a = await publish("A", true);
+    assert(a.success);
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const cleanup = h.historyService.cleanupCompactionFollowUp.bind(h.historyService);
+    spyOn(h.historyService, "cleanupCompactionFollowUp").mockImplementationOnce(async (...args) => {
+      const result = await cleanup(...args);
+      entered.resolve();
+      await release.promise;
+      return result;
+    });
+    const rollback = lifecycle.rollbackHeartbeat(a.data.summaryMessage, () => true);
+    try {
+      await entered.promise;
+      expect(await historyIds()).toEqual(["prior"]);
+      expect((await publish("B", true, lifecycle, false)).success).toBe(false);
+      expect((await lifecycle.capture("pending"))?.readFiles).toEqual(["/prior.ts"]);
+      release.resolve();
+      expect((await rollback).success).toBe(true);
+      expect((await lifecycle.capture("pending"))?.readFiles).toEqual(["/prior.ts"]);
+    } finally {
+      release.resolve();
+      await rollback;
+    }
+  });
+
+  it("does not restore unpublished A when a superseding B also fails", async () => {
+    const bInput = { ...(await input("B")), shouldPersist: () => false };
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const remove = syncFs.promises.rm;
+    let paused = false;
+    spyOn(syncFs.promises, "rm").mockImplementation(async (file, options) => {
+      if (String(file).startsWith(`${pendingPath}.continuous-`) && !paused) {
+        paused = true;
+        entered.resolve();
+        await release.promise;
+      }
+      return remove(file, options);
+    });
+    const a = publish("A");
+    let b: ReturnType<typeof publish> | undefined;
+    try {
+      await entered.promise;
+      expect(JSON.parse(await bytes())).toMatchObject({ boundaryMessageId: "A" });
+      const bPreparation = lifecycle.begin(() => true);
+      b = lifecycle.publish(bPreparation, bInput);
+      release.resolve();
+      expect((await a).success).toBe(false);
+      expect((await b).success).toBe(false);
+      expect(await lifecycle.capture("pending")).toBeUndefined();
+      expect(await restart().load(() => true)).toBeUndefined();
+      expect(await historyIds()).toEqual(["seed"]);
+    } finally {
+      release.resolve();
+      await a;
+      await b;
+    }
+  });
+
+  it.each(["ack", "discard"] as const)(
+    "consumed A stays retired after provisional B commits and rolls back (%s)",
+    async (disposition) => {
+      await publish("A");
+      const snapshot = await lifecycle.capture("pending");
+      assert(snapshot);
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const remove = syncFs.promises.rm;
+      let paused = false;
+      spyOn(syncFs.promises, "rm").mockImplementation(async (file, options) => {
+        if (String(file).startsWith(`${pendingPath}.continuous-`) && !paused) {
+          paused = true;
+          entered.resolve();
+          await release.promise;
+        }
+        return remove(file, options);
+      });
+      const b = publish("B", true);
+      let consuming: Promise<void> | undefined;
+      try {
+        await entered.promise;
+        consuming = lifecycle.consume(snapshot, disposition);
+        release.resolve();
+        const result = await b;
+        assert(result.success);
+        await consuming;
+        expect((await lifecycle.capture("pending"))?.readFiles).toEqual(["/B.ts"]);
+        expect(
+          (await lifecycle.rollbackHeartbeat(result.data.summaryMessage, () => true)).success
+        ).toBe(true);
+        expect(await lifecycle.capture("pending")).toBeUndefined();
+        expect((await lifecycle.capture("carryover"))?.readFiles).toEqual(
+          disposition === "ack" ? ["/A.ts"] : undefined
+        );
+        expect(await restart().load(() => true)).toBeUndefined();
+      } finally {
+        release.resolve();
+        await b;
+        await consuming;
+      }
+    }
+  );
+
+  it.each(["ack", "discard"] as const)(
+    "old request %s preserves the published successor",
+    async (disposition) => {
+      await publish("A");
+      const snapshot = await lifecycle.capture("pending");
+      assert(snapshot);
+      await publish("B");
+      await lifecycle.consume(snapshot, disposition);
+      expect((await lifecycle.capture("pending"))?.readFiles).toEqual(["/B.ts"]);
+      expect((await restart().load(() => true))?.attachments.readFiles).toEqual(["/B.ts"]);
+    }
+  );
+
+  it.each(["none", "before", "during"] as const)(
+    "captures surviving A authority when B's enrichment fails (C=%s)",
+    async (successor) => {
+      await publish("A");
+      const aBytes = await bytes();
+      const rename = syncFs.renameSync;
+      const failure = spyOn(syncFs, "renameSync").mockImplementation((from, to) => {
+        if (to === pendingPath) throw new Error("Optional write failed");
+        rename(from, to);
+      });
+      const b = await publish("B", true);
+      assert(b.success);
+      failure.mockRestore();
+      expect(await bytes()).toBe(aBytes);
+      const snapshot = await lifecycle.capture("pending");
+      assert(snapshot);
+      expect(snapshot).toEqual({ diffs: [], loadedSkills: [], readFiles: [] });
+      if (successor === "before") await publish("C");
+      const consuming = lifecycle.consume(snapshot, "discard");
+      if (successor === "during") await publish("C");
+      await consuming;
+      expect((await lifecycle.capture("pending"))?.readFiles).toEqual(
+        successor === "none" ? undefined : ["/C.ts"]
+      );
+      expect((await restart().load(() => true))?.attachments.readFiles).toEqual(
+        successor === "none" ? undefined : ["/C.ts"]
+      );
+      if (successor === "none")
+        expect(await fs.stat(pendingPath).catch((error: unknown) => error)).toMatchObject({
+          code: "ENOENT",
+        });
+    }
+  );
+
+  it.each([false, true])(
+    "retires surviving A after two failed enrichments and rollback (failed unlink=%s)",
+    async (failUnlink) => {
+      await publish("A");
+      const rename = syncFs.renameSync;
+      const failure = spyOn(syncFs, "renameSync").mockImplementation((from, to) => {
+        if (to === pendingPath) throw new Error("Optional write failed");
+        rename(from, to);
+      });
+      // Best-effort archive rotation may fail after commit. Keep both heartbeat rows active
+      // so this exercises two applied rollbacks, not cleanup skipping an archived B.
+      const open = fs.open;
+      const rotation = spyOn(fs, "open").mockImplementation(async (file, flags, mode) => {
+        if (String(file).endsWith("chat-archive.jsonl") && flags === "a+")
+          throw new Error("Archive rotation unavailable");
+        return open(file, flags, mode);
+      });
+      const b = await publish("B", true);
+      assert(b.success);
+      const c = await publish("C", true);
+      assert(c.success);
+      failure.mockRestore();
+      expect(await lifecycle.rollbackHeartbeat(c.data.summaryMessage, () => true)).toMatchObject({
+        success: true,
+        data: { outcome: "applied" },
+      });
+      const snapshot = await lifecycle.capture("pending");
+      assert(snapshot);
+      expect(snapshot).toEqual({ diffs: [], loadedSkills: [], readFiles: [] });
+      const remove = fs.unlink;
+      const unlink = spyOn(fs, "unlink").mockImplementation(async (file) => {
+        if (failUnlink && file === pendingPath) throw new Error("Cleanup unavailable");
+        await remove(file);
+      });
+      await lifecycle.consume(snapshot, "discard");
+      unlink.mockRestore();
+      expect(await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).toMatchObject({
+        success: true,
+        data: { outcome: "applied" },
+      });
+      rotation.mockRestore();
+      expect(await lifecycle.capture("pending")).toBeUndefined();
+      expect(await lifecycle.capture("carryover")).toBeUndefined();
+      expect(
+        await new CompactionPreparationLifecycle(restart()).capture("pending")
+      ).toBeUndefined();
+    }
+  );
+
+  it.each([
+    { disposition: "ack", acknowledgePrevious: false },
+    { disposition: "discard", acknowledgePrevious: false },
+    { disposition: "discard", acknowledgePrevious: true },
+  ] as const)(
+    "does not restore B's fallback after target consumption with failed unlink (%j)",
+    async ({ disposition, acknowledgePrevious }) => {
+      await publish("A");
+      if (acknowledgePrevious) {
+        const a = await lifecycle.capture("pending");
+        assert(a);
+        await lifecycle.consume(a, "ack");
+      }
+      const b = await publish("B", true);
+      assert(b.success);
+      const snapshot = await lifecycle.capture("pending");
+      assert(snapshot);
+      expect(snapshot.readFiles).toEqual(["/B.ts"]);
+      const before = await bytes();
+      const remove = fs.unlink;
+      const unlink = spyOn(fs, "unlink").mockImplementation(async (file) => {
+        if (file === pendingPath) throw new Error("Cleanup unavailable");
+        await remove(file);
+      });
+      await lifecycle.consume(snapshot, disposition);
+      unlink.mockRestore();
+      expect(await bytes()).toBe(before);
+      expect(await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).toMatchObject({
+        success: true,
+        data: { outcome: "applied" },
+      });
+      expect(await lifecycle.capture("pending")).toBeUndefined();
+      // B's retirement must not discard unrelated A warmth that was already acknowledged.
+      expect((await lifecycle.capture("carryover"))?.readFiles).toEqual(
+        acknowledgePrevious ? ["/A.ts"] : undefined
+      );
+      expect(
+        await new CompactionPreparationLifecycle(restart()).capture("pending")
+      ).toBeUndefined();
+    }
+  );
+
+  it("keeps future data inert and byte-preserved through publication, consumption and reset", async () => {
+    await publish("A");
+    const future = '{"version":9,"payload":"future"}\n';
+    await fs.writeFile(pendingPath, future);
+    expect((await publish("B")).success).toBe(true);
+    const snapshot = await lifecycle.capture("pending");
+    assert(snapshot);
+    expect(snapshot.readFiles).toEqual([]);
+    await lifecycle.consume(snapshot, "discard");
+    expect(await bytes()).toBe(future);
+    assert((await new HistoryService(h.config).clearHistory(workspaceId)).success);
+    await lifecycle.discardAfterBoundary();
+    expect(await bytes()).toBe(future);
+    expect(await lifecycle.capture("pending")).toBeUndefined();
+    expect(await lifecycle.capture("carryover")).toBeUndefined();
+  });
+
+  it("qualifies acknowledged carryover against a foreign reset on every capture", async () => {
+    await publish("A");
+    const snapshot = await lifecycle.capture("pending");
+    assert(snapshot);
+    await lifecycle.consume(snapshot, "ack");
+    expect((await lifecycle.capture("carryover"))?.readFiles).toEqual(["/A.ts"]);
+    expect((await lifecycle.capture("carryover"))?.diffs).toEqual([]);
+    assert((await new HistoryService(h.config).clearHistory(workspaceId)).success);
+    expect(await lifecycle.capture("carryover")).toBeUndefined();
+    expect(await lifecycle.capture("pending")).toBeUndefined();
+  });
+
+  it.each(["published", "history-only"] as const)(
+    "replaces acknowledged A warmth after a foreign same-generation B (%s)",
+    async (enrichment) => {
+      assert((await publish("A")).success);
+      const a = await lifecycle.capture("pending");
+      assert(a);
+      await lifecycle.consume(a, "ack");
+      expect((await lifecycle.capture("carryover"))?.readFiles).toEqual(["/A.ts"]);
+      const journal = h.historyService.getContinuousCompactionJournal(workspaceId);
+      const generation = await journal.captureGeneration();
+      const rename = syncFs.renameSync;
+      const failure = spyOn(syncFs, "renameSync").mockImplementation((from, to) => {
+        if (enrichment === "history-only" && to === pendingPath)
+          throw new Error("Optional enrichment unavailable");
+        rename(from, to);
+      });
+      const foreign = new CompactionPreparationLifecycle(restart());
+      assert((await publish("B", false, foreign)).success);
+      failure.mockRestore();
+      expect(await historyIds()).toEqual(["B"]);
+      expect(await journal.captureGeneration()).toBe(generation);
+      const before = await bytes().catch(() => undefined);
+      expect((await lifecycle.capture("carryover"))?.readFiles).toEqual(
+        enrichment === "published" ? ["/B.ts"] : undefined
+      );
+      expect((await lifecycle.capture("pending"))?.readFiles).toEqual(
+        enrichment === "published" ? ["/B.ts"] : undefined
+      );
+      expect(await bytes().catch(() => undefined)).toBe(before);
+    }
+  );
+
+  it("fences a delayed initial load when reset clears memory before cleanup awaits", async () => {
+    await publish("A");
+    const restarted = new CompactionPreparationLifecycle(store);
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const load = store.observe.bind(store);
+    spyOn(store, "observe").mockImplementationOnce(async (...args) => {
+      const result = await load(...args);
+      entered.resolve();
+      await release.promise;
+      return result;
+    });
+    const capturing = restarted.capture("pending");
+    try {
+      await entered.promise;
+      assert((await new HistoryService(h.config).clearHistory(workspaceId)).success);
+      await restarted.discardAfterBoundary();
+      release.resolve();
+      expect(await capturing).toBeUndefined();
+      expect(await restarted.capture("pending")).toBeUndefined();
+    } finally {
+      release.resolve();
+      await capturing;
+    }
+  });
+
+  it("restores a restart heartbeat through the store's exact receipt", async () => {
+    await publish("A");
+    const b = await publish("B", true);
+    assert(b.success);
+    const restarted = new CompactionPreparationLifecycle(restart());
+    expect((await restarted.rollbackHeartbeat(b.data.summaryMessage, () => true)).success).toBe(
+      true
+    );
+    expect((await restarted.capture("pending"))?.readFiles).toEqual(["/A.ts"]);
+  });
+
+  it("retains consumption facts when a foreign heartbeat restores a known predecessor", async () => {
+    await publish("A");
+    const a = await lifecycle.capture("pending");
+    assert(a);
+    const foreign = new CompactionPreparationLifecycle(restart());
+    const b = await publish("B", true, foreign);
+    assert(b.success);
+    expect((await lifecycle.capture("pending"))?.readFiles).toEqual(["/B.ts"]);
+    expect((await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).success).toBe(
+      true
+    );
+    expect((await lifecycle.capture("pending"))?.readFiles).toEqual(["/A.ts"]);
+    const before = await bytes();
+    const remove = fs.unlink;
+    const unlink = spyOn(fs, "unlink").mockImplementation(async (file) => {
+      if (file === pendingPath) throw new Error("Cleanup unavailable");
+      await remove(file);
+    });
+    await lifecycle.consume(a, "discard");
+    unlink.mockRestore();
+    expect(await bytes()).toBe(before);
+    expect(await lifecycle.capture("pending")).toBeUndefined();
+    expect(await lifecycle.capture("carryover")).toBeUndefined();
+  });
+
+  it("requires pending proof for unacknowledged carryover after a foreign publication", async () => {
+    await publish("A");
+    await publish("B", true, new CompactionPreparationLifecycle(restart()));
+    expect((await lifecycle.capture("carryover"))?.readFiles).toEqual(["/B.ts"]);
+  });
+
+  it.each([
+    { disposition: "ack", captureForeign: true },
+    { disposition: "discard", captureForeign: true },
+    { disposition: "ack", captureForeign: false },
+    { disposition: "discard", captureForeign: false },
+  ] as const)(
+    "does not restore consumed A after failed foreign fallback cleanup (%j)",
+    async ({ disposition, captureForeign }) => {
+      await publish("A");
+      const a = await lifecycle.capture("pending");
+      assert(a);
+      const b = await publish("B", true, new CompactionPreparationLifecycle(restart()));
+      assert(b.success);
+      if (captureForeign)
+        expect((await lifecycle.capture("pending"))?.readFiles).toEqual(["/B.ts"]);
+      const before = await bytes();
+      const rename = syncFs.renameSync;
+      const failure = spyOn(syncFs, "renameSync").mockImplementation((from, to) => {
+        if (to === pendingPath) throw new Error("Fallback cleanup unavailable");
+        rename(from, to);
+      });
+      await lifecycle.consume(a, disposition);
+      failure.mockRestore();
+      expect(await bytes()).toBe(before);
+      expect((await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).success).toBe(
+        true
+      );
+      expect(await lifecycle.capture("pending")).toBeUndefined();
+      expect(
+        await new CompactionPreparationLifecycle(restart()).capture("pending")
+      ).toBeUndefined();
+    }
+  );
+
+  it("does not promote acknowledged predecessor warmth over a foreign successor", async () => {
+    await publish("A");
+    const a = await lifecycle.capture("pending");
+    assert(a);
+    await lifecycle.consume(a, "ack");
+    await publish("B");
+    await publish("C", true, new CompactionPreparationLifecycle(restart()));
+    expect((await lifecycle.capture("carryover"))?.readFiles).toEqual(["/C.ts"]);
+  });
+
+  it("does not retain acknowledged warmth from a loaded heartbeat after its exact rollback", async () => {
+    await publish("A");
+    const b = await publish("B", true);
+    assert(b.success);
+    const restarted = new CompactionPreparationLifecycle(restart());
+    const snapshot = await restarted.capture("pending");
+    assert(snapshot);
+    await restarted.consume(snapshot, "ack");
+    expect((await restarted.rollbackHeartbeat(b.data.summaryMessage, () => true)).success).toBe(
+      true
+    );
+    expect(await restarted.capture("pending")).toBeUndefined();
+    expect(await restarted.capture("carryover")).toBeUndefined();
+  });
+
+  it("retains acknowledged local warmth when an uncaptured foreign heartbeat rolls back", async () => {
+    await publish("A");
+    const a = await lifecycle.capture("pending");
+    assert(a);
+    await lifecycle.consume(a, "ack");
+    const b = await publish("B", true, new CompactionPreparationLifecycle(restart()));
+    assert(b.success);
+    expect(await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).toMatchObject({
+      success: true,
+      data: { outcome: "applied" },
+    });
+    expect(await lifecycle.capture("pending")).toBeUndefined();
+    expect((await lifecycle.capture("carryover"))?.readFiles).toEqual(["/A.ts"]);
+    expect(await new CompactionPreparationLifecycle(restart()).capture("pending")).toBeUndefined();
+  });
+
+  it.each(["ack", "discard"] as const)(
+    "restores the persisted foreign predecessor instead of applying stale local %s facts",
+    async (disposition) => {
+      await publish("A");
+      const a = await lifecycle.capture("pending");
+      assert(a);
+      await lifecycle.consume(a, disposition);
+      assert((await publish("B", true, new CompactionPreparationLifecycle(restart()))).success);
+      const c = await publish("C", true);
+      assert(c.success);
+      expect(await lifecycle.rollbackHeartbeat(c.data.summaryMessage, () => true)).toMatchObject({
+        success: true,
+        data: { outcome: "applied" },
+      });
+      expect((await lifecycle.capture("pending"))?.readFiles).toEqual(["/B.ts"]);
+      expect((await lifecycle.capture("carryover"))?.readFiles).toEqual(["/B.ts"]);
+      expect(
+        (await new CompactionPreparationLifecycle(restart()).capture("pending"))?.readFiles
+      ).toEqual(["/B.ts"]);
+    }
+  );
+
+  it.each([
+    { acknowledgePrevious: false, failUnlink: false, consumeAfterRollback: false },
+    { acknowledgePrevious: true, failUnlink: false, consumeAfterRollback: false },
+    { acknowledgePrevious: true, failUnlink: true, consumeAfterRollback: false },
+    { acknowledgePrevious: true, failUnlink: true, consumeAfterRollback: true },
+  ])(
+    "discards the exact uncaptured foreign survivor (%j)",
+    async ({ acknowledgePrevious, failUnlink, consumeAfterRollback }) => {
+      await publish("A");
+      const a = await lifecycle.capture("pending");
+      assert(a);
+      await lifecycle.consume(a, acknowledgePrevious ? "ack" : "discard");
+      const b = await publish("B", true, new CompactionPreparationLifecycle(restart()));
+      assert(b.success);
+      // Preserve B as an active row so its later exact rollback can qualify A's original warmth.
+      const open = fs.open;
+      const rotation = spyOn(fs, "open").mockImplementation(async (file, flags, mode) => {
+        if (String(file).endsWith("chat-archive.jsonl") && flags === "a+")
+          throw new Error("Archive rotation unavailable");
+        return open(file, flags, mode);
+      });
+      const before = await bytes();
+      const rename = syncFs.renameSync;
+      const failure = spyOn(syncFs, "renameSync").mockImplementation((from, to) => {
+        if (to === pendingPath) throw new Error("Optional write failed");
+        rename(from, to);
+      });
+      const c = await publish("C", true);
+      assert(c.success);
+      failure.mockRestore();
+      expect(await bytes()).toBe(before);
+      const snapshot = await lifecycle.capture("pending");
+      assert(snapshot);
+      expect(snapshot).toEqual({ diffs: [], loadedSkills: [], readFiles: [] });
+      const rollbackC = () => lifecycle.rollbackHeartbeat(c.data.summaryMessage, () => true);
+      if (consumeAfterRollback) {
+        expect(await rollbackC()).toMatchObject({
+          success: true,
+          data: { outcome: "applied" },
+        });
+        expect((await lifecycle.capture("pending"))?.readFiles).toEqual(["/B.ts"]);
+      }
+      const remove = fs.unlink;
+      const unlink = spyOn(fs, "unlink").mockImplementation(async (file) => {
+        if (failUnlink && file === pendingPath) throw new Error("Cleanup unavailable");
+        await remove(file);
+      });
+      await lifecycle.consume(snapshot, "discard");
+      unlink.mockRestore();
+      if (!consumeAfterRollback)
+        expect(await rollbackC()).toMatchObject({
+          success: true,
+          data: { outcome: "applied" },
+        });
+      expect(await lifecycle.capture("pending")).toBeUndefined();
+      if (!consumeAfterRollback)
+        expect(
+          await new CompactionPreparationLifecycle(restart()).capture("pending")
+        ).toBeUndefined();
+      expect(await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).toMatchObject({
+        success: true,
+        data: { outcome: "applied" },
+      });
+      rotation.mockRestore();
+      expect(
+        await new CompactionPreparationLifecycle(restart()).capture("pending")
+      ).toBeUndefined();
+      expect((await lifecycle.capture("carryover"))?.readFiles).toEqual(
+        acknowledgePrevious ? ["/A.ts"] : undefined
+      );
+    }
+  );
+  it("retires an unobserved foreign predecessor after publication read recovery and rollback", async () => {
+    assert((await publish("A", false, new CompactionPreparationLifecycle(restart()))).success);
+    const readFile = fs.readFile;
+    const unreadable = spyOn(fs, "readFile").mockImplementation((async (
+      ...args: Parameters<typeof fs.readFile>
+    ) => {
+      if (args[0] === pendingPath) throw new Error("Pending read unavailable");
+      return readFile(...args);
+    }) as typeof fs.readFile);
+    const b = await publish("B", true);
+    assert(b.success);
+    const empty = await lifecycle.capture("pending");
+    assert(empty);
+    expect(empty.readFiles).toEqual([]);
+    await lifecycle.consume(empty, "discard");
+    unreadable.mockRestore();
+    expect(await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).toMatchObject({
+      success: true,
+      data: { outcome: "applied" },
+    });
+    expect(await lifecycle.capture("pending")).toBeUndefined();
+    expect(await new CompactionPreparationLifecycle(restart()).capture("pending")).toBeUndefined();
+  });
+
+  it.each(["ack", "discard"] as const)(
+    "retries known %s cleanup after an uncaptured foreign history-only rollback",
+    async (disposition) => {
+      await publish("A");
+      const a = await lifecycle.capture("pending");
+      assert(a);
+      const unlink = fs.unlink;
+      const unavailable = spyOn(fs, "unlink").mockImplementation(async (file) => {
+        if (file === pendingPath) throw new Error("Pending unlink unavailable");
+        await unlink(file);
+      });
+      await lifecycle.consume(a, disposition);
+      unavailable.mockRestore();
+      const rename = syncFs.renameSync;
+      const failedWrite = spyOn(syncFs, "renameSync").mockImplementation((from, to) => {
+        if (to === pendingPath) throw new Error("Optional write unavailable");
+        rename(from, to);
+      });
+      const b = await publish("B", true, new CompactionPreparationLifecycle(restart()));
+      assert(b.success);
+      failedWrite.mockRestore();
+      expect(await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).toMatchObject({
+        success: true,
+        data: { outcome: "applied" },
+      });
+      expect(await lifecycle.capture("pending")).toBeUndefined();
+      expect(
+        await new CompactionPreparationLifecycle(restart()).capture("pending")
+      ).toBeUndefined();
+      expect((await lifecycle.capture("carryover"))?.readFiles).toEqual(
+        disposition === "ack" ? ["/A.ts"] : undefined
+      );
+    }
+  );
+
+  it.each([
+    { acknowledgeA: true, acknowledgeB: false },
+    { acknowledgeA: true, acknowledgeB: true },
+    { acknowledgeA: false, acknowledgeB: false },
+    { acknowledgeA: false, acknowledgeB: true },
+  ])(
+    "retains only acknowledged warmth across nested rollback (%j)",
+    async ({ acknowledgeA, acknowledgeB }) => {
+      await publish("A");
+      const a = await lifecycle.capture("pending");
+      assert(a);
+      if (acknowledgeA) await lifecycle.consume(a, "ack");
+      const open = fs.open;
+      const rotation = spyOn(fs, "open").mockImplementation(async (file, flags, mode) => {
+        if (String(file).endsWith("chat-archive.jsonl") && flags === "a+")
+          throw new Error("Archive rotation unavailable");
+        return open(file, flags, mode);
+      });
+      const b = await publish("B", true);
+      assert(b.success);
+      if (acknowledgeB) {
+        const bSnapshot = await lifecycle.capture("pending");
+        assert(bSnapshot);
+        await lifecycle.consume(bSnapshot, "ack");
+      }
+      const c = await publish("C", true);
+      assert(b.success && c.success);
+      expect(await lifecycle.rollbackHeartbeat(c.data.summaryMessage, () => true)).toMatchObject({
+        success: true,
+        data: { outcome: "applied" },
+      });
+      expect((await lifecycle.capture("pending"))?.readFiles).toEqual(
+        acknowledgeB ? undefined : ["/B.ts"]
+      );
+      expect((await lifecycle.capture("carryover"))?.readFiles).toEqual(["/B.ts"]);
+      expect(await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).toMatchObject({
+        success: true,
+        data: { outcome: "applied" },
+      });
+      rotation.mockRestore();
+      expect(await lifecycle.capture("pending")).toBeUndefined();
+      expect((await lifecycle.capture("carryover"))?.readFiles).toEqual(
+        acknowledgeA ? ["/A.ts"] : undefined
+      );
+    }
+  );
+  it("skips an older active heartbeat and preserves the successor's fallback", async () => {
+    assert((await publish("A")).success);
+    const open = fs.open;
+    spyOn(fs, "open").mockImplementation(async (file, flags, mode) => {
+      if (String(file).endsWith("chat-archive.jsonl") && flags === "a+")
+        throw new Error("Archive unavailable");
+      return open(file, flags, mode);
+    });
+    const b = await publish("B", true);
+    const c = await publish("C", true);
+    assert(b.success && c.success);
+    const before = await bytes();
+    expect(await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).toMatchObject({
+      success: true,
+      data: { outcome: "skipped" },
+    });
+    expect(await bytes()).toBe(before);
+    expect(await lifecycle.rollbackHeartbeat(c.data.summaryMessage, () => true)).toMatchObject({
+      success: true,
+      data: { outcome: "applied" },
+    });
+    expect(
+      (await new CompactionPreparationLifecycle(restart()).capture("pending"))?.readFiles
+    ).toEqual(["/B.ts"]);
+  });
+
+  it("refuses consumed rollback until exact pending retirement becomes durable", async () => {
+    assert((await publish("A")).success);
+    const b = await publish("B", true);
+    assert(b.success);
+    const captured = await lifecycle.capture("pending");
+    assert(captured);
+    const unlink = fs.unlink;
+    const failedUnlink = spyOn(fs, "unlink").mockImplementation(async (file) => {
+      if (file === pendingPath) throw new Error("Pending unlink unavailable");
+      return unlink(file);
+    });
+    const rename = syncFs.renameSync;
+    const failedReplacement = spyOn(syncFs, "renameSync").mockImplementation((from, to) => {
+      if (to === pendingPath) throw new Error("Pending replacement unavailable");
+      rename(from, to);
+    });
+    await lifecycle.consume(captured, "discard");
+    expect((await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).success).toBe(
+      false
+    );
+    expect(await historyIds()).toEqual(["B"]);
+    failedUnlink.mockRestore();
+    failedReplacement.mockRestore();
+    expect(await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).toMatchObject({
+      success: true,
+      data: { outcome: "applied" },
+    });
+    expect(await new CompactionPreparationLifecycle(restart()).capture("pending")).toBeUndefined();
+  });
+
+  it.each([false, true])(
+    "skips staged rollback when consumption changes after its retirement checkpoint (%s)",
+    async (priorConsumption) => {
+      assert((await publish("A")).success);
+      if (priorConsumption) {
+        const a = await lifecycle.capture("pending");
+        assert(a);
+        await lifecycle.consume(a, "ack");
+      }
+      const b = await publish("B", true);
+      assert(b.success);
+      const snapshot = await lifecycle.capture("pending");
+      assert(snapshot);
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const atomic = atomicWrite.default;
+      spyOn(atomicWrite, "default").mockImplementation(
+        new Proxy(atomic, {
+          async apply(target, receiver, args: Parameters<typeof atomic>) {
+            const result = await Reflect.apply(target, receiver, args);
+            if (String(args[0]).includes(".follow-up-")) {
+              entered.resolve();
+              await release.promise;
+            }
+            return result;
+          },
+        })
+      );
+      const rollback = lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true);
+      let consuming: Promise<void> | undefined;
+      try {
+        await entered.promise;
+        consuming = lifecycle.consume(snapshot, "discard");
+        release.resolve();
+        expect(await rollback).toMatchObject({ success: true, data: { outcome: "skipped" } });
+        await consuming;
+        expect(await historyIds()).toEqual(["B"]);
+        expect(await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).toMatchObject({
+          success: true,
+          data: { outcome: "applied" },
+        });
+        expect(
+          await new CompactionPreparationLifecycle(restart()).capture("pending")
+        ).toBeUndefined();
+      } finally {
+        release.resolve();
+        await rollback;
+        await consuming;
+      }
+    }
+  );
+
+  it("preserves unconsumed B when predecessor retirement succeeds but history staging fails", async () => {
+    assert((await publish("A")).success);
+    const a = await lifecycle.capture("pending");
+    assert(a);
+    const unlink = fs.unlink;
+    const unavailable = spyOn(fs, "unlink").mockImplementation(async (file) => {
+      if (file === pendingPath) throw new Error("Pending unlink unavailable");
+      return unlink(file);
+    });
+    await lifecycle.consume(a, "ack");
+    unavailable.mockRestore();
+    const b = await publish("B", true);
+    assert(b.success);
+    const rename = syncFs.renameSync;
+    const failure = spyOn(syncFs, "renameSync").mockImplementation((from, to) => {
+      if (to === path.join(h.config.sessionsDir, workspaceId, "chat.jsonl"))
+        throw new Error("History rename unavailable");
+      rename(from, to);
+    });
+    expect((await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).success).toBe(
+      false
+    );
+    expect(await historyIds()).toEqual(["B"]);
+    expect((await lifecycle.capture("pending"))?.readFiles).toEqual(["/B.ts"]);
+    expect((await restart().load(() => true))?.attachments.readFiles).toEqual(["/B.ts"]);
+    failure.mockRestore();
+    expect(await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).toMatchObject({
+      success: true,
+      data: { outcome: "applied" },
+    });
+    expect((await lifecycle.capture("carryover"))?.readFiles).toEqual(["/A.ts"]);
+  });
+
+  it("does not apply a consumed noncurrent heartbeat to a foreign successor", async () => {
+    await publish("A");
+    const open = fs.open;
+    const rotation = spyOn(fs, "open").mockImplementation(async (file, flags, mode) => {
+      if (String(file).endsWith("chat-archive.jsonl") && flags === "a+")
+        throw new Error("Archive unavailable");
+      return open(file, flags, mode);
+    });
+    const b = await publish("B", true);
+    assert(b.success);
+    const snapshot = await lifecycle.capture("pending");
+    assert(snapshot);
+    await lifecycle.consume(snapshot, "discard");
+    assert((await publish("C", true, new CompactionPreparationLifecycle(restart()))).success);
+    rotation.mockRestore();
+    const before = await bytes();
+    expect(await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).toMatchObject({
+      success: true,
+      data: { outcome: "skipped" },
+    });
+    expect(await bytes()).toBe(before);
+    expect((await lifecycle.capture("pending"))?.readFiles).toEqual(["/C.ts"]);
+    expect(
+      (await new CompactionPreparationLifecycle(restart()).capture("pending"))?.readFiles
+    ).toEqual(["/C.ts"]);
+  });
+
+  it("does not apply an old-generation empty token to newly eligible pending state", async () => {
+    await publish("A");
+    const original = JSON.parse(await bytes()) as Record<string, unknown>;
+    const rename = syncFs.renameSync;
+    const failure = spyOn(syncFs, "renameSync").mockImplementation((from, to) => {
+      if (to === pendingPath) throw new Error("Optional write unavailable");
+      rename(from, to);
+    });
+    const b = await publish("B", true);
+    assert(b.success);
+    const snapshot = await lifecycle.capture("pending");
+    assert(snapshot);
+    expect(snapshot.readFiles).toEqual([]);
+    await lifecycle.consume(snapshot, "discard");
+    failure.mockRestore();
+    const journal = new HistoryService(h.config).getContinuousCompactionJournal(workspaceId);
+    await journal.advanceGeneration();
+    const replacement = JSON.stringify({
+      ...original,
+      // The restored A occurrence remains exact; the changed generation is the new owner.
+      writeId: original.writeId,
+      publicationGeneration: await journal.captureGeneration(),
+      readFiles: ["/new.ts"],
+    });
+    await fs.writeFile(pendingPath, replacement);
+    expect(await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).toMatchObject({
+      success: true,
+      data: { outcome: "applied" },
+    });
+    expect(await bytes()).toBe(replacement);
+    expect((await lifecycle.capture("pending"))?.readFiles).toEqual(["/new.ts"]);
+  });
+
+  it("bounds retained acknowledged candidates after successful archive rotations", async () => {
+    const observed = spyOn(store, "observe");
+    for (const name of ["A", "B", "C", "D", "E"]) {
+      assert((await publish(name, name !== "A")).success);
+      const snapshot = await lifecycle.capture("pending");
+      assert(snapshot);
+      await lifecycle.consume(snapshot, "ack");
+    }
+    expect((await lifecycle.capture("carryover"))?.readFiles).toEqual(["/E.ts"]);
+    expect(observed.mock.calls.at(-1)?.[0].length).toBeLessThanOrEqual(2);
+  });
+  it.each([
+    { failUnlink: false, disposition: "discard" as const },
+    { failUnlink: true, disposition: "discard" as const },
+    { failUnlink: false, disposition: "ack" as const },
+    { failUnlink: true, disposition: "ack" as const },
+  ])(
+    "preserves independently acknowledged A warmth when consuming an empty B (%j)",
+    async ({ failUnlink, disposition }) => {
+      await publish("A");
+      const a = await lifecycle.capture("pending");
+      assert(a);
+      const unlink = fs.unlink;
+      const failedAck = spyOn(fs, "unlink").mockImplementation(async (file) => {
+        if (failUnlink && file === pendingPath) throw new Error("Unlink unavailable");
+        return unlink(file);
+      });
+      await lifecycle.consume(a, "ack");
+      failedAck.mockRestore();
+      const rename = syncFs.renameSync;
+      const optional = spyOn(syncFs, "renameSync").mockImplementation((from, to) => {
+        if (to === pendingPath) throw new Error("Optional write unavailable");
+        rename(from, to);
+      });
+      const b = await publish("B", true);
+      assert(b.success);
+      const empty = await lifecycle.capture("pending");
+      assert(empty);
+      expect(empty.readFiles).toEqual([]);
+      await lifecycle.consume(empty, disposition);
+      optional.mockRestore();
+      expect(await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).toMatchObject({
+        success: true,
+        data: { outcome: "applied" },
+      });
+      expect(await lifecycle.capture("pending")).toBeUndefined();
+      expect((await lifecycle.capture("carryover"))?.readFiles).toEqual(["/A.ts"]);
+      expect(
+        await new CompactionPreparationLifecycle(restart()).capture("pending")
+      ).toBeUndefined();
+    }
+  );
+  it("retries unreadable consumed rollback across a deeper heartbeat without deleting later bytes", async () => {
+    assert((await publish("A", false, new CompactionPreparationLifecycle(restart()))).success);
+    const original = await bytes();
+    const read = fs.readFile;
+    const unavailable = spyOn(fs, "readFile").mockImplementation((async (
+      ...args: Parameters<typeof fs.readFile>
+    ) => {
+      if (args[0] === pendingPath) throw new Error("Pending read unavailable");
+      return read(...args);
+    }) as typeof fs.readFile);
+    const b = await publish("B", true);
+    assert(b.success);
+    const empty = await lifecycle.capture("pending");
+    assert(empty);
+    expect(empty.readFiles).toEqual([]);
+    await lifecycle.consume(empty, "discard");
+    expect((await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).success).toBe(
+      false
+    );
+    expect(await historyIds()).toEqual(["B"]);
+    unavailable.mockRestore();
+    expect(await lifecycle.capture("pending")).toBeUndefined();
+    expect(await bytes()).toBe(original);
+    // The unchanged B boundary keeps A ineligible until retirement can be established.
+    expect(await new CompactionPreparationLifecycle(restart()).capture("pending")).toBeUndefined();
+    const open = fs.open;
+    const rotation = spyOn(fs, "open").mockImplementation(async (file, flags, mode) => {
+      if (String(file).endsWith("chat-archive.jsonl") && flags === "a+")
+        throw new Error("Archive unavailable");
+      return open(file, flags, mode);
+    });
+    const c = await publish("C", true);
+    assert(c.success);
+    expect((await lifecycle.capture("pending"))?.readFiles).toEqual(["/C.ts"]);
+    expect(await lifecycle.rollbackHeartbeat(c.data.summaryMessage, () => true)).toMatchObject({
+      success: true,
+      data: { outcome: "applied" },
+    });
+    expect(await lifecycle.capture("pending")).toBeUndefined();
+    expect(await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).toMatchObject({
+      success: true,
+      data: { outcome: "applied" },
+    });
+    expect(await new CompactionPreparationLifecycle(restart()).capture("pending")).toBeUndefined();
+    rotation.mockRestore();
+    const replacement = JSON.stringify({
+      ...(JSON.parse(original) as Record<string, unknown>),
+      writeId: "foreign-replacement",
+      readFiles: ["/replacement.ts"],
+    });
+    await fs.writeFile(pendingPath, replacement);
+    expect(await lifecycle.capture("pending")).toBeUndefined();
+    expect(await bytes()).toBe(replacement);
+    assert((await publish("D")).success);
+    expect((await lifecycle.capture("pending"))?.readFiles).toEqual(["/D.ts"]);
+  });
+
+  it("retains initial acknowledged warmth across a heartbeat and prunes it after an irreversible boundary", async () => {
+    await fs.writeFile(
+      pendingPath,
+      JSON.stringify({
+        version: 1,
+        createdAt: 1,
+        diffs: [],
+        loadedSkills: [],
+        readFiles: ["/initial.ts"],
+      })
+    );
+    const initial = await lifecycle.capture("pending");
+    assert(initial);
+    await lifecycle.consume(initial, "ack");
+    const b = await publish("B", true);
+    assert(b.success);
+    expect((await lifecycle.capture("pending"))?.readFiles).toEqual(["/B.ts"]);
+    expect(await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).toMatchObject({
+      success: true,
+      data: { outcome: "applied" },
+    });
+    expect((await lifecycle.capture("carryover"))?.readFiles).toEqual(["/initial.ts"]);
+    assert((await publish("C")).success);
+    const c = await lifecycle.capture("pending");
+    assert(c);
+    await lifecycle.consume(c, "ack");
+    const observed = spyOn(store, "observe");
+    expect((await lifecycle.capture("carryover"))?.readFiles).toEqual(["/C.ts"]);
+    expect(observed.mock.calls[0]?.[0]).toHaveLength(1);
+  });
+  it.each(["ack", "discard"] as const)(
+    "does not apply loaded %s facts from an older write at a reused boundary ID",
+    async (disposition) => {
+      const foreign = new CompactionPreparationLifecycle(restart());
+      const old = await publish("B", true, foreign);
+      assert(old.success);
+      const captured = await lifecycle.capture("pending");
+      assert(captured);
+      await lifecycle.consume(captured, disposition);
+      assert((await publish("A", false, foreign)).success);
+      const newer = await publish("B", true, foreign);
+      assert(newer.success);
+      expect(newer.data.summaryMessage.metadata?.historySequence).not.toBe(
+        old.data.summaryMessage.metadata?.historySequence
+      );
+      expect(
+        await lifecycle.rollbackHeartbeat(newer.data.summaryMessage, () => true)
+      ).toMatchObject({ success: true, data: { outcome: "applied" } });
+      expect((await lifecycle.capture("pending"))?.readFiles).toEqual(["/A.ts"]);
+      expect(
+        (await new CompactionPreparationLifecycle(restart()).capture("pending"))?.readFiles
+      ).toEqual(["/A.ts"]);
+    }
+  );
+
+  it.each(["ack", "discard"] as const)(
+    "uses exact loaded %s facts to veto fallback restoration after failed unlink",
+    async (disposition) => {
+      const foreign = new CompactionPreparationLifecycle(restart());
+      assert((await publish("A", false, foreign)).success);
+      const b = await publish("B", true, foreign);
+      assert(b.success);
+      const captured = await lifecycle.capture("pending");
+      assert(captured);
+      const unlink = fs.unlink;
+      const unavailable = spyOn(fs, "unlink").mockImplementation(async (file) => {
+        if (file === pendingPath) throw new Error("Unlink unavailable");
+        return unlink(file);
+      });
+      await lifecycle.consume(captured, disposition);
+      unavailable.mockRestore();
+      expect(await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).toMatchObject({
+        success: true,
+        data: { outcome: "applied" },
+      });
+      expect(await lifecycle.capture("pending")).toBeUndefined();
+      expect(
+        await new CompactionPreparationLifecycle(restart()).capture("pending")
+      ).toBeUndefined();
+    }
+  );
+  it("selects acknowledged warmth from the latest observed write at a reused boundary ID", async () => {
+    const first = await publish("B", true);
+    assert(first.success);
+    const captured = await lifecycle.capture("pending");
+    assert(captured);
+    await lifecycle.consume(captured, "ack");
+    expect(
+      await new CompactionPreparationLifecycle(restart()).rollbackHeartbeat(
+        first.data.summaryMessage,
+        () => true
+      )
+    ).toMatchObject({ success: true, data: { outcome: "applied" } });
+    const second = await input("B", true);
+    second.attachments.readFiles = ["/B2.ts"];
+    assert(
+      (
+        await lifecycle.publish(
+          lifecycle.begin(() => true),
+          second
+        )
+      ).success
+    );
+    const latest = await lifecycle.capture("pending");
+    assert(latest);
+    expect(latest.readFiles).toEqual(["/B2.ts"]);
+    await lifecycle.consume(latest, "ack");
+    expect((await lifecycle.capture("carryover"))?.readFiles).toEqual(["/B2.ts"]);
+  });
+
+  it("rejects old warmth after an unobserved foreign replacement at a reused boundary", async () => {
+    const first = await publish("B", true);
+    assert(first.success);
+    const firstReceipt = await store.load(() => true);
+    assert(firstReceipt);
+    const captured = await lifecycle.capture("pending");
+    assert(captured);
+    await lifecycle.consume(captured, "ack");
+    const foreign = new CompactionPreparationLifecycle(restart());
+    expect(await foreign.rollbackHeartbeat(first.data.summaryMessage, () => true)).toMatchObject({
+      success: true,
+      data: { outcome: "applied" },
+    });
+    // A restarted publisher can reuse the removed sequence and identical summary bytes.
+    // Only attachment ownership differs; local row-content hashes cannot distinguish it.
+    const writer = new CompactionPreparationLifecycle(restart());
+    const replacement = await input("B", true);
+    replacement.summaryMessage = structuredClone(first.data.summaryMessage);
+    delete replacement.summaryMessage.metadata!.historySequence;
+    replacement.attachments.readFiles = ["/B2.ts"];
+    const second = await writer.publish(
+      writer.begin(() => true),
+      replacement
+    );
+    assert(second.success);
+    expect(second.data.summaryMessage.metadata?.historySequence).toBe(
+      first.data.summaryMessage.metadata?.historySequence
+    );
+    const delivered = await writer.capture("pending");
+    assert(delivered);
+    await writer.consume(delivered, "ack");
+    expect(await store.isCurrent(firstReceipt, "carryover", () => true)).toBe(false);
+    expect(await lifecycle.capture("carryover")).toBeUndefined();
+    expect(await lifecycle.rollbackHeartbeat(first.data.summaryMessage, () => true)).toMatchObject({
+      success: true,
+      data: { outcome: "skipped" },
+    });
+    expect((await writer.capture("carryover"))?.readFiles).toEqual(["/B2.ts"]);
+  });
+
+  it("bounds acknowledged receipt retention across repeated foreign rollback and ID reuse", async () => {
+    const observed = spyOn(store, "observe");
+    for (let iteration = 0; iteration < 5; iteration++) {
+      const result = await publish("B", true);
+      assert(result.success);
+      const snapshot = await lifecycle.capture("pending");
+      assert(snapshot);
+      await lifecycle.consume(snapshot, "ack");
+      expect(
+        await new CompactionPreparationLifecycle(restart()).rollbackHeartbeat(
+          result.data.summaryMessage,
+          () => true
+        )
+      ).toMatchObject({ success: true, data: { outcome: "applied" } });
+    }
+    expect(observed.mock.calls.at(-1)?.[0].length).toBeLessThanOrEqual(1);
+  });
+
+  it("does not adopt an old history-only token after an unobserved foreign replacement", async () => {
+    const rename = syncFs.renameSync;
+    spyOn(syncFs, "renameSync").mockImplementation((from, to) => {
+      if (to === pendingPath) throw new Error("Optional write unavailable");
+      rename(from, to);
+    });
+    const first = await publish("B", true);
+    assert(first.success);
+    expect((await lifecycle.capture("pending"))?.readFiles).toEqual([]);
+    const foreign = new CompactionPreparationLifecycle(restart());
+    expect(await foreign.rollbackHeartbeat(first.data.summaryMessage, () => true)).toMatchObject({
+      success: true,
+      data: { outcome: "applied" },
+    });
+    assert((await publish("B", true, foreign)).success);
+    expect(await lifecycle.capture("pending")).toBeUndefined();
+    expect((await foreign.capture("pending"))?.readFiles).toEqual([]);
+  });
+
+  it("preserves warmth through follow-up clear, summary finalization, and unrelated append", async () => {
+    const b = await publish("B", true);
+    assert(b.success);
+    const snapshot = await lifecycle.capture("pending");
+    assert(snapshot);
+    await lifecycle.consume(snapshot, "ack");
+    expect(
+      await h.historyService.cleanupCompactionFollowUp(
+        workspaceId,
+        b.data.summaryMessage,
+        "clear",
+        () => true
+      )
+    ).toMatchObject({ success: true, data: "applied" });
+    const finalized = structuredClone(b.data.summaryMessage);
+    finalized.parts = [{ type: "text", text: "Finalized summary" }];
+    assert(finalized.metadata);
+    delete finalized.metadata.compactionPublicationId;
+    delete finalized.metadata.muxMetadata;
+    assert((await h.historyService.updateHistory(workspaceId, finalized)).success);
+    assert(
+      (
+        await h.historyService.appendToHistory(
+          workspaceId,
+          createMuxMessage("later", "user", "Later")
+        )
+      ).success
+    );
+    expect((await lifecycle.capture("carryover"))?.readFiles).toEqual(["/B.ts"]);
+  });
+
+  it("rejects a marked boundary's stale pending write after foreign enrichment fails", async () => {
+    const first = await publish("B", true);
+    assert(first.success);
+    const oldBytes = await bytes();
+    const captured = await lifecycle.capture("pending");
+    assert(captured);
+    const unlink = fs.unlink;
+    spyOn(fs, "unlink").mockImplementation(async (file) => {
+      if (file === pendingPath) throw new Error("Pending unlink unavailable");
+      return unlink(file);
+    });
+    const rename = syncFs.renameSync;
+    spyOn(syncFs, "renameSync").mockImplementation((from, to) => {
+      if (to === pendingPath) throw new Error("Pending replacement unavailable");
+      rename(from, to);
+    });
+    await lifecycle.consume(captured, "ack");
+    const foreign = new CompactionPreparationLifecycle(restart());
+    expect(await foreign.rollbackHeartbeat(first.data.summaryMessage, () => true)).toMatchObject({
+      success: true,
+      data: { outcome: "applied" },
+    });
+    assert((await publish("B", true, foreign)).success);
+    expect(await bytes()).toBe(oldBytes);
+    expect(await restart().load(() => true)).toBeUndefined();
+    expect(await new CompactionPreparationLifecycle(restart()).capture("pending")).toBeUndefined();
+    expect(await lifecycle.capture("carryover")).toBeUndefined();
+  });
+
+  it("does not restore a fallback with another writeId into a marked predecessor", async () => {
+    assert((await publish("A")).success);
+    const b = await publish("B", true);
+    assert(b.success);
+    const pending = JSON.parse(await bytes()) as { previousState: { writeId: string } };
+    pending.previousState.writeId = "unrelated-write";
+    await fs.writeFile(pendingPath, JSON.stringify(pending));
+    expect(
+      await new CompactionPreparationLifecycle(restart()).rollbackHeartbeat(
+        b.data.summaryMessage,
+        () => true
+      )
+    ).toMatchObject({ success: true, data: { outcome: "applied" } });
+    expect(await restart().load(() => true)).toBeUndefined();
+  });
+
+  it("loads compatible unmarked rows without inventing absent-file warmth", async () => {
+    const b = await publish("B", true);
+    assert(b.success);
+    const chatPath = path.join(h.config.sessionsDir, workspaceId, "chat.jsonl");
+    const rows = (await fs.readFile(chatPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as typeof b.data.summaryMessage);
+    for (const row of rows) if (row.metadata) delete row.metadata.compactionPublicationId;
+    await fs.writeFile(chatPath, rows.map((row) => JSON.stringify(row)).join("\n") + "\n");
+    const legacy = new CompactionPreparationLifecycle(restart());
+    const snapshot = await legacy.capture("pending");
+    assert(snapshot);
+    expect(snapshot.readFiles).toEqual(["/B.ts"]);
+    await legacy.consume(snapshot, "ack");
+    expect(await legacy.capture("carryover")).toBeUndefined();
+  });
+
+  it("does not grant acknowledged warmth to attachments omitted by a history-only request", async () => {
+    assert((await publish("A")).success);
+    const rename = syncFs.renameSync;
+    const unavailable = spyOn(syncFs, "renameSync").mockImplementation((from, to) => {
+      if (to === pendingPath) throw new Error("Optional write unavailable");
+      rename(from, to);
+    });
+    const b = await publish("B", true);
+    assert(b.success);
+    unavailable.mockRestore();
+    const empty = await lifecycle.capture("pending");
+    assert(empty);
+    expect(empty.readFiles).toEqual([]);
+    await lifecycle.consume(empty, "ack");
+    expect(await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).toMatchObject({
+      success: true,
+      data: { outcome: "applied" },
+    });
+    expect(await lifecycle.capture("carryover")).toBeUndefined();
+  });
+
+  it("retires rollback fallback durably when unlink fails", async () => {
+    await publish("A");
+    const b = await publish("B", true);
+    assert(b.success);
+    const captured = await lifecycle.capture("pending");
+    assert(captured);
+    const unlink = fs.unlink;
+    const unavailable = spyOn(fs, "unlink").mockImplementation(async (file) => {
+      if (file === pendingPath) throw new Error("Unlink unavailable");
+      return unlink(file);
+    });
+    await lifecycle.consume(captured, "discard");
+    expect(await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).toMatchObject({
+      success: true,
+      data: { outcome: "applied" },
+    });
+    expect(await lifecycle.capture("pending")).toBeUndefined();
+    unavailable.mockRestore();
+    expect(await new CompactionPreparationLifecycle(restart()).capture("pending")).toBeUndefined();
+    const rename = syncFs.renameSync;
+    const failedWrite = spyOn(syncFs, "renameSync").mockImplementation((from, to) => {
+      if (to === pendingPath) throw new Error("Optional publication unavailable");
+      rename(from, to);
+    });
+    assert((await publish("B", true, new CompactionPreparationLifecycle(restart()))).success);
+    failedWrite.mockRestore();
+    expect(await new CompactionPreparationLifecycle(restart()).capture("pending")).toBeUndefined();
+  });
+});

--- a/src/node/services/compactionPreparationLifecycle.test.ts
+++ b/src/node/services/compactionPreparationLifecycle.test.ts
@@ -769,6 +769,59 @@ describe("inactive local compaction preparation lifecycle", () => {
       );
     }
   );
+  it("retires a predecessor adopted by an earlier queued capture when publication reads fail", async () => {
+    assert((await publish("A", false, new CompactionPreparationLifecycle(restart()))).success);
+    const prepared = await input("B", true);
+    const preparation = lifecycle.begin(() => true);
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const readFile = fs.readFile;
+    let pendingReads = 0;
+    const reading = spyOn(fs, "readFile").mockImplementation((async (
+      ...args: Parameters<typeof fs.readFile>
+    ) => {
+      if (args[0] === pendingPath) {
+        pendingReads++;
+        if (pendingReads === 1) {
+          const result = await readFile(...args);
+          entered.resolve();
+          await release.promise;
+          return result;
+        }
+        if (pendingReads === 2) throw new Error("Pending preparation read unavailable");
+      }
+      return readFile(...args);
+    }) as typeof fs.readFile);
+    const capturing = lifecycle.capture("pending");
+    await entered.promise;
+    // Start publication while capture is still awaiting real file I/O.
+    const publishing = lifecycle.publish(preparation, prepared);
+    release.resolve();
+    try {
+      expect((await capturing)?.readFiles).toEqual(["/A.ts"]);
+      const b = await publishing;
+      assert(b.success);
+      expect(pendingReads).toBe(2);
+      reading.mockRestore();
+      const empty = await lifecycle.capture("pending");
+      assert(empty);
+      expect(empty.readFiles).toEqual([]);
+      await lifecycle.consume(empty, "discard");
+      const restarted = new CompactionPreparationLifecycle(restart());
+      expect(await restarted.rollbackHeartbeat(b.data.summaryMessage, () => true)).toMatchObject({
+        success: true,
+        data: { outcome: "applied" },
+      });
+      expect(await restarted.capture("pending")).toBeUndefined();
+      expect(
+        await new CompactionPreparationLifecycle(restart()).capture("pending")
+      ).toBeUndefined();
+    } finally {
+      release.resolve();
+      await Promise.allSettled([capturing, publishing]);
+    }
+  });
+
   it("retires an unobserved foreign predecessor after publication read recovery and rollback", async () => {
     assert((await publish("A", false, new CompactionPreparationLifecycle(restart()))).success);
     const readFile = fs.readFile;

--- a/src/node/services/compactionPreparationLifecycle.test.ts
+++ b/src/node/services/compactionPreparationLifecycle.test.ts
@@ -5,7 +5,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as atomicWrite from "write-file-atomic";
 import { createMuxMessage } from "@/common/types/message";
-import { CompactionPendingState } from "./compactionPendingState";
+import { CompactionPendingState, type CompactionPendingRetention } from "./compactionPendingState";
 import { CompactionPreparationLifecycle } from "./compactionPreparationLifecycle";
 import { HistoryService } from "./historyService";
 import { createTestHistoryService } from "./testHistoryService";
@@ -769,6 +769,222 @@ describe("inactive local compaction preparation lifecycle", () => {
       );
     }
   );
+  it("retires the locked foreign predecessor after read recovery before restart rollback", async () => {
+    assert((await publish("A")).success);
+    expect((await lifecycle.capture("pending"))?.readFiles).toEqual(["/A.ts"]);
+    assert((await publish("C", false, new CompactionPreparationLifecycle(restart()))).success);
+    const readFile = fs.readFile;
+    const unreadable = spyOn(fs, "readFile").mockImplementation((async (
+      ...args: Parameters<typeof fs.readFile>
+    ) => {
+      if (args[0] === pendingPath) throw new Error("Pending preparation read unavailable");
+      return readFile(...args);
+    }) as typeof fs.readFile);
+    const b = await publish("B", true);
+    assert(b.success);
+    unreadable.mockRestore();
+    const empty = await lifecycle.capture("pending");
+    assert(empty);
+    expect(empty.readFiles).toEqual([]);
+    await lifecycle.consume(empty, "discard");
+    const restarted = new CompactionPreparationLifecycle(restart());
+    expect(await restarted.rollbackHeartbeat(b.data.summaryMessage, () => true)).toMatchObject({
+      success: true,
+      data: { outcome: "applied" },
+    });
+    expect(await restarted.capture("pending")).toBeUndefined();
+    expect(await new CompactionPreparationLifecycle(restart()).capture("pending")).toBeUndefined();
+  });
+
+  it.each([
+    "fallback",
+    "replacement",
+    "reset",
+    "future",
+    "unmarked",
+    "unlink failure",
+    "read failure",
+  ] as const)("bounds recovered predecessor retirement (%s)", async (scenario) => {
+    assert((await publish("A")).success);
+    const foreign = new CompactionPreparationLifecycle(restart());
+    const c = await publish("C", false, foreign);
+    assert(c.success);
+    if (scenario === "unmarked") {
+      const chatPath = path.join(h.config.sessionsDir, workspaceId, "chat.jsonl");
+      const rows = (await fs.readFile(chatPath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as typeof c.data.summaryMessage);
+      for (const row of rows) if (row.metadata) delete row.metadata.compactionPublicationId;
+      await fs.writeFile(chatPath, rows.map((row) => JSON.stringify(row)).join("\n") + "\n");
+    }
+    const cBytes = await bytes();
+    const readFile = fs.readFile;
+    let unavailable = true;
+    const reading = spyOn(fs, "readFile").mockImplementation((async (
+      ...args: Parameters<typeof fs.readFile>
+    ) => {
+      if (args[0] === pendingPath && unavailable) throw new Error("Pending read unavailable");
+      return readFile(...args);
+    }) as typeof fs.readFile);
+    const b = await publish("B", true);
+    assert(b.success);
+    unavailable = false;
+    const empty = await lifecycle.capture("pending");
+    assert(empty);
+    expect(empty.readFiles).toEqual([]);
+    let d: Awaited<ReturnType<typeof publish>> | undefined;
+    if (scenario === "fallback") {
+      assert((await foreign.rollbackHeartbeat(b.data.summaryMessage, () => true)).success);
+      d = await publish("D", true, foreign);
+      assert(d.success);
+    } else if (scenario === "replacement") {
+      assert((await publish("D", false, foreign)).success);
+      const replacement = await publish("C", false, foreign);
+      assert(replacement.success);
+      expect(replacement.data.summaryMessage.metadata?.compactionPublicationId).not.toBe(
+        c.data.summaryMessage.metadata?.compactionPublicationId
+      );
+    } else if (scenario === "reset") {
+      assert((await h.historyService.clearHistory(workspaceId)).success);
+      await fs.writeFile(pendingPath, cBytes);
+    } else if (scenario === "future") {
+      await fs.writeFile(pendingPath, JSON.stringify({ version: 2, owner: "newer version" }));
+    }
+    const before = await bytes();
+    const unlink = fs.unlink;
+    const unlinking = spyOn(fs, "unlink").mockImplementation(async (file) => {
+      if (file === pendingPath && scenario === "unlink failure")
+        throw new Error("Unlink unavailable");
+      return unlink(file);
+    });
+    unavailable = scenario === "read failure";
+    await lifecycle.consume(empty, "discard");
+    unavailable = false;
+    unlinking.mockRestore();
+    reading.mockRestore();
+    if (scenario === "fallback") {
+      const retained = JSON.parse(await bytes()) as Record<string, unknown>;
+      const original = JSON.parse(before) as Record<string, unknown>;
+      expect(retained).toEqual({
+        ...original,
+        previousState: undefined,
+        previousStateGeneration: undefined,
+        previousStateBoundary: undefined,
+      });
+      expect(
+        (await new CompactionPreparationLifecycle(restart()).capture("pending"))?.readFiles
+      ).toEqual(["/D.ts"]);
+      assert(d?.success);
+      const restarted = new CompactionPreparationLifecycle(restart());
+      assert((await restarted.rollbackHeartbeat(d.data.summaryMessage, () => true)).success);
+      expect(await restarted.capture("pending")).toBeUndefined();
+    } else {
+      expect(await bytes()).toBe(before);
+      if (scenario === "unlink failure" || scenario === "read failure") {
+        // Failed retirement is only local debt until a later successful physical cleanup.
+        assert((await lifecycle.rollbackHeartbeat(b.data.summaryMessage, () => true)).success);
+        expect(await lifecycle.capture("pending")).toBeUndefined();
+        expect(
+          await new CompactionPreparationLifecycle(restart()).capture("pending")
+        ).toBeUndefined();
+      }
+    }
+  });
+
+  it.each(["legacy receipt", "history-only chain", "irreversible boundary"] as const)(
+    "retains only rollbackable predecessor authority (%s)",
+    async (scenario) => {
+      const foreign = new CompactionPreparationLifecycle(restart());
+      const a = await publish("A", false, foreign);
+      assert(a.success);
+      if (scenario === "legacy receipt") {
+        const chatPath = path.join(h.config.sessionsDir, workspaceId, "chat.jsonl");
+        const rows = (await fs.readFile(chatPath, "utf8"))
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line) as typeof a.data.summaryMessage);
+        for (const row of rows) if (row.metadata) delete row.metadata.compactionPublicationId;
+        await fs.writeFile(chatPath, rows.map((row) => JSON.stringify(row)).join("\n") + "\n");
+        expect((await lifecycle.capture("pending"))?.readFiles).toEqual(["/A.ts"]);
+      }
+      const original = await bytes();
+      const readFile = fs.readFile;
+      const reading = spyOn(fs, "readFile").mockImplementation((async (
+        ...args: Parameters<typeof fs.readFile>
+      ) => {
+        if (args[0] === pendingPath) throw new Error("Pending read unavailable");
+        return readFile(...args);
+      }) as typeof fs.readFile);
+      const b = await publish("B", true);
+      assert(b.success);
+      const d =
+        scenario === "legacy receipt"
+          ? undefined
+          : await publish("D", scenario === "history-only chain");
+      if (d) assert(d.success);
+      reading.mockRestore();
+      const empty = await lifecycle.capture("pending");
+      assert(empty);
+      expect(empty.readFiles).toEqual([]);
+      await lifecycle.consume(empty, "discard");
+      if (scenario === "irreversible boundary") {
+        // A is no longer in the physical rollback horizon; old capabilities must not delete it.
+        expect(await bytes()).toBe(original);
+        return;
+      }
+      const restarted = new CompactionPreparationLifecycle(restart());
+      if (d?.success)
+        assert((await restarted.rollbackHeartbeat(d.data.summaryMessage, () => true)).success);
+      assert((await restarted.rollbackHeartbeat(b.data.summaryMessage, () => true)).success);
+      expect(await restarted.capture("pending")).toBeUndefined();
+      expect(
+        await new CompactionPreparationLifecycle(restart()).capture("pending")
+      ).toBeUndefined();
+    }
+  );
+
+  it("does not enlarge predecessor retirement authority through copied or mutated retention", async () => {
+    const foreign = new CompactionPreparationLifecycle(restart());
+    assert((await publish("C", false, foreign)).success);
+    const original = await bytes();
+    const publishBoundary = store.publishBoundary.bind(store);
+    let captured: CompactionPendingRetention | undefined;
+    spyOn(store, "publishBoundary").mockImplementationOnce((boundary) =>
+      publishBoundary({
+        ...boundary,
+        onCommitted: (receipt, previous, retention) => {
+          captured = retention;
+          boundary.onCommitted(receipt, previous, retention);
+        },
+      })
+    );
+    const readFile = fs.readFile;
+    const reading = spyOn(fs, "readFile").mockImplementation((async (
+      ...args: Parameters<typeof fs.readFile>
+    ) => {
+      if (args[0] === pendingPath) throw new Error("Pending read unavailable");
+      return readFile(...args);
+    }) as typeof fs.readFile);
+    assert((await publish("B", true)).success);
+    reading.mockRestore();
+    assert(captured);
+    const d = await publish("D", false, foreign);
+    assert(d.success);
+    const newer = await bytes();
+    captured.boundary = { kind: "identified", messageId: "D" };
+    captured.boundaryPublicationId = d.data.summaryMessage.metadata?.compactionPublicationId;
+    const observed = mock(() => undefined);
+    expect(await store.consumePredecessor([structuredClone(captured)], observed)).toBe(false);
+    expect(await store.consumePredecessor([captured], observed)).toBe(false);
+    expect(observed).not.toHaveBeenCalled();
+    expect(await bytes()).toBe(newer);
+    await fs.writeFile(pendingPath, original);
+    expect(await store.consumePredecessor([captured], observed)).toBe(true);
+    expect(observed).toHaveBeenCalledTimes(1);
+    expect(await bytes().catch(() => undefined)).toBeUndefined();
+  });
+
   it("retires a predecessor adopted by an earlier queued capture when publication reads fail", async () => {
     assert((await publish("A", false, new CompactionPreparationLifecycle(restart()))).success);
     const prepared = await input("B", true);

--- a/src/node/services/compactionPreparationLifecycle.test.ts
+++ b/src/node/services/compactionPreparationLifecycle.test.ts
@@ -112,6 +112,65 @@ describe("inactive local compaction preparation lifecycle", () => {
     expect(locked.mock.calls.length).toBe(beforeWarmth + 1);
   });
 
+  it.each([false, true])(
+    "observes an earlier queued publication before probing absence (history-only=%s)",
+    async (historyOnly) => {
+      const adapter = h.historyService.getCompactionPendingHistory(workspaceId);
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const target = new CompactionPreparationLifecycle(
+        new CompactionPendingState(pendingPath, {
+          ...adapter,
+          withLock: async (operation) => {
+            entered.resolve();
+            await release.promise;
+            return adapter.withLock(operation);
+          },
+        })
+      );
+      const prepared = await input("A");
+      const stat = fs.stat;
+      const absent = await stat(pendingPath).catch((error: NodeJS.ErrnoException) => error);
+      assert("code" in absent && absent.code === "ENOENT");
+      let released = false;
+      spyOn(fs, "stat").mockImplementation((async (...args: Parameters<typeof fs.stat>) => {
+        if (args[0] === pendingPath && !released) throw absent;
+        return stat(...args);
+      }) as typeof fs.stat);
+      const readFile = fs.readFile;
+      spyOn(fs, "readFile").mockImplementation((async (...args: Parameters<typeof fs.readFile>) => {
+        if (historyOnly && args[0] === pendingPath) throw new Error("Sidecar unavailable");
+        return readFile(...args);
+      }) as typeof fs.readFile);
+      const publishing = target.publish(
+        target.begin(() => true),
+        prepared
+      );
+      let capturing: ReturnType<typeof target.capture> | undefined;
+      try {
+        await entered.promise;
+        let settled = false;
+        capturing = target.capture("pending").then((result) => {
+          settled = true;
+          return result;
+        });
+        // The absent probe rejects synchronously, so this event-loop turn drains its promise
+        // continuations without racing disk latency. Publication is still held by our barrier.
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        expect(settled).toBe(false);
+        released = true;
+        release.resolve();
+        assert((await publishing).success);
+        expect((await capturing)?.readFiles).toEqual(historyOnly ? [] : ["/A.ts"]);
+      } finally {
+        released = true;
+        release.resolve();
+        await publishing;
+        await capturing;
+      }
+    }
+  );
+
   it.each(["error", "directory"] as const)(
     "qualifies ambiguous sidecar presence through history (%s)",
     async (presence) => {

--- a/src/node/services/compactionPreparationLifecycle.ts
+++ b/src/node/services/compactionPreparationLifecycle.ts
@@ -1,0 +1,383 @@
+import type { MuxMessage } from "@/common/types/message";
+import { Err, Ok, type Result } from "@/common/types/result";
+import type {
+  CompactionPendingAttachments,
+  CompactionPendingBoundary,
+  CompactionPendingBoundaryWrite,
+  CompactionPendingObservation,
+  CompactionPendingReceipt,
+  CompactionPendingRetention,
+  CompactionPendingState,
+} from "./compactionPendingState";
+import { log } from "./log";
+
+export interface CompactionPreparation {
+  readonly isCurrent: () => boolean;
+}
+
+export type CompactionPreparationSnapshot = Readonly<CompactionPendingAttachments>;
+type BoundaryInput = CompactionPendingBoundaryWrite & { attachments: CompactionPendingAttachments };
+type BoundaryRows = Pick<CompactionPendingBoundaryWrite, "summaryMessage" | "tailCopies">;
+type Consumption = "ack" | "discard";
+
+interface Facts {
+  rolledBack: boolean;
+  consumed?: Consumption;
+  // Retiring a restored fallback must not discard unrelated acknowledged warmth.
+  pendingRetired?: boolean;
+}
+interface OwnerFacts {
+  facts: Facts;
+  generation: string | undefined;
+  summaryId?: string;
+  // Read failure proves no exact file identity. This fence suppresses locally but never deletes.
+  suppressedBoundary?: CompactionPendingBoundary;
+  suppressedPublicationId?: string;
+  attachments: CompactionPendingAttachments;
+}
+interface ReceiptOwner extends OwnerFacts {
+  kind: "receipt";
+  receipt: CompactionPendingReceipt;
+}
+interface PublicationOwner extends OwnerFacts {
+  kind: "publication";
+  sequence?: number;
+  publicationId?: string;
+  historyOnly: boolean;
+  surviving?: ReceiptOwner;
+}
+
+type Owner = ReceiptOwner | PublicationOwner;
+
+/** Local ownership facts; disk admission and all serialization belong to the pending store. */
+export class CompactionPreparationLifecycle {
+  private epoch = {};
+  private consumptionEpoch = {};
+  private current?: Owner;
+  // Retain canonical facts over the physically rollbackable history horizon, not a fixed
+  // predecessor depth. Request snapshots keep their facts independently after pruning.
+  private readonly receipts = new Set<ReceiptOwner>();
+  private readonly publications = new Set<PublicationOwner>();
+  private readonly preparations = new WeakMap<
+    CompactionPreparation,
+    { used: boolean; done: boolean }
+  >();
+  private readonly snapshots = new WeakMap<CompactionPreparationSnapshot, Owner>();
+
+  constructor(private readonly store: CompactionPendingState) {}
+
+  begin(isCurrent: () => boolean): CompactionPreparation {
+    const epoch = {};
+    const state = { used: false, done: false };
+    if (isCurrent()) this.epoch = epoch;
+    const preparation = { isCurrent: () => this.epoch === epoch && !state.done && isCurrent() };
+    this.preparations.set(preparation, state);
+    return preparation;
+  }
+
+  private canonical(
+    receipt: CompactionPendingReceipt,
+    retention: CompactionPendingRetention,
+    summaryId = retention.boundary.kind === "identified" ? retention.boundary.messageId : undefined,
+    facts: Facts = { rolledBack: false }
+  ): ReceiptOwner {
+    const known = [...this.receipts].find((owner) =>
+      this.store.isSameReceipt(owner.receipt, receipt)
+    );
+    if (known) return known;
+    const owner: ReceiptOwner = {
+      kind: "receipt",
+      receipt,
+      generation: retention.generation,
+      summaryId,
+      facts,
+      attachments: structuredClone(receipt.attachments),
+    };
+    this.receipts.add(owner);
+    return owner;
+  }
+
+  private prune(retention: CompactionPendingRetention) {
+    const reachable = (id: string | undefined) => retention.reachableBoundaryIds?.has(id) ?? true;
+    const retain = (owner: Owner) =>
+      owner.generation === retention.generation &&
+      (reachable(owner.summaryId) ||
+        (owner.suppressedBoundary &&
+          owner.suppressedBoundary.kind !== "unreadable-reset" &&
+          reachable(
+            owner.suppressedBoundary.kind === "identified"
+              ? owner.suppressedBoundary.messageId
+              : undefined
+          )));
+    for (const owner of this.receipts) if (!retain(owner)) this.receipts.delete(owner);
+    for (const owner of this.publications) if (!retain(owner)) this.publications.delete(owner);
+    if (this.current && !retain(this.current)) this.current = undefined;
+  }
+
+  private matchesSuppression(owner: Owner, retention: CompactionPendingRetention) {
+    const suppressed = owner.suppressedBoundary;
+    const boundary = retention.boundary;
+    return (
+      owner.generation === retention.generation &&
+      suppressed?.kind === boundary.kind &&
+      (boundary.kind === "none" ||
+        (owner.suppressedPublicationId !== undefined &&
+          owner.suppressedPublicationId === retention.boundaryPublicationId)) &&
+      (suppressed?.kind === "none" ||
+        (suppressed?.kind === "identified" &&
+          boundary.kind === "identified" &&
+          suppressed.messageId === boundary.messageId))
+    );
+  }
+
+  private warmth() {
+    return [...this.receipts]
+      .filter((owner) => owner.facts.consumed === "ack" && !owner.facts.rolledBack)
+      .map((owner) => owner.receipt);
+  }
+
+  private adopt(observation: CompactionPendingObservation) {
+    this.prune(observation.retention);
+    const receipt = observation.pending ?? observation.warmth;
+    const boundary = observation.retention.boundary;
+    this.current = receipt
+      ? this.canonical(receipt, observation.retention)
+      : [...this.publications].findLast(
+          (owner) =>
+            owner.historyOnly &&
+            !owner.facts.rolledBack &&
+            boundary.kind === "identified" &&
+            owner.summaryId === boundary.messageId &&
+            owner.publicationId !== undefined &&
+            owner.publicationId === observation.retention.boundaryPublicationId
+        );
+  }
+
+  private snapshot(owner: Owner, scope: "pending" | "carryover") {
+    if (
+      owner.facts.rolledBack ||
+      owner.facts.consumed === "discard" ||
+      (scope === "pending" && (owner.facts.consumed || owner.facts.pendingRetired)) ||
+      (owner.facts.pendingRetired && owner.facts.consumed !== "ack")
+    )
+      return;
+    const snapshot = structuredClone(owner.attachments);
+    if (scope === "carryover") snapshot.diffs = [];
+    this.snapshots.set(snapshot, owner);
+    return snapshot;
+  }
+
+  async capture(
+    scope: "pending" | "carryover"
+  ): Promise<CompactionPreparationSnapshot | undefined> {
+    const epoch = this.epoch;
+    const isCurrent = () => this.epoch === epoch;
+    try {
+      // One held-lock observation qualifies both the exact disk owner and absent-file warmth.
+      const observation = await this.store.observe(
+        this.warmth(),
+        isCurrent,
+        this.receipts.size === 0 && this.publications.size === 0
+      );
+      if (!observation || !isCurrent()) return;
+      this.adopt(observation);
+      if (
+        this.current &&
+        !(
+          this.current.facts.consumed !== "ack" &&
+          [...this.receipts, ...this.publications].some((owner) =>
+            this.matchesSuppression(owner, observation.retention)
+          )
+        )
+      )
+        return this.snapshot(this.current, scope);
+    } catch (error) {
+      log.warn("Pending attachment capture unavailable", error);
+    }
+  }
+
+  async publish(
+    preparation: CompactionPreparation,
+    input: BoundaryInput
+  ): Promise<Result<BoundaryRows>> {
+    const state = this.preparations.get(preparation);
+    if (!state || state.used || !preparation.isCurrent())
+      return Err("Compaction preparation was replaced");
+    state.used = true;
+    // History assigns sequences. Private copies protect caller snapshots even on delayed returns.
+    const summaryMessage = structuredClone(input.summaryMessage);
+    const tailCopies = structuredClone(input.tailCopies);
+    const publication = structuredClone(input.publication);
+    const attachments = structuredClone(input.attachments);
+    const current = this.current;
+    const surviving = current?.kind === "receipt" ? current : current?.surviving;
+    const owner: PublicationOwner = {
+      kind: "publication",
+      historyOnly: true,
+      generation: publication.generation,
+      summaryId: summaryMessage.id,
+      facts: { rolledBack: false },
+      attachments: { diffs: [], loadedSkills: [], readFiles: [] },
+      surviving:
+        surviving &&
+        !surviving.facts.consumed &&
+        !surviving.facts.pendingRetired &&
+        !surviving.facts.rolledBack
+          ? surviving
+          : undefined,
+    };
+    let committed = false;
+    try {
+      const result = await this.store.publishBoundary({
+        summaryMessage,
+        tailCopies,
+        publication,
+        attachments,
+        shouldPersist: input.shouldPersist,
+        updateExisting: input.updateExisting,
+        isCurrent: preparation.isCurrent,
+        onCommitted: (receipt, previous, retention) => {
+          committed = true;
+          owner.historyOnly = !receipt;
+          // Prune the pre-commit registry against its starting horizon before adding this
+          // publication; reusing an ID cannot retain an already rolled-back occurrence.
+          this.prune(retention);
+          owner.sequence = summaryMessage.metadata?.historySequence;
+          owner.publicationId = summaryMessage.metadata?.compactionPublicationId;
+          if (previous) owner.surviving = this.canonical(previous, retention);
+          this.publications.add(owner);
+          this.current = receipt
+            ? this.canonical(receipt, retention, summaryMessage.id, owner.facts)
+            : owner;
+          // Successful writes own their fallback through the store; only history-only tokens
+          // retain an exact physical survivor for late request consumption.
+          if (receipt) owner.surviving = undefined;
+        },
+      });
+      if (committed) return Ok({ summaryMessage, tailCopies });
+      return result.success ? Err("Compaction boundary did not commit") : result;
+    } finally {
+      state.done = true;
+    }
+  }
+
+  async consume(snapshot: CompactionPreparationSnapshot, disposition: Consumption): Promise<void> {
+    const owner = this.snapshots.get(snapshot);
+    if (!owner) return;
+    this.consumptionEpoch = {};
+    const file = owner.kind === "receipt" ? owner : owner.surviving;
+    if (disposition === "discard" || !owner.facts.consumed) owner.facts.consumed = disposition;
+    if (file && file !== owner) {
+      // The empty token did not deliver its survivor. Retire pending authority without
+      // granting acknowledgment; independently earned warmth keeps its existing ack fact.
+      file.facts.pendingRetired = true;
+    }
+    if (file)
+      try {
+        await this.store.consume(file.receipt);
+      } catch (error) {
+        log.warn("Pending attachment consumption unavailable", error);
+      }
+  }
+
+  async rollbackHeartbeat(summaryMessage: MuxMessage, isCurrent: () => boolean) {
+    const epoch = {};
+    const consumptionEpoch = this.consumptionEpoch;
+    const target = [...this.publications].findLast(
+      (owner) =>
+        owner.summaryId === summaryMessage.id &&
+        owner.sequence === summaryMessage.metadata?.historySequence &&
+        owner.publicationId === summaryMessage.metadata?.compactionPublicationId
+    );
+    let removedOwner: ReceiptOwner | undefined;
+    let removedWasRolledBack = false;
+    const alreadyRolledBack = target?.facts.rolledBack;
+    if (isCurrent()) this.epoch = epoch;
+    const retired = (owner: Owner | undefined) =>
+      !!owner && (!!owner.facts.consumed || !!owner.facts.pendingRetired || owner.facts.rolledBack);
+    const knownReceipt = (receipt: CompactionPendingReceipt | undefined) =>
+      receipt &&
+      [...this.receipts].find((owner) => this.store.isSameReceipt(owner.receipt, receipt));
+    return this.store.rollbackHeartbeat({
+      summaryMessage,
+      // Consumption after the retirement checkpoint requires a new checkpoint, not an
+      // unguarded history commit while its newly forbidden fallback remains on disk.
+      isCurrent: () =>
+        this.epoch === epoch && this.consumptionEpoch === consumptionEpoch && isCurrent(),
+      warmth: this.warmth(),
+      canRestorePrevious: () => true,
+      isRetiredBeforeRollback: [...this.receipts, ...this.publications].some(retired)
+        ? (receipt, restoredContext, retention, removed) =>
+            retired(knownReceipt(receipt)) ||
+            (restoredContext &&
+              ((target?.generation === retention.generation && retired(target)) ||
+                retired(knownReceipt(removed))))
+        : undefined,
+      isRetired: (receipt, restoredContext, retention, removed) => {
+        if (removed && !removedOwner) {
+          // Boundary IDs can be reused: loaded facts require the exact removed write identity.
+          removedOwner = [...this.receipts].find((owner) =>
+            this.store.isSameReceipt(owner.receipt, removed)
+          );
+          if (removedOwner) {
+            removedWasRolledBack =
+              removedOwner.facts === target?.facts
+                ? !!alreadyRolledBack
+                : removedOwner.facts.rolledBack;
+            removedOwner.facts.rolledBack = true;
+          }
+        }
+        // Canonicalize before attempting cleanup so unlink failure cannot mint fresh facts.
+        const known = this.canonical(receipt, retention);
+        if (
+          restoredContext &&
+          ((target?.generation === retention.generation &&
+            (target?.facts.consumed || alreadyRolledBack)) ||
+            removedOwner?.facts.consumed ||
+            removedOwner?.facts.pendingRetired ||
+            removedWasRolledBack)
+        ) {
+          known.facts.pendingRetired = true;
+          return true;
+        }
+        return (
+          known.facts.consumed !== undefined ||
+          known.facts.pendingRetired === true ||
+          known.facts.rolledBack
+        );
+      },
+      onCommitted: () => {
+        if (target) target.facts.rolledBack = true;
+        if (this.current?.summaryId === summaryMessage.id) this.current = undefined;
+      },
+      onRestored: () => undefined,
+      onReconciled: (observation, removedCurrentBoundary) => {
+        if (
+          !observation.readable &&
+          removedCurrentBoundary &&
+          target?.facts.consumed &&
+          target.generation === observation.retention.generation &&
+          observation.retention.boundary.kind !== "unreadable-reset"
+        ) {
+          // Keep one unresolved fence per reachable boundary, even through deeper heartbeats.
+          // Restart cannot recover this intent while reads remain unavailable; it is not a disk receipt.
+          for (const owner of [...this.receipts, ...this.publications])
+            if (this.matchesSuppression(owner, observation.retention))
+              owner.suppressedBoundary = undefined;
+          target.suppressedBoundary = observation.retention.boundary;
+          target.suppressedPublicationId = observation.retention.boundaryPublicationId;
+        }
+        if (this.epoch === epoch) this.adopt(observation);
+      },
+    });
+  }
+
+  async discardAfterBoundary(): Promise<void> {
+    this.epoch = {};
+    for (const owner of [...this.receipts, ...this.publications]) owner.facts.consumed = "discard";
+    this.receipts.clear();
+    this.publications.clear();
+    this.current = undefined;
+    await this.store.discardAfterBoundary();
+  }
+}

--- a/src/node/services/compactionPreparationLifecycle.ts
+++ b/src/node/services/compactionPreparationLifecycle.ts
@@ -197,7 +197,7 @@ export class CompactionPreparationLifecycle {
       const observation = await this.store.observe(
         this.warmth(),
         isCurrent,
-        this.receipts.size === 0 && this.publications.size === 0
+        () => this.receipts.size === 0 && this.publications.size === 0
       );
       if (!observation || !isCurrent()) return;
       this.adopt(observation);

--- a/src/node/services/compactionPreparationLifecycle.ts
+++ b/src/node/services/compactionPreparationLifecycle.ts
@@ -209,8 +209,6 @@ export class CompactionPreparationLifecycle {
     const tailCopies = structuredClone(input.tailCopies);
     const publication = structuredClone(input.publication);
     const attachments = structuredClone(input.attachments);
-    const current = this.current;
-    const surviving = current?.kind === "receipt" ? current : current?.surviving;
     const owner: PublicationOwner = {
       kind: "publication",
       historyOnly: true,
@@ -218,13 +216,6 @@ export class CompactionPreparationLifecycle {
       summaryId: summaryMessage.id,
       facts: { rolledBack: false },
       attachments: { diffs: [], loadedSkills: [], readFiles: [] },
-      surviving:
-        surviving &&
-        !surviving.facts.consumed &&
-        !surviving.facts.pendingRetired &&
-        !surviving.facts.rolledBack
-          ? surviving
-          : undefined,
     };
     let committed = false;
     try {
@@ -239,6 +230,18 @@ export class CompactionPreparationLifecycle {
         onCommitted: (receipt, previous, retention) => {
           committed = true;
           owner.historyOnly = !receipt;
+          // Earlier queued captures have adopted their observations by this held-lock commit.
+          // Keep their exact survivor if enrichment could not read it, before pruning/resetting
+          // current; choosing before queue entry can miss a receipt still being observed.
+          const current = this.current;
+          const surviving = current?.kind === "receipt" ? current : current?.surviving;
+          owner.surviving =
+            surviving &&
+            !surviving.facts.consumed &&
+            !surviving.facts.pendingRetired &&
+            !surviving.facts.rolledBack
+              ? surviving
+              : undefined;
           // Prune the pre-commit registry against its starting horizon before adding this
           // publication; reusing an ID cannot retain an already rolled-back occurrence.
           this.prune(retention);

--- a/src/node/services/compactionPreparationLifecycle.ts
+++ b/src/node/services/compactionPreparationLifecycle.ts
@@ -45,6 +45,7 @@ interface PublicationOwner extends OwnerFacts {
   publicationId?: string;
   historyOnly: boolean;
   surviving?: ReceiptOwner;
+  predecessors?: readonly CompactionPendingRetention[];
 }
 
 type Owner = ReceiptOwner | PublicationOwner;
@@ -97,6 +98,21 @@ export class CompactionPreparationLifecycle {
     return owner;
   }
 
+  private retainedPredecessors(
+    predecessors: readonly CompactionPendingRetention[],
+    retention: CompactionPendingRetention
+  ) {
+    return predecessors.filter(
+      (previous) =>
+        previous.generation === retention.generation &&
+        previous.boundary.kind !== "unreadable-reset" &&
+        (retention.reachableBoundaryIds?.has(
+          previous.boundary.kind === "identified" ? previous.boundary.messageId : undefined
+        ) ??
+          true)
+    );
+  }
+
   private prune(retention: CompactionPendingRetention) {
     const reachable = (id: string | undefined) => retention.reachableBoundaryIds?.has(id) ?? true;
     const retain = (owner: Owner) =>
@@ -110,7 +126,11 @@ export class CompactionPreparationLifecycle {
               : undefined
           )));
     for (const owner of this.receipts) if (!retain(owner)) this.receipts.delete(owner);
-    for (const owner of this.publications) if (!retain(owner)) this.publications.delete(owner);
+    for (const owner of this.publications) {
+      if (!retain(owner)) this.publications.delete(owner);
+      else if (owner.predecessors)
+        owner.predecessors = this.retainedPredecessors(owner.predecessors, retention);
+    }
     if (this.current && !retain(this.current)) this.current = undefined;
   }
 
@@ -230,11 +250,26 @@ export class CompactionPreparationLifecycle {
         onCommitted: (receipt, previous, retention) => {
           committed = true;
           owner.historyOnly = !receipt;
-          // Earlier queued captures have adopted their observations by this held-lock commit.
-          // Keep their exact survivor if enrichment could not read it, before pruning/resetting
-          // current; choosing before queue entry can miss a receipt still being observed.
+          // Carry an unresolved chain only through the exact local history-only predecessor.
+          // Foreign publications can supersede cached receipts without this instance observing them.
           const current = this.current;
-          const surviving = current?.kind === "receipt" ? current : current?.surviving;
+          const priorPublication =
+            current?.kind === "publication" &&
+            current.generation === retention.generation &&
+            retention.boundary.kind === "identified" &&
+            current.summaryId === retention.boundary.messageId &&
+            current.publicationId !== undefined &&
+            current.publicationId === retention.boundaryPublicationId
+              ? current
+              : undefined;
+          owner.predecessors = [
+            ...this.retainedPredecessors(priorPublication?.predecessors ?? [], retention),
+            retention,
+          ];
+          const surviving =
+            current?.kind === "receipt" && this.store.isPredecessor(current.receipt, retention)
+              ? current
+              : priorPublication?.surviving;
           owner.surviving =
             surviving &&
             !surviving.facts.consumed &&
@@ -275,12 +310,21 @@ export class CompactionPreparationLifecycle {
       // granting acknowledgment; independently earned warmth keeps its existing ack fact.
       file.facts.pendingRetired = true;
     }
-    if (file)
-      try {
-        await this.store.consume(file.receipt);
-      } catch (error) {
-        log.warn("Pending attachment consumption unavailable", error);
+    try {
+      if (owner.kind === "publication" && owner.predecessors) {
+        if (
+          await this.store.consumePredecessor(owner.predecessors, (receipt, predecessor) => {
+            const recovered = this.canonical(receipt, predecessor);
+            recovered.facts.pendingRetired = true;
+            owner.surviving = recovered;
+          })
+        )
+          return;
       }
+      if (file) await this.store.consume(file.receipt);
+    } catch (error) {
+      log.warn("Pending attachment consumption unavailable", error);
+    }
   }
 
   async rollbackHeartbeat(summaryMessage: MuxMessage, isCurrent: () => boolean) {

--- a/src/node/services/historyScanner.ts
+++ b/src/node/services/historyScanner.ts
@@ -200,6 +200,7 @@ function historyFileStamp(
 
 interface LocatedHistoryBoundary {
   offset: number;
+  boundaryPublicationId?: string;
   boundary: Exclude<PendingBoundary, { kind: "none" }>;
 }
 type ProviderHistoryStart =
@@ -244,6 +245,7 @@ async function findProviderHistoryStart(
       if (durableBoundary || (includeReadableResetFloor && message))
         return {
           offset: start,
+          boundaryPublicationId: message.metadata?.compactionPublicationId,
           boundary: durableBoundary
             ? { kind: "identified", messageId: message.id }
             : { kind: "unreadable-reset" },
@@ -253,7 +255,11 @@ async function findProviderHistoryStart(
       return { offset: unreadableRunEnd ?? rowEnd, boundary: { kind: "unreadable-reset" } };
     }
     if (durableBoundary) {
-      oldestBoundary = { offset: start, boundary: { kind: "identified", messageId: message.id } };
+      oldestBoundary = {
+        offset: start,
+        boundary: { kind: "identified", messageId: message.id },
+        boundaryPublicationId: message.metadata?.compactionPublicationId,
+      };
       if (boundaryCount++ === skip) return oldestBoundary;
     }
     if (message) {
@@ -293,8 +299,9 @@ async function readHistoryProjectionFromLatestBoundary<Row>(
   paths: Record<HistoryArtifact, string>,
   skip: number,
   project?: (value: unknown) => Row | null,
-  includeReadableResetFloor = false
-): Promise<{ messages: Row[]; boundary: PendingBoundary }> {
+  includeReadableResetFloor = false,
+  clampToOldest = true
+): Promise<{ messages: Row[]; boundary: PendingBoundary; boundaryPublicationId?: string }> {
   assert(Number.isSafeInteger(skip) && skip >= 0, "provider boundary skip must be non-negative");
   const files = new Map<HistoryArtifact, { handle: fs.FileHandle; size: number; stamp: string }>();
   try {
@@ -342,20 +349,24 @@ async function readHistoryProjectionFromLatestBoundary<Row>(
     const chat = await locate("chat", skip);
     let messages: Row[];
     let boundary: PendingBoundary = { kind: "none" };
+    let boundaryPublicationId: string | undefined;
     if (chat.kind === "start") {
       boundary = chat.boundary;
+      boundaryPublicationId = chat.boundaryPublicationId;
       messages = await readTail("chat", chat.offset);
     } else {
       const archive = await locate("archive", skip - chat.boundaryCount);
-      if (archive.kind === "start" || archive.oldestBoundary !== null) {
+      if (archive.kind === "start" || (clampToOldest && archive.oldestBoundary !== null)) {
         const location = archive.kind === "start" ? archive : archive.oldestBoundary!;
         boundary = location.boundary;
+        boundaryPublicationId = location.boundaryPublicationId;
         messages = [
           ...(await readTail("archive", location.offset)),
           ...(await readTail("chat", 0)),
         ];
-      } else if (chat.oldestBoundary !== null) {
+      } else if (clampToOldest && chat.oldestBoundary !== null) {
         boundary = chat.oldestBoundary.boundary;
+        boundaryPublicationId = chat.oldestBoundary.boundaryPublicationId;
         messages = await readTail("chat", chat.oldestBoundary.offset);
       } else messages = [...(await readTail("archive", 0)), ...(await readTail("chat", 0))];
     }
@@ -370,7 +381,7 @@ async function readHistoryProjectionFromLatestBoundary<Row>(
         throw new Error("History changed during provider read");
       }
     }
-    return { messages, boundary };
+    return { messages, boundary, boundaryPublicationId };
   } finally {
     await Promise.all([...files.values()].map((file) => file.handle.close()));
   }
@@ -392,13 +403,31 @@ export function readProviderHistoryFromLatestBoundary(
   ).then((view) => view.messages);
 }
 
+/** Exact occurrence evidence shares the verified boundary scan; never persist it in legacy fallback tags. */
+export async function readCompactionPendingHistoryObservation(
+  paths: Record<HistoryArtifact, string>,
+  skip = 0
+) {
+  const { boundary, boundaryPublicationId } = await readHistoryProjectionFromLatestBoundary(
+    paths,
+    skip,
+    undefined,
+    false,
+    false
+  );
+  return { boundary, boundaryPublicationId };
+}
+
 /** Inactive pending-state evidence from the same raw locator and snapshot verification as reads. */
 export async function readCompactionPendingHistoryBoundary(
-  paths: Record<HistoryArtifact, string>
+  paths: Record<HistoryArtifact, string>,
+  skip = 0
 ): Promise<PendingBoundary> {
   // Known absence requires exhausting BOTH files; an unreadable reset never becomes absence.
   // No row projection is needed, so the verified location does not re-read the active tail.
-  return (await readHistoryProjectionFromLatestBoundary(paths, 0)).boundary;
+  // Retention needs the actual exposed base; provider reads may clamp excessive skips to the oldest window.
+  return (await readHistoryProjectionFromLatestBoundary(paths, skip, undefined, false, false))
+    .boundary;
 }
 
 /** Ordered lifecycle evidence, not a provider message or a source of repaired IDs. */

--- a/src/node/services/historyService.compactionFollowUpCleanup.test.ts
+++ b/src/node/services/historyService.compactionFollowUpCleanup.test.ts
@@ -200,13 +200,15 @@ describe("conditional compaction follow-up cleanup", () => {
           action,
           () => true
         )
-      ).toEqual(Ok("applied"));
+      ).toEqual(Ok(action === "clear" ? "applied" : "skipped"));
       const history = await store.historyService.getLastMessages(workspaceId, 2);
       assert(history.success, "Expected history after cleanup");
-      expect(history.data).toHaveLength(action === "clear" ? 2 : 1);
+      expect(history.data).toHaveLength(2);
       expect(history.data.at(-1)).toMatchObject(unrelated);
       if (action === "clear") {
         expect(history.data[0].metadata?.muxMetadata).not.toHaveProperty("pendingFollowUp");
+      } else {
+        expect(history.data[0]).toMatchObject(expected);
       }
     });
 

--- a/src/node/services/historyService.compactionPending.test.ts
+++ b/src/node/services/historyService.compactionPending.test.ts
@@ -815,4 +815,82 @@ describe("inactive compaction history transactions", () => {
       expect(await fs.readFile(chatPath, "utf8")).toBe(before);
     }
   );
+  it.each([
+    {
+      name: "rollbackable suffix",
+      metadata: {
+        type: "compaction-summary",
+        pendingFollowUp: { text: "Resume", model: "model", agentId: "exec" },
+      },
+      expected: ["C", "B", "A"],
+    },
+    { name: "cleared follow-up", metadata: { type: "compaction-summary" }, expected: ["C", "B"] },
+    { name: "future metadata", metadata: { type: "future-summary" }, expected: undefined },
+    {
+      name: "malformed follow-up",
+      metadata: { type: "compaction-summary", pendingFollowUp: null },
+      expected: undefined,
+    },
+    {
+      name: "incomplete follow-up",
+      metadata: { type: "compaction-summary", pendingFollowUp: {} },
+      expected: undefined,
+    },
+  ])("bounds retention only with proven $name history", async ({ metadata, expected }) => {
+    const heartbeat = (id: string) =>
+      createMuxMessage(id, "assistant", id, {
+        compacted: "heartbeat",
+        compactionBoundary: true,
+        compactionEpoch: 1,
+        muxMetadata: {
+          type: "compaction-summary",
+          pendingFollowUp: { text: "Resume", model: "model", agentId: "exec" },
+        },
+      });
+    const b = heartbeat("B");
+    await fs.writeFile(archivePath, line(boundary("A")));
+    // Raw fixtures deliberately include future/invalid metadata that the history projection preserves.
+    await fs.writeFile(
+      chatPath,
+      JSON.stringify({ ...b, metadata: { ...b.metadata, muxMetadata: metadata } }) +
+        "\n" +
+        line(heartbeat("C"))
+    );
+    await transaction().withLock(async (view) => {
+      await view.assertStillOwned();
+      expect(view.boundary).toEqual({ kind: "identified", messageId: "C" });
+      expect(view.reachableBoundaryIds && [...view.reachableBoundaryIds]).toEqual(
+        expected && [...expected]
+      );
+    });
+  });
+
+  it("does not prune through duplicate active boundary identities", async () => {
+    await fs.writeFile(chatPath, line(boundary("A")) + line(boundary("A")));
+    await transaction().withLock(async (view) => {
+      await view.assertStillOwned();
+      expect(view.reachableBoundaryIds).toBeUndefined();
+    });
+  });
+  it("bounds the rollback horizon at a verified archived raw reset floor", async () => {
+    const heartbeat = createMuxMessage("C", "assistant", "C", {
+      compacted: "heartbeat",
+      compactionBoundary: true,
+      compactionEpoch: 1,
+      muxMetadata: {
+        type: "compaction-summary",
+        pendingFollowUp: { text: "Resume", model: "model", agentId: "exec" },
+      },
+    });
+    await fs.writeFile(
+      archivePath,
+      line(boundary("A")) + '{"metadata":{"contextBoundaryKind":"reset"},broken\n'
+    );
+    await fs.writeFile(chatPath, line(heartbeat));
+    await transaction().withLock(async (view) => {
+      await view.assertStillOwned();
+      expect(view.boundary).toEqual({ kind: "identified", messageId: "C" });
+      expect(view.reachableBoundaryIds && [...view.reachableBoundaryIds]).toEqual(["C"]);
+    });
+  });
 });

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -15,6 +15,7 @@ import {
   scanHistoryFilesBounded,
   readProviderHistoryFromLatestBoundary,
   readCompactionPendingHistoryBoundary,
+  readCompactionPendingHistoryObservation,
   readHistoryControlEvidenceFromLatestBoundary,
   type HistoryControlRow,
   type BoundedHistoryScanOptions,
@@ -27,7 +28,10 @@ import { createHash, randomUUID } from "node:crypto";
 import { renameSync, unlinkSync } from "node:fs";
 import { isDeepStrictEqual } from "node:util";
 import * as fs from "fs/promises";
-import type { CompactionPendingHistory } from "./compactionPendingState";
+import type {
+  CompactionPendingHistory,
+  CompactionPendingHistoryView,
+} from "./compactionPendingState";
 import {
   ContinuousCompactionJournalStore,
   publishCompactionFile,
@@ -232,13 +236,17 @@ function getCompactionMetadataToPreserve(
   }
 
   if (hasDurableCompactionBoundary(incomingMessage.metadata)) {
-    return null;
+    return incomingMessage.metadata?.compactionPublicationId === undefined &&
+      existingMetadata.compactionPublicationId
+      ? { compactionPublicationId: existingMetadata.compactionPublicationId }
+      : null;
   }
 
   const preserved: Partial<MuxMetadata> = {
     compacted: existingMetadata.compacted,
     compactionBoundary: true,
     compactionEpoch: existingMetadata.compactionEpoch,
+    compactionPublicationId: existingMetadata.compactionPublicationId,
   };
 
   if (
@@ -455,59 +463,125 @@ export class HistoryService {
   /** Inactive G1 adapter: pending-file I/O must finish before either history lock is released. */
   getCompactionPendingHistory(workspaceId: string): CompactionPendingHistory {
     return {
-      cleanupHeartbeat: (summary, isCurrent, onCommitted) =>
+      cleanupHeartbeat: (summary, isCurrent, onCommitted, reconcileUnderLock, beforeRollback) =>
         this.cleanupCompactionFollowUp(
           workspaceId,
           summary,
           "rollback-heartbeat",
           isCurrent,
-          onCommitted
+          onCommitted,
+          reconcileUnderLock,
+          beforeRollback
         ),
       withLock: (operation) =>
         this.fileLocks.withLock(workspaceId, () =>
           this.withCrossProcessWriteLock(workspaceId, async (assertStillOwned) => {
-            const journal = this.getContinuousCompactionJournal(workspaceId);
-            // Carry raw reset evidence: missing projected rows cannot prove legacy context safe.
-            // Avoid the public history reader: its lazy rotation would re-enter the lock.
-            const boundary = await readCompactionPendingHistoryBoundary({
-              chat: this.getChatHistoryPath(workspaceId),
-              archive: this.getChatArchivePath(workspaceId),
-            });
-            return await operation({
-              generation: await journal.captureGenerationUnderHistoryLock(),
-              assertStillOwned,
-              boundary,
-              isPublicationCurrent: (publication) =>
-                journal.isPublicationCurrentUnderHistoryLock(publication),
-              publishBoundary: async (input, onCommitted) => {
-                // The public partial reader treats errors as absence. Admission must refuse
-                // unreadable state, and cannot re-enter the history reader's lazy rotation.
-                const raw = await fs
-                  .readFile(this.getPartialPath(workspaceId), "utf8")
-                  .catch((error: unknown) => {
-                    if (isErrnoWithCode(error, "ENOENT")) return undefined;
-                    throw error;
-                  });
-                let partial: MuxMessage | null = null;
-                if (raw !== undefined) {
-                  const parsed: unknown = JSON.parse(raw);
-                  if (!isReadableHistoryMessage(parsed))
-                    throw new Error("Compaction partial is unreadable");
-                  partial = normalizeLegacyMuxMetadata(parsed);
-                }
-                return this.persistBoundaryWithTailCopiesUnderWriteLock(
-                  workspaceId,
-                  input.summaryMessage,
-                  input.tailCopies,
-                  input.updateExisting,
-                  (messages) => input.shouldPersist(messages, partial),
-                  { publication: input.publication, onCommitted },
-                  assertStillOwned
-                );
-              },
-            });
+            return await operation(
+              await this.compactionPendingViewUnderLock(workspaceId, assertStillOwned)
+            );
           })
         ),
+    };
+  }
+
+  private async compactionPendingViewUnderLock(
+    workspaceId: string,
+    assertStillOwned: () => Promise<void>,
+    activeRows?: HistoryRewriteRow[],
+    skippedBoundaries = 0
+  ): Promise<CompactionPendingHistoryView> {
+    const journal = this.getContinuousCompactionJournal(workspaceId);
+    const paths = {
+      chat: this.getChatHistoryPath(workspaceId),
+      archive: this.getChatArchivePath(workspaceId),
+    };
+    const { boundary, boundaryPublicationId } = await readCompactionPendingHistoryObservation(
+      paths,
+      skippedBoundaries
+    );
+    const rows = activeRows ?? (await this.readHistoryForRewrite(paths.chat)).rows;
+    const identityCounts = new Map<string, number>();
+    for (const row of rows) {
+      const message = row.message ?? row.protectedMessage;
+      if (message) identityCounts.set(message.id, (identityCounts.get(message.id) ?? 0) + 1);
+    }
+    let reachableBoundaryIds: Set<string | undefined> | undefined = new Set();
+    let suffix = 0;
+    for (const row of rows.toReversed()) {
+      if (!row.message) {
+        // Corruption cannot justify dropping a potentially rollbackable warm owner.
+        reachableBoundaryIds = undefined;
+        break;
+      }
+      if (!isDurableContextBoundaryMarker(row.message)) continue;
+      if (identityCounts.get(row.message.id) !== 1) {
+        reachableBoundaryIds = undefined;
+        break;
+      }
+      const metadata = row.message.metadata?.muxMetadata;
+      if (row.message.metadata?.compacted !== "heartbeat") break;
+      if (
+        !isCompactionSummaryMetadata(metadata) ||
+        (metadata.pendingFollowUp !== undefined &&
+          (!metadata.pendingFollowUp ||
+            typeof metadata.pendingFollowUp !== "object" ||
+            typeof metadata.pendingFollowUp.text !== "string" ||
+            typeof metadata.pendingFollowUp.model !== "string" ||
+            typeof metadata.pendingFollowUp.agentId !== "string"))
+      ) {
+        reachableBoundaryIds = undefined;
+        break;
+      }
+      if (metadata.pendingFollowUp === undefined) break;
+      reachableBoundaryIds.add(row.message.id);
+      suffix++;
+    }
+    if (reachableBoundaryIds) {
+      // One verified lookup finds the base, including when successful rotation archived it.
+      const base = suffix
+        ? await readCompactionPendingHistoryBoundary(paths, suffix + skippedBoundaries)
+        : boundary;
+      if (base.kind === "identified") reachableBoundaryIds.add(base.messageId);
+      if (base.kind === "none") reachableBoundaryIds.add(undefined);
+      // unreadable-reset is a verified raw reset floor, not an I/O failure: older
+      // boundaries cannot be exposed through it. Failed scans throw and prove no horizon.
+    }
+    const generation = await journal.captureGenerationUnderHistoryLock();
+    await assertStillOwned();
+    return {
+      generation,
+      assertStillOwned,
+      boundary,
+      boundaryPublicationId,
+      reachableBoundaryIds,
+      isPublicationCurrent: (publication) =>
+        journal.isPublicationCurrentUnderHistoryLock(publication),
+      publishBoundary: async (input, onCommitted) => {
+        // The public partial reader treats errors as absence. Admission must refuse
+        // unreadable state, and cannot re-enter the history reader's lazy rotation.
+        const raw = await fs
+          .readFile(this.getPartialPath(workspaceId), "utf8")
+          .catch((error: unknown) => {
+            if (isErrnoWithCode(error, "ENOENT")) return undefined;
+            throw error;
+          });
+        let partial: MuxMessage | null = null;
+        if (raw !== undefined) {
+          const parsed: unknown = JSON.parse(raw);
+          if (!isReadableHistoryMessage(parsed))
+            throw new Error("Compaction partial is unreadable");
+          partial = normalizeLegacyMuxMetadata(parsed);
+        }
+        return this.persistBoundaryWithTailCopiesUnderWriteLock(
+          workspaceId,
+          input.summaryMessage,
+          input.tailCopies,
+          input.updateExisting,
+          (messages) => input.shouldPersist(messages, partial),
+          { publication: input.publication, onCommitted },
+          assertStillOwned
+        );
+      },
     };
   }
 
@@ -3217,7 +3291,12 @@ export class HistoryService {
     action: "clear" | "rollback-heartbeat",
     isCurrent: () => boolean,
     // Unlike void, undefined rejects async observers that would outlive the held locks.
-    onCommitted?: () => undefined
+    onCommitted?: () => undefined,
+    reconcileUnderLock?: (
+      view: CompactionPendingHistoryView,
+      removedCurrentBoundary: boolean
+    ) => Promise<void>,
+    beforeRollback?: (restoredView: CompactionPendingHistoryView) => Promise<void>
   ): Promise<Result<CompactionFollowUpCleanupOutcome>> {
     const expected = summary.metadata?.muxMetadata;
     const sequence = summary.metadata?.historySequence;
@@ -3248,6 +3327,8 @@ export class HistoryService {
         if (
           !current ||
           current.role !== "assistant" ||
+          // Reused IDs/sequences do not transfer a handoff to a different publication.
+          current.metadata?.compactionPublicationId !== summary.metadata?.compactionPublicationId ||
           !isCompactionSummaryMetadata(metadata) ||
           !isDeepStrictEqual(metadata.pendingFollowUp, expected.pendingFollowUp) ||
           (action === "rollback-heartbeat" && current.metadata?.compacted !== "heartbeat") ||
@@ -3266,6 +3347,34 @@ export class HistoryService {
         const serialized = this.serializeHistoryRewrite(rows, workspaceId, (row) =>
           row === current ? replacement : row
         );
+        let removedCurrentBoundary = false;
+        if (action === "rollback-heartbeat") {
+          const boundary = await readCompactionPendingHistoryBoundary({
+            chat: historyPath,
+            archive: this.getChatArchivePath(workspaceId),
+          }).catch(() => undefined);
+          const latest = messages.findLast(isDurableContextBoundaryMarker);
+          removedCurrentBoundary =
+            boundary?.kind === "identified" &&
+            boundary.messageId === summary.id &&
+            latest === current &&
+            rows.filter((row) => (row.message ?? row.protectedMessage)?.id === summary.id)
+              .length === 1;
+          // Older active heartbeats cannot roll back through a later boundary's fallback.
+          if (!removedCurrentBoundary) return Ok("skipped");
+          // Only already-consumed ownership is retired here. If storage cannot establish
+          // that retirement, keep history unchanged so rollback can be retried honestly.
+          await beforeRollback?.(
+            await this.compactionPendingViewUnderLock(
+              workspaceId,
+              assertStillOwned,
+              rows.filter((row) => row.message !== current),
+              1
+            )
+          );
+          await assertStillOwned();
+          if (!isCurrent()) return Ok("skipped");
+        }
         const stagedPath = `${historyPath}.follow-up-${randomUUID()}`;
         let published = false;
         try {
@@ -3290,6 +3399,21 @@ export class HistoryService {
               workspaceId,
               Math.max(this.sequenceCounters.get(workspaceId) ?? 0, sequence + 1)
             );
+          }
+          if (reconcileUnderLock) {
+            try {
+              // Mandatory history is committed; finish this obligation before a successor can enter.
+              await reconcileUnderLock(
+                await this.compactionPendingViewUnderLock(
+                  workspaceId,
+                  assertStillOwned,
+                  rows.filter((row) => row.message !== current)
+                ),
+                removedCurrentBoundary
+              );
+            } catch (error) {
+              log.warn("Pending heartbeat reconciliation unavailable after history commit", error);
+            }
           }
           return Ok("applied");
         } finally {


### PR DESCRIPTION
Adds a local lifecycle for compaction preparation and attachment consumption. Admission is claimed before asynchronous work; only the history commit callback installs a publication. Captured requests share consumption facts so delayed completion, failed enrichment, and heartbeat rollback cannot revive discarded attachments. Runtime activation is isolated in #4190.

Each publication receives a fresh `compactionPublicationId` committed with its history boundary and reused as the existing pending V1 `writeId`. It distinguishes foreign replacements even when boundary ID, sequence, timestamp, and summary content match. Same-boundary finalization, follow-up clearing, and rotation preserve that occurrence. Loading, acknowledged warmth, request adoption, suppression, and rollback cleanup use this exact identity. Compatible unmarked rows still load persisted attachments; absent-file warmth needs occurrence proof, except for proven initial history.

History-only publications retain cleanup authority for attachments they omitted. The store captures private predecessor provenance under the publication lock. Consumption can recover the matching receipt after a failed preparation read, using one queued sidecar read for the retained chain and the existing exact-identity cleanup. A stale cached owner cannot substitute for the locked predecessor. Already authenticated legacy receipts retain their authority; newly inferred cleanup requires a marked occurrence. Copied or mutated callback metadata cannot enlarge the store's authority. Consecutive history-only publications carry unresolved predecessors only through an exact matching local publication, and pruning follows the reachable rollback horizon.

Acknowledging an empty request retires omitted attachments without granting them acknowledgment; independently acknowledged warmth remains eligible. Before rollback removes history, a checkpoint under the same locks durably retires already-consumed ownership. If a required read or retirement is unavailable, rollback leaves history unchanged for retry. A consumption epoch makes final admission skip when acknowledgement or discard changes during staging. Older heartbeat rollback skips while a successor owns the boundary, preserving that successor's fallback and payload.

Ordinary captures probe sidecar existence in the store queue after earlier publications settle. Local ownership is checked at execution, so a queued history-only publication cannot be missed. Only ENOENT with no local owner skips the extra locked history scan, and every call probes again. Present or uncertain storage, probe errors, warmth, and history-only tokens retain full qualification; there is no negative cache.

The merge queue also exposed a lost-abort race in the plugin-install watchdog fixtures. Both fake checkout callbacks now check an already-aborted signal after awaited file creation and before registering their listener. A count-quota regression forces this ordering using the real watchdog. Production quotas, watchdog code, and timeouts are unchanged.

Validation:

- The foreign-predecessor, queued-capture, and absent-probe FIFO regressions fail before their respective fixes. Queued successful and history-only publications are covered while ordinary absence still avoids history locks and scans. The final lifecycle/store/runtime-preparation run passes 171 tests and 752 assertions, covering restart rollback, legacy receipts, history-only chains, fallback preservation, foreign replacements, resets, future formats, failed cleanup, pruning, and authority mutation.
- Canonical `make static-check` passes on combined tree `4638cf400821ae9e9bb3d18ef48fd12b35ff5809`, including both TypeScript configurations, lint, formatting, and documentation checks. Nix is unavailable locally.
- The watchdog suite passes 130 tests. The current-main provider/MCP integration passed 411 tests. Earlier combined compaction coverage passed 2,321 tests across 40 files; these groups overlap and are not a unique total.

Risk: uncertain storage conservatively withholds attachment context. Failed disk retirement remains local debt until successful cleanup; the in-memory capability does not persist discard intent across a crash. Unknown future formats remain untouched. The pending file stays V1; no new journal, migration, or sidecar version is introduced.

This is the remaining pair of the pending-state phase: #4181, #4183, and #4186 have merged. Keep #4189 and #4190 together through review, CI, and the merge queue.

---

_Generated with `xum` • Model: `unavailable` • Thinking: `unavailable` • Cost: `$unavailable`_

<!-- mux-attribution: model=unavailable thinking=unavailable costs=unavailable -->
