### PR TITLE
🤖 refactor: activate compaction preparation across runtime paths

### DIFF
--- a/src/constants/compaction.ts
+++ b/src/constants/compaction.ts
@@ -1,0 +1,2 @@
+/** Shared by the qualified pending store's runtime producers and metadata readers. */
+export const POST_COMPACTION_STATE_FILENAME = "post-compaction.json";

--- a/src/node/services/agentSession.continuousCompaction.test.ts
+++ b/src/node/services/agentSession.continuousCompaction.test.ts
@@ -456,9 +456,18 @@ describe("AgentSession continuous compaction wiring", () => {
     const retained = createMuxMessage("retained-user", "user", "Earlier task");
     await h.historyService.appendToHistory(workspaceId, retained);
     const handler = Reflect.get(h.session, "compactionHandler") as CompactionHandler;
+    const preparation = handler.beginPreparation(() => true);
+    const source = await rows(h);
     expect(
       await handler.persistContinuousCompaction({
-        messages: await rows(h),
+        preparation,
+        publication: {
+          generation: await h.historyService
+            .getContinuousCompactionJournal(workspaceId)
+            .captureGeneration(),
+        },
+        attachmentMessages: source,
+        messages: source,
         text: "Continuous summary",
         model,
         tail: [retained],
@@ -826,8 +835,16 @@ describe("AgentSession continuous compaction wiring", () => {
           if (context.phase !== "mid-stream") return "none";
           const applied = await internals(h.session).interruptForContinuousCompaction(
             async (followUp) => {
+              const preparation = handler.beginPreparation(() => true);
               const history = await rows(h);
               const applied = await handler.persistContinuousCompaction({
+                preparation,
+                publication: {
+                  generation: await h.historyService
+                    .getContinuousCompactionJournal(workspaceId)
+                    .captureGeneration(),
+                },
+                attachmentMessages: history,
                 messages: history,
                 text: "Recovered summary",
                 model,

--- a/src/node/services/agentSession.disposeRace.test.ts
+++ b/src/node/services/agentSession.disposeRace.test.ts
@@ -5,7 +5,6 @@ import * as fs from "node:fs/promises";
 import * as nodePath from "node:path";
 import { AgentSession } from "./agentSession";
 import type { Config } from "@/node/config";
-import type { HistoryService } from "./historyService";
 import { createTestHistoryService } from "./testHistoryService";
 import type { AIService } from "./aiService";
 import type { InitStateManager } from "./initStateManager";
@@ -252,7 +251,7 @@ describe("AgentSession disposal race conditions", () => {
     }
   });
 
-  test("forwards task-created events to onChatEvent subscribers for the matching workspace", () => {
+  test("forwards task-created events to onChatEvent subscribers for the matching workspace", async () => {
     const aiHandlers = new Map<string, (...args: unknown[]) => void>();
 
     const aiService: AIService = {
@@ -269,9 +268,9 @@ describe("AgentSession disposal race conditions", () => {
       streamMessage: mock(() => Promise.resolve(Ok(undefined))),
     } as unknown as AIService;
 
-    const historyService: HistoryService = {
-      appendToHistory: mock(() => Promise.resolve(Ok(undefined))),
-    } as unknown as HistoryService;
+    // Session startup owns compaction/history services even when this test only forwards events.
+    const { historyService, config, cleanup } = await createTestHistoryService();
+    await using _history = { [Symbol.asyncDispose]: cleanup };
 
     const initStateManager: InitStateManager = {
       on(_eventName: string | symbol, _listener: (...args: unknown[]) => void) {
@@ -287,11 +286,6 @@ describe("AgentSession disposal race conditions", () => {
       setMessageQueued: mock(() => undefined),
     } as unknown as BackgroundProcessManager;
 
-    const config: Config = {
-      srcDir: "/tmp",
-      sessionsDir: "/tmp",
-    } as unknown as Config;
-
     const session = new AgentSession({
       workspaceId: "ws",
       config,
@@ -300,6 +294,7 @@ describe("AgentSession disposal race conditions", () => {
       initStateManager,
       backgroundProcessManager,
     });
+    await using _session = { [Symbol.asyncDispose]: () => session.dispose() };
 
     const chatEvents: Array<{ workspaceId: string; message: unknown }> = [];
     session.onChatEvent((event) => {
@@ -339,7 +334,7 @@ describe("AgentSession disposal race conditions", () => {
     });
   });
 
-  test("forwards session-usage-delta events to onChatEvent subscribers for the matching workspace", () => {
+  test("forwards session-usage-delta events to onChatEvent subscribers for the matching workspace", async () => {
     const aiHandlers = new Map<string, (...args: unknown[]) => void>();
 
     const aiService: AIService = {
@@ -356,9 +351,8 @@ describe("AgentSession disposal race conditions", () => {
       streamMessage: mock(() => Promise.resolve(Ok(undefined))),
     } as unknown as AIService;
 
-    const historyService: HistoryService = {
-      appendToHistory: mock(() => Promise.resolve(Ok(undefined))),
-    } as unknown as HistoryService;
+    const { historyService, config, cleanup } = await createTestHistoryService();
+    await using _history = { [Symbol.asyncDispose]: cleanup };
 
     const initStateManager: InitStateManager = {
       on(_eventName: string | symbol, _listener: (...args: unknown[]) => void) {
@@ -374,11 +368,6 @@ describe("AgentSession disposal race conditions", () => {
       setMessageQueued: mock(() => undefined),
     } as unknown as BackgroundProcessManager;
 
-    const config: Config = {
-      srcDir: "/tmp",
-      sessionsDir: "/tmp",
-    } as unknown as Config;
-
     const session = new AgentSession({
       workspaceId: "ws",
       config,
@@ -387,6 +376,7 @@ describe("AgentSession disposal race conditions", () => {
       initStateManager,
       backgroundProcessManager,
     });
+    await using _session = { [Symbol.asyncDispose]: () => session.dispose() };
 
     const chatEvents: Array<{ workspaceId: string; message: unknown }> = [];
     session.onChatEvent((event) => {
@@ -450,9 +440,8 @@ describe("AgentSession disposal race conditions", () => {
       streamMessage: mock(() => Promise.resolve(Ok(undefined))),
     } as unknown as AIService;
 
-    const historyService: HistoryService = {
-      appendToHistory: mock(() => Promise.resolve(Ok(undefined))),
-    } as unknown as HistoryService;
+    const { historyService, config, cleanup } = await createTestHistoryService();
+    await using _history = { [Symbol.asyncDispose]: cleanup };
 
     const initStateManager: InitStateManager = {
       on(_eventName: string | symbol, _listener: (...args: unknown[]) => void) {
@@ -468,11 +457,6 @@ describe("AgentSession disposal race conditions", () => {
       setMessageQueued: mock(() => undefined),
     } as unknown as BackgroundProcessManager;
 
-    const config: Config = {
-      srcDir: "/tmp",
-      sessionsDir: "/tmp",
-    } as unknown as Config;
-
     const session = new AgentSession({
       workspaceId: "ws",
       config,
@@ -481,20 +465,13 @@ describe("AgentSession disposal race conditions", () => {
       initStateManager,
       backgroundProcessManager,
     });
+    await using _session = { [Symbol.asyncDispose]: () => session.dispose() };
 
-    const cancel = mock(() => undefined);
-    const setEnabled = mock((_enabled: boolean) => undefined);
-    (
-      session as unknown as {
-        retryManager: {
-          cancel: typeof cancel;
-          setEnabled: typeof setEnabled;
-        };
-      }
-    ).retryManager = {
-      cancel,
-      setEnabled,
+    const { retryManager } = session as unknown as {
+      retryManager: { cancel: () => void; setEnabled: (enabled: boolean) => void };
     };
+    const cancel = spyOn(retryManager, "cancel");
+    const setEnabled = spyOn(retryManager, "setEnabled");
 
     const options = {
       model: "anthropic:claude-sonnet-4-5",
@@ -583,7 +560,7 @@ describe("AgentSession disposal race conditions", () => {
     }
   });
 
-  test("preserves synthetic flag when flushing queued messages", () => {
+  test("preserves synthetic flag when flushing queued messages", async () => {
     const aiService: AIService = {
       ...createStreamLifecycleMocks(),
       on(_eventName: string | symbol, _listener: (...args: unknown[]) => void) {
@@ -597,9 +574,8 @@ describe("AgentSession disposal race conditions", () => {
       streamMessage: mock(() => Promise.resolve(Ok(undefined))),
     } as unknown as AIService;
 
-    const historyService: HistoryService = {
-      appendToHistory: mock(() => Promise.resolve(Ok(undefined))),
-    } as unknown as HistoryService;
+    const { historyService, config, cleanup } = await createTestHistoryService();
+    await using _history = { [Symbol.asyncDispose]: cleanup };
 
     const initStateManager: InitStateManager = {
       on(_eventName: string | symbol, _listener: (...args: unknown[]) => void) {
@@ -615,11 +591,6 @@ describe("AgentSession disposal race conditions", () => {
       setMessageQueued: mock(() => undefined),
     } as unknown as BackgroundProcessManager;
 
-    const config: Config = {
-      srcDir: "/tmp",
-      sessionsDir: "/tmp",
-    } as unknown as Config;
-
     const session = new AgentSession({
       workspaceId: "ws",
       config,
@@ -628,6 +599,7 @@ describe("AgentSession disposal race conditions", () => {
       initStateManager,
       backgroundProcessManager,
     });
+    await using _session = { [Symbol.asyncDispose]: () => session.dispose() };
 
     const sendMessage = mock(
       (

--- a/src/node/services/agentSession.pendingOwnership.test.ts
+++ b/src/node/services/agentSession.pendingOwnership.test.ts
@@ -91,22 +91,25 @@ describe("pending snapshot consumers", () => {
             output: { success: true },
           },
         ];
+        const preparation = handler.beginPreparation(() => true);
         expect(
-          await handler.withContinuousPendingState(
-            [edit],
-            (boundaryMessageId) =>
-              handler.persistContinuousCompaction({
-                messages: [edit],
-                boundaryMessageId,
-                text: `${id} summary`,
-                model,
-                tail: [],
-                systemMessageTokens: 0,
-                attachmentTokens: 0,
-                shouldPersist: () => true,
-              }),
-            id
-          )
+          await handler.persistContinuousCompaction({
+            preparation,
+            publication: {
+              generation: await h.historyService
+                .getContinuousCompactionJournal(workspaceId)
+                .captureGeneration(),
+            },
+            attachmentMessages: [edit],
+            messages: [edit],
+            boundaryMessageId: id,
+            text: `${id} summary`,
+            model,
+            tail: [],
+            systemMessageTokens: 0,
+            attachmentTokens: 0,
+            shouldPersist: () => true,
+          })
         ).toBe(true);
       }
       let policy: Promise<void> | undefined;
@@ -197,7 +200,14 @@ describe("pending snapshot consumers", () => {
             (await handler.peekPendingState())?.diffs.some((diff) => diff.path === "/b.ts")
           ).toBe(true);
           assert(bytes !== undefined, "Expected replacement file");
-          expect(await readFile(pendingPath, "utf8")).toBe(bytes);
+          const {
+            previousState: _previous,
+            previousStateGeneration: _generation,
+            previousStateBoundary: _boundary,
+            ...successor
+          } = JSON.parse(bytes) as Record<string, unknown>;
+          // Retiring A also retires its crash fallback, while B's exact owner survives.
+          expect(JSON.parse(await readFile(pendingPath, "utf8"))).toEqual(successor);
         } else {
           // The failed periodic injection still owns A's retained read-path carryover after ack.
           await publish("c");

--- a/src/node/services/agentSession.postCompactionAttachments.test.ts
+++ b/src/node/services/agentSession.postCompactionAttachments.test.ts
@@ -10,12 +10,15 @@ import type {
 } from "@/common/types/attachment";
 import { TURNS_BETWEEN_ATTACHMENTS } from "@/common/constants/attachments";
 import { createMuxMessage, type MuxMessage } from "@/common/types/message";
+import { POST_COMPACTION_STATE_FILENAME } from "@/constants/compaction";
 import type { Config } from "@/node/config";
 
 import type { AIService } from "./aiService";
 import { AgentSession } from "./agentSession";
 import { createStreamLifecycleMocks } from "./agentSession.testHarness";
 import type { BackgroundProcessManager } from "./backgroundProcessManager";
+import type { CompactionHandler } from "./compactionHandler";
+import { CompactionPendingState } from "./compactionPendingState";
 import type { HistoryService } from "./historyService";
 import type { InitStateManager } from "./initStateManager";
 import { DisposableTempDir } from "./tempDir";
@@ -156,7 +159,7 @@ function createSessionForHistory(historyService: HistoryService, sessionDir: str
 interface PrivateSessionAccess {
   compactionOccurred: boolean;
   turnsSinceLastAttachment: number;
-  postCompactionLoadedSkills: LoadedSkillSnapshot[];
+  compactionHandler: CompactionHandler;
   getPostCompactionAttachmentsIfNeeded: () => Promise<PostCompactionAttachment[] | null>;
 }
 
@@ -170,14 +173,12 @@ async function getImmediatePostCompactionAttachments(
 }
 
 async function generatePeriodicPostCompactionAttachments(
-  session: AgentSession,
-  loadedSkills: LoadedSkillSnapshot[] = []
+  session: AgentSession
 ): Promise<PostCompactionAttachment[]> {
   const privateSession = session as unknown as PrivateSessionAccess;
 
   privateSession.compactionOccurred = true;
   privateSession.turnsSinceLastAttachment = TURNS_BETWEEN_ATTACHMENTS - 1;
-  privateSession.postCompactionLoadedSkills = loadedSkills;
 
   const attachments = await privateSession.getPostCompactionAttachmentsIfNeeded();
   expect(attachments).not.toBeNull();
@@ -190,6 +191,7 @@ async function writePendingPostCompactionState(args: {
   diffs: Array<{ path: string; diff: string; truncated: boolean }>;
   loadedSkills: LoadedSkillSnapshot[];
   readFiles?: string[];
+  boundaryMessageId?: string;
 }): Promise<void> {
   await fs.mkdir(args.sessionDir, { recursive: true });
   await fs.writeFile(
@@ -199,6 +201,7 @@ async function writePendingPostCompactionState(args: {
       createdAt: Date.now(),
       diffs: args.diffs,
       loadedSkills: args.loadedSkills,
+      boundaryMessageId: args.boundaryMessageId,
       ...(args.readFiles ? { readFiles: args.readFiles } : {}),
     })
   );
@@ -225,6 +228,14 @@ describe("AgentSession post-compaction attachments", () => {
     const { historyService, cleanup } = await createTestHistoryService();
     historyCleanup = cleanup;
 
+    expect(
+      (
+        await historyService.appendToHistory(
+          WORKSPACE_ID,
+          createMuxMessage("source", "user", "Context")
+        )
+      ).success
+    ).toBe(true);
     // A compaction persisted cumulative pre-boundary read paths...
     await writePendingPostCompactionState({
       sessionDir: path.join(sessionDir.path, WORKSPACE_ID),
@@ -250,6 +261,7 @@ describe("AgentSession post-compaction attachments", () => {
 
       // A new context segment starts (context reset / full history clear):
       // the reset was meant to discard that context, so...
+      expect((await historyService.clearHistory(WORKSPACE_ID)).success).toBe(true);
       await session.clearPostCompactionState();
 
       // ...no later turn may re-inject pre-boundary paths — neither
@@ -257,8 +269,7 @@ describe("AgentSession post-compaction attachments", () => {
       for (let turn = 0; turn <= TURNS_BETWEEN_ATTACHMENTS; turn++) {
         expect(await privateSession.getPostCompactionAttachmentsIfNeeded(true)).toBeNull();
       }
-      // The persisted pending state is discarded too, so a NEW session after
-      // an app restart cannot resurrect the carryover either.
+      // Explicit destruction removes compatible legacy bytes so a downgrade cannot reload them.
       const stateExists = await fs
         .access(path.join(sessionDir.path, WORKSPACE_ID, "post-compaction.json"))
         .then(
@@ -266,6 +277,19 @@ describe("AgentSession post-compaction attachments", () => {
           () => false
         );
       expect(stateExists).toBe(false);
+      const restarted = createSessionForHistory(
+        historyService,
+        path.join(sessionDir.path, WORKSPACE_ID)
+      );
+      try {
+        expect(
+          await (
+            restarted as unknown as PrivateSessionAccess
+          ).getPostCompactionAttachmentsIfNeeded()
+        ).toBeNull();
+      } finally {
+        await restarted.dispose();
+      }
     } finally {
       await session.dispose();
     }
@@ -426,9 +450,6 @@ describe("AgentSession post-compaction attachments", () => {
     const workspaceId = "workspace-post-compaction-test";
     const { historyService, cleanup } = await createTestHistoryService();
     historyCleanup = cleanup;
-    for (const msg of history) {
-      await historyService.appendToHistory(workspaceId, msg);
-    }
 
     const session = createSessionForHistory(
       historyService,
@@ -440,7 +461,37 @@ describe("AgentSession post-compaction attachments", () => {
     });
 
     try {
-      const attachments = await generatePeriodicPostCompactionAttachments(session, [loadedSkill]);
+      // Acknowledged warmth belongs to the exact durable publication; seed its row and
+      // pending file together so the test exercises the same identity as real compaction.
+      const pending = new CompactionPendingState(
+        path.join(sessionDir.path, WORKSPACE_ID, POST_COMPACTION_STATE_FILENAME),
+        historyService.getCompactionPendingHistory(workspaceId)
+      );
+      expect(
+        (
+          await pending.publishBoundary({
+            summaryMessage: history[0],
+            tailCopies: history.slice(1),
+            updateExisting: false,
+            attachments: { diffs: [], loadedSkills: [loadedSkill], readFiles: [] },
+            publication: {
+              generation: await historyService
+                .getContinuousCompactionJournal(workspaceId)
+                .captureGeneration(),
+            },
+            isCurrent: () => true,
+            shouldPersist: () => true,
+            onCommitted: () => undefined,
+          })
+        ).success
+      ).toBe(true);
+      expect(getLoadedSkillNames(await getImmediatePostCompactionAttachments(session))).toEqual([
+        "react-effects",
+      ]);
+      await (
+        session as unknown as PrivateSessionAccess
+      ).compactionHandler.ackPendingStateConsumed();
+      const attachments = await generatePeriodicPostCompactionAttachments(session);
       expect(getLoadedSkillNames(attachments)).toEqual(["react-effects"]);
       expect(getLoadedSkillAttachment(attachments)?.skills[0]?.body).toContain(
         "Persist this guardrail across follow-up turns."

--- a/src/node/services/agentSession.tokenBudget.test.ts
+++ b/src/node/services/agentSession.tokenBudget.test.ts
@@ -28,6 +28,9 @@ import { createTurnCompletionController, type SettledStepBudget } from "./stream
 import { createRolloverPrefix, type ContextWindowRollover } from "./contextWindowRollover";
 import * as rolloverMessages from "./contextWindowRollover";
 import * as contextLimits from "@/common/utils/compaction/contextLimit";
+import { CompactionPendingState } from "./compactionPendingState";
+import { POST_COMPACTION_STATE_FILENAME } from "@/constants/compaction";
+import { log } from "./log";
 
 const workspaceId = "token-budget-session";
 const model = "openai:gpt-4o";
@@ -1362,6 +1365,144 @@ describe("AgentSession token-budget lifecycle", () => {
       expect(rolloverRows(rows)).toHaveLength(1);
       expect(text(rows.at(-1)!)).toBe("Recover accepted work");
       expect(h.requests).toHaveLength(1);
+    }
+  );
+
+  test.each(
+    (["on-send", "emergency"] as const).flatMap((mode) =>
+      (
+        [
+          "committed",
+          "append-failed",
+          "ack-failed",
+          "successor",
+          "cleanup-failed",
+          "ack-and-cleanup-failed",
+        ] as const
+      ).map((outcome) => ({ mode, outcome }))
+    )
+  )(
+    "rollover pending cleanup follows durable history ($mode, $outcome)",
+    async ({ mode, outcome }) => {
+      const h = await setup({
+        failure:
+          mode === "emergency" ? (attempt) => (attempt === 1 ? exceeded : undefined) : undefined,
+      });
+      await seedHistory(h, mode === "emergency" ? 20_000 : 110_000);
+      const sessionDir = path.join(h.config.sessionsDir, workspaceId);
+      const pendingPath = path.join(sessionDir, POST_COMPACTION_STATE_FILENAME);
+      const journal = h.historyService.getContinuousCompactionJournal(workspaceId);
+      let before = "";
+      let successor = "";
+      const acknowledgmentFailure = "injected post-commit failure";
+      const cleanupFails = outcome === "cleanup-failed" || outcome === "ack-and-cleanup-failed";
+      const reportedErrors = spyOn(log, "error");
+      const cleanup = h.session.applyContextResetSideEffects.bind(h.session);
+      spyOn(h.session, "applyContextResetSideEffects").mockImplementationOnce(async (...args) => {
+        // A foreign pending publication can arrive after preparation, including after the
+        // emergency path rejected an earlier attachment. The reset must retire this owner too.
+        before = JSON.stringify({
+          version: 1,
+          createdAt: 1,
+          publicationGeneration: (await journal.captureGeneration()) ?? null,
+          diffs: [{ path: "/before.ts", diff: "+before", truncated: false }],
+          loadedSkills: [{ name: "before", scope: "project", body: "Pre-reset instructions" }],
+          readFiles: ["/before.ts"],
+        });
+        await fs.writeFile(pendingPath, before);
+        await cleanup(...args);
+      });
+      const append = h.historyService.appendManyToHistory.bind(h.historyService);
+      spyOn(h.historyService, "appendManyToHistory").mockImplementation(async (id, rows) => {
+        const rollover = rolloverRows(rows).length > 0;
+        if (rollover && outcome === "append-failed") return Err("injected rollover append failure");
+        const result = await append(id, rows);
+        if (!rollover || !result.success) return result;
+        if (outcome === "successor") {
+          const pending = new CompactionPendingState(
+            pendingPath,
+            h.historyService.getCompactionPendingHistory(workspaceId)
+          );
+          expect(
+            (
+              await pending.publishBoundary({
+                summaryMessage: createMuxMessage("successor", "assistant", "New context", {
+                  compacted: "user",
+                  compactionBoundary: true,
+                  compactionEpoch: 1,
+                }),
+                tailCopies: [],
+                updateExisting: false,
+                attachments: { diffs: [], loadedSkills: [], readFiles: ["/after.ts"] },
+                publication: { generation: await journal.captureGeneration() },
+                isCurrent: () => true,
+                shouldPersist: () => true,
+                onCommitted: () => undefined,
+              })
+            ).success
+          ).toBe(true);
+          successor = await fs.readFile(pendingPath, "utf8");
+        }
+        if (cleanupFails) {
+          const unlink = fs.unlink;
+          spyOn(fs, "unlink").mockImplementation((file) =>
+            file === pendingPath
+              ? Promise.reject(
+                  Object.assign(new Error("pending unlink failed"), { code: "EACCES" })
+                )
+              : unlink(file)
+          );
+        }
+        if (outcome === "ack-failed" || outcome === "ack-and-cleanup-failed") {
+          throw new Error(acknowledgmentFailure);
+        }
+        return result;
+      });
+
+      const sent = await h.session.sendMessage("Roll over this window", options);
+      if (cleanupFails) {
+        const causes = reportedErrors.mock.calls.flatMap((args) =>
+          args.filter((value): value is Error => value instanceof Error).map((error) => error.cause)
+        );
+        expect(causes).toContainEqual(expect.objectContaining({ code: "EACCES" }));
+      }
+      expect(sent.success).toBe(
+        outcome === "committed" || outcome === "successor" || outcome === "cleanup-failed"
+      );
+      expect(rolloverRows(await allRows(h))).toHaveLength(outcome === "append-failed" ? 0 : 1);
+      const persistedPending = await fs.readFile(pendingPath, "utf8").catch((error: unknown) => {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+        throw error;
+      });
+      // Generation fences protect the current reader only. Removing the compatible bytes is
+      // what prevents a preceding version from reloading them immediately after a downgrade.
+      expect(persistedPending).toBe(
+        outcome === "successor"
+          ? successor
+          : outcome === "append-failed" || cleanupFails
+            ? before
+            : undefined
+      );
+      if (!sent.success) {
+        expect(h.requests).toHaveLength(mode === "emergency" ? 1 : 0);
+        if (outcome === "ack-and-cleanup-failed") {
+          expect(sent.error).toMatchObject({ type: "unknown", raw: acknowledgmentFailure });
+        }
+      }
+      if (outcome === "cleanup-failed") {
+        expect(h.requests).toHaveLength(mode === "emergency" ? 2 : 1);
+        h.settleStream(0);
+        await h.session.waitForIdle();
+        expect((await h.session.sendMessage("Continue accepted work", options)).success).toBe(true);
+        const rows = await allRows(h);
+        expect(rolloverRows(rows)).toHaveLength(1);
+        const active = await h.historyService.getHistoryFromLatestBoundary(workspaceId);
+        expect(active.success).toBe(true);
+        if (active.success)
+          expect(active.data.filter((row) => text(row) === "Roll over this window")).toHaveLength(
+            1
+          );
+      }
     }
   );
 

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -1032,19 +1032,6 @@ export class AgentSession {
   private compactionOccurred = false;
 
   /**
-   * Skill guardrails loaded before compaction are preserved here so later turns can
-   * continue reattaching them even after the pending on-disk state is acknowledged.
-   */
-  private postCompactionLoadedSkills: LoadedSkillSnapshot[] = [];
-
-  /**
-   * Cumulative read-file paths from summarized epochs, mirrored like
-   * postCompactionLoadedSkills so periodic re-injections keep the pre-boundary
-   * reads after the pending on-disk state is acknowledged. RLM-only surface.
-   */
-  private postCompactionReadFilePaths: string[] = [];
-
-  /**
    * Retain the exact injected snapshot so a late completion cannot consume a replacement.
    *
    * This is intentionally delayed until stream-end so a crash mid-stream doesn't lose the diffs.
@@ -1052,8 +1039,6 @@ export class AgentSession {
   private pendingPostCompactionStateToAcknowledge: Awaited<
     ReturnType<CompactionHandler["peekPendingState"]>
   > = null;
-  /** Periodic reinjection retains the consumed owner of the cached skill/read carryover. */
-  private postCompactionState: typeof this.pendingPostCompactionStateToAcknowledge = null;
 
   /**
    * Cached memory session context (memory experiment): index snapshot for
@@ -4344,10 +4329,9 @@ export class AgentSession {
           if (isAdmissionStale() || this.coordinator.admissionBlocked || this.coordinator.closing) {
             return Err(createUnknownSendMessageError(CONTEXT_MUTATION_SEND_BLOCKED_MESSAGE));
           }
-          // Fail closed before publication: a crash must not reopen a fresh window
-          // with stale carryover/kernel state. An append failure may leave the old
-          // transcript with disposable context state cleared (ADR-0005).
-          await this.applyContextResetSideEffects();
+          // Invalidate disposable/kernel state before publication. Pending carryover must
+          // wait for the writer's generation fence or it still qualifies as current.
+          await this.applyContextResetSideEffects({ deferCarryoverDiscard: true });
         }
         if (await cancelBeforeAcceptance()) return Ok(undefined);
         if (
@@ -4358,8 +4342,9 @@ export class AgentSession {
           return Err(createUnknownSendMessageError(CONTEXT_MUTATION_SEND_BLOCKED_MESSAGE));
         }
         // Ordinary sends stay append-only; only coupled snapshots/boundaries need an atomic batch.
-        const appended =
-          batch.length === 1
+        const appended = contextRollover
+          ? await this.appendContextRolloverRows(batch)
+          : batch.length === 1
             ? await this.historyService.appendToHistory(this.workspaceId, userMessage)
             : await this.historyService.appendManyToHistory(this.workspaceId, batch);
         if (!appended.success) return Err(createUnknownSendMessageError(appended.error));
@@ -5083,7 +5068,7 @@ export class AgentSession {
   }
 
   /** Shared with manual reset, but only context-scoped state: tasks, costs and goal consent survive. */
-  async applyContextResetSideEffects(): Promise<void> {
+  async applyContextResetSideEffects(options?: { deferCarryoverDiscard?: boolean }): Promise<void> {
     assert(
       !this.streamManager.isStreaming(this.workspaceId),
       "context reset requires a settled stream"
@@ -5094,14 +5079,7 @@ export class AgentSession {
     this.continuousCompactor.reset("context-changed");
     this.clearFileState();
     this.memoryContextByModelString.clear();
-    try {
-      await this.clearPostCompactionState();
-    } catch (error) {
-      throw new Error(
-        `The persisted post-compaction carryover could not be durably discarded (${getErrorMessage(error)}). Pre-reset read/skill context may be re-injected after a restart.`,
-        { cause: error }
-      );
-    }
+    if (!options?.deferCarryoverDiscard) await this.discardContextResetCarryover();
     try {
       await sandboxHostService.discardScope(
         this.workspaceId,
@@ -5113,6 +5091,37 @@ export class AgentSession {
         { cause: error }
       );
     }
+  }
+
+  private async discardContextResetCarryover(): Promise<void> {
+    try {
+      await this.clearPostCompactionState();
+    } catch (error) {
+      throw new Error(
+        `The persisted post-compaction carryover could not be durably discarded (${getErrorMessage(error)}). Pre-reset read/skill context may be re-injected after a restart.`,
+        { cause: error }
+      );
+    }
+  }
+
+  private async appendContextRolloverRows(rows: MuxMessage[]): Promise<Result<void>> {
+    let appended: Result<void>;
+    try {
+      appended = await this.historyService.appendManyToHistory(this.workspaceId, rows);
+    } catch (error) {
+      appended = Err(getErrorMessage(error));
+    }
+    // The writer may commit its boundary/fence before reporting an error. Always reconcile
+    // afterward: unchanged generations and newer successors remain protected by the store.
+    try {
+      await this.discardContextResetCarryover();
+    } catch (error) {
+      // Cleanup cannot undo accepted rows. Preserve the writer's result so success completes
+      // rollover bookkeeping instead of inviting a duplicate send; generation checks still
+      // exclude stale carryover in this version. Keep the downgrade cleanup failure visible.
+      log.error("Carryover cleanup failed after rollover history append", error);
+    }
+    return appended;
   }
 
   private async checkContextBudgetHistoryAccess(
@@ -5429,7 +5438,7 @@ export class AgentSession {
         this.contextBudgetGeneration !== generation
       )
         return Ok(undefined);
-      await this.applyContextResetSideEffects();
+      await this.applyContextResetSideEffects({ deferCarryoverDiscard: true });
       if (
         !this.coordinator.isCurrentTurn(turn) ||
         !this.coordinator.isCurrentOperation(operation) ||
@@ -5440,7 +5449,7 @@ export class AgentSession {
         this.coordinator.closing
       )
         return Ok(undefined);
-      const appended = await this.historyService.appendManyToHistory(this.workspaceId, rows);
+      const appended = await this.appendContextRolloverRows(rows);
       if (
         !this.coordinator.isCurrentTurn(turn) ||
         !this.coordinator.isCurrentOperation(operation) ||
@@ -6535,14 +6544,15 @@ export class AgentSession {
 
   private async buildContinuousCompactionAttachments(head: MuxMessage[]) {
     const pending = await this.compactionHandler.peekPendingState();
+    const warm = await this.compactionHandler.peekCarryoverState();
     return this.buildAttachmentsFromContext({
       diffs: [...(pending?.diffs ?? []), ...extractEditedFileDiffs(head)],
       loadedSkills: mergeLoadedSkillSnapshots([
-        ...this.postCompactionLoadedSkills,
+        ...(warm?.loadedSkills ?? []),
         ...(pending?.loadedSkills ?? []),
         ...extractLoadedSkillSnapshotsFromMessages(head),
       ]),
-      readFilePaths: mergeReadFilePaths(this.postCompactionReadFilePaths, [
+      readFilePaths: mergeReadFilePaths(warm?.readFiles ?? [], [
         ...(pending?.readFiles ?? []),
         ...extractReadFilePaths(head),
       ]),
@@ -7915,11 +7925,6 @@ export class AgentSession {
     });
 
     // The post-compaction context is likely the culprit; discard it so we don't loop.
-    if (this.postCompactionState === pendingState) {
-      this.postCompactionLoadedSkills = [];
-      this.postCompactionReadFilePaths = [];
-      this.postCompactionState = null;
-    }
     try {
       await this.compactionHandler.discardPendingState("context_exceeded", pendingState);
       this.onPostCompactionStateChange?.();
@@ -8510,7 +8515,8 @@ export class AgentSession {
 
       const handled = await this.compactionHandler.handleCompletion(
         streamEndPayload,
-        completedCompactionRequest?.id
+        completedCompactionRequest?.id,
+        () => this.coordinator.isCurrentTurn(turn) && this.coordinator.isCurrentOperation(operation)
       );
       if (!this.coordinator.isCurrentTurn(turn) || !this.coordinator.isCurrentOperation(operation))
         return;
@@ -10293,24 +10299,17 @@ export class AgentSession {
    * resurrect context the user explicitly discarded and tell the model files
    * were "previously read" when their contents are gone from active context.
    * Covers both injection routes: the immediate pending-state path (on-disk
-   * post-compaction.json + handler caches) and the periodic re-merge path
-   * (compactionOccurred + the in-session mirrors).
+   * post-compaction.json) and the periodic capture of qualified carryover.
    */
   async clearPostCompactionState(): Promise<void> {
-    this.postCompactionState = null;
     this.memoryContextByModelString.clear();
     // In-memory clears stay unconditional: they stop THIS session from
     // injecting carryover even when the durable discard below fails.
     this.compactionOccurred = false;
     this.turnsSinceLastAttachment = TURNS_BETWEEN_ATTACHMENTS;
-    this.postCompactionLoadedSkills = [];
-    this.postCompactionReadFilePaths = [];
     this.pendingPostCompactionStateToAcknowledge = null;
-    // Durable-or-throw: a swallowed unlink failure would leave the stale
-    // post-compaction.json to re-inject pre-boundary carryover after a
-    // restart while the boundary caller reports success — the same
-    // invalidation-must-be-durable invariant as the sandbox reset tombstone.
-    // Boundary callers surface the throw as a partial failure.
+    // The destructive history operation already fenced its captured context under the locks.
+    // Retire compatible old bytes for downgrades; preserve newer publications and unknown schemas.
     await this.compactionHandler.discardPendingStateDurably("context-boundary");
     this.onPostCompactionStateChange?.();
   }
@@ -10401,12 +10400,9 @@ export class AgentSession {
     // Check if compaction just occurred (immediate injection with cached post-compaction state)
     const pendingState = await this.compactionHandler.peekPendingState();
     if (pendingState !== null) {
-      this.postCompactionState = pendingState;
       this.pendingPostCompactionStateToAcknowledge = pendingState;
       this.compactionOccurred = true;
       this.turnsSinceLastAttachment = 0;
-      this.postCompactionLoadedSkills = pendingState.loadedSkills;
-      this.postCompactionReadFilePaths = pendingState.readFiles;
       // Compaction boundary: invalidate the session-cached memory context so
       // the next stream recomputes the index and hot set from current
       // files/pins/usage stats.
@@ -10430,9 +10426,10 @@ export class AgentSession {
 
     // Check cooldown for subsequent injections (re-read from current history)
     if (this.compactionOccurred && this.turnsSinceLastAttachment >= TURNS_BETWEEN_ATTACHMENTS) {
-      this.pendingPostCompactionStateToAcknowledge = this.postCompactionState;
+      const warm = await this.compactionHandler.peekCarryoverState();
+      this.pendingPostCompactionStateToAcknowledge = warm;
       this.turnsSinceLastAttachment = 0;
-      return this.generatePostCompactionAttachments(includeReadFiles);
+      return this.generatePostCompactionAttachments(includeReadFiles, warm);
     }
 
     return null;
@@ -10442,7 +10439,8 @@ export class AgentSession {
    * Generate post-compaction attachments by extracting diffs and loaded skills from message history.
    */
   private async generatePostCompactionAttachments(
-    includeReadFiles: boolean
+    includeReadFiles: boolean,
+    warm: Awaited<ReturnType<CompactionHandler["peekCarryoverState"]>>
   ): Promise<PostCompactionAttachment[]> {
     // getHistoryFromLatestBoundary already returns only the active compaction epoch,
     // so no further boundary slicing is needed.
@@ -10453,16 +10451,13 @@ export class AgentSession {
 
     const fileDiffs = extractEditedFileDiffs(historyResult.data);
     const loadedSkills = mergeLoadedSkillSnapshots([
-      ...this.postCompactionLoadedSkills,
+      ...(warm?.loadedSkills ?? []),
       ...extractLoadedSkillSnapshotsFromMessages(historyResult.data),
     ]);
     // Mirror loadedSkills: cumulative pre-boundary reads carried in memory,
     // merged with reads from the current epoch (newest-first, capped).
     const readFilePaths = includeReadFiles
-      ? mergeReadFilePaths(
-          this.postCompactionReadFilePaths,
-          extractReadFilePaths(historyResult.data)
-        )
+      ? mergeReadFilePaths(warm?.readFiles ?? [], extractReadFilePaths(historyResult.data))
       : [];
 
     // Reports completed before the latest boundary had their tool results summarized away;
@@ -11026,9 +11021,16 @@ export class AgentSession {
       return Err("Cannot reset heartbeat context while queued user input is pending.");
     }
 
+    const turn = this.coordinator.turnId;
     const result = await this.compactionHandler.appendHeartbeatContextResetBoundary({
       boundaryText: params.boundaryText,
       pendingFollowUp: params.pendingFollowUp,
+      isCurrent: () =>
+        this.coordinator.isCurrentTurn(turn) &&
+        !this.isBusy() &&
+        !this.hasQueuedMessages() &&
+        !this.coordinator.closing &&
+        !this.coordinator.disposed,
     });
     if (result.success) {
       this.clearUsageState();
@@ -11049,7 +11051,7 @@ export class AgentSession {
    * Peek at cached file paths from pending compaction.
    * Returns paths that will be reinjected, or null if no pending compaction.
    */
-  getPendingTrackedFilePaths(): string[] | null {
+  async getPendingTrackedFilePaths(): Promise<string[] | null> {
     return this.compactionHandler.peekCachedFilePaths();
   }
 

--- a/src/node/services/agentSession.turnCompletion.test.ts
+++ b/src/node/services/agentSession.turnCompletion.test.ts
@@ -5,6 +5,9 @@ import { Exit, Scope } from "effect";
 import { defaultEffectRunner as runner } from "./di/effectRunner";
 import { log } from "./log";
 import { EventEmitter } from "events";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { CONTINUOUS_COMPACTION_GENERATION_FILE } from "@/constants/continuousCompaction";
 import type { StreamAbortEvent, StreamEndEvent } from "@/common/types/stream";
 import { Err, Ok } from "@/common/types/result";
 import type { StreamMessageOptions } from "./turnRequestBuilder";
@@ -62,6 +65,71 @@ function observePolicy(session: AgentSession) {
 }
 
 describe("AgentSession turn completion", () => {
+  test("ordinary completion drains queued input despite an unreadable compaction generation", async () => {
+    const completion = Promise.withResolvers<TurnCompletion>();
+    const nextStarted = Promise.withResolvers<void>();
+    const emitter = new EventEmitter();
+    let calls = 0;
+    const h = await createAgentSessionHarness({
+      workspaceId,
+      aiEmitter: emitter,
+      captureEvents: true,
+      aiServiceOverrides: {
+        streamMessage: mock(() => {
+          const messageId = `assistant-${++calls}`;
+          start(emitter, messageId);
+          if (calls === 2) nextStarted.resolve();
+          return Promise.resolve(
+            Ok({
+              messageId,
+              completion:
+                calls === 1
+                  ? completion.promise
+                  : createStartedTurnHandle(h.session.closingSignal).completion,
+            })
+          );
+        }),
+      },
+    });
+    const consumer = observePolicy(h.session);
+    const observation = spyOn(internal(h.session), "observeContinuousCompactionAtStreamEnd");
+    const accounting = spyOn(internal(h.session), "recordGoalAccountingFromUsage");
+    try {
+      expect((await h.session.sendMessage("original", sendOptions)).success).toBe(true);
+      const firstPolicy = policyPromise(consumer);
+      h.session.queueMessage("queued follow-up", sendOptions);
+      // A compaction-only sidecar must not strand ordinary completion policy or its queue.
+      const generationPath = path.join(
+        h.config.sessionsDir,
+        workspaceId,
+        CONTINUOUS_COMPACTION_GENERATION_FILE
+      );
+      await fs.mkdir(generationPath);
+      completion.resolve({ status: "completed", streamEnd: end() });
+      await firstPolicy;
+      expect(h.session.hasQueuedMessages()).toBe(false);
+      expect(observation).toHaveBeenCalledTimes(1);
+      expect(accounting).toHaveBeenCalledTimes(1);
+      await nextStarted.promise;
+      expect(calls).toBe(2);
+      expect(h.session.isBusy()).toBe(true);
+      expect(h.events.filter((event) => event.type === "stream-end")).toHaveLength(1);
+      const history = await h.historyService.getHistoryFromLatestBoundary(workspaceId);
+      if (!history.success) throw new Error(history.error);
+      expect(history.data.at(-1)?.parts).toMatchObject([
+        { type: "text", text: "queued follow-up" },
+      ]);
+      expect((await fs.stat(generationPath)).isDirectory()).toBe(true);
+    } finally {
+      completion.resolve({ status: "completed", streamEnd: end() });
+      observation.mockRestore();
+      accounting.mockRestore();
+      consumer.mockRestore();
+      await h.session.dispose();
+      await h.cleanup();
+    }
+  });
+
   test("late abort bookkeeping failure preserves output in the renderer lifecycle", async () => {
     const completion = Promise.withResolvers<TurnCompletion>();
     const emitter = new EventEmitter();

--- a/src/node/services/compactionHandler.continuous.test.ts
+++ b/src/node/services/compactionHandler.continuous.test.ts
@@ -43,12 +43,23 @@ describe("continuous compaction provider replay", () => {
       });
     const handler = makeHandler();
     expect((await handler.peekPendingState())?.diffs).toEqual(diffs);
+    const preparation = handler.beginPreparation(() => true);
     expect(
-      await handler.withContinuousPendingState([], async () => {
-        // New preparation has no boundary: a restart must load the preceding
-        // pending snapshot, not treat the uncommitted one as a completed fold.
-        expect((await makeHandler().peekPendingState())?.diffs).toEqual(diffs);
-        return false;
+      await handler.persistContinuousCompaction({
+        preparation,
+        attachmentMessages: [],
+        publication: {
+          generation: await store.historyService
+            .getContinuousCompactionJournal(workspaceId)
+            .captureGeneration(),
+        },
+        messages: [],
+        tail: [],
+        text: "Unpublished summary",
+        model: "anthropic:test",
+        systemMessageTokens: 0,
+        attachmentTokens: 0,
+        shouldPersist: () => false,
       })
     ).toBe(false);
     expect((await handler.peekPendingState())?.diffs).toEqual(diffs);
@@ -81,22 +92,21 @@ describe("continuous compaction provider replay", () => {
         .getContinuousCompactionJournal(workspaceId)
         .captureGeneration(),
     };
+    const preparation = handler.beginPreparation(() => true);
     expect(
       await handler
-        .withContinuousPendingState([source], (boundaryMessageId, onCommitted) =>
-          handler.persistContinuousCompaction({
-            boundaryMessageId,
-            onCommitted,
-            publication,
-            shouldPersist: () => true,
-            messages: [source],
-            tail: [],
-            text: "Fix completed",
-            model: "anthropic:test",
-            systemMessageTokens: 0,
-            attachmentTokens: 0,
-          })
-        )
+        .persistContinuousCompaction({
+          preparation,
+          attachmentMessages: [source],
+          publication,
+          shouldPersist: () => true,
+          messages: [source],
+          tail: [],
+          text: "Fix completed",
+          model: "anthropic:test",
+          systemMessageTokens: 0,
+          attachmentTokens: 0,
+        })
         .catch((error: unknown) => error)
     ).toEqual(new Error("observer failed"));
     const restarted = new CompactionHandler({
@@ -164,7 +174,12 @@ describe("continuous compaction provider replay", () => {
         sessionDir: path.join(store.tempDir, "pending"),
         emitter,
       });
-      await handler.preparePendingStateFromMessages(before.data);
+      const preparation = handler.beginPreparation(() => true);
+      const publication = {
+        generation: await store.historyService
+          .getContinuousCompactionJournal(workspaceId)
+          .captureGeneration(),
+      };
       const tail = [
         prompt,
         {
@@ -175,6 +190,9 @@ describe("continuous compaction provider replay", () => {
       ];
       expect(
         await handler.persistContinuousCompaction({
+          preparation,
+          publication,
+          attachmentMessages: before.data,
           shouldPersist: () => true,
           messages: before.data,
           text: "The bug is fixed; verification is in progress.",

--- a/src/node/services/compactionHandler.partialRecovery.test.ts
+++ b/src/node/services/compactionHandler.partialRecovery.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { createMuxMessage } from "@/common/types/message";
+import { CompactionHandler } from "./compactionHandler";
+import { createTestHistoryService } from "./testHistoryService";
+
+describe("compaction partial recovery", () => {
+  const workspaceId = "partial-recovery";
+  let h: Awaited<ReturnType<typeof createTestHistoryService>>;
+  let handler: CompactionHandler;
+  let partialPath: string;
+
+  beforeEach(async () => {
+    h = await createTestHistoryService();
+    const sessionDir = path.join(h.config.sessionsDir, workspaceId);
+    partialPath = path.join(sessionDir, "partial.json");
+    assert(
+      (
+        await h.historyService.appendToHistory(
+          workspaceId,
+          createMuxMessage("request", "user", "Compact", {
+            muxMetadata: { type: "compaction-request", rawCommand: "/compact", parsed: {} },
+          })
+        )
+      ).success
+    );
+    handler = new CompactionHandler({
+      workspaceId,
+      historyService: h.historyService,
+      sessionDir,
+      emitter: new EventEmitter(),
+    });
+  });
+
+  afterEach(async () => {
+    mock.restore();
+    await h.cleanup();
+  });
+
+  async function compact(route: "manual" | "heartbeat" | "continuous") {
+    if (route === "heartbeat")
+      return (
+        await handler.appendHeartbeatContextResetBoundary({
+          boundaryText: "Summary",
+          pendingFollowUp: { text: "Resume", model: "openai:gpt-4o", agentId: "exec" },
+        })
+      ).success;
+    if (route === "manual")
+      return handler.handleCompletion(
+        {
+          type: "stream-end",
+          workspaceId,
+          messageId: "summary",
+          metadata: { model: "openai:gpt-4o" },
+          parts: [{ type: "text", text: "Summary" }],
+        },
+        "request"
+      );
+    const preparation = handler.beginPreparation(() => true);
+    const history = await h.historyService.getHistoryFromLatestBoundary(workspaceId);
+    assert(history.success);
+    return handler.persistContinuousCompaction({
+      preparation,
+      publication: {
+        generation: await h.historyService
+          .getContinuousCompactionJournal(workspaceId)
+          .captureGeneration(),
+      },
+      attachmentMessages: history.data,
+      messages: history.data,
+      tail: [],
+      text: "Summary",
+      model: "openai:gpt-4o",
+      systemMessageTokens: 0,
+      attachmentTokens: 0,
+      shouldPersist: () => true,
+    });
+  }
+
+  it.each(
+    (["manual", "heartbeat", "continuous"] as const).flatMap((route) =>
+      (["missing", "malformed", "directory"] as const).map((partial) => ({ route, partial }))
+    )
+  )("$route publishes after partial recovery ($partial)", async ({ route, partial }) => {
+    if (partial === "malformed") await fs.writeFile(partialPath, "{");
+    if (partial === "directory") await fs.mkdir(partialPath);
+    expect(await compact(route)).toBe(true);
+    const history = await h.historyService.getHistoryFromLatestBoundary(workspaceId);
+    assert(history.success);
+    expect(history.data).toHaveLength(1);
+    expect(history.data[0].metadata?.compactionBoundary).toBe(true);
+    expect(await handler.peekPendingState()).not.toBeNull();
+    expect(await fs.stat(partialPath).catch(() => undefined)).toBeUndefined();
+  });
+
+  it.each(["manual", "heartbeat", "continuous"] as const)(
+    "%s preserves unrelated partial read failures and refuses publication",
+    async (route) => {
+      await fs.writeFile(partialPath, "{");
+      const readFile = fs.readFile;
+      spyOn(fs, "readFile").mockImplementation((async (...args: Parameters<typeof fs.readFile>) => {
+        if (args[0] === partialPath)
+          throw Object.assign(new Error("Partial read denied"), { code: "EACCES" });
+        return readFile(...args);
+      }) as typeof fs.readFile);
+      expect(await compact(route)).toBe(false);
+      mock.restore();
+      expect(await fs.readFile(partialPath, "utf8")).toBe("{");
+      const history = await h.historyService.getHistoryFromLatestBoundary(workspaceId);
+      assert(history.success);
+      expect(history.data.map((row) => row.id)).toEqual(["request"]);
+      expect(await handler.peekPendingState()).toBeNull();
+    }
+  );
+});

--- a/src/node/services/compactionHandler.pendingOwnership.test.ts
+++ b/src/node/services/compactionHandler.pendingOwnership.test.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from "events";
 import * as fs from "fs/promises";
 import * as path from "path";
 import { createMuxMessage } from "@/common/types/message";
-import { Err } from "@/common/types/result";
+import * as syncFs from "node:fs";
 import assert from "@/common/utils/assert";
 import { CompactionHandler } from "./compactionHandler";
 import { createTestHistoryService } from "./testHistoryService";
@@ -56,6 +56,14 @@ describe("exact pending snapshot consumption", () => {
     await store.cleanup();
   });
 
+  function failRename(target: string) {
+    const rename = syncFs.renameSync;
+    return spyOn(syncFs, "renameSync").mockImplementation((from, to) => {
+      if (to === target) throw new Error("Publication unavailable");
+      rename(from, to);
+    });
+  }
+
   async function publish(id?: string) {
     if (id) {
       await store.historyService.appendToHistory(workspaceId, readMessage(id));
@@ -78,7 +86,7 @@ describe("exact pending snapshot consumption", () => {
       [false, true].map((reload) => ({ action, reload }))
     )
   )(
-    "late $action preserves an identical-byte successor (reload=$reload)",
+    "late $action preserves a successor with identical attachments (reload=$reload)",
     async ({ action, reload }) => {
       spyOn(Date, "now").mockReturnValue(1234);
       await publish();
@@ -86,11 +94,14 @@ describe("exact pending snapshot consumption", () => {
       const consumed = await handler.peekPendingState();
       const previous = await fs.readFile(pendingPath, "utf8");
       await publish();
-      expect(await fs.readFile(pendingPath, "utf8")).toBe(previous);
+      const successor = JSON.parse(await fs.readFile(pendingPath, "utf8")) as { writeId: string };
+      expect(successor.writeId).not.toBe((JSON.parse(previous) as { writeId: string }).writeId);
       if (action === "ack") await handler.ackPendingStateConsumed(consumed);
       else await handler.discardPendingState("context_exceeded", consumed);
       expect(await handler.peekPendingState()).not.toBeNull();
-      expect(await fs.readFile(pendingPath, "utf8")).toBe(previous);
+      expect(JSON.parse(await fs.readFile(pendingPath, "utf8"))).toMatchObject({
+        writeId: successor.writeId,
+      });
     }
   );
 
@@ -113,26 +124,20 @@ describe("exact pending snapshot consumption", () => {
       let replacement: ReturnType<typeof publish> | undefined;
       try {
         await entered.promise;
-        // Observe the real persistence call after B's cache update; keep A's physical unlink held.
-        const persistence = handler as unknown as {
-          persistPendingStateBestEffort(...args: unknown[]): Promise<void>;
-        };
-        const persist = persistence.persistPendingStateBestEffort.bind(handler);
-        const writeRequested = Promise.withResolvers<void>();
-        spyOn(persistence, "persistPendingStateBestEffort").mockImplementation((...args) => {
-          const result = persist(...args);
-          writeRequested.resolve();
+        const begin = handler.beginPreparation.bind(handler);
+        const requested = Promise.withResolvers<void>();
+        spyOn(handler, "beginPreparation").mockImplementation((guard) => {
+          const result = begin(guard);
+          requested.resolve();
           return result;
         });
-        const mkdir = spyOn(fs, "mkdir");
-        replacement = publish("b");
-        await writeRequested.promise;
-        expect(mkdir.mock.calls.some(([dir]) => String(dir) === sessionDir)).toBe(false);
+        replacement = publish();
+        await requested.promise;
         release.resolve();
         await cleanup;
         await replacement;
-        expect((await handler.peekPendingState())?.readFiles).toContain("/b.ts");
-        expect((await restart().peekPendingState())?.readFiles).toContain("/b.ts");
+        expect(await handler.peekPendingState()).not.toBeNull();
+        expect(await restart().peekPendingState()).not.toBeNull();
       } finally {
         release.resolve();
         await cleanup;
@@ -146,17 +151,11 @@ describe("exact pending snapshot consumption", () => {
     async (action) => {
       await publish("a");
       const previous = await fs.readFile(pendingPath, "utf8");
-      const mkdir = fs.mkdir;
-      const failure = spyOn(fs, "mkdir").mockImplementation((async (
-        ...args: Parameters<typeof fs.mkdir>
-      ) => {
-        if (String(args[0]) === sessionDir) throw new Error("pending mkdir failed");
-        return mkdir(...args);
-      }) as typeof fs.mkdir);
+      const failure = failRename(pendingPath);
       let consumed: Awaited<ReturnType<typeof publish>>;
       try {
         consumed = await publish("b");
-        expect(failure.mock.calls.some(([dir]) => String(dir) === sessionDir)).toBe(true);
+        expect(failure.mock.calls.some(([, target]) => target === pendingPath)).toBe(true);
       } finally {
         failure.mockRestore();
       }
@@ -179,9 +178,14 @@ describe("exact pending snapshot consumption", () => {
 
   it("a failed unlink cannot let a retried old acknowledgement remove its successor", async () => {
     const consumed = await publish("a");
-    spyOn(fs, "unlink").mockRejectedValueOnce(new Error("pending unlink failed"));
+    const unlink = fs.unlink;
+    const failure = spyOn(fs, "unlink").mockImplementation(async (target) => {
+      if (target === pendingPath) throw new Error("pending unlink failed");
+      await unlink(target);
+    });
     await handler.ackPendingStateConsumed(consumed);
     expect(await fs.readFile(pendingPath, "utf8")).toContain("/a.ts");
+    failure.mockRestore();
     await publish("b");
     await handler.ackPendingStateConsumed(consumed);
     expect((await handler.peekPendingState())?.readFiles).toContain("/b.ts");
@@ -197,7 +201,7 @@ describe("exact pending snapshot consumption", () => {
         muxMetadata: { type: "compaction-request", rawCommand: "/compact", parsed: {} },
       })
     );
-    spyOn(store.historyService, "appendToHistory").mockResolvedValueOnce(Err("B boundary failed"));
+    failRename(path.join(store.config.sessionsDir, workspaceId, "chat.jsonl"));
     expect(
       await handler.handleCompletion({
         type: "stream-end",
@@ -211,7 +215,7 @@ describe("exact pending snapshot consumption", () => {
     const history = await store.historyService.getHistoryFromLatestBoundary(workspaceId);
     assert(history.success, "Expected readable history after failed boundary");
     expect(history.data.some((message) => message.metadata?.compacted === "user")).toBe(false);
-    expect(await handler.peekPendingState()).toBeNull();
+    expect((await handler.peekPendingState())?.readFiles).toEqual(["/a.ts"]);
     await handler.ackPendingStateConsumed(consumed);
     expect(await handler.peekPendingState()).toBeNull();
     expect(await restart().peekPendingState()).toBeNull();
@@ -225,29 +229,34 @@ describe("exact pending snapshot consumption", () => {
     "request A can $action after continuous rollback (failed rewrite=$failedRestore)",
     async ({ action, failedRestore }) => {
       const consumed = await publish("a");
-      let restore: ReturnType<typeof spyOn<typeof fs, "mkdir">> | undefined;
-      const mkdir = fs.mkdir;
-      try {
-        expect(
-          await handler.withContinuousPendingState(
-            [readMessage("b")],
-            () => {
-              if (failedRestore) {
-                restore = spyOn(fs, "mkdir").mockImplementation((async (
-                  ...args: Parameters<typeof fs.mkdir>
-                ) => {
-                  if (String(args[0]) === sessionDir) throw new Error("restore mkdir failed");
-                  return mkdir(...args);
-                }) as typeof fs.mkdir);
-              }
-              return Promise.resolve(false);
-            },
-            "b"
-          )
-        ).toBe(false);
-      } finally {
-        restore?.mockRestore();
-      }
+      const rename = syncFs.renameSync;
+      let pendingWrites = 0;
+      const failure = spyOn(syncFs, "renameSync").mockImplementation((from, to) => {
+        if (to === pendingPath && ++pendingWrites > 1 && failedRestore)
+          throw new Error("Restore unavailable");
+        rename(from, to);
+      });
+      const preparation = handler.beginPreparation(() => true);
+      const publication = {
+        generation: await store.historyService
+          .getContinuousCompactionJournal(workspaceId)
+          .captureGeneration(),
+      };
+      expect(
+        await handler.persistContinuousCompaction({
+          preparation,
+          publication,
+          attachmentMessages: [readMessage("b")],
+          messages: [readMessage("b")],
+          tail: [],
+          text: "B",
+          model: followUp.model,
+          systemMessageTokens: 0,
+          attachmentTokens: 0,
+          shouldPersist: () => false,
+        })
+      ).toBe(false);
+      failure.mockRestore();
       expect((await handler.peekPendingState())?.readFiles).toEqual(["/a.ts"]);
       if (action === "ack") await handler.ackPendingStateConsumed(consumed);
       else await handler.discardPendingState("context_exceeded", consumed);
@@ -267,24 +276,23 @@ describe("exact pending snapshot consumption", () => {
     async ({ outcome, action, failedRestore }) => {
       const consumed = await publish("a");
       await store.historyService.appendToHistory(workspaceId, readMessage("b"));
-      let restore: ReturnType<typeof spyOn<typeof fs, "mkdir">> | undefined;
-      const mkdir = fs.mkdir;
+      let restore: ReturnType<typeof failRename> | undefined;
       function failRestoreIfRequested() {
-        if (!failedRestore) return;
-        restore = spyOn(fs, "mkdir").mockImplementation((async (
-          ...args: Parameters<typeof fs.mkdir>
-        ) => {
-          if (String(args[0]) === sessionDir) throw new Error("heartbeat restore mkdir failed");
-          return mkdir(...args);
-        }) as typeof fs.mkdir);
+        if (failedRestore) restore = failRename(pendingPath);
       }
 
       try {
         if (outcome === "failed append") {
-          spyOn(store.historyService, "appendToHistory").mockImplementationOnce(() => {
-            // B's provisional file already exists; only its restoration write should fail.
-            failRestoreIfRequested();
-            return Promise.resolve(Err("heartbeat B append failed"));
+          const rename = syncFs.renameSync;
+          let failedBoundary = false;
+          restore = spyOn(syncFs, "renameSync").mockImplementation((from, to) => {
+            if (to === path.join(store.config.sessionsDir, workspaceId, "chat.jsonl")) {
+              failedBoundary = true;
+              throw new Error("heartbeat B append failed");
+            }
+            if (to === pendingPath && failedBoundary && failedRestore)
+              throw new Error("Restore unavailable");
+            rename(from, to);
           });
           expect(
             (
@@ -311,7 +319,7 @@ describe("exact pending snapshot consumption", () => {
           expect(history.data.some((row) => row.id === message.id)).toBe(false);
         }
         if (failedRestore) {
-          expect(restore?.mock.calls.some(([dir]) => String(dir) === sessionDir)).toBe(true);
+          expect(restore?.mock.calls.some(([, target]) => target === pendingPath)).toBe(true);
         }
       } finally {
         restore?.mockRestore();
@@ -336,7 +344,11 @@ describe("exact pending snapshot consumption", () => {
       const unlink = fs.unlink;
       let current = true;
       spyOn(fs, "unlink").mockImplementation(async (target) => {
-        if (String(target) === lockPath && current) {
+        if (
+          String(target) === lockPath &&
+          current &&
+          (await fs.readFile(historyPath)).length === 0
+        ) {
           // Admission changes during real lock release, after the boundary deletion committed.
           expect((await fs.readFile(historyPath)).length).toBe(0);
           current = false;

--- a/src/node/services/compactionHandler.preparation.test.ts
+++ b/src/node/services/compactionHandler.preparation.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { CONTINUOUS_COMPACTION_GENERATION_FILE } from "@/constants/continuousCompaction";
+import { createMuxMessage } from "@/common/types/message";
+import type { StreamEndEvent } from "@/common/types/stream";
+import { CompactionHandler } from "./compactionHandler";
+import { HistoryService } from "./historyService";
+import { createTestHistoryService } from "./testHistoryService";
+
+afterEach(() => mock.restore());
+
+describe("runtime compaction preparation admission", () => {
+  it("rejects a foreign generation reset while the first history read is held", async () => {
+    const h = await createTestHistoryService();
+    const workspaceId = "classification-generation-reset";
+    const sessionDir = path.join(h.config.sessionsDir, workspaceId);
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    let operation: Promise<boolean> | undefined;
+    try {
+      assert(
+        (
+          await h.historyService.appendToHistory(
+            workspaceId,
+            createMuxMessage("request", "user", "Compact", {
+              muxMetadata: { type: "compaction-request", rawCommand: "/compact", parsed: {} },
+            })
+          )
+        ).success
+      );
+      const handler = new CompactionHandler({
+        workspaceId,
+        historyService: h.historyService,
+        sessionDir,
+        emitter: new EventEmitter(),
+      });
+      const read = h.historyService.getHistoryFromLatestBoundary.bind(h.historyService);
+      spyOn(h.historyService, "getHistoryFromLatestBoundary").mockImplementationOnce(async (id) => {
+        const history = await read(id);
+        entered.resolve();
+        await release.promise;
+        return history;
+      });
+      operation = handler.handleCompletion(
+        {
+          type: "stream-end",
+          workspaceId,
+          messageId: "summary",
+          metadata: { model: "openai:gpt-4o" },
+          parts: [{ type: "text", text: "Summary from before the reset" }],
+        },
+        "request"
+      );
+      await entered.promise;
+      const historyPath = path.join(sessionDir, "chat.jsonl");
+      const historyBytes = await fs.readFile(historyPath);
+      // A foreign destructive fence can advance without changing the already-read rows.
+      const foreign = new HistoryService(h.config);
+      await foreign.getContinuousCompactionJournal(workspaceId).advanceGeneration();
+      expect(await fs.readFile(historyPath)).toEqual(historyBytes);
+      release.resolve();
+      expect(await operation).toBe(false);
+      const history = await read(workspaceId);
+      assert(history.success);
+      expect(history.data.map((row) => row.id)).toEqual(["request"]);
+      expect(await handler.peekPendingState()).toBeNull();
+    } finally {
+      release.resolve();
+      await operation;
+      await h.cleanup();
+    }
+  });
+
+  it("refuses compaction publication with an unreadable generation", async () => {
+    const h = await createTestHistoryService();
+    const workspaceId = "unreadable-generation";
+    const sessionDir = path.join(h.config.sessionsDir, workspaceId);
+    try {
+      assert(
+        (
+          await h.historyService.appendToHistory(
+            workspaceId,
+            createMuxMessage("request", "user", "Compact", {
+              muxMetadata: { type: "compaction-request", rawCommand: "/compact", parsed: {} },
+            })
+          )
+        ).success
+      );
+      const handler = new CompactionHandler({
+        workspaceId,
+        historyService: h.historyService,
+        sessionDir,
+        emitter: new EventEmitter(),
+      });
+      await fs.mkdir(path.join(sessionDir, CONTINUOUS_COMPACTION_GENERATION_FILE));
+      const failure = await handler
+        .handleCompletion(
+          {
+            type: "stream-end",
+            workspaceId,
+            messageId: "summary",
+            metadata: { model: "openai:gpt-4o" },
+            parts: [{ type: "text", text: "Must not publish without a generation fence" }],
+          },
+          "request"
+        )
+        .catch((error: unknown) => error);
+      assert(failure instanceof Error && "code" in failure);
+      expect(failure.code).toBe("EISDIR");
+      const history = await h.historyService.getHistoryFromLatestBoundary(workspaceId);
+      assert(history.success);
+      expect(history.data.map((row) => row.id)).toEqual(["request"]);
+      expect(await handler.peekPendingState()).toBeNull();
+    } finally {
+      await h.cleanup();
+    }
+  });
+
+  it.each(
+    (["manual", "idle", "heartbeat"] as const).flatMap((route) =>
+      (["none", "admission", "generation"] as const).map((superseded) => ({ route, superseded }))
+    )
+  )(
+    "$route captures immutable input before its first await (superseded=$superseded)",
+    async ({ route, superseded }) => {
+      const h = await createTestHistoryService();
+      const workspaceId = "preparation-entry";
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      let operation: Promise<boolean> | undefined;
+      try {
+        assert(
+          (
+            await h.historyService.appendToHistory(
+              workspaceId,
+              createMuxMessage("request", "user", "Compact", {
+                muxMetadata: {
+                  type: "compaction-request",
+                  rawCommand: "/compact",
+                  parsed: {},
+                  ...(route === "idle" && { source: "idle-compaction" }),
+                },
+              })
+            )
+          ).success
+        );
+        const handler = new CompactionHandler({
+          workspaceId,
+          historyService: h.historyService,
+          sessionDir: path.join(h.config.sessionsDir, workspaceId),
+          emitter: new EventEmitter(),
+        });
+        const journal = h.historyService.getContinuousCompactionJournal(workspaceId);
+        const capture = journal.captureGeneration.bind(journal);
+        spyOn(journal, "captureGeneration").mockImplementationOnce(async () => {
+          const generation = await capture();
+          entered.resolve();
+          await release.promise;
+          return generation;
+        });
+        const event: StreamEndEvent = {
+          type: "stream-end",
+          workspaceId,
+          messageId: "summary",
+          metadata: { model: "openai:gpt-4o" },
+          parts: [{ type: "text", text: "Captured summary" }],
+        };
+        const heartbeat = {
+          boundaryText: "Captured summary",
+          pendingFollowUp: { text: "Resume", model: "openai:gpt-4o", agentId: "exec" },
+        };
+        operation =
+          route === "heartbeat"
+            ? handler
+                .appendHeartbeatContextResetBoundary(heartbeat)
+                .then((result) => result.success)
+            : handler.handleCompletion(event, "request");
+        await entered.promise;
+        event.parts = [{ type: "text", text: "Caller changed summary" }];
+        heartbeat.boundaryText = "Caller changed summary";
+        heartbeat.pendingFollowUp.text = "Caller changed continuation";
+        if (superseded === "admission") {
+          // A failed successor still owns the newer admission; A cannot revive afterward.
+          expect(await handler.handleCompletion(event, "missing-request")).toBe(false);
+        } else if (superseded === "generation") {
+          // Unchanged history cannot revive a publication from before a destructive reset.
+          await journal.advanceGeneration();
+        }
+        release.resolve();
+        expect(await operation).toBe(superseded === "none");
+        const history = await h.historyService.getHistoryFromLatestBoundary(workspaceId);
+        assert(history.success);
+        if (superseded !== "none") {
+          expect(history.data.map((row) => row.id)).toEqual(["request"]);
+          expect(await handler.peekPendingState()).toBeNull();
+        } else {
+          expect(history.data[0].parts).toMatchObject([{ type: "text", text: "Captured summary" }]);
+          expect(history.data[0].metadata?.compactionBoundary).toBe(true);
+          if (route === "heartbeat")
+            expect(history.data[0].metadata?.muxMetadata).toMatchObject({
+              pendingFollowUp: { text: "Resume" },
+            });
+          expect(await handler.peekPendingState()).not.toBeNull();
+        }
+      } finally {
+        release.resolve();
+        await operation;
+        await h.cleanup();
+      }
+    }
+  );
+});

--- a/src/node/services/compactionHandler.test.ts
+++ b/src/node/services/compactionHandler.test.ts
@@ -3,6 +3,7 @@ import { CompactionHandler } from "./compactionHandler";
 import type { HistoryService } from "./historyService";
 import { createTestHistoryService } from "./testHistoryService";
 import * as fsPromises from "fs/promises";
+import * as syncFs from "node:fs";
 import * as os from "os";
 import * as path from "path";
 
@@ -139,26 +140,41 @@ describe("CompactionHandler", () => {
   let telemetryCapture: ReturnType<typeof mock>;
   let telemetryService: TelemetryService;
   let sessionDir: string;
+  let historyPath: string;
   let emittedEvents: EmittedEvent[];
   const workspaceId = "test-workspace";
 
-  // Helper: seed messages into real history and return spies for tracking handler calls.
-  // Spies are created AFTER seeding so they only track handler-initiated calls.
+  async function historyRows() {
+    const result = await historyService.getLastMessages(workspaceId, 1000);
+    if (!result.success) throw new Error(result.error);
+    return result.data;
+  }
+
+  function failBoundaryCommit(message = "Boundary commit failed") {
+    const rename = syncFs.renameSync;
+    return spyOn(syncFs, "renameSync").mockImplementation((from, to) => {
+      if (to === historyPath) throw new Error(message);
+      rename(from, to);
+    });
+  }
+
+  // Assert the actual committed rows so the test does not depend on a particular write route.
   const seedHistory = async (...messages: MuxMessage[]) => {
     for (const msg of messages) {
       const result = await historyService.appendToHistory(workspaceId, msg);
       if (!result.success) throw new Error(`Seed failed: ${result.error}`);
     }
     return {
-      appendSpy: spyOn(historyService, "appendToHistory"),
+      appended: async () =>
+        (await historyRows()).filter((row) => !messages.some((seed) => seed.id === row.id)),
       clearSpy: spyOn(historyService, "clearHistory"),
-      updateSpy: spyOn(historyService, "updateHistory"),
     };
   };
 
   beforeEach(async () => {
     const testHistory = await createTestHistoryService();
     historyService = testHistory.historyService;
+    historyPath = path.join(testHistory.config.sessionsDir, workspaceId, "chat.jsonl");
     cleanup = testHistory.cleanup;
 
     const { emitter, events } = createMockEmitter();
@@ -182,7 +198,9 @@ describe("CompactionHandler", () => {
   });
 
   afterEach(async () => {
+    mock.restore();
     await cleanup();
+    await fsPromises.rm(sessionDir, { recursive: true, force: true });
   });
 
   describe("handleCompletion() - Normal Compaction Flow", () => {
@@ -530,6 +548,7 @@ describe("CompactionHandler", () => {
         persistedPath,
         JSON.stringify({
           version: 1,
+          boundaryMessageId: existingBoundary.id,
           createdAt: Date.now(),
           diffs: [
             {
@@ -579,6 +598,7 @@ describe("CompactionHandler", () => {
         persistedPath,
         JSON.stringify({
           version: 1,
+          boundaryMessageId: existingBoundary.id,
           createdAt: Date.now(),
           diffs: [
             {
@@ -658,6 +678,7 @@ describe("CompactionHandler", () => {
         persistedPath,
         JSON.stringify({
           version: 1,
+          boundaryMessageId: existingBoundary.id,
           createdAt: Date.now(),
           diffs: staleDiffs,
           loadedSkills: [],
@@ -895,7 +916,7 @@ describe("CompactionHandler", () => {
 
     it("should join multiple text parts from event.parts", async () => {
       const compactionReq = createCompactionRequest();
-      const { appendSpy } = await seedHistory(compactionReq);
+      const { appended } = await seedHistory(compactionReq);
 
       // Create event with multiple text parts
       const event: StreamEndEvent = {
@@ -915,7 +936,7 @@ describe("CompactionHandler", () => {
       };
       await handler.handleCompletion(event);
 
-      const appendedMsg = appendSpy.mock.calls[0][1];
+      const appendedMsg = (await appended())[0];
       expect((appendedMsg.parts[0] as { type: "text"; text: string }).text).toBe(
         "Part 1 Part 2 Part 3"
       );
@@ -923,44 +944,39 @@ describe("CompactionHandler", () => {
 
     it("should extract summary text from event.parts", async () => {
       const compactionReq = createCompactionRequest();
-      const { appendSpy } = await seedHistory(compactionReq);
+      const { appended } = await seedHistory(compactionReq);
 
       const event = createStreamEndEvent("This is the summary");
       await handler.handleCompletion(event);
 
-      const appendedMsg = appendSpy.mock.calls[0][1];
+      const appendedMsg = (await appended())[0];
       expect((appendedMsg.parts[0] as { type: "text"; text: string }).text).toBe(
         "This is the summary"
       );
     });
 
-    it("should delete partial.json before appending summary (race condition fix)", async () => {
-      const compactionReq = createCompactionRequest();
-      await seedHistory(compactionReq);
-      const deletePartialSpy = spyOn(historyService, "deletePartial");
-
-      const event = createStreamEndEvent("Summary");
-      await handler.handleCompletion(event);
-
-      // deletePartial should be called once before appendToHistory
-      expect(deletePartialSpy.mock.calls).toHaveLength(1);
-      expect(deletePartialSpy.mock.calls[0][0]).toBe(workspaceId);
-
-      // Verify deletePartial was called (we can't easily verify order without more complex mocking,
-      // but the important thing is that it IS called during compaction)
+    it("retires the completed partial before its summary can be replayed", async () => {
+      await seedHistory(createCompactionRequest());
+      const partial = createMuxMessage("msg-id", "assistant", "Old partial");
+      expect((await historyService.writePartial(workspaceId, partial)).success).toBe(true);
+      expect(await handler.handleCompletion(createStreamEndEvent("Summary"))).toBe(true);
+      expect(await historyService.readPartial(workspaceId)).toBeNull();
+      expect((await historyService.commitPartial(workspaceId)).success).toBe(true);
+      const summaries = (await historyRows()).filter((row) => row.metadata?.compactionBoundary);
+      expect(summaries).toHaveLength(1);
+      expect(summaries[0].parts).toMatchObject([{ type: "text", text: "Summary" }]);
     });
 
     it("should append summary without clearing history", async () => {
       const compactionReq = createCompactionRequest();
-      const { appendSpy, clearSpy } = await seedHistory(compactionReq);
+      const { appended, clearSpy } = await seedHistory(compactionReq);
 
       const event = createStreamEndEvent("Summary");
       await handler.handleCompletion(event);
 
       expect(clearSpy.mock.calls).toHaveLength(0);
-      expect(appendSpy.mock.calls).toHaveLength(1);
-      expect(appendSpy.mock.calls[0][0]).toBe(workspaceId);
-      const appendedMsg = appendSpy.mock.calls[0][1];
+      expect(await appended()).toHaveLength(1);
+      const appendedMsg = (await appended())[0];
       expect(appendedMsg.role).toBe("assistant");
       expect((appendedMsg.parts[0] as { type: "text"; text: string }).text).toBe("Summary");
     });
@@ -1082,12 +1098,12 @@ describe("CompactionHandler", () => {
         historySequence: 5,
         muxMetadata: { type: "compaction-request", rawCommand: "/compact", parsed: {} },
       });
-      const { appendSpy } = await seedHistory(priorMessage, compactionReq);
+      const { appended } = await seedHistory(priorMessage, compactionReq);
 
       const event = createStreamEndEvent("Summary");
       await handler.handleCompletion(event);
 
-      const appendedMsg = appendSpy.mock.calls[0][1];
+      const appendedMsg = (await appended())[0];
       expect(appendedMsg.metadata?.compacted).toBe("user");
       expect(appendedMsg.metadata?.compactionBoundary).toBe(true);
       expect(appendedMsg.metadata?.compactionEpoch).toBe(1);
@@ -1127,15 +1143,18 @@ describe("CompactionHandler", () => {
       spyOn(historyService, "getLastMessages").mockResolvedValueOnce(
         Ok([malformedNegativeSequence, malformedFractionalSequence, priorMessage, compactionReq])
       );
-      const appendSpy = spyOn(historyService, "appendToHistory");
+      const appended = async () =>
+        (await historyRows()).filter(
+          (row) => row.id !== priorMessage.id && row.id !== compactionReq.id
+        );
 
       const event = createStreamEndEvent("Summary");
       const result = await handler.handleCompletion(event);
 
       expect(result).toBe(true);
-      expect(appendSpy.mock.calls).toHaveLength(1);
+      expect(await appended()).toHaveLength(1);
 
-      const appendedMsg = appendSpy.mock.calls[0][1];
+      const appendedMsg = (await appended())[0];
       expect(appendedMsg.metadata?.historySequence).toBe(6);
       expect(appendedMsg.metadata?.compactionBoundary).toBe(true);
       expect(appendedMsg.metadata?.compactionEpoch).toBe(1);
@@ -1151,12 +1170,12 @@ describe("CompactionHandler", () => {
         muxMetadata: { type: "compaction-request", rawCommand: "/compact", parsed: {} },
       });
 
-      const { appendSpy } = await seedHistory(legacySummary, compactionReq);
+      const { appended } = await seedHistory(legacySummary, compactionReq);
 
       const event = createStreamEndEvent("Summary");
       await handler.handleCompletion(event);
 
-      const appendedMsg = appendSpy.mock.calls[0][1];
+      const appendedMsg = (await appended())[0];
       expect(appendedMsg.metadata?.compactionEpoch).toBe(2);
       expect(appendedMsg.metadata?.compactionBoundary).toBe(true);
       expect(appendedMsg.metadata?.historySequence).toBe(4);
@@ -1175,16 +1194,15 @@ describe("CompactionHandler", () => {
         contextProviderMetadata: { anthropic: { cacheReadInputTokens: 10_000 } },
       });
 
-      const { appendSpy, updateSpy } = await seedHistory(compactionReq, streamedSummary);
+      const { appended } = await seedHistory(compactionReq, streamedSummary);
 
       const event = createStreamEndEvent("Summary");
       const result = await handler.handleCompletion(event);
 
       expect(result).toBe(true);
-      expect(updateSpy.mock.calls).toHaveLength(1);
-      expect(appendSpy.mock.calls).toHaveLength(0);
+      expect(await appended()).toHaveLength(0);
 
-      const updatedSummary = updateSpy.mock.calls[0][1];
+      const updatedSummary = (await historyRows()).find((row) => row.id === streamedSummary.id)!;
       expect(updatedSummary.id).toBe("msg-id");
       expect(updatedSummary.metadata?.historySequence).toBe(6);
       expect(updatedSummary.metadata?.compactionBoundary).toBe(true);
@@ -1345,7 +1363,7 @@ describe("CompactionHandler", () => {
         muxMetadata: { type: "compaction-request", rawCommand: "/compact", parsed: {} },
       });
 
-      const { appendSpy } = await seedHistory(
+      const { appended } = await seedHistory(
         validBoundary,
         malformedBoundaryMissingEpoch,
         malformedBoundaryMissingCompacted,
@@ -1357,8 +1375,8 @@ describe("CompactionHandler", () => {
       const result = await handler.handleCompletion(createStreamEndEvent("Summary"));
 
       expect(result).toBe(true);
-      expect(appendSpy.mock.calls).toHaveLength(1);
-      const appendedMsg = appendSpy.mock.calls[0][1];
+      expect(await appended()).toHaveLength(1);
+      const appendedMsg = (await appended())[0];
       expect(appendedMsg.metadata?.compactionEpoch).toBe(4);
       expect(appendedMsg.metadata?.compactionBoundary).toBe(true);
     });
@@ -1367,18 +1385,18 @@ describe("CompactionHandler", () => {
   describe("handleCompletion() - Deduplication", () => {
     it("should track processed compaction-request IDs", async () => {
       const compactionReq = createCompactionRequest("req-unique");
-      const { appendSpy, clearSpy } = await seedHistory(compactionReq);
+      const { appended, clearSpy } = await seedHistory(compactionReq);
 
       const event = createStreamEndEvent("Summary");
       await handler.handleCompletion(event);
 
       expect(clearSpy.mock.calls).toHaveLength(0);
-      expect(appendSpy.mock.calls).toHaveLength(1);
+      expect(await appended()).toHaveLength(1);
     });
 
     it("should return true without re-processing when same request ID seen twice", async () => {
       const compactionReq = createCompactionRequest("req-dupe");
-      const { appendSpy, clearSpy } = await seedHistory(compactionReq);
+      const { appended, clearSpy } = await seedHistory(compactionReq);
 
       const event = createStreamEndEvent("Summary");
       const result1 = await handler.handleCompletion(event);
@@ -1387,7 +1405,7 @@ describe("CompactionHandler", () => {
       expect(result1).toBe(true);
       expect(result2).toBe(true);
       expect(clearSpy.mock.calls).toHaveLength(0);
-      expect(appendSpy.mock.calls).toHaveLength(1);
+      expect(await appended()).toHaveLength(1);
     });
 
     it("should not emit duplicate events", async () => {
@@ -1406,22 +1424,22 @@ describe("CompactionHandler", () => {
 
     it("should not append summary twice", async () => {
       const compactionReq = createCompactionRequest("req-dupe-3");
-      const { appendSpy, clearSpy } = await seedHistory(compactionReq);
+      const { appended, clearSpy } = await seedHistory(compactionReq);
 
       const event = createStreamEndEvent("Summary");
       await handler.handleCompletion(event);
       await handler.handleCompletion(event);
 
       expect(clearSpy.mock.calls).toHaveLength(0);
-      expect(appendSpy.mock.calls).toHaveLength(1);
+      expect(await appended()).toHaveLength(1);
     });
   });
 
   describe("Error Handling", () => {
-    it("should return false when appendToHistory() fails", async () => {
+    it("should return false when the boundary commit fails", async () => {
       const compactionReq = createCompactionRequest();
-      const { appendSpy } = await seedHistory(compactionReq);
-      appendSpy.mockResolvedValueOnce(Err("Append failed"));
+      await seedHistory(compactionReq);
+      failBoundaryCommit("Append failed");
 
       const event = createStreamEndEvent("Summary");
       const result = await handler.handleCompletion(event);
@@ -1441,8 +1459,8 @@ describe("CompactionHandler", () => {
 
     it("should log errors but not throw", async () => {
       const compactionReq = createCompactionRequest();
-      const { appendSpy } = await seedHistory(compactionReq);
-      appendSpy.mockResolvedValueOnce(Err("Database corruption"));
+      await seedHistory(compactionReq);
+      failBoundaryCommit("Database corruption");
 
       const event = createStreamEndEvent("Summary");
 
@@ -1453,8 +1471,8 @@ describe("CompactionHandler", () => {
 
     it("should not emit events when compaction fails mid-process", async () => {
       const compactionReq = createCompactionRequest();
-      const { appendSpy } = await seedHistory(compactionReq);
-      appendSpy.mockResolvedValueOnce(Err("Append failed"));
+      await seedHistory(compactionReq);
+      failBoundaryCommit("Append failed");
 
       const event = createStreamEndEvent("Summary");
       await handler.handleCompletion(event);
@@ -1689,7 +1707,7 @@ describe("CompactionHandler", () => {
         timestamp: Date.now() - 1000,
         muxMetadata: { type: "compaction-request", rawCommand: "/compact", parsed: {} },
       });
-      const { appendSpy, clearSpy } = await seedHistory(compactionRequestMsg);
+      const { appended, clearSpy } = await seedHistory(compactionRequestMsg);
 
       // Empty parts array simulates stream crash before producing content
       const event = createStreamEndEvent("");
@@ -1699,7 +1717,7 @@ describe("CompactionHandler", () => {
       // Should return false and NOT perform compaction
       expect(result).toBe(false);
       expect(clearSpy).not.toHaveBeenCalled();
-      expect(appendSpy).not.toHaveBeenCalled();
+      expect(await appended()).toHaveLength(0);
     });
 
     it("should reject compaction when summary is only whitespace", async () => {
@@ -1727,7 +1745,7 @@ describe("CompactionHandler", () => {
         timestamp: Date.now() - 1000,
         muxMetadata: { type: "compaction-request", rawCommand: "/compact", parsed: {} },
       });
-      const { appendSpy, clearSpy } = await seedHistory(compactionRequestMsg);
+      const { appended, clearSpy } = await seedHistory(compactionRequestMsg);
 
       // Any JSON object should be rejected - this catches all tool call leaks
       const jsonObject = JSON.stringify({
@@ -1743,7 +1761,7 @@ describe("CompactionHandler", () => {
       // Should return false and NOT perform compaction
       expect(result).toBe(false);
       expect(clearSpy).not.toHaveBeenCalled();
-      expect(appendSpy).not.toHaveBeenCalled();
+      expect(await appended()).toHaveLength(0);
     });
 
     it("should reject any JSON object regardless of structure", async () => {
@@ -1771,7 +1789,7 @@ describe("CompactionHandler", () => {
         timestamp: Date.now() - 1000,
         muxMetadata: { type: "compaction-request", rawCommand: "/compact", parsed: {} },
       });
-      const { appendSpy, clearSpy } = await seedHistory(compactionRequestMsg);
+      const { appended, clearSpy } = await seedHistory(compactionRequestMsg);
 
       // Normal summary text
       const event = createStreamEndEvent(
@@ -1781,7 +1799,7 @@ describe("CompactionHandler", () => {
       const result = await handler.handleCompletion(event);
       expect(result).toBe(true);
       expect(clearSpy).not.toHaveBeenCalled();
-      expect(appendSpy).toHaveBeenCalled();
+      expect(await appended()).toHaveLength(1);
     });
 
     it("should accept summary with embedded JSON as part of prose", async () => {
@@ -1989,9 +2007,7 @@ describe("CompactionHandler", () => {
         createStampedCompactionRequest("compact-req", 2)
       );
 
-      spyOn(historyService, "persistBoundaryWithTailCopies").mockResolvedValueOnce(
-        Err("injected commit failure")
-      );
+      failBoundaryCommit("injected commit failure");
 
       await handler.handleCompletion(createStreamEndEvent("Summary"));
 

--- a/src/node/services/compactionHandler.ts
+++ b/src/node/services/compactionHandler.ts
@@ -1,5 +1,5 @@
 import type { EventEmitter } from "events";
-import * as fsPromises from "fs/promises";
+import { isDeepStrictEqual } from "node:util";
 import assert from "@/common/utils/assert";
 import { isNonNegativeInteger, isPositiveInteger } from "@/common/utils/numbers";
 import * as path from "path";
@@ -8,9 +8,19 @@ import type { CompactionFollowUpCleanupOutcome, HistoryService } from "./history
 
 import type { CompactionCompletionMetadata } from "@/common/types/compaction";
 import type { ContinuousCompactionPublication } from "./continuousCompactionJournal";
+import { exactJson } from "./continuousCompactionJournal";
+import { POST_COMPACTION_STATE_FILENAME } from "@/constants/compaction";
+import {
+  CompactionPendingState,
+  type CompactionPendingBoundaryWrite,
+} from "./compactionPendingState";
+import {
+  CompactionPreparationLifecycle,
+  type CompactionPreparation,
+  type CompactionPreparationSnapshot,
+} from "./compactionPreparationLifecycle";
 import type { StreamEndEvent } from "@/common/types/stream";
 import type { WorkspaceChatMessage } from "@/common/orpc/types";
-import type { LoadedSkillSnapshot } from "@/common/types/attachment";
 import type { Result } from "@/common/types/result";
 import { Ok, Err } from "@/common/types/result";
 import type { LanguageModelV2Usage } from "@ai-sdk/provider";
@@ -24,11 +34,7 @@ import {
 } from "@/common/types/message";
 import { createCompactionSummaryMessageId } from "@/node/services/utils/messageIds";
 import type { TelemetryService } from "@/node/services/telemetryService";
-import {
-  MAX_EDITED_FILES,
-  MAX_FILE_CONTENT_SIZE,
-  MAX_POST_COMPACTION_LOADED_SKILLS,
-} from "@/common/constants/attachments";
+import { MAX_EDITED_FILES } from "@/common/constants/attachments";
 import { roundToBase2 } from "@/common/telemetry/utils";
 import { log } from "@/node/services/log";
 import { computeRecencyFromMessages } from "@/common/utils/recency";
@@ -47,11 +53,8 @@ import {
   getKeepRecentTailStartHistorySequence,
 } from "@/common/utils/messages/keepRecentTail";
 import { createPreservedTailCopyMessageId } from "@/node/services/utils/messageIds";
-import { getErrorMessage } from "@/common/utils/errors";
 import {
-  createLoadedSkillSnapshot,
   mergeLoadedSkillSnapshots,
-  type PersistedLoadedSkillSnapshotInput,
   extractLoadedSkillSnapshotsFromMessages,
 } from "@/node/services/agentSkills/loadedSkillSnapshots";
 
@@ -77,135 +80,6 @@ export function looksLikeRawJsonObject(text: string): boolean {
   } catch {
     return false;
   }
-}
-
-const POST_COMPACTION_STATE_FILENAME = "post-compaction.json";
-
-interface PersistedPostCompactionStateV1 {
-  version: 1;
-  createdAt: number;
-  diffs: FileEditDiff[];
-  loadedSkills: LoadedSkillSnapshot[];
-  /**
-   * Cumulative file paths read during summarized epochs (newest-first, capped).
-   * Written unconditionally (internal bookkeeping) but only surfaced to the
-   * model when RLM mode is on. Absent in files written by older builds.
-   */
-  readFiles: string[];
-  /** Only continuous preparation is provisional until this boundary is durable. */
-  boundaryMessageId?: string;
-  previousState?: PersistedPostCompactionStateV1;
-}
-
-interface HeartbeatResetRollbackState {
-  owner: symbol;
-  postCompactionAttachmentsPending: boolean;
-  cachedFileDiffs: FileEditDiff[];
-  cachedLoadedSkills: LoadedSkillSnapshot[];
-  cachedReadFilePaths: string[];
-  persistedPendingStateLoaded: boolean;
-}
-
-interface PendingPostCompactionState {
-  diffs: FileEditDiff[];
-  loadedSkills: LoadedSkillSnapshot[];
-  readFiles: string[];
-}
-
-function coerceFileEditDiffs(value: unknown): FileEditDiff[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  const diffs: FileEditDiff[] = [];
-  for (const item of value) {
-    if (!item || typeof item !== "object") {
-      continue;
-    }
-
-    const filePath = (item as { path?: unknown }).path;
-    const diff = (item as { diff?: unknown }).diff;
-    const truncated = (item as { truncated?: unknown }).truncated;
-
-    if (typeof filePath !== "string") continue;
-    const trimmedPath = filePath.trim();
-    if (trimmedPath.length === 0) continue;
-
-    if (typeof diff !== "string") continue;
-    if (typeof truncated !== "boolean") continue;
-
-    const clampedDiff =
-      diff.length > MAX_FILE_CONTENT_SIZE ? diff.slice(0, MAX_FILE_CONTENT_SIZE) : diff;
-
-    diffs.push({
-      path: trimmedPath,
-      diff: clampedDiff,
-      truncated: truncated || diff.length > MAX_FILE_CONTENT_SIZE,
-    });
-
-    if (diffs.length >= MAX_EDITED_FILES) {
-      break;
-    }
-  }
-
-  return diffs;
-}
-
-function coerceLoadedSkillSnapshots(value: unknown): LoadedSkillSnapshot[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  const loadedSkills: LoadedSkillSnapshot[] = [];
-  for (const [index, item] of value.entries()) {
-    if (!item || typeof item !== "object") {
-      log.debug("Skipping malformed persisted loaded skill snapshot", {
-        index,
-        reason: "not-object",
-      });
-      continue;
-    }
-
-    const candidate = item as PersistedLoadedSkillSnapshotInput;
-    const name = typeof candidate.name === "string" ? candidate.name.trim() : "";
-    const body = typeof candidate.body === "string" ? candidate.body : null;
-    const frontmatterYaml =
-      typeof candidate.frontmatterYaml === "string" ? candidate.frontmatterYaml : undefined;
-    const truncated = candidate.truncated === true;
-
-    if (name.length === 0 || body === null) {
-      log.debug("Skipping malformed persisted loaded skill snapshot", {
-        index,
-        reason: name.length === 0 ? "invalid-name" : "invalid-body",
-      });
-      continue;
-    }
-
-    try {
-      loadedSkills.push(
-        createLoadedSkillSnapshot({
-          name,
-          scope: candidate.scope,
-          body,
-          frontmatterYaml,
-          alreadyNormalized: true,
-          truncated,
-        })
-      );
-    } catch (error) {
-      log.debug("Skipping malformed persisted loaded skill snapshot", {
-        index,
-        reason: getErrorMessage(error),
-      });
-      continue;
-    }
-
-    if (loadedSkills.length >= MAX_POST_COMPACTION_LOADED_SKILLS) {
-      break;
-    }
-  }
-
-  return mergeLoadedSkillSnapshots(loadedSkills);
 }
 
 function mergeFileEditDiffs(existing: FileEditDiff[], incoming: FileEditDiff[]): FileEditDiff[] {
@@ -235,67 +109,6 @@ function mergeFileEditDiffs(existing: FileEditDiff[], incoming: FileEditDiff[]):
   }
 
   return merged;
-}
-
-function coerceReadFilePaths(value: unknown): string[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-  // mergeReadFilePaths already dedupes and caps (without trimming, since
-  // whitespace is part of a path's identity); merging against an empty list
-  // reuses that sanitization for persisted rows.
-  return mergeReadFilePaths(
-    [],
-    value.filter((item): item is string => typeof item === "string")
-  );
-}
-
-function coercePersistedPostCompactionState(
-  value: unknown,
-  allowPrevious = true
-): PersistedPostCompactionStateV1 | null {
-  if (!value || typeof value !== "object") {
-    return null;
-  }
-
-  const version = (value as { version?: unknown }).version;
-  if (version !== 1) {
-    return null;
-  }
-
-  const createdAt = (value as { createdAt?: unknown }).createdAt;
-  if (typeof createdAt !== "number") {
-    return null;
-  }
-
-  const boundaryMessageId = (value as { boundaryMessageId?: unknown }).boundaryMessageId;
-  if (
-    boundaryMessageId !== undefined &&
-    (typeof boundaryMessageId !== "string" || !boundaryMessageId)
-  )
-    return null;
-  const previousState = allowPrevious
-    ? (coercePersistedPostCompactionState(
-        (value as { previousState?: unknown }).previousState,
-        false
-      ) ?? undefined)
-    : undefined;
-  const diffsRaw = (value as { diffs?: unknown }).diffs;
-  const diffs = coerceFileEditDiffs(diffsRaw);
-  const loadedSkillsRaw = (value as { loadedSkills?: unknown }).loadedSkills;
-  const loadedSkills = coerceLoadedSkillSnapshots(loadedSkillsRaw);
-  const readFilesRaw = (value as { readFiles?: unknown }).readFiles;
-  const readFiles = coerceReadFilePaths(readFilesRaw);
-
-  return {
-    version: 1,
-    createdAt,
-    diffs,
-    loadedSkills,
-    readFiles,
-    boundaryMessageId,
-    previousState,
-  };
 }
 
 function isCompactedSummaryMessage(message: MuxMessage): boolean {
@@ -404,32 +217,13 @@ interface CompactionHandlerOptions {
 export class CompactionHandler {
   private readonly workspaceId: string;
   private readonly historyService: HistoryService;
-  private readonly sessionDir: string;
-  private readonly postCompactionStatePath: string;
-  private persistedPendingStateLoaded = false;
-  private pendingStateBoundaryMessageId?: string;
+  private readonly pendingLifecycle: CompactionPreparationLifecycle;
   private readonly telemetryService?: TelemetryService;
   private readonly emitter: EventEmitter;
   private readonly processedCompactionRequestIds: Set<string> = new Set<string>();
 
   private readonly onCompactionComplete?: (metadata: CompactionCompletionMetadata) => void;
   private readonly onIdleCompactionOutcome?: (success: boolean) => void;
-
-  /** Flag indicating post-compaction attachments should be generated on next turn */
-  private postCompactionAttachmentsPending = false;
-  /** Cached file diffs extracted from history before appending compaction summary */
-  private cachedFileDiffs: FileEditDiff[] = [];
-  /** Rollback snapshot for synthetic heartbeat reset boundaries that get skipped before dispatch. */
-  private heartbeatResetRollbackState: HeartbeatResetRollbackState | null = null;
-  // Request consumers retain this identity rather than claiming whichever snapshot is current later.
-  private pendingStateOwner = Symbol();
-  private pendingStateFileOwner?: symbol;
-  private pendingStateWrites: Promise<unknown> = Promise.resolve();
-  private readonly pendingStateOwners = new WeakMap<PendingPostCompactionState, symbol>();
-  /** Cached loaded skill snapshots extracted from history before appending compaction summary */
-  private cachedLoadedSkills: LoadedSkillSnapshot[] = [];
-  /** Cumulative file paths read in summarized epochs (paths only, newest-first, capped). */
-  private cachedReadFilePaths: string[] = [];
 
   constructor(options: CompactionHandlerOptions) {
     assert(options, "CompactionHandler requires options");
@@ -439,374 +233,109 @@ export class CompactionHandler {
 
     this.workspaceId = options.workspaceId;
     this.historyService = options.historyService;
-    this.sessionDir = trimmedSessionDir;
-    this.postCompactionStatePath = path.join(trimmedSessionDir, POST_COMPACTION_STATE_FILENAME);
+    this.pendingLifecycle = new CompactionPreparationLifecycle(
+      new CompactionPendingState(
+        path.join(trimmedSessionDir, POST_COMPACTION_STATE_FILENAME),
+        this.historyService.getCompactionPendingHistory(this.workspaceId)
+      )
+    );
     this.telemetryService = options.telemetryService;
     this.emitter = options.emitter;
     this.onCompactionComplete = options.onCompactionComplete;
     this.onIdleCompactionOutcome = options.onIdleCompactionOutcome;
   }
 
-  private enqueuePendingStateWrite<T>(operation: () => Promise<T>): Promise<T> {
-    const result = this.pendingStateWrites.then(operation);
-    this.pendingStateWrites = result.catch(() => undefined);
-    return result;
+  beginPreparation(isCurrent: () => boolean): CompactionPreparation {
+    return this.pendingLifecycle.begin(isCurrent);
   }
 
-  private async loadPersistedPendingStateIfNeeded(): Promise<void> {
-    if (this.persistedPendingStateLoaded || this.postCompactionAttachmentsPending) {
-      return;
-    }
-
-    this.persistedPendingStateLoaded = true;
-    const owner = Symbol();
-    this.pendingStateOwner = owner;
-
-    let raw: string;
-    try {
-      raw = await this.enqueuePendingStateWrite(async () => {
-        const contents = await fsPromises.readFile(this.postCompactionStatePath, "utf-8");
-        this.pendingStateFileOwner = owner;
-        return contents;
-      });
-    } catch {
-      return;
-    }
-
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(raw);
-    } catch {
-      log.warn("Invalid post-compaction state JSON; ignoring", { workspaceId: this.workspaceId });
-      await this.deletePersistedPendingStateBestEffort(owner);
-      return;
-    }
-
-    let state = coercePersistedPostCompactionState(parsed);
-    if (!state) {
-      log.warn("Invalid post-compaction state schema; ignoring", { workspaceId: this.workspaceId });
-      await this.deletePersistedPendingStateBestEffort(owner);
-      return;
-    }
-
-    if (state.boundaryMessageId) {
-      const history = await this.historyService.getHistoryFromLatestBoundary(this.workspaceId);
-      if (!history.success) {
-        if (this.pendingStateOwner === owner) this.persistedPendingStateLoaded = false;
-        return;
-      }
-      const boundaryId = history.data.findLast(isDurableContextBoundaryMarker)?.id;
-      if (state.boundaryMessageId !== boundaryId) {
-        // A crash before the boundary must neither resurrect canceled head state
-        // nor lose an older, still-pending attachment snapshot.
-        state = state.previousState ?? null;
-        if (!state || (state.boundaryMessageId && state.boundaryMessageId !== boundaryId)) {
-          await this.deletePersistedPendingStateBestEffort(owner);
-          return;
-        }
-      }
-    }
-    // A load must not relabel a snapshot written while its history check was awaiting I/O.
-    if (this.pendingStateOwner !== owner) return;
-    this.pendingStateBoundaryMessageId = state.boundaryMessageId;
-    this.cachedFileDiffs = state.diffs;
-    this.cachedLoadedSkills = state.loadedSkills;
-    this.cachedReadFilePaths = state.readFiles;
-    this.postCompactionAttachmentsPending = true;
+  async peekPendingState(): Promise<CompactionPreparationSnapshot | null> {
+    return (await this.pendingLifecycle.capture("pending")) ?? null;
   }
 
-  /**
-   * Peek pending post-compaction state without consuming it.
-   * Returns null if no compaction occurred, otherwise returns cached diffs and skills.
-   */
-  async peekPendingState(): Promise<PendingPostCompactionState | null> {
-    if (!this.postCompactionAttachmentsPending) {
-      await this.loadPersistedPendingStateIfNeeded();
-    }
-
-    if (!this.postCompactionAttachmentsPending) {
-      return null;
-    }
-
-    const state = {
-      diffs: this.cachedFileDiffs,
-      loadedSkills: this.cachedLoadedSkills,
-      readFiles: this.cachedReadFilePaths,
-    };
-    this.pendingStateOwners.set(state, this.pendingStateOwner);
-    return state;
+  async peekCarryoverState(): Promise<CompactionPreparationSnapshot | null> {
+    return (await this.pendingLifecycle.capture("carryover")) ?? null;
   }
 
-  /**
-   * Peek pending post-compaction diffs without consuming them.
-   * Returns null if no compaction occurred, otherwise returns the cached diffs.
-   */
   async peekPendingDiffs(): Promise<FileEditDiff[] | null> {
-    const state = await this.peekPendingState();
-    return state?.diffs ?? null;
+    return (await this.peekPendingState())?.diffs ?? null;
   }
 
-  /**
-   * Acknowledge that pending post-compaction state has been consumed successfully.
-   * Clears the pending diff snapshot and deletes the persisted state from disk.
-   *
-   * We intentionally retain loaded skill snapshots in memory after acknowledgement so
-   * later compactions in the same session can keep carrying those guardrails forward
-   * even when no new agent_skill_read call occurs between compactions.
-   *
-   * Read-file paths are retained the same way: they are cumulative "already
-   * seen" memory, so the next compaction must merge them even when the pending
-   * state was consumed in between.
-   */
-  async ackPendingStateConsumed(expected?: PendingPostCompactionState | null): Promise<void> {
-    await this.consumePendingState(expected, false);
+  async ackPendingStateConsumed(expected?: CompactionPreparationSnapshot | null): Promise<void> {
+    const snapshot = expected === undefined ? await this.peekPendingState() : expected;
+    if (snapshot) await this.pendingLifecycle.consume(snapshot, "ack");
   }
 
-  /**
-   * Drop pending post-compaction state (e.g., because it caused context_exceeded).
-   */
   async discardPendingState(
     reason: string,
-    expected?: PendingPostCompactionState | null
+    expected?: CompactionPreparationSnapshot | null
   ): Promise<void> {
     log.debug("Discarding pending post-compaction state", {
       workspaceId: this.workspaceId,
       reason,
     });
-    await this.consumePendingState(expected, true);
+    const snapshot = expected === undefined ? await this.peekPendingState() : expected;
+    if (snapshot) await this.pendingLifecycle.consume(snapshot, "discard");
   }
 
-  private async consumePendingState(
-    expected: PendingPostCompactionState | null | undefined,
-    discard: boolean
-  ): Promise<void> {
-    if (expected === undefined) await this.loadPersistedPendingStateIfNeeded();
-    const owner =
-      expected === undefined
-        ? this.pendingStateOwner
-        : expected && this.pendingStateOwners.get(expected);
-    if (!owner || this.pendingStateOwner !== owner) return;
-
-    // Clear this request's cache before yielding. A queued unlink must not later clear B's cache.
-    this.pendingStateBoundaryMessageId = undefined;
-    this.postCompactionAttachmentsPending = false;
-    this.cachedFileDiffs = [];
-    if (discard) {
-      this.cachedLoadedSkills = [];
-      this.cachedReadFilePaths = [];
-    }
-    await this.deletePersistedPendingStateBestEffort(owner);
+  /** The destructive history generation is already durable; future-format bytes remain inert. */
+  async discardPendingStateDurably(_reason: string): Promise<void> {
+    await this.pendingLifecycle.discardAfterBoundary();
   }
 
-  /**
-   * Context-boundary variant of discardPendingState: the persisted pending
-   * state must be provably gone before the boundary caller reports success —
-   * a stale post-compaction.json re-injects PRE-boundary read paths / skills
-   * / diffs into a fresh session after a restart. Performs the same in-memory
-   * discard, then deletes the persisted file durable-or-throw (ENOENT counts
-   * as deleted; it also heals an earlier swallowed best-effort unlink
-   * failure, since the in-memory early return above cannot see the file).
-   */
-  async discardPendingStateDurably(reason: string): Promise<void> {
-    await this.discardPendingState(reason);
-    try {
-      await this.enqueuePendingStateWrite(async () => {
-        await fsPromises.unlink(this.postCompactionStatePath);
-        this.pendingStateFileOwner = undefined;
-      });
-    } catch (error) {
-      if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
-        return;
-      }
-      throw error;
-    }
-  }
-
-  private async deletePersistedPendingStateBestEffort(owner?: symbol): Promise<void> {
-    try {
-      await this.enqueuePendingStateWrite(async () => {
-        if (owner && this.pendingStateFileOwner !== owner) return;
-        await fsPromises.unlink(this.postCompactionStatePath);
-        this.pendingStateFileOwner = undefined;
-      });
-    } catch {
-      // ignore
-    }
-  }
-
-  private captureHeartbeatResetRollbackState(): void {
-    this.heartbeatResetRollbackState = {
-      owner: this.pendingStateOwner,
-      postCompactionAttachmentsPending: this.postCompactionAttachmentsPending,
-      cachedFileDiffs: [...this.cachedFileDiffs],
-      cachedLoadedSkills: [...this.cachedLoadedSkills],
-      cachedReadFilePaths: [...this.cachedReadFilePaths],
-      persistedPendingStateLoaded: this.persistedPendingStateLoaded,
-    };
-  }
-
-  private async restoreHeartbeatResetRollbackState(): Promise<void> {
-    const rollbackState = this.heartbeatResetRollbackState;
-    if (!rollbackState) {
-      return;
-    }
-
-    // Keep the original request's authority even if the best-effort restoration write fails.
-    this.pendingStateOwner = rollbackState.owner;
-    this.postCompactionAttachmentsPending = rollbackState.postCompactionAttachmentsPending;
-    this.cachedFileDiffs = [...rollbackState.cachedFileDiffs];
-    this.cachedLoadedSkills = [...rollbackState.cachedLoadedSkills];
-    this.cachedReadFilePaths = [...rollbackState.cachedReadFilePaths];
-    this.persistedPendingStateLoaded = rollbackState.persistedPendingStateLoaded;
-
-    if (rollbackState.postCompactionAttachmentsPending) {
-      await this.persistPendingStateBestEffort(
-        this.cachedFileDiffs,
-        this.cachedLoadedSkills,
-        this.cachedReadFilePaths,
-        undefined,
-        undefined,
-        rollbackState.owner
-      );
-    } else {
-      await this.deletePersistedPendingStateBestEffort();
-    }
-
-    this.heartbeatResetRollbackState = null;
-  }
-
-  private async persistPendingStateBestEffort(
-    diffs: FileEditDiff[],
-    loadedSkills: LoadedSkillSnapshot[],
-    readFiles: string[],
-    boundaryMessageId?: string,
-    previousState?: PersistedPostCompactionStateV1,
-    owner = Symbol()
-  ): Promise<void> {
-    this.pendingStateOwner = owner;
-    try {
-      for (const snapshot of loadedSkills) {
-        assert(snapshot.name.trim().length > 0, "loaded skill snapshot name must not be empty");
-      }
-
-      const persisted: PersistedPostCompactionStateV1 = {
-        version: 1,
-        createdAt: Date.now(),
-        diffs,
-        loadedSkills,
-        readFiles,
-        ...(boundaryMessageId && { boundaryMessageId, previousState }),
-      };
-
-      await this.enqueuePendingStateWrite(async () => {
-        // This write owns retirement even if it fails and leaves earlier bytes on disk.
-        // Queueing writes with consumption prevents a held unlink from deleting a later write.
-        this.pendingStateFileOwner = owner;
-        await fsPromises.mkdir(this.sessionDir, { recursive: true });
-        await fsPromises.writeFile(this.postCompactionStatePath, JSON.stringify(persisted));
-      });
-    } catch (error) {
-      log.warn("Failed to persist post-compaction state", {
-        workspaceId: this.workspaceId,
-        error: getErrorMessage(error),
-      });
-    }
-  }
-
-  async preparePendingStateFromMessages(
+  private async publishPreparedBoundary(
+    preparation: CompactionPreparation,
     messages: MuxMessage[],
-    boundaryMessageId?: string,
-    previousState?: PersistedPostCompactionStateV1
-  ): Promise<void> {
-    await this.loadPersistedPendingStateIfNeeded();
-    this.pendingStateBoundaryMessageId = boundaryMessageId;
-
-    const latestCompactionEpochMessages = sliceMessagesFromLatestCompactionBoundary(messages);
-    this.cachedFileDiffs = mergeFileEditDiffs(
-      this.cachedFileDiffs,
-      extractEditedFileDiffs(latestCompactionEpochMessages)
+    boundary: CompactionPendingBoundaryWrite
+  ) {
+    messages = structuredClone(messages);
+    boundary = {
+      ...boundary,
+      summaryMessage: structuredClone(boundary.summaryMessage),
+      tailCopies: structuredClone(boundary.tailCopies),
+      publication: structuredClone(boundary.publication),
+    };
+    // Every producer reaches this seam, including continuous recovery. Strict publication
+    // must not leave a malformed partial permanently blocking otherwise valid compaction.
+    const retired = await this.historyService.deletePartialIfMatches(
+      this.workspaceId,
+      null,
+      preparation.isCurrent
     );
-    this.cachedLoadedSkills = mergeLoadedSkillSnapshots([
-      ...this.cachedLoadedSkills,
-      ...extractLoadedSkillSnapshotsFromMessages(latestCompactionEpochMessages),
-    ]);
-    // Cumulative read tracking mirrors cachedFileDiffs: newest epoch reads
-    // first, then previously tracked paths, capped. Tracked in both modes
-    // (internal bookkeeping); surfaced to the model only when RLM is on.
-    this.cachedReadFilePaths = mergeReadFilePaths(
-      this.cachedReadFilePaths,
-      extractReadFilePaths(latestCompactionEpochMessages)
-    );
-
-    // Persist pending state before append so pre-boundary diffs survive crashes/restarts.
-    // Best-effort: boundary creation must not fail just because persistence fails.
-    await this.persistPendingStateBestEffort(
-      this.cachedFileDiffs,
-      this.cachedLoadedSkills,
-      this.cachedReadFilePaths,
-      boundaryMessageId,
-      previousState
-    );
+    if (!retired.success) return retired;
+    const pending = await this.peekPendingState();
+    const warm = await this.peekCarryoverState();
+    const epoch = sliceMessagesFromLatestCompactionBoundary(messages);
+    return this.pendingLifecycle.publish(preparation, {
+      ...boundary,
+      attachments: {
+        diffs: mergeFileEditDiffs(pending?.diffs ?? [], extractEditedFileDiffs(epoch)),
+        loadedSkills: mergeLoadedSkillSnapshots([
+          ...(warm?.loadedSkills ?? []),
+          ...(pending?.loadedSkills ?? []),
+          ...extractLoadedSkillSnapshotsFromMessages(epoch),
+        ]),
+        readFiles: mergeReadFilePaths(
+          mergeReadFilePaths(warm?.readFiles ?? [], pending?.readFiles ?? []),
+          extractReadFilePaths(epoch)
+        ),
+      },
+    });
   }
 
-  async withContinuousPendingState(
-    messages: MuxMessage[],
-    apply: (boundaryMessageId: string, onCommitted: () => void) => Promise<boolean>,
-    boundaryMessageId = createCompactionSummaryMessageId()
-  ): Promise<boolean> {
-    await this.loadPersistedPendingStateIfNeeded();
-    const previous = {
-      owner: this.pendingStateOwner,
-      pending: this.postCompactionAttachmentsPending,
-      diffs: this.cachedFileDiffs,
-      loadedSkills: this.cachedLoadedSkills,
-      readFiles: this.cachedReadFilePaths,
-      boundaryMessageId: this.pendingStateBoundaryMessageId,
-    };
-    const previousState: PersistedPostCompactionStateV1 | undefined = previous.pending
-      ? {
-          version: 1,
-          createdAt: Date.now(),
-          diffs: previous.diffs,
-          loadedSkills: previous.loadedSkills,
-          readFiles: previous.readFiles,
-          boundaryMessageId: previous.boundaryMessageId,
-        }
-      : undefined;
-    let applied = false;
-    try {
-      await this.preparePendingStateFromMessages(messages, boundaryMessageId, previousState);
-      // A committed boundary must retain its pending attachments even if a later
-      // observer or cleanup throws before the apply promise returns.
-      const result = await apply(boundaryMessageId, () => {
-        applied = true;
-      });
-      applied ||= result;
-      return applied;
-    } finally {
-      // Never roll an older apply back over a newer preparation/consumption.
-      if (!applied && this.pendingStateBoundaryMessageId === boundaryMessageId) {
-        // Restoring A must preserve the authority already captured by A's request.
-        this.pendingStateOwner = previous.owner;
-        this.postCompactionAttachmentsPending = previous.pending;
-        this.cachedFileDiffs = previous.diffs;
-        this.cachedLoadedSkills = previous.loadedSkills;
-        this.cachedReadFilePaths = previous.readFiles;
-        this.pendingStateBoundaryMessageId = previous.boundaryMessageId;
-        if (previous.pending) {
-          await this.persistPendingStateBestEffort(
-            previous.diffs,
-            previous.loadedSkills,
-            previous.readFiles,
-            previous.boundaryMessageId,
-            undefined,
-            previous.owner
-          );
-        } else {
-          await this.deletePersistedPendingStateBestEffort();
-        }
-      }
-    }
+  private async retirePartial(
+    preparation: CompactionPreparation,
+    messageId?: string
+  ): Promise<void> {
+    const partial = await this.historyService.readPartial(this.workspaceId);
+    if (!partial || (messageId != null && partial.id !== messageId)) return;
+    // A new turn can flush while preparation awaits; only the captured partial may be removed.
+    const result = await this.historyService.deletePartialIfMatches(
+      this.workspaceId,
+      partial,
+      preparation.isCurrent
+    );
+    if (!result.success) log.warn("Failed to retire compaction partial", result.error);
   }
 
   private getMaxExistingHistorySequence(messages: MuxMessage[]): number {
@@ -836,18 +365,22 @@ export class CompactionHandler {
   async appendHeartbeatContextResetBoundary(params: {
     boundaryText: string;
     pendingFollowUp: CompactionFollowUpRequest;
+    isCurrent?: () => boolean;
   }): Promise<Result<{ summaryMessageId: string }, string>> {
     assert(
       params.boundaryText.trim().length > 0,
       "appendHeartbeatContextResetBoundary requires non-empty boundary text"
     );
 
-    const deletePartialResult = await this.historyService.deletePartial(this.workspaceId);
-    if (!deletePartialResult.success) {
-      log.warn(
-        `Failed to delete partial before heartbeat reset boundary: ${deletePartialResult.error}`
-      );
-    }
+    const preparation = this.beginPreparation(params.isCurrent ?? (() => true));
+    const { boundaryText } = params;
+    const pendingFollowUp = structuredClone(params.pendingFollowUp);
+    const publication = {
+      generation: await this.historyService
+        .getContinuousCompactionJournal(this.workspaceId)
+        .captureGeneration(),
+    };
+    await this.retirePartial(preparation);
 
     const historyResult = await this.historyService.getHistoryFromLatestBoundary(this.workspaceId);
     if (!historyResult.success) {
@@ -855,9 +388,6 @@ export class CompactionHandler {
     }
 
     const messages = historyResult.data;
-    await this.loadPersistedPendingStateIfNeeded();
-    this.captureHeartbeatResetRollbackState();
-    await this.preparePendingStateFromMessages(messages);
 
     const nextCompactionEpoch = getNextCompactionEpoch(messages);
     assert(
@@ -868,7 +398,7 @@ export class CompactionHandler {
     const summaryMessage = createMuxMessage(
       createCompactionSummaryMessageId(),
       "assistant",
-      params.boundaryText,
+      boundaryText,
       {
         timestamp: Date.now(),
         synthetic: true,
@@ -878,7 +408,7 @@ export class CompactionHandler {
         compactionBoundary: true,
         muxMetadata: {
           type: "compaction-summary",
-          pendingFollowUp: params.pendingFollowUp,
+          pendingFollowUp,
         },
       }
     );
@@ -897,16 +427,25 @@ export class CompactionHandler {
     );
 
     const maxExistingHistorySequence = this.getMaxExistingHistorySequence(messages);
-    const persistenceResult = await this.historyService.appendToHistory(
-      this.workspaceId,
-      summaryMessage
-    );
+    const fingerprint = exactJson(messages);
+    const persistenceResult = await this.publishPreparedBoundary(preparation, messages, {
+      summaryMessage,
+      tailCopies: [],
+      updateExisting: false,
+      publication,
+      shouldPersist: (current, partial) =>
+        !partial &&
+        isDeepStrictEqual(
+          exactJson(sliceMessagesFromLatestCompactionBoundary(current)),
+          fingerprint
+        ),
+    });
     if (!persistenceResult.success) {
-      await this.restoreHeartbeatResetRollbackState();
       return Err(`Failed to append heartbeat reset boundary: ${persistenceResult.error}`);
     }
 
-    const persistedSequence = summaryMessage.metadata?.historySequence;
+    const persisted = persistenceResult.data.summaryMessage;
+    const persistedSequence = persisted.metadata?.historySequence;
     assert(
       isNonNegativeInteger(persistedSequence),
       "heartbeat reset boundary persistence must produce a non-negative historySequence"
@@ -918,9 +457,8 @@ export class CompactionHandler {
       );
     }
 
-    this.postCompactionAttachmentsPending = true;
-    this.emitChatEvent({ ...summaryMessage, type: "message" });
-    return Ok({ summaryMessageId: summaryMessage.id });
+    this.emitChatEvent({ ...persisted, type: "message" });
+    return Ok({ summaryMessageId: persisted.id });
   }
 
   async rollbackHeartbeatContextResetBoundary(
@@ -936,22 +474,12 @@ export class CompactionHandler {
       "rollbackHeartbeatContextResetBoundary requires a heartbeat reset boundary"
     );
 
-    const owner = this.pendingStateOwner;
-    const deleteResult = await this.historyService.cleanupCompactionFollowUp(
-      this.workspaceId,
-      summaryMessage,
-      "rollback-heartbeat",
-      () => this.pendingStateOwner === owner && isCurrent()
-    );
+    const deleteResult = await this.pendingLifecycle.rollbackHeartbeat(summaryMessage, isCurrent);
     if (!deleteResult.success) {
       return Err(`Failed to delete heartbeat reset boundary: ${deleteResult.error}`);
     }
     // A replacement retained its boundary, so its cached state and renderer row must survive too.
-    if (deleteResult.data === "skipped") return deleteResult;
-
-    // Once deletion commits, a new turn cannot cancel reconciliation of this owner's snapshot.
-    // A replacement pending-state owner still takes precedence over the rollback.
-    if (this.pendingStateOwner === owner) await this.restoreHeartbeatResetRollbackState();
+    if (deleteResult.data.outcome === "skipped") return Ok("skipped");
 
     const historySequence = summaryMessage.metadata?.historySequence;
     if (isNonNegativeInteger(historySequence)) {
@@ -964,16 +492,8 @@ export class CompactionHandler {
     return Ok("applied");
   }
 
-  /**
-   * Peek at cached file paths without consuming them.
-   * Returns paths of files that will be reinjected after compaction.
-   * Returns null if no pending compaction attachments.
-   */
-  peekCachedFilePaths(): string[] | null {
-    if (!this.postCompactionAttachmentsPending) {
-      return null;
-    }
-    return this.cachedFileDiffs.map((diff) => diff.path);
+  async peekCachedFilePaths(): Promise<string[] | null> {
+    return (await this.peekPendingState())?.diffs.map((diff) => diff.path) ?? null;
   }
 
   /**
@@ -984,8 +504,20 @@ export class CompactionHandler {
    */
   async handleCompletion(
     event: StreamEndEvent,
-    compactionRequestMessageId?: string
+    compactionRequestMessageId?: string,
+    isCurrent: () => boolean = () => true
   ): Promise<boolean> {
+    const preparation = this.beginPreparation(isCurrent);
+    event = structuredClone(event);
+    // Capture before reading history so a reset during classification cannot adopt old rows.
+    // Defer storage errors until classification: ordinary completion must still run its policy.
+    const generation = await this.historyService
+      .getContinuousCompactionJournal(this.workspaceId)
+      .captureGeneration()
+      .then(
+        (value) => Ok(value),
+        (error: unknown) => Err(error)
+      );
     // The current stream identifies its request when available. Synthetic prompt snapshots can
     // follow that request in history, so the last user row is not always the compaction request.
     const historyResult = compactionRequestMessageId
@@ -1006,6 +538,9 @@ export class CompactionHandler {
     if (!isCompaction || !compactionRequestMessage) {
       return false;
     }
+
+    if (!generation.success) throw generation.error;
+    const publication = { generation: generation.data };
 
     // Determine idle-compaction (auto-triggered due to inactivity) up-front so the
     // post-stream failure paths below can report a terminal outcome to the idle loop.
@@ -1076,6 +611,8 @@ export class CompactionHandler {
     }
 
     const result = await this.performCompaction(
+      preparation,
+      publication,
       summary,
       event.metadata,
       messagesForCompaction,
@@ -1294,11 +831,16 @@ export class CompactionHandler {
     params: Parameters<CompactionHandler["buildContinuousCompactionRows"]>[0] & {
       prepared?: { boundary: MuxMessage; copies: MuxMessage[] };
       shouldPersist: (messages: MuxMessage[]) => boolean;
-      publication?: ContinuousCompactionPublication;
-      onCommitted?: () => void;
+      publication: ContinuousCompactionPublication;
+      preparation: CompactionPreparation;
+      attachmentMessages: MuxMessage[];
     }
   ): Promise<boolean> {
-    const { boundary, copies } = params.prepared ?? this.buildContinuousCompactionRows(params);
+    const shouldPersist = params.shouldPersist;
+    const previousBoundaryHistorySequence = getLatestBoundaryHistorySequence(params.messages);
+    const { boundary, copies } = params.prepared
+      ? structuredClone(params.prepared)
+      : this.buildContinuousCompactionRows(params);
     const inputTokens =
       params.systemMessageTokens +
       params.attachmentTokens +
@@ -1312,30 +854,26 @@ export class CompactionHandler {
       cachedInputTokens: 0,
       reasoningTokens: 0,
     };
-    const result = await this.historyService.persistBoundaryWithTailCopies(
-      this.workspaceId,
-      boundary,
-      copies,
-      false,
-      params.shouldPersist,
-      params.publication
-        ? {
-            publication: params.publication,
-            onCommitted: () => {
-              params.onCommitted?.();
-            },
-          }
-        : undefined
+    const result = await this.publishPreparedBoundary(
+      params.preparation,
+      params.attachmentMessages,
+      {
+        summaryMessage: boundary,
+        tailCopies: copies,
+        updateExisting: false,
+        publication: params.publication,
+        shouldPersist: (messages, partial) => !partial && shouldPersist(messages),
+      }
     );
     if (!result.success) {
       log.warn("[continuous-compaction] persist failed", result.error);
       return false;
     }
-    this.postCompactionAttachmentsPending = true;
-    this.emitChatEvent({ ...boundary, type: "message" });
-    for (const copy of copies) this.emitChatEvent({ ...copy, type: "message" });
-    const sequence = boundary.metadata.historySequence;
-    const epoch = boundary.metadata.compactionEpoch;
+    const persisted = result.data.summaryMessage;
+    this.emitChatEvent({ ...persisted, type: "message" });
+    for (const copy of result.data.tailCopies) this.emitChatEvent({ ...copy, type: "message" });
+    const sequence = persisted.metadata?.historySequence;
+    const epoch = persisted.metadata?.compactionEpoch;
     assert(isNonNegativeInteger(sequence), "Continuous boundary requires a persisted sequence");
     assert(isPositiveInteger(epoch), "Continuous boundary requires an epoch");
     this.onCompactionComplete?.({
@@ -1343,7 +881,7 @@ export class CompactionHandler {
       summaryMessageId: boundary.id,
       summaryHistorySequence: sequence,
       compactionEpoch: epoch,
-      previousBoundaryHistorySequence: getLatestBoundaryHistorySequence(params.messages),
+      previousBoundaryHistorySequence,
       compactionRequestMessageId: boundary.id,
       preservedTailMessageCount: copies.length,
     });
@@ -1360,6 +898,8 @@ export class CompactionHandler {
    * 4. Emit summary message to frontend
    */
   private async performCompaction(
+    preparation: CompactionPreparation,
+    publication: ContinuousCompactionPublication,
     summary: string,
     metadata: {
       model: string;
@@ -1385,23 +925,8 @@ export class CompactionHandler {
       "performCompaction requires streamed summary message ID"
     );
 
-    // CRITICAL: Delete partial.json BEFORE persisting compaction summary.
-    // This prevents a race condition where:
-    // 1. CompactionHandler persists summary
-    // 2. sendQueuedMessages triggers commitPartial
-    // 3. commitPartial finds stale partial.json and appends it to history
-    // By deleting partial first, commitPartial becomes a no-op
-    const deletePartialResult = await this.historyService.deletePartial(this.workspaceId);
-    if (!deletePartialResult.success) {
-      log.warn(`Failed to delete partial before compaction: ${deletePartialResult.error}`);
-      // Continue anyway - the partial may not exist, which is fine
-    }
-
-    // Extract diffs from the latest compaction epoch only, so append-only history
-    // does not re-inject stale pre-boundary edits after subsequent compactions.
-    // If boundary markers are malformed, slicing self-heals by falling back to
-    // full history instead of crashing or dropping all diffs.
-    await this.preparePendingStateFromMessages(messages);
+    // Retire only this completed stream's partial before committing its summary boundary.
+    await this.retirePartial(preparation, streamedSummaryMessageId);
 
     const nextCompactionEpoch = getNextCompactionEpoch(messages);
     assert(Number.isInteger(nextCompactionEpoch), "next compaction epoch must be an integer");
@@ -1516,37 +1041,24 @@ export class CompactionHandler {
       summaryMessage.id
     );
 
-    const persistenceResult =
-      preservedTailCopies.length > 0
-        ? await this.historyService.persistBoundaryWithTailCopies(
-            this.workspaceId,
-            summaryMessage,
-            preservedTailCopies,
-            persistedStreamSummary !== null
-          )
-        : persistedStreamSummary
-          ? await this.historyService.updateHistory(this.workspaceId, summaryMessage)
-          : await this.historyService.appendToHistory(this.workspaceId, summaryMessage);
-    if (!persistenceResult.success) {
-      // No boundary committed: retire this provisional snapshot independently of an older
-      // request's acknowledgement, which correctly cannot consume its replacement owner.
-      this.pendingStateOwner = Symbol();
-      this.pendingStateBoundaryMessageId = undefined;
-      this.postCompactionAttachmentsPending = false;
-      this.cachedFileDiffs = [];
-      this.cachedLoadedSkills = [];
-      this.cachedReadFilePaths = [];
-      await this.deletePersistedPendingStateBestEffort();
-      const operation =
-        preservedTailCopies.length > 0
-          ? "commit boundary with preserved tail"
-          : persistedStreamSummary
-            ? "update streamed summary"
-            : "append summary";
-      return Err(`Failed to ${operation}: ${persistenceResult.error}`);
-    }
+    const fingerprint = exactJson(messages);
+    const persistenceResult = await this.publishPreparedBoundary(preparation, messages, {
+      summaryMessage,
+      tailCopies: preservedTailCopies,
+      updateExisting: persistedStreamSummary !== null,
+      publication,
+      shouldPersist: (current, partial) =>
+        !partial &&
+        isDeepStrictEqual(
+          exactJson(sliceMessagesFromLatestCompactionBoundary(current)),
+          fingerprint
+        ),
+    });
+    if (!persistenceResult.success)
+      return Err(`Failed to commit compaction boundary: ${persistenceResult.error}`);
+    const persisted = persistenceResult.data.summaryMessage;
 
-    const persistedSequence = summaryMessage.metadata?.historySequence;
+    const persistedSequence = persisted.metadata?.historySequence;
     assert(
       isNonNegativeInteger(persistedSequence),
       "Compaction summary persistence must produce a non-negative historySequence"
@@ -1564,15 +1076,12 @@ export class CompactionHandler {
       );
     }
 
-    // Set flag to trigger post-compaction attachment injection on next turn
-    this.postCompactionAttachmentsPending = true;
-
     // Emit summary message to frontend (add type: "message" for discriminated union)
-    this.emitChatEvent({ ...summaryMessage, type: "message" });
+    this.emitChatEvent({ ...persisted, type: "message" });
 
     // The tail copies were committed atomically with the boundary above;
     // sequences were assigned in place, so the emitted events carry them.
-    for (const copy of preservedTailCopies) {
+    for (const copy of persistenceResult.data.tailCopies) {
       this.emitChatEvent({ ...copy, type: "message" });
     }
 

--- a/src/node/services/compactionPendingState.ts
+++ b/src/node/services/compactionPendingState.ts
@@ -70,7 +70,7 @@ export interface CompactionPendingBoundaryWrite {
   tailCopies: readonly MuxMessage[];
   updateExisting: boolean;
   publication: ContinuousCompactionPublication;
-  /** Pure admission check over held-lock history and a strictly parsed partial (null if absent). */
+  /** Pure admission over held-lock provider history and a strictly parsed partial (null if absent). */
   shouldPersist: (messages: MuxMessage[], partial: MuxMessage | null) => boolean;
 }
 
@@ -97,7 +97,6 @@ export interface CompactionPendingHistory {
   /**
    * Hold BOTH existing history locks throughout the callback, reject removed workspaces,
    * and provide a stable view without reacquiring history/journal queues inside the lock.
-   * The HistoryService adapter remains inactive: every producer/consumer must activate together.
    */
   withLock<T>(operation: (view: CompactionPendingHistoryView) => Promise<T>): Promise<T>;
 }
@@ -314,11 +313,11 @@ function eligibleState(
 }
 
 /**
- * Inactive pending-file protocol. CompactionHandler owns local caches/preparation; this owns disk.
+ * Pending-file protocol. CompactionPreparationLifecycle owns local facts; this owns disk.
  * Read-side cleanup is best-effort; mutation failures propagate so callers can distinguish
  * attachment writes from mandatory reset cleanup.
  *
- * Activation must use `publishBoundary` for every producer, with matching receipt consumers
+ * Producers must use `publishBoundary`, with matching receipt consumers
  * and an explicit policy for ambiguous legacy files. `prepare` alone is not atomic with history.
  * Queued methods acquire their own locks; never call them inside held locks.
  */

--- a/src/node/services/continuousCompactor.test.ts
+++ b/src/node/services/continuousCompactor.test.ts
@@ -3,7 +3,7 @@ import { stat, writeFile } from "node:fs/promises";
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
 import * as atomicWrite from "write-file-atomic";
 import { EventEmitter } from "node:events";
-import { readFile } from "node:fs/promises";
+import * as syncFs from "node:fs";
 import * as path from "node:path";
 import assert from "@/common/utils/assert";
 import {
@@ -392,20 +392,22 @@ describe("ContinuousCompactor", () => {
     });
     expect((await store.historyService.updateHistory(workspaceId, edit)).success).toBe(true);
     await stage();
-    const original = store.historyService.persistBoundaryWithTailCopies.bind(store.historyService);
-    const persist = spyOn(store.historyService, "persistBoundaryWithTailCopies").mockImplementation(
-      async (...args) => {
+    const rename = syncFs.renameSync;
+    let preparedBeforeBoundary = false;
+    spyOn(syncFs, "renameSync").mockImplementation((from, to) => {
+      if (to === path.join(store.config.sessionsDir, workspaceId, "chat.jsonl")) {
         const state: unknown = JSON.parse(
-          await readFile(path.join(store.tempDir, "pending", "post-compaction.json"), "utf8")
+          syncFs.readFileSync(path.join(store.tempDir, "pending", "post-compaction.json"), "utf8")
         );
         expect(state).toMatchObject({
           diffs: [{ path: "/tmp/fix.ts", diff: "@@ -1 +1 @@\n-broken\n+fixed\n" }],
         });
-        return original(...args);
+        preparedBeforeBoundary = true;
       }
-    );
+      rename(from, to);
+    });
     expect(await compactor.observe(context.thresholdPercent, context)).toBe("applied");
-    expect(persist).toHaveBeenCalledTimes(1);
+    expect(preparedBeforeBoundary).toBe(true);
     const restarted = new CompactionHandler({
       workspaceId,
       historyService: store.historyService,
@@ -422,11 +424,17 @@ describe("ContinuousCompactor", () => {
     await stage();
     const entered = deferred();
     const release = deferred();
-    const original = handler.preparePendingStateFromMessages.bind(handler);
-    spyOn(handler, "preparePendingStateFromMessages").mockImplementation(async (...args) => {
-      await original(...args);
-      entered.resolve();
-      await release.promise;
+    const remove = syncFs.promises.rm;
+    spyOn(syncFs.promises, "rm").mockImplementation(async (file, options) => {
+      if (
+        String(file).startsWith(
+          path.join(store.tempDir, "pending", "post-compaction.json.continuous-")
+        )
+      ) {
+        entered.resolve();
+        await release.promise;
+      }
+      return remove(file, options);
     });
     const applying = compactor.observe(context.thresholdPercent, context);
     await entered.promise;
@@ -455,7 +463,11 @@ describe("ContinuousCompactor", () => {
           callback?: (error?: Error) => void
         ) => {
           await original(filename, data, typeof options === "function" ? undefined : options);
-          if (filename.includes(".continuous-")) {
+          if (
+            filename.startsWith(
+              path.join(store.config.sessionsDir, workspaceId, "chat.jsonl.continuous-")
+            )
+          ) {
             entered.resolve();
             await release.promise;
           }
@@ -485,23 +497,28 @@ describe("ContinuousCompactor", () => {
   it("ignores provisional pending state on restart until its boundary is durable", async () => {
     await seedConversation();
     await stage();
-    const original = store.historyService.persistBoundaryWithTailCopies.bind(store.historyService);
-    spyOn(store.historyService, "persistBoundaryWithTailCopies").mockImplementationOnce(
-      async (...args) => {
-        const restarted = new CompactionHandler({
-          workspaceId,
-          historyService: store.historyService,
-          sessionDir: path.join(store.tempDir, "pending"),
-          emitter: new EventEmitter(),
-        });
-        expect(await restarted.peekPendingState()).toBeNull();
-        // Simulate the crash by rejecting the publication after testing its orphan snapshot.
+    const pendingPath = path.join(store.tempDir, "pending", "post-compaction.json");
+    let provisional: string | undefined;
+    const rename = syncFs.renameSync;
+    spyOn(syncFs, "renameSync").mockImplementation((from, to) => {
+      rename(from, to);
+      if (to === pendingPath) {
+        provisional = syncFs.readFileSync(pendingPath, "utf8");
         compactor.reset("crash before boundary");
-        return original(...args);
       }
-    );
+    });
     expect(await compactor.observe(context.thresholdPercent, context)).toBe("none");
     expect((await rows())[0].id).toBe("old-user");
+    assert(provisional, "Expected a real provisional write");
+    // Reproduce crash residue after the real rejected publication releases its locks.
+    await writeFile(pendingPath, provisional);
+    const restarted = new CompactionHandler({
+      workspaceId,
+      historyService: new HistoryService(store.config),
+      sessionDir: path.join(store.tempDir, "pending"),
+      emitter: new EventEmitter(),
+    });
+    expect(await restarted.peekPendingState()).toBeNull();
   });
 
   it.each(["reset", "append"] as const)(
@@ -511,16 +528,12 @@ describe("ContinuousCompactor", () => {
       await stage();
       const entered = deferred();
       const release = deferred();
-      const original = store.historyService.persistBoundaryWithTailCopies.bind(
-        store.historyService
-      );
-      spyOn(store.historyService, "persistBoundaryWithTailCopies").mockImplementationOnce(
-        async (...args) => {
-          entered.resolve();
-          await release.promise;
-          return original(...args);
-        }
-      );
+      const original = handler.persistContinuousCompaction.bind(handler);
+      spyOn(handler, "persistContinuousCompaction").mockImplementationOnce(async (...args) => {
+        entered.resolve();
+        await release.promise;
+        return original(...args);
+      });
       const applying = compactor.observe(context.thresholdPercent, context);
       await entered.promise;
       if (mutation === "reset") compactor.reset("archive");
@@ -965,11 +978,15 @@ describe("ContinuousCompactor", () => {
     await store.historyService.writePartial(workspaceId, answer);
     streaming = false;
     live = undefined;
-    spyOn(store.historyService, "persistBoundaryWithTailCopies").mockImplementationOnce(() =>
-      Promise.resolve({ success: false, error: "transient write failure" })
-    );
+    const rename = syncFs.renameSync;
+    const failure = spyOn(syncFs, "renameSync").mockImplementation((from, to) => {
+      if (to === path.join(store.config.sessionsDir, workspaceId, "chat.jsonl"))
+        throw new Error("Transient write failure");
+      rename(from, to);
+    });
     const disabled = { ...context, enabled: false, thresholdPercent: 100 };
     expect(await compactor.observe(0, disabled)).toBe("none");
+    failure.mockRestore();
     compactor.reset("disabled");
     expect(await journalStore.read()).not.toBeNull();
     expect(await compactor.observe(0, disabled)).toBe("applied");
@@ -986,8 +1003,8 @@ describe("ContinuousCompactor", () => {
     live = undefined;
     const entered = deferred();
     const release = deferred();
-    const original = handler.withContinuousPendingState.bind(handler);
-    spyOn(handler, "withContinuousPendingState").mockImplementation(async (...args) => {
+    const original = handler.persistContinuousCompaction.bind(handler);
+    spyOn(handler, "persistContinuousCompaction").mockImplementation(async (...args) => {
       entered.resolve();
       await release.promise;
       return original(...args);
@@ -1124,8 +1141,8 @@ describe("ContinuousCompactor", () => {
     compactor = new ContinuousCompactor(dependencies);
     const entered = deferred();
     const release = deferred();
-    const original = handler.withContinuousPendingState.bind(handler);
-    spyOn(handler, "withContinuousPendingState").mockImplementation(async (...args) => {
+    const original = handler.persistContinuousCompaction.bind(handler);
+    spyOn(handler, "persistContinuousCompaction").mockImplementation(async (...args) => {
       entered.resolve();
       await release.promise;
       return original(...args);

--- a/src/node/services/continuousCompactor.ts
+++ b/src/node/services/continuousCompactor.ts
@@ -598,6 +598,11 @@ export class ContinuousCompactor {
 
   private async finalizeJournal(pendingFollowUp?: CompactionFollowUpRequest): Promise<boolean> {
     const generation = this.generation;
+    const preparation = this.deps.compactionHandler.beginPreparation(
+      () =>
+        generation === this.generation &&
+        !this.deps.streamManager.isStreaming(this.deps.workspaceId)
+    );
     const store = this.deps.historyService.getContinuousCompactionJournal(this.deps.workspaceId);
     const journal = await store.read(
       () => generation === this.generation,
@@ -681,39 +686,29 @@ export class ContinuousCompactor {
     const boundary = structuredClone(journal.boundary);
     if (pendingFollowUp && boundary.metadata?.muxMetadata?.type === "compaction-summary")
       boundary.metadata.muxMetadata.pendingFollowUp = pendingFollowUp;
-    const applied = await this.deps.compactionHandler.withContinuousPendingState(
-      head,
-      async (_boundaryMessageId, onCommitted) => {
-        if (
-          generation !== this.generation ||
-          this.deps.streamManager.isStreaming(this.deps.workspaceId)
-        )
-          return false;
-        return this.deps.compactionHandler.persistContinuousCompaction({
-          messages: rows,
-          text: boundary.parts
-            .filter((part) => part.type === "text")
-            .map((part) => part.text)
-            .join("\n"),
-          model: journal.summaryModel,
-          tail: [],
-          systemMessageTokens: boundary.metadata?.systemMessageTokens ?? 0,
-          attachmentTokens: injectPostCompactionAttachments(
-            [],
-            journal.postCompactionAttachments
-          ).reduce((sum, row) => sum + estimateMuxMessageTokens(row), 0),
-          // Sequence assignment must not mutate the exact journal receipt used by cleanup.
-          prepared: { boundary, copies: [...structuredClone(journal.staticCopies), liveCopy] },
-          publication: { generation: journal.publicationGeneration, journal },
-          onCommitted,
-          shouldPersist: (current) =>
-            generation === this.generation &&
-            !this.deps.streamManager.isStreaming(this.deps.workspaceId) &&
-            fingerprint(sliceMessagesFromLatestCompactionBoundary(current)) === snapshot,
-        });
-      },
-      boundary.id
-    );
+    const applied = await this.deps.compactionHandler.persistContinuousCompaction({
+      messages: rows,
+      text: boundary.parts
+        .filter((part) => part.type === "text")
+        .map((part) => part.text)
+        .join("\n"),
+      model: journal.summaryModel,
+      tail: [],
+      systemMessageTokens: boundary.metadata?.systemMessageTokens ?? 0,
+      attachmentTokens: injectPostCompactionAttachments(
+        [],
+        journal.postCompactionAttachments
+      ).reduce((sum, row) => sum + estimateMuxMessageTokens(row), 0),
+      // Sequence assignment must not mutate the exact journal receipt used by cleanup.
+      prepared: { boundary, copies: [...structuredClone(journal.staticCopies), liveCopy] },
+      publication: { generation: journal.publicationGeneration, journal },
+      preparation,
+      attachmentMessages: head,
+      shouldPersist: (current) =>
+        generation === this.generation &&
+        !this.deps.streamManager.isStreaming(this.deps.workspaceId) &&
+        fingerprint(sliceMessagesFromLatestCompactionBoundary(current)) === snapshot,
+    });
     if (applied && generation === this.generation) {
       await this.clearJournalBestEffort(journal);
       if (generation === this.generation) {
@@ -729,6 +724,11 @@ export class ContinuousCompactor {
     context: ContinuousCompactionContext,
     pendingFollowUp?: CompactionFollowUpRequest
   ): Promise<boolean> {
+    const preparation = this.deps.compactionHandler.beginPreparation(
+      () =>
+        staged.generation === this.generation &&
+        !this.deps.streamManager.isStreaming(this.deps.workspaceId)
+    );
     assert(
       !this.deps.streamManager.isStreaming(this.deps.workspaceId),
       "Cannot apply a boundary while a stream is active"
@@ -739,46 +739,41 @@ export class ContinuousCompactor {
     assert(head !== null, "Validated rolling head disappeared");
     context = await this.withAttachmentEstimate(head, context);
     if (staged.generation !== this.generation) return false;
-    return this.deps.compactionHandler.withContinuousPendingState(
-      head,
-      async (boundaryMessageId, onCommitted) => {
-        // Pending-state persistence yields; a reset/edit during it must still invalidate this job.
-        rows = await this.readSnapshot();
-        if (!rows || !this.isValid(staged, rows)) return false;
-        assert(
-          !this.deps.streamManager.isStreaming(this.deps.workspaceId),
-          "Stream started during continuous apply"
-        );
-        const partial = await this.deps.historyService.readPartial(this.deps.workspaceId);
-        assert(!partial, "Continuous apply requires the partial to be committed first");
-        if (staged.generation !== this.generation) return false;
-        if (!this.wouldFit(staged, rows, context)) return false;
-        const tail = this.materializeTail(staged, rows);
-        const snapshotFingerprint = fingerprint(rows);
-        const applied = await this.deps.compactionHandler.persistContinuousCompaction({
-          boundaryMessageId,
-          publication: { generation: staged.publicationGeneration },
-          onCommitted,
-          shouldPersist: (currentRows) => {
-            const current = sliceMessagesFromLatestCompactionBoundary(currentRows);
-            return (
-              staged.generation === this.generation &&
-              !this.deps.streamManager.isStreaming(this.deps.workspaceId) &&
-              this.isValid(staged, current) &&
-              fingerprint(current) === snapshotFingerprint
-            );
-          },
-          messages: rows,
-          text: staged.text,
-          model: staged.model,
-          tail,
-          systemMessageTokens: context.systemMessageTokens ?? 0,
-          attachmentTokens: context.attachmentTokens ?? 0,
-          pendingFollowUp,
-        });
-        if (applied && staged.generation === this.generation) this.reset("applied");
-        return applied;
-      }
+    // Attachment estimation yields; revalidate the captured source before preparing rows.
+    rows = await this.readSnapshot();
+    if (!rows || !this.isValid(staged, rows)) return false;
+    assert(
+      !this.deps.streamManager.isStreaming(this.deps.workspaceId),
+      "Stream started during continuous apply"
     );
+    const partial = await this.deps.historyService.readPartial(this.deps.workspaceId);
+    assert(!partial, "Continuous apply requires the partial to be committed first");
+    if (staged.generation !== this.generation) return false;
+    if (!this.wouldFit(staged, rows, context)) return false;
+    const tail = this.materializeTail(staged, rows);
+    const snapshotFingerprint = fingerprint(rows);
+    const applied = await this.deps.compactionHandler.persistContinuousCompaction({
+      publication: { generation: staged.publicationGeneration },
+      preparation,
+      attachmentMessages: head,
+      shouldPersist: (currentRows) => {
+        const current = sliceMessagesFromLatestCompactionBoundary(currentRows);
+        return (
+          staged.generation === this.generation &&
+          !this.deps.streamManager.isStreaming(this.deps.workspaceId) &&
+          this.isValid(staged, current) &&
+          fingerprint(current) === snapshotFingerprint
+        );
+      },
+      messages: rows,
+      text: staged.text,
+      model: staged.model,
+      tail,
+      systemMessageTokens: context.systemMessageTokens ?? 0,
+      attachmentTokens: context.attachmentTokens ?? 0,
+      pendingFollowUp,
+    });
+    if (applied && staged.generation === this.generation) this.reset("applied");
+    return applied;
   }
 }

--- a/src/node/services/historyService.compactionPending.test.ts
+++ b/src/node/services/historyService.compactionPending.test.ts
@@ -114,6 +114,64 @@ describe("inactive compaction history transactions", () => {
     });
   });
 
+  it.each(["unchanged", "archive edit", "raw reset"] as const)(
+    "qualifies publication against the archive-backed provider source (%s)",
+    async (change) => {
+      const { pending, summary, publication } = await preparedHeartbeat();
+      assert(
+        (
+          await pending.rollbackHeartbeat({
+            summaryMessage: summary,
+            isCurrent: () => true,
+            canRestorePrevious: () => true,
+            onCommitted: () => undefined,
+            onRestored: () => undefined,
+          })
+        ).success
+      );
+      assert(
+        (await foreign.appendToHistory(workspaceId, createMuxMessage("tail", "user", "New task")))
+          .success
+      );
+      const source = await service.getHistoryFromLatestBoundary(workspaceId);
+      assert(source.success);
+      expect(source.data.map((row) => row.id)).toEqual(["seed", "tail"]);
+      expect(await fs.readFile(chatPath, "utf8")).not.toContain('"seed"');
+      if (change === "archive edit") {
+        const edited = structuredClone(source.data[0]);
+        edited.parts = [{ type: "text", text: "Changed archived context" }];
+        await fs.writeFile(archivePath, line(edited));
+      } else if (change === "raw reset") {
+        await fs.appendFile(chatPath, '{"metadata":{"contextBoundaryKind":"reset"},broken\n');
+      }
+      const before = await Promise.all([
+        fs.readFile(chatPath, "utf8"),
+        fs.readFile(archivePath, "utf8"),
+      ]);
+      const result = await pending.publishBoundary({
+        summaryMessage: boundary("next"),
+        tailCopies: [],
+        updateExisting: false,
+        publication,
+        attachments: { diffs: [], loadedSkills: [], readFiles: [] },
+        isCurrent: () => true,
+        shouldPersist: (messages, partial) =>
+          partial === null && JSON.stringify(messages) === JSON.stringify(source.data),
+        onCommitted: () => undefined,
+      });
+      expect(result.success).toBe(change === "unchanged");
+      if (change === "unchanged") {
+        const current = await service.getHistoryFromLatestBoundary(workspaceId);
+        assert(current.success);
+        expect(current.data.map((row) => row.id)).toEqual(["next"]);
+      } else {
+        expect(
+          await Promise.all([fs.readFile(chatPath, "utf8"), fs.readFile(archivePath, "utf8")])
+        ).toEqual(before);
+      }
+    }
+  );
+
   it("holds both locks through the callback and releases them after rejection", async () => {
     const entered = Promise.withResolvers<void>();
     const release = Promise.withResolvers<void>();
@@ -381,6 +439,148 @@ describe("inactive compaction history transactions", () => {
     failure.mockRestore();
     expect(await currentBoundary()).toEqual({ kind: "identified", messageId: "recoverable" });
   });
+
+  it.each([undefined, "{", "null", "{}", "[]"])(
+    "malformed-only retirement distinguishes missing and invalid content (%s)",
+    async (raw) => {
+      if (raw !== undefined) await fs.writeFile(partialPath, raw);
+      expect(await service.deletePartialIfMatches(workspaceId, null, () => true)).toEqual({
+        success: true,
+        data: raw !== undefined,
+      });
+      expect(await fs.stat(partialPath).catch((error: unknown) => error)).toMatchObject({
+        code: "ENOENT",
+      });
+    }
+  );
+
+  it("malformed-only retirement preserves a valid successor after an unreadable observation", async () => {
+    await fs.writeFile(partialPath, "{");
+    expect(await service.readPartial(workspaceId)).toBeNull();
+    assert(
+      (await foreign.writePartial(workspaceId, createMuxMessage("next", "assistant", "Valid")))
+        .success
+    );
+    const before = await fs.readFile(partialPath, "utf8");
+    expect(await service.deletePartialIfMatches(workspaceId, null, () => true)).toEqual({
+      success: true,
+      data: false,
+    });
+    expect(await fs.readFile(partialPath, "utf8")).toBe(before);
+  });
+
+  it.each(
+    (["logical", "physical", "queued successor"] as const).flatMap((scenario) =>
+      [false, true].map((directory) => ({ scenario, directory }))
+    )
+  )(
+    "malformed retirement preserves a successor after $scenario ownership changes (directory=$directory)",
+    async ({ scenario, directory }) => {
+      if (directory) await fs.mkdir(partialPath);
+      else await fs.writeFile(partialPath, "{");
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const readFile = fs.readFile;
+      const held = spyOn(fs, "readFile").mockImplementation((async (
+        ...args: Parameters<typeof fs.readFile>
+      ) => {
+        try {
+          return await readFile(...args);
+        } finally {
+          if (args[0] === partialPath) {
+            entered.resolve();
+            await release.promise;
+          }
+        }
+      }) as typeof fs.readFile);
+      let current = true;
+      const retiring = service.deletePartialIfMatches(workspaceId, null, () => current);
+      let lease: Awaited<ReturnType<typeof reclaimHistoryLock>> | undefined;
+      let queued: ReturnType<HistoryService["writePartial"]> | undefined;
+      const successor = createMuxMessage("next", "assistant", "Valid successor");
+      try {
+        await entered.promise;
+        held.mockRestore();
+        if (scenario === "logical") current = false;
+        if (scenario === "physical") {
+          lease = await reclaimHistoryLock();
+          // Another process owns the reclaimed lease and writes its new stream partial.
+          if (directory) await fs.rmdir(partialPath);
+          await fs.writeFile(partialPath, JSON.stringify(successor));
+        }
+        if (scenario === "queued successor") queued = foreign.writePartial(workspaceId, successor);
+        release.resolve();
+        const result = await retiring;
+        if (scenario === "physical") expect(result.success).toBe(false);
+        else expect(result).toEqual({ success: true, data: scenario === "queued successor" });
+        if (queued) expect((await queued).success).toBe(true);
+        if (scenario === "logical") {
+          if (directory) expect((await fs.stat(partialPath)).isDirectory()).toBe(true);
+          else expect(await fs.readFile(partialPath, "utf8")).toBe("{");
+        } else expect((await capturedPartial()).id).toBe(successor.id);
+      } finally {
+        release.resolve();
+        await retiring;
+        await lease?.[Symbol.asyncDispose]();
+        await queued;
+      }
+    }
+  );
+
+  it.each(["read", "unlink", "rmdir"] as const)(
+    "malformed retirement reports %s permission failure and preserves bytes for retry",
+    async (operation) => {
+      if (operation === "rmdir") await fs.mkdir(partialPath);
+      else await fs.writeFile(partialPath, "{");
+      const error = Object.assign(new Error("Permission denied"), { code: "EACCES" });
+      const readFile = fs.readFile;
+      const failure =
+        operation === "read"
+          ? spyOn(fs, "readFile").mockImplementation((async (
+              ...args: Parameters<typeof fs.readFile>
+            ) => {
+              if (args[0] === partialPath) throw error;
+              return readFile(...args);
+            }) as typeof fs.readFile)
+          : spyOn(
+              syncFs,
+              operation === "rmdir" ? "rmdirSync" : "unlinkSync"
+            ).mockImplementationOnce(() => {
+              throw error;
+            });
+      const result = await service.deletePartialIfMatches(workspaceId, null, () => true);
+      assert(!result.success);
+      expect(result.error).toContain("Permission denied");
+      failure.mockRestore();
+      if (operation === "rmdir") expect((await fs.stat(partialPath)).isDirectory()).toBe(true);
+      else expect(await fs.readFile(partialPath, "utf8")).toBe("{");
+      expect(await service.deletePartialIfMatches(workspaceId, null, () => true)).toEqual({
+        success: true,
+        data: true,
+      });
+    }
+  );
+
+  it.each(["nonempty", "symlink", "captured message"] as const)(
+    "directory retirement preserves %s ownership",
+    async (scenario) => {
+      const directoryPath = scenario === "symlink" ? `${partialPath}.target` : partialPath;
+      await fs.mkdir(directoryPath);
+      if (scenario === "nonempty") await fs.writeFile(path.join(directoryPath, "keep"), "Owned");
+      if (scenario === "symlink") await fs.symlink(directoryPath, partialPath);
+      const result = await service.deletePartialIfMatches(
+        workspaceId,
+        scenario === "captured message" ? createMuxMessage("old", "assistant", "Captured") : null,
+        () => true
+      );
+      if (scenario === "captured message") expect(result).toEqual({ success: true, data: false });
+      else expect(result.success).toBe(false);
+      expect((await fs.stat(directoryPath)).isDirectory()).toBe(true);
+      if (scenario === "nonempty")
+        expect(await fs.readFile(path.join(directoryPath, "keep"), "utf8")).toBe("Owned");
+      if (scenario === "symlink") expect(await fs.readlink(partialPath)).toBe(directoryPath);
+    }
+  );
 
   it.each(["successor", "same-id flush", "captured mutation", "owner retired", "missing"])(
     "partial retirement preserves mismatched ownership (%s)",

--- a/src/node/services/historyService.contextReset.test.ts
+++ b/src/node/services/historyService.contextReset.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as atomicWrite from "write-file-atomic";
+import { createMuxMessage } from "@/common/types/message";
+import { CONTINUOUS_COMPACTION_GENERATION_FILE } from "@/constants/continuousCompaction";
+import * as fileLock from "@/node/utils/concurrency/fileLock";
+import { CompactionPendingState } from "./compactionPendingState";
+import { HistoryService } from "./historyService";
+import { createTestHistoryService } from "./testHistoryService";
+import { historyWriteLockPath } from "./workspaceRemoval";
+
+describe("empty context reset transactions", () => {
+  const workspaceId = "empty-reset-transaction";
+  let h: Awaited<ReturnType<typeof createTestHistoryService>>;
+  beforeEach(async () => {
+    h = await createTestHistoryService();
+  });
+  afterEach(async () => {
+    mock.restore();
+    await h.cleanup();
+  });
+
+  it.each(["generation", "journal", "source"] as const)(
+    "holds the initial empty view through its fence before a foreign %s publication",
+    async (change) => {
+      const journal = h.historyService.getContinuousCompactionJournal(workspaceId);
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const attempted = Promise.withResolvers<void>();
+      const order: string[] = [];
+      const advance = journal.advanceGenerationUnderHistoryLock.bind(journal);
+      spyOn(journal, "advanceGenerationUnderHistoryLock").mockImplementationOnce(
+        async (...args) => {
+          entered.resolve();
+          await release.promise;
+          await advance(...args);
+          order.push("fenced");
+        }
+      );
+      const fencing = h.historyService.fenceEmptyContext(workspaceId);
+      let changing: Promise<void> | undefined;
+      try {
+        await entered.promise;
+        const acquire = fileLock.acquireProcessFileLock;
+        spyOn(fileLock, "acquireProcessFileLock").mockImplementationOnce((options) => {
+          attempted.resolve();
+          return acquire(options);
+        });
+        const target =
+          change === "generation"
+            ? path.join(path.dirname(journal.path), CONTINUOUS_COMPACTION_GENERATION_FILE)
+            : change === "journal"
+              ? journal.path
+              : path.join(path.dirname(journal.path), "chat.jsonl");
+        const bytes =
+          change === "source"
+            ? JSON.stringify(createMuxMessage("B", "user", "New context", { historySequence: 0 })) +
+              "\n"
+            : "foreign publication";
+        changing = (async () => {
+          await using _lease = await fileLock.acquireProcessFileLock({
+            lockPath: historyWriteLockPath(h.config.rootDir, workspaceId),
+            timeoutMs: 1000,
+            label: "foreign publication",
+          });
+          await fs.writeFile(target, bytes);
+          order.push("foreign");
+        })();
+        await attempted.promise;
+        expect(order).toEqual([]);
+        release.resolve();
+        expect((await fencing).success).toBe(true);
+        await changing;
+        expect(order).toEqual(["fenced", "foreign"]);
+        expect(await fs.readFile(target, "utf8")).toBe(bytes);
+      } finally {
+        release.resolve();
+        await Promise.all([fencing, changing]);
+      }
+    }
+  );
+
+  it.each(["{", '{"version":9,"opaque":"future journal"}\n'])(
+    "fences unchanged unreadable journal context while preserving its bytes (%s)",
+    async (bytes) => {
+      const journal = h.historyService.getContinuousCompactionJournal(workspaceId);
+      await fs.mkdir(path.dirname(journal.path), { recursive: true });
+      await fs.writeFile(journal.path, bytes);
+      const generation = await journal.captureGeneration();
+      expect((await h.historyService.fenceEmptyContext(workspaceId)).success).toBe(true);
+      expect(await journal.captureGeneration()).not.toBe(generation);
+      expect(await fs.readFile(journal.path, "utf8")).toBe(bytes);
+    }
+  );
+
+  it.each(["noop", "clear"] as const)(
+    "lost lease during %s generation staging preserves the foreign successor",
+    async (operation) => {
+      const sessionDir = path.join(h.config.sessionsDir, workspaceId);
+      const generationPath = path.join(sessionDir, CONTINUOUS_COMPACTION_GENERATION_FILE);
+      const chatPath = path.join(sessionDir, "chat.jsonl");
+      const pendingPath = path.join(sessionDir, "post-compaction.json");
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const write = atomicWrite.default;
+      spyOn(atomicWrite, "default").mockImplementation(
+        new Proxy(write, {
+          async apply(target, _thisArg, args: Parameters<typeof write>) {
+            await target(...args);
+            if (String(args[0]).startsWith(`${generationPath}.continuous-`)) {
+              entered.resolve();
+              await release.promise;
+            }
+          },
+        })
+      );
+      const fencing =
+        operation === "noop"
+          ? h.historyService.fenceEmptyContext(workspaceId)
+          : h.historyService.clearHistory(workspaceId, { fenceEmptyHistory: true });
+      let successor: Awaited<ReturnType<typeof fileLock.acquireProcessFileLock>> | undefined;
+      try {
+        await entered.promise;
+        const lockPath = historyWriteLockPath(h.config.rootDir, workspaceId);
+        const token = await fs.readFile(lockPath, "utf8");
+        await fs.writeFile(lockPath, token.split(":").slice(0, 2).join(":"));
+        await fs.utimes(lockPath, new Date(0), new Date(0));
+        successor = await fileLock.acquireProcessFileLock({
+          lockPath,
+          timeoutMs: 1000,
+          label: "foreign reset",
+        });
+        // Simulate another process writing while it owns the reclaimed physical lease.
+        await fs.writeFile(generationPath, "foreign generation");
+        const generation = await h.historyService
+          .getContinuousCompactionJournal(workspaceId)
+          .captureGenerationUnderHistoryLock();
+        const chat =
+          JSON.stringify(
+            createMuxMessage("B", "assistant", "New context", {
+              historySequence: 0,
+              compacted: "user",
+              compactionBoundary: true,
+              compactionEpoch: 1,
+            })
+          ) + "\n";
+        const pending = JSON.stringify({
+          version: 1,
+          createdAt: 1,
+          boundaryMessageId: "B",
+          writeId: "foreign-owner",
+          publicationGeneration: generation,
+          diffs: [],
+          loadedSkills: [],
+          readFiles: ["/tmp/B.ts"],
+        });
+        await fs.writeFile(chatPath, chat);
+        await fs.writeFile(pendingPath, pending);
+        release.resolve();
+        expect((await fencing).success).toBe(false);
+        expect(await fs.readFile(generationPath, "utf8")).toBe("foreign generation");
+        expect(await fs.readFile(chatPath, "utf8")).toBe(chat);
+        expect(await fs.readFile(pendingPath, "utf8")).toBe(pending);
+        await successor[Symbol.asyncDispose]();
+        successor = undefined;
+        const restarted = new CompactionPendingState(
+          pendingPath,
+          new HistoryService(h.config).getCompactionPendingHistory(workspaceId)
+        );
+        expect((await restarted.load(() => true))?.attachments.readFiles).toEqual(["/tmp/B.ts"]);
+      } finally {
+        release.resolve();
+        await fencing;
+        await successor?.[Symbol.asyncDispose]();
+      }
+    }
+  );
+});

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -25,7 +25,7 @@ import { isManualHistoryReset } from "@/common/utils/messages/contextWindows";
 import { createContextBudgetRejectedMessage } from "@/common/utils/messages/contextBudgetRejection";
 import * as path from "path";
 import { createHash, randomUUID } from "node:crypto";
-import { renameSync, unlinkSync } from "node:fs";
+import { renameSync, rmdirSync, unlinkSync } from "node:fs";
 import { isDeepStrictEqual } from "node:util";
 import * as fs from "fs/promises";
 import type {
@@ -572,12 +572,16 @@ export class HistoryService {
             throw new Error("Compaction partial is unreadable");
           partial = normalizeLegacyMuxMetadata(parsed);
         }
+        // Preparation uses provider history, including archive rows exposed by a
+        // heartbeat rollback. Compare that same privacy-filtered view under the locks;
+        // active chat rows alone would reject an unchanged archive-backed source.
+        const providerMessages = await readProviderHistoryFromLatestBoundary(paths, 0);
         return this.persistBoundaryWithTailCopiesUnderWriteLock(
           workspaceId,
           input.summaryMessage,
           input.tailCopies,
           input.updateExisting,
-          (messages) => input.shouldPersist(messages, partial),
+          () => input.shouldPersist(providerMessages, partial),
           { publication: input.publication, onCommitted },
           assertStillOwned
         );
@@ -2581,10 +2585,10 @@ export class HistoryService {
     }
   }
 
-  /** Inactive compaction seam: retire only the captured partial, including its last flush. */
+  /** Retire the captured flush, or only malformed bytes when no readable partial was captured. */
   deletePartialIfMatches(
     workspaceId: string,
-    captured: MuxMessage,
+    captured: MuxMessage | null,
     isCurrent: () => boolean
   ): Promise<Result<boolean>> {
     // Capture before queueing: callers may keep updating their streamed message object.
@@ -2595,19 +2599,35 @@ export class HistoryService {
       async (assertStillOwned) => {
         if (!isCurrent()) return Ok(false);
         const partialPath = this.getPartialPath(workspaceId);
+        let directory = false;
         let raw: string;
         try {
           raw = await fs.readFile(partialPath, "utf8");
         } catch (error) {
           if (isErrnoWithCode(error, "ENOENT")) return Ok(false);
-          throw error;
+          if (!isErrnoWithCode(error, "EISDIR")) throw error;
+          directory = true;
+          raw = "";
         }
-        const current = normalizeLegacyMuxMetadata(JSON.parse(raw) as MuxMessage);
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(raw);
+        } catch (error) {
+          if (!(error instanceof SyntaxError)) throw error;
+        }
+        // A failed public read is not absence evidence. Re-read under both locks, and only
+        // heal malformed content; a now-valid successor or an I/O error must remain intact.
+        const current = isReadableHistoryMessage(parsed)
+          ? normalizeLegacyMuxMetadata(parsed)
+          : null;
         await assertStillOwned();
         if (!isDeepStrictEqual(current, expected) || !isCurrent()) return Ok(false);
-        // Keep the final ownership check and unlink indivisible to local cancellation.
+        // Keep the final ownership check and removal indivisible to local cancellation.
         // Both history locks exclude successor flushes from another service/process.
-        unlinkSync(partialPath);
+        // A directory at the partial path cannot contain a stream message. Remove only an
+        // empty directory: rmdir refuses children, symlinks and any replacement regular file.
+        if (directory) rmdirSync(partialPath);
+        else unlinkSync(partialPath);
         return Ok(true);
       }
     );
@@ -4285,12 +4305,14 @@ export class HistoryService {
       refuseFullDelete?: boolean;
       refuseRowRemoval?: boolean;
       requireFullDelete?: boolean;
+      /** Explicit context destruction must also fence carryover when no transcript rows exist. */
+      fenceEmptyHistory?: boolean;
     }
   ): Promise<Result<number[], string>> {
     return this.withRecoveredHistoryWriteResultLock(
       workspaceId,
       "Failed to truncate history",
-      async () => {
+      async (assertStillOwned) => {
         invalidateHistoryAppendProvenance();
         try {
           const { rows: archiveRows, messages: archivedMessages } =
@@ -4305,11 +4327,12 @@ export class HistoryService {
 
           if (percentage >= 1.0) {
             // Explicit full-clear intent includes display-only or malformed history.
-            // An already-empty history remains a no-op for publication ownership.
-            if (archiveRows.length > 0 || chatRows.length > 0) {
+            // Plain storage cleanup may be a no-op; explicit context destruction also fences
+            // attachments from legacy sessions whose transcript is already empty.
+            if (options?.fenceEmptyHistory || archiveRows.length > 0 || chatRows.length > 0) {
               await this.getContinuousCompactionJournal(
                 workspaceId
-              ).advanceGenerationUnderHistoryLock();
+              ).advanceGenerationUnderHistoryLock(undefined, assertStillOwned);
             }
             await this.rewriteHistoryFilesUnlocked(workspaceId, null, null);
             this.sequenceCounters.set(workspaceId, 0);
@@ -4470,8 +4493,37 @@ export class HistoryService {
     );
   }
 
-  async clearHistory(workspaceId: string): Promise<Result<number[], string>> {
-    const result = await this.truncateHistory(workspaceId, 1.0);
+  /** Read reset context and fence an empty provider view before either history lock is released. */
+  async fenceEmptyContext(workspaceId: string): Promise<Result<MuxMessage[]>> {
+    return this.withRecoveredHistoryWriteResultLock(
+      workspaceId,
+      "Failed to read or fence reset context",
+      async (assertStillOwned) => {
+        const messages = await readProviderHistoryFromLatestBoundary(
+          {
+            chat: this.getChatHistoryPath(workspaceId),
+            archive: this.getChatArchivePath(workspaceId),
+          },
+          0
+        );
+        await assertStillOwned();
+        // The no-op decision and generation publication share this lease: a foreign reset,
+        // Stop, or journal publication cannot enter between them. Later cleanup never fences.
+        if (!hasProviderEligibleMessages(messages))
+          await this.getContinuousCompactionJournal(workspaceId).advanceGenerationUnderHistoryLock(
+            undefined,
+            assertStillOwned
+          );
+        return Ok(messages);
+      }
+    );
+  }
+
+  async clearHistory(
+    workspaceId: string,
+    options?: { fenceEmptyHistory?: boolean }
+  ): Promise<Result<number[], string>> {
+    const result = await this.truncateHistory(workspaceId, 1.0, options);
     if (!result.success) {
       return Err(result.error);
     }

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -1,4 +1,6 @@
 import type { TurnCompletion } from "./streamManager";
+import { CompactionPendingState } from "./compactionPendingState";
+import * as historyScanner from "./historyScanner";
 import type { TurnCoordinator } from "./turnCoordinator";
 import { MutexMap } from "@/node/utils/concurrency/mutexMap";
 import { describe, expect, test, mock, beforeEach, afterEach, spyOn, type Mock } from "bun:test";
@@ -27,7 +29,7 @@ import { SCRATCH_PROJECT_CONFIG_KEY } from "@/common/constants/scratch";
 import type { SendMessageError } from "@/common/types/errors";
 import type { ProjectsConfig } from "@/common/types/project";
 import type { Config, SecretsStore } from "@/node/config";
-import type { HistoryService } from "./historyService";
+import { HistoryService } from "./historyService";
 import { createTestHistoryService } from "./testHistoryService";
 import { projectWorkspace, saveWorkspaces } from "./taskService.testHarness";
 import type { SessionTimingService } from "./sessionTimingService";
@@ -7818,16 +7820,28 @@ describe("WorkspaceService truncateHistory goal acknowledgment", () => {
       const sessionDir = path.join(config.sessionsDir, workspaceId);
       await fsPromises.mkdir(sessionDir, { recursive: true });
       const pendingStatePath = path.join(sessionDir, "post-compaction.json");
-      await fsPromises.writeFile(
+      const pending = new CompactionPendingState(
         pendingStatePath,
-        JSON.stringify({
-          version: 1,
-          createdAt: Date.now(),
-          diffs: [],
-          loadedSkills: [],
-          readFiles: ["/tmp/pre-reset-read.ts"],
-        })
+        historyService.getCompactionPendingHistory(workspaceId)
       );
+      expect(
+        (
+          await pending.publishBoundary({
+            summaryMessage: createMuxMessage("summary", "assistant", "Summary", {
+              compacted: "user",
+              compactionBoundary: true,
+              compactionEpoch: 1,
+            }),
+            tailCopies: [],
+            updateExisting: false,
+            publication: { generation: undefined },
+            attachments: { diffs: [], loadedSkills: [], readFiles: ["/tmp/pre-reset-read.ts"] },
+            isCurrent: () => true,
+            shouldPersist: () => true,
+            onCommitted: () => undefined,
+          })
+        ).success
+      ).toBe(true);
 
       expect(await workspaceService.resetContext(workspaceId)).toEqual({
         success: true,
@@ -7844,11 +7858,7 @@ describe("WorkspaceService truncateHistory goal acknowledgment", () => {
     }
   });
 
-  test("context reset fails when the post-compaction carryover discard is not durable", async () => {
-    // Best-effort deletion of post-compaction.json swallowed unlink failures
-    // while resetContext still reported success — after a restart the stale
-    // file re-injects PRE-reset read paths/skills/diffs. The discard must be
-    // durable-or-fail, matching the sandbox invalidation posture.
+  test("context reset repairs an empty directory at the pending-state path", async () => {
     const { config, historyService, workspaceService, cleanup } = await createServices();
     const workspaceId = "context-reset-carryover-not-durable";
     try {
@@ -7863,19 +7873,362 @@ describe("WorkspaceService truncateHistory goal acknowledgment", () => {
         workspaceId,
         createMuxMessage("pre-reset-user", "user", "before reset", {})
       );
-      // Deterministic unlink failure: a DIRECTORY at the pending-state path
-      // fails unlink with EISDIR (read errors are swallowed at load, so this
-      // models exactly the stale-undeletable-file case).
+      // Invalid optional state should heal without blocking a durable history reset.
       const pendingStatePath = path.join(config.sessionsDir, workspaceId, "post-compaction.json");
       await fsPromises.mkdir(pendingStatePath, { recursive: true });
 
       const result = await workspaceService.resetContext(workspaceId);
-      expect(result.success).toBe(false);
-      expect(result.success ? "" : result.error).toContain("post-compaction carryover");
+      expect(result.success).toBe(true);
+      expect(
+        await fsPromises.stat(pendingStatePath).catch((error: unknown) => error)
+      ).toMatchObject({ code: "ENOENT" });
     } finally {
       await cleanup();
     }
   });
+
+  test.each(
+    (["reset", "clear", "replace"] as const).flatMap((operation) =>
+      (["legacy", "future", "current"] as const).map((format) => ({ operation, format }))
+    )
+  )(
+    "empty-history $operation durably fences initial $format carryover",
+    async ({ operation, format }) => {
+      const { config, historyService, workspaceService, cleanup } = await createServices();
+      const workspaceId = "empty-history-carryover";
+      try {
+        await config.addWorkspace("/tmp/empty-history-carryover", {
+          id: workspaceId,
+          name: workspaceId,
+          projectName: "empty-history-carryover",
+          projectPath: "/tmp/empty-history-carryover",
+          runtimeConfig: { type: "local" },
+        });
+        const pendingPath = path.join(config.sessionsDir, workspaceId, "post-compaction.json");
+        let original = JSON.stringify({
+          version: format === "future" ? 9 : 1,
+          createdAt: 1,
+          diffs: [],
+          loadedSkills: [],
+          readFiles: ["/tmp/discarded.ts"],
+        });
+        await fsPromises.mkdir(path.dirname(pendingPath), { recursive: true });
+        await fsPromises.writeFile(pendingPath, original);
+        const pending = new CompactionPendingState(
+          pendingPath,
+          historyService.getCompactionPendingHistory(workspaceId)
+        );
+        const journal = historyService.getContinuousCompactionJournal(workspaceId);
+        if (format === "current") {
+          await journal.advanceGeneration();
+          expect(
+            (
+              await pending.publishBoundary({
+                summaryMessage: createMuxMessage("A", "assistant", "", {
+                  compacted: "user",
+                  compactionBoundary: true,
+                  compactionEpoch: 1,
+                }),
+                tailCopies: [],
+                updateExisting: false,
+                publication: { generation: await journal.captureGeneration() },
+                attachments: { diffs: [], loadedSkills: [], readFiles: ["/tmp/discarded.ts"] },
+                isCurrent: () => true,
+                shouldPersist: () => true,
+                onCommitted: () => undefined,
+              })
+            ).success
+          ).toBe(true);
+          original = await fsPromises.readFile(pendingPath, "utf8");
+        }
+        expect((await pending.load(() => true))?.attachments.readFiles).toEqual(
+          format === "future" ? undefined : ["/tmp/discarded.ts"]
+        );
+        if (format !== "current") expect(await journal.captureGeneration()).toBeUndefined();
+        const result =
+          operation === "reset"
+            ? await workspaceService.resetContext(workspaceId)
+            : operation === "clear"
+              ? await workspaceService.truncateHistory(workspaceId, 1)
+              : await workspaceService.replaceHistory(
+                  workspaceId,
+                  createMuxMessage("replacement", "user", "New context")
+                );
+        expect(result.success).toBe(true);
+        if (operation === "reset") expect(result).toEqual({ success: true, data: "noop" });
+        expect(await journal.captureGeneration()).toBeDefined();
+        if (format === "future")
+          expect(await fsPromises.readFile(pendingPath, "utf8")).toBe(original);
+        else
+          expect(await fsPromises.stat(pendingPath).catch((error: unknown) => error)).toMatchObject(
+            {
+              code: "ENOENT",
+            }
+          );
+        expect(await pending.load(() => true)).toBeUndefined();
+        await workspaceService.disposeSession(workspaceId);
+        const restarted = new CompactionPendingState(
+          pendingPath,
+          new HistoryService(config).getCompactionPendingHistory(workspaceId)
+        );
+        expect(await restarted.load(() => true)).toBeUndefined();
+      } finally {
+        await cleanup();
+      }
+    }
+  );
+
+  test("late no-op reset cleanup preserves a foreign successor after its committed fence", async () => {
+    const { config, historyService, workspaceService, cleanup } = await createServices();
+    const workspaceId = "empty-reset-successor";
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    let resetting: ReturnType<WorkspaceService["resetContext"]> | undefined;
+    try {
+      await config.addWorkspace("/tmp/empty-reset-successor", {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "empty-reset-successor",
+        projectPath: "/tmp/empty-reset-successor",
+        runtimeConfig: { type: "local" },
+      });
+      const capture = historyService.fenceEmptyContext.bind(historyService);
+      spyOn(historyService, "fenceEmptyContext").mockImplementationOnce(async (...args) => {
+        const captured = await capture(...args);
+        entered.resolve();
+        await release.promise;
+        return captured;
+      });
+      resetting = workspaceService.resetContext(workspaceId);
+      await entered.promise;
+      const foreign = new HistoryService(config);
+      const foreignJournal = foreign.getContinuousCompactionJournal(workspaceId);
+      await foreignJournal.advanceGeneration();
+      const generation = await foreignJournal.captureGeneration();
+      const pendingPath = path.join(config.sessionsDir, workspaceId, "post-compaction.json");
+      const pending = new CompactionPendingState(
+        pendingPath,
+        foreign.getCompactionPendingHistory(workspaceId)
+      );
+      expect(
+        (
+          await pending.publishBoundary({
+            summaryMessage: createMuxMessage("B", "assistant", "New context", {
+              compacted: "user",
+              compactionBoundary: true,
+              compactionEpoch: 1,
+            }),
+            tailCopies: [],
+            updateExisting: false,
+            publication: { generation },
+            attachments: { diffs: [], loadedSkills: [], readFiles: ["/tmp/successor.ts"] },
+            isCurrent: () => true,
+            shouldPersist: () => true,
+            onCommitted: () => undefined,
+          })
+        ).success
+      ).toBe(true);
+      release.resolve();
+      expect(await resetting).toEqual({ success: true, data: "noop" });
+      expect(await foreignJournal.captureGeneration()).toBe(generation);
+      expect((await pending.load(() => true))?.attachments.readFiles).toEqual([
+        "/tmp/successor.ts",
+      ]);
+    } finally {
+      release.resolve();
+      await resetting;
+      await cleanup();
+    }
+  });
+
+  test.each(["absent", "probe error"] as const)(
+    "post-compaction metadata avoids only proven absent pending scans (%s)",
+    async (state) => {
+      const { config, historyService, workspaceService, cleanup } = await createServices();
+      const workspaceId = "pending-metadata-scan";
+      try {
+        await config.addWorkspace("/tmp/pending-metadata-project", {
+          id: workspaceId,
+          name: workspaceId,
+          projectName: "pending-metadata-project",
+          projectPath: "/tmp/pending-metadata-project",
+          runtimeConfig: { type: "local" },
+        });
+        const edited = createMuxMessage("edited", "assistant", "");
+        edited.parts = [
+          {
+            type: "dynamic-tool",
+            toolCallId: "edit",
+            toolName: "file_edit_replace_string",
+            state: "output-available",
+            input: { path: "/tmp/from-history.ts" },
+            output: { success: true, diff: "changed" },
+          },
+        ];
+        expect((await historyService.appendToHistory(workspaceId, edited)).success).toBe(true);
+        const pendingPath = path.join(config.sessionsDir, workspaceId, "post-compaction.json");
+        const stat = fsPromises.stat;
+        const probe = spyOn(fsPromises, "stat").mockImplementation((async (
+          ...args: Parameters<typeof fsPromises.stat>
+        ) => {
+          if (state === "probe error" && args[0] === pendingPath)
+            throw Object.assign(new Error("Probe denied"), { code: "EACCES" });
+          return stat(...args);
+        }) as typeof fsPromises.stat);
+        const proof = spyOn(historyScanner, "readCompactionPendingHistoryObservation");
+        const fallback = spyOn(historyService, "getHistoryFromLatestBoundary");
+        using _spies = {
+          [Symbol.dispose]: () => {
+            probe.mockRestore();
+            proof.mockRestore();
+            fallback.mockRestore();
+          },
+        };
+        for (let attempt = 0; attempt < 2; attempt++) {
+          expect(
+            (await workspaceService.getPostCompactionState(workspaceId)).trackedFilePaths
+          ).toEqual(["/tmp/from-history.ts"]);
+        }
+        expect(proof).toHaveBeenCalledTimes(state === "absent" ? 0 : 2);
+        expect(fallback).toHaveBeenCalledTimes(2);
+        probe.mockRestore();
+
+        // A fresh store models another backend publishing after the earlier absence checks.
+        const foreign = new HistoryService(config);
+        const pending = new CompactionPendingState(
+          pendingPath,
+          foreign.getCompactionPendingHistory(workspaceId)
+        );
+        expect(
+          (
+            await pending.publishBoundary({
+              summaryMessage: createMuxMessage("published", "assistant", "Summary", {
+                compacted: "user",
+                compactionBoundary: true,
+                compactionEpoch: 1,
+              }),
+              tailCopies: [],
+              updateExisting: false,
+              publication: {
+                generation: await foreign
+                  .getContinuousCompactionJournal(workspaceId)
+                  .captureGeneration(),
+              },
+              attachments: {
+                diffs: [{ path: "/tmp/published.ts", diff: "changed", truncated: false }],
+                loadedSkills: [],
+                readFiles: [],
+              },
+              isCurrent: () => true,
+              shouldPersist: () => true,
+              onCommitted: () => undefined,
+            })
+          ).success
+        ).toBe(true);
+        proof.mockClear();
+        fallback.mockClear();
+        expect(
+          (await workspaceService.getPostCompactionState(workspaceId)).trackedFilePaths
+        ).toEqual(["/tmp/published.ts"]);
+        expect(proof).toHaveBeenCalledTimes(1);
+        expect(fallback).not.toHaveBeenCalled();
+      } finally {
+        await cleanup();
+      }
+    }
+  );
+
+  test.each([
+    "current",
+    "foreign boundary",
+    "reset",
+    "future",
+    "directory",
+    "nonempty directory",
+  ] as const)(
+    "post-compaction metadata qualifies pending paths against history (%s)",
+    async (change) => {
+      const { config, historyService, workspaceService, cleanup } = await createServices();
+      const workspaceId = "pending-path-qualification";
+      try {
+        await config.addWorkspace("/tmp/pending-path-project", {
+          id: workspaceId,
+          name: workspaceId,
+          projectName: "pending-path-project",
+          projectPath: "/tmp/pending-path-project",
+          runtimeConfig: { type: "local" },
+        });
+        const pendingPath = path.join(config.sessionsDir, workspaceId, "post-compaction.json");
+        const pending = new CompactionPendingState(
+          pendingPath,
+          historyService.getCompactionPendingHistory(workspaceId)
+        );
+        expect(
+          (
+            await pending.publishBoundary({
+              summaryMessage: createMuxMessage("A", "assistant", "A", {
+                compacted: "user",
+                compactionBoundary: true,
+                compactionEpoch: 1,
+              }),
+              tailCopies: [],
+              updateExisting: false,
+              publication: { generation: undefined },
+              attachments: {
+                diffs: [{ path: "/tmp/pending.ts", diff: "changed", truncated: false }],
+                loadedSkills: [],
+                readFiles: [],
+              },
+              isCurrent: () => true,
+              shouldPersist: () => true,
+              onCommitted: () => undefined,
+            })
+          ).success
+        ).toBe(true);
+        if (change === "foreign boundary")
+          expect(
+            (
+              await historyService.appendToHistory(
+                workspaceId,
+                createMuxMessage("B", "assistant", "B", {
+                  compacted: "user",
+                  compactionBoundary: true,
+                  compactionEpoch: 2,
+                })
+              )
+            ).success
+          ).toBe(true);
+        else if (change === "reset")
+          expect((await historyService.clearHistory(workspaceId)).success).toBe(true);
+        const future = '{"version":9,"diffs":[{"path":"/tmp/future.ts"}]}\n';
+        if (change === "future") await fsPromises.writeFile(pendingPath, future);
+        if (change === "directory" || change === "nonempty directory") {
+          await fsPromises.unlink(pendingPath);
+          await fsPromises.mkdir(pendingPath);
+          if (change === "nonempty directory")
+            await fsPromises.writeFile(path.join(pendingPath, "keep"), "Owned content");
+        }
+        const proof = spyOn(historyScanner, "readCompactionPendingHistoryObservation");
+        using _proof = { [Symbol.dispose]: () => proof.mockRestore() };
+        expect(
+          (await workspaceService.getPostCompactionState(workspaceId)).trackedFilePaths
+        ).toEqual(change === "current" ? ["/tmp/pending.ts"] : []);
+        expect(proof).toHaveBeenCalledTimes(1);
+        if (change === "future")
+          expect(await fsPromises.readFile(pendingPath, "utf8")).toBe(future);
+        if (change === "directory")
+          expect(await fsPromises.stat(pendingPath).catch((error: unknown) => error)).toMatchObject(
+            { code: "ENOENT" }
+          );
+        if (change === "nonempty directory")
+          expect(await fsPromises.readFile(path.join(pendingPath, "keep"), "utf8")).toBe(
+            "Owned content"
+          );
+      } finally {
+        await cleanup();
+      }
+    }
+  );
 
   test("context reset fails when the sandbox invalidation is not durable", async () => {
     // The reset's kernel-vars invalidation is only durable once the
@@ -8627,17 +8980,16 @@ describe("WorkspaceService truncateHistory goal acknowledgment", () => {
         projectPath: "/tmp/context-reset-history-read-fails-project",
         runtimeConfig: { type: "local" },
       });
-      const historySpy = spyOn(
-        historyService,
-        "getHistoryFromLatestBoundary"
-      ).mockResolvedValueOnce(Err("read failed"));
+      const historySpy = spyOn(historyService, "fenceEmptyContext").mockResolvedValueOnce(
+        Err("read failed")
+      );
 
       try {
         const result = await workspaceService.resetContext(workspaceId);
 
         expect(result).toEqual({
           success: false,
-          error: "Failed to read active context before reset: read failed",
+          error: "read failed",
         });
       } finally {
         historySpy.mockRestore();

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -1,4 +1,6 @@
 import type { RestartBlocker } from "@/common/orpc/types";
+import { CompactionPendingState } from "./compactionPendingState";
+import { POST_COMPACTION_STATE_FILENAME } from "@/constants/compaction";
 import { Effect, type Scope } from "effect";
 import { defaultEffectRunner, type EffectRunner } from "./di/effectRunner";
 import {
@@ -4447,34 +4449,26 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
   }
 
   private async getPersistedPostCompactionDiffPaths(workspaceId: string): Promise<string[] | null> {
-    const postCompactionPath = path.join(
+    const pendingPath = path.join(
       this.config.sessionsDir,
       workspaceId,
-      "post-compaction.json"
+      POST_COMPACTION_STATE_FILENAME
     );
-
-    try {
-      const raw = await fsPromises.readFile(postCompactionPath, "utf-8");
-      const parsed: unknown = JSON.parse(raw);
-      const diffsRaw = (parsed as { diffs?: unknown }).diffs;
-      if (!Array.isArray(diffsRaw)) {
-        return null;
-      }
-
-      const result: string[] = [];
-      for (const diff of diffsRaw) {
-        if (!diff || typeof diff !== "object") continue;
-        const p = (diff as { path?: unknown }).path;
-        if (typeof p !== "string") continue;
-        const trimmed = p.trim();
-        if (trimmed.length === 0) continue;
-        result.push(trimmed);
-      }
-
-      return result;
-    } catch {
+    // This reader owns no local receipts. Skip the redundant history proof only for
+    // confirmed absence; present or uncertain paths retain load qualification and cleanup.
+    if (
+      await fsPromises.stat(pendingPath).then(
+        () => false,
+        (error: unknown) => isErrnoWithCode(error, "ENOENT")
+      )
+    )
       return null;
-    }
+    const pending = new CompactionPendingState(
+      pendingPath,
+      this.historyService.getCompactionPendingHistory(workspaceId)
+    );
+    const receipt = await pending.load(() => true).catch(() => undefined);
+    return receipt?.attachments.diffs.map((diff) => diff.path) ?? null;
   }
 
   /**
@@ -4529,7 +4523,7 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
     // If session has pending compaction attachments, use cached paths
     // (history is cleared after compaction, but cache survives)
     const session = this.sessions.get(workspaceId);
-    const pendingPaths = session?.getPendingTrackedFilePaths();
+    const pendingPaths = await session?.getPendingTrackedFilePaths();
     if (pendingPaths) {
       // Filter out both new and legacy plan file paths
       const trackedFilePaths = pendingPaths.filter((p) => !isPlanPath(p));
@@ -12774,6 +12768,7 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
         refuseFullDelete: truncationScope === "partial",
         refuseRowRemoval: truncationScope === "none",
         requireFullDelete: truncationScope === "all",
+        fenceEmptyHistory: isFullClear,
       });
     const truncateResult =
       effectivePercentage > 0
@@ -12936,24 +12931,15 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
           );
         }
       }
-      const historyResult = await this.historyService.getHistoryFromLatestBoundary(workspaceId);
-      if (!historyResult.success) {
-        return Err(`Failed to read active context before reset: ${historyResult.error}`);
-      }
+      const captured = await this.historyService.fenceEmptyContext(workspaceId);
+      if (!captured.success) return captured;
 
       const activeContextMessages = sliceMessagesForProviderFromLatestContextBoundary(
-        historyResult.data
+        captured.data
       );
       if (!hasProviderEligibleMessages(activeContextMessages)) {
-        // An earlier reset may have failed AFTER writing its boundary but
-        // BEFORE its durable cleanup landed (the partial-failure Errs below).
-        // A retry then reaches this branch — no provider-eligible rows after
-        // the boundary — so pending cleanup must be re-attempted before the
-        // no-op is reported, or the UI claims success while a restart can
-        // still restore pre-reset carryover or kernel vars across the reset
-        // boundary. Both steps are idempotent: the pending-state unlink
-        // treats ENOENT as success and a discard tombstone re-publish is
-        // harmless, so a genuinely clean no-op stays a no-op.
+        // The provider-empty view was already fenced under the history locks. Retrying cleanup
+        // retires compatible legacy bytes without invalidating a post-reset successor.
         try {
           await this.getOrCreateSession(workspaceId).clearPostCompactionState();
         } catch (error) {
@@ -13194,7 +13180,7 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
         this.sessions.get(workspaceId)?.clearUsageState();
         const clearResult = await this.clearHistoryWithRetiredBashMonitorWakes(
           workspaceId,
-          () => this.historyService.clearHistory(workspaceId),
+          () => this.historyService.clearHistory(workspaceId, { fenceEmptyHistory: !isCompaction }),
           { discardUnacceptedOnSuccess: true }
         );
         if (!clearResult.success) {


### PR DESCRIPTION
Activates the compaction preparation lifecycle across ordinary, idle, heartbeat, continuous, and recovery compaction. Producers capture admission before asynchronous work and publish boundaries through the same pending-state owner. Immediate and periodic attachments retain their exact qualified receipt for acknowledgement or discard; metadata reads use that qualification too. This completes activation above #4189 and removes the handler's duplicate pending-file parser, writer queue, rollback protocol, and skill/read caches. The pending file remains V1.

Boundary admission compares the privacy-filtered, archive-aware provider history used to prepare the summary. Restored source history can remain eligible after heartbeat rollback; changed history, generations, partials, or ownership prevent publication. Reset decisions and generation fences share the recovered history locks and physical lease, including explicit clear or replacement of empty history. Successful destructive cleanup removes recognized legacy V1 bytes so preceding versions cannot reload pre-reset attachments. Unknown future formats and current-generation successors remain intact.

All compaction producers retire malformed partial content before strict publication. Empty directories at `partial.json` recover through nonrecursive removal after final ownership checks. Nonempty directories, symlinks, valid replacement partials, lost logical or physical ownership, and unrelated I/O failures remain protected. Disposal and carryover fixtures use real history and store publication, including the occurrence identity required for acknowledged warmth.

Ordinary-send and emergency-retry rollovers retire carryover after the history writer settles, so cleanup observes the committed generation. Reconciliation also runs when an append commits before reporting an error. Failed appends and current-generation successors retain their protection. If an append succeeds but cleanup fails, the diagnosis is logged and the successful writer result continues through reset and acceptance. Original append errors remain authoritative when both operations fail. Kernel and local reset effects remain ordered before publication.

Metadata fetches use a fresh reader and skip the extra history proof only when the sidecar is absent, retaining the normal history fallback and tracked-file data. Every fetch probes again, so later foreign publication is discovered without a negative cache.

Ordinary completion continues accounting, acknowledgement, continuous observation, queue drain, and goal work when compaction generation storage is unreadable. `handleCompletion` captures admission and generation before its first history read, retains capture as a Result, and propagates an error only after confirming a compaction request. Successful compaction still publishes against that early generation, preserving the foreign-reset fence.

The runtime changes are unchanged by the latest parent repairs. The parent contains exact predecessor retirement for history-only publications and the watchdog-fixture CI repair; this child preserves runtime activation on that corrected foundation and current main `bad3c4f2`.

Validation: canonical static checks pass on final tree `4638cf400821ae9e9bb3d18ef48fd12b35ff5809`; the final lifecycle/store/runtime-preparation run passes 171 tests. The new-main provider/MCP integration passed 411 tests. Earlier evidence includes 229 completion/admission tests, all 509 WorkspaceService tests, and 2,321 combined tests across 40 files plus actual preceding-handler compatibility controls. CI is re-evaluated on each published head; earlier passing runs do not establish readiness for this revision. Test groups overlap. Local provider calls were blocked, with loopback HTTP allowed for local MCP fixtures; Nix was unavailable locally.

Risk: publication and carryover ownership affect every compaction path; regressions can omit or repeat context. Tests use real files, deterministic barriers, multiple store/service instances, and restart behavior. If durable cleanup remains unavailable after a committed reset, current generation checks exclude stale attachments, but compatible bytes can remain readable by a preceding version after downgrade. Cleanup errors stay logged without misclassifying a committed send.

This is the remaining pair of the pending-state phase: #4181, #4183, and #4186 have merged. Keep #4189 and #4190 together through review, CI, and the merge queue.

---

_Generated with `xum` • Model: `unavailable` • Thinking: `unavailable` • Cost: `$unavailable`_

<!-- mux-attribution: model=unavailable thinking=unavailable costs=unavailable -->
