### PR TITLE
🤖 feat: consolidate compaction strategy in General settings

### DIFF
--- a/docs/workspaces/compaction/token-budget.md
+++ b/docs/workspaces/compaction/token-budget.md
@@ -3,7 +3,7 @@ title: Token-Budget Context Windows
 description: Start fresh context windows without automatic summaries and retrieve earlier work on demand
 ---
 
-Enable **Token-budget context windows** in **Settings → Experiments** to replace usage-triggered automatic summaries with fresh context windows. The experiment is off by default.
+Select **Token Budget** from **Compaction strategy** in **Settings → General** to replace usage-triggered automatic summaries with fresh context windows. The default strategy is **Summarize**.
 
 ## Threshold and precedence
 

--- a/src/browser/contexts/ExperimentsContext.test.tsx
+++ b/src/browser/contexts/ExperimentsContext.test.tsx
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 import { GlobalWindow } from "happy-dom";
 import {
   EXPERIMENT_IDS,
+  type ExperimentId,
   getExperimentKey,
   getLegacyPtcExclusiveExperimentKey,
 } from "@/common/constants/experiments";
@@ -266,6 +267,116 @@ describe("ExperimentsProvider", () => {
     await waitFor(() => expect(view.getByText("false")).toBeDefined());
     expect(setOverride).not.toHaveBeenCalled();
   });
+
+  test.each([false, true])(
+    "compaction writes stay FIFO across rapid selections and consumer remounts (failure=%s)",
+    async (failFirstWrite) => {
+      const continuous = EXPERIMENT_IDS.CONTINUOUS_COMPACTION;
+      const budget = EXPERIMENT_IDS.TOKEN_BUDGET;
+      const backend: Partial<Record<ExperimentId, boolean>> = {};
+      const pending: Array<{ finish: () => void; fail: () => void }> = [];
+      const setOverride = mock(
+        ({ experimentId, enabled }: Parameters<APIClient["experiments"]["setOverride"]>[0]) =>
+          new Promise<void>((resolve, reject) => {
+            if (typeof enabled !== "boolean") throw new Error("Expected an explicit override");
+            pending.push({
+              finish: () => {
+                backend[experimentId] = enabled;
+                resolve();
+              },
+              fail: () => reject(new Error("offline")),
+            });
+          })
+      );
+      currentClientMock = {
+        experiments: { setOverride, getOverrides: () => Promise.resolve({ ...backend }) },
+      };
+      // Start a reconnect upload before any selection; it must not overtake later choices.
+      window.localStorage.setItem(getExperimentKey(continuous), "true");
+      function Settings() {
+        const [continuousEnabled, setContinuous] = useExperiment(continuous);
+        const [budgetEnabled, setBudget] = useExperiment(budget);
+        const [, setUnrelated] = useExperiment(EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES);
+        return (
+          <>
+            <output>{`${continuousEnabled}/${budgetEnabled}`}</output>
+            <button
+              onClick={() => {
+                setBudget(true);
+                setContinuous(false);
+              }}
+            >
+              budget
+            </button>
+            <button
+              onClick={() => {
+                setContinuous(true);
+                setBudget(false);
+              }}
+            >
+              continuous
+            </button>
+            <button
+              onClick={() => {
+                setBudget(false);
+                setContinuous(false);
+              }}
+            >
+              summarize
+            </button>
+            <button onClick={() => setUnrelated(true)}>unrelated</button>
+          </>
+        );
+      }
+      const tree = (showSettings: boolean) => (
+        <APIProvider client={currentClientMock as APIClient}>
+          <ExperimentsProvider>{showSettings && <Settings />}</ExperimentsProvider>
+        </APIProvider>
+      );
+      const view = render(tree(true));
+      await waitFor(() => expect(setOverride).toHaveBeenCalledTimes(1));
+      fireEvent.click(view.getByText("budget"));
+      fireEvent.click(view.getByText("continuous"));
+      view.rerender(tree(false));
+      view.rerender(tree(true));
+      fireEvent.click(view.getByText("summarize"));
+      expect(view.getByRole("status").textContent).toBe("false/false");
+      expect(setOverride).toHaveBeenCalledTimes(1);
+
+      // Unrelated flags retain their immediate dispatch even while compaction is blocked.
+      fireEvent.click(view.getByText("unrelated"));
+      expect(setOverride).toHaveBeenCalledTimes(2);
+      await act(async () => {
+        pending[1].finish();
+        await Promise.resolve();
+      });
+      for (let index = 0; index < 7; index++) {
+        const pendingIndex = index === 0 ? 0 : index + 1;
+        await act(async () => {
+          if (index === 0 && failFirstWrite) pending[pendingIndex].fail();
+          else pending[pendingIndex].finish();
+          await Promise.resolve();
+        });
+        expect(setOverride).toHaveBeenCalledTimes(Math.min(index + 3, 8));
+      }
+      expect(setOverride.mock.calls.map(([input]) => input)).toEqual([
+        { experimentId: continuous, enabled: true },
+        { experimentId: EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES, enabled: true },
+        { experimentId: budget, enabled: true },
+        { experimentId: continuous, enabled: false },
+        { experimentId: continuous, enabled: true },
+        { experimentId: budget, enabled: false },
+        { experimentId: budget, enabled: false },
+        { experimentId: continuous, enabled: false },
+      ]);
+      expect(backend).toEqual({
+        [continuous]: false,
+        [budget]: false,
+        [EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES]: true,
+      });
+      expect(view.getByRole("status").textContent).toBe("false/false");
+    }
+  );
 
   test("syncs existing local overrides to the backend on connect", async () => {
     globalThis.window.localStorage.setItem(

--- a/src/browser/contexts/ExperimentsContext.tsx
+++ b/src/browser/contexts/ExperimentsContext.tsx
@@ -39,6 +39,13 @@ function subscribeToExperiment(experimentId: ExperimentId, callback: () => void)
   };
 }
 
+function isCompactionExperiment(experimentId: ExperimentId): boolean {
+  return (
+    experimentId === EXPERIMENT_IDS.CONTINUOUS_COMPACTION ||
+    experimentId === EXPERIMENT_IDS.TOKEN_BUDGET
+  );
+}
+
 function getCurrentDesktopPlatform(): NodeJS.Platform | undefined {
   return window.api?.platform;
 }
@@ -187,19 +194,30 @@ export function ExperimentsProvider(props: { children: React.ReactNode }) {
     Record<ExperimentId, boolean>
   > | null>(null);
 
+  // The strategy is stored as two legacy flags. Order their actual writes (including
+  // reconnect uploads) so rapid choices cannot persist a stale pair. Provider ownership
+  // keeps the queue alive when Settings closes; this is not a cross-client transaction.
+  const compactionWrites = useRef(Promise.resolve(true));
   const persistOverride = useCallback(
-    async (experimentId: ExperimentId, enabled: boolean) => {
-      // A degraded (slow) connection still has a usable api; only a missing api means offline.
-      if (!apiState.api) {
-        return false;
-      }
+    (experimentId: ExperimentId, enabled: boolean) => {
+      const persist = async () => {
+        // A degraded (slow) connection still has a usable api; only a missing api means offline.
+        if (!apiState.api) {
+          return false;
+        }
 
-      try {
-        await apiState.api.experiments.setOverride({ experimentId, enabled });
-        return true;
-      } catch {
-        return false;
+        try {
+          await apiState.api.experiments.setOverride({ experimentId, enabled });
+          return true;
+        } catch {
+          return false;
+        }
+      };
+      if (isCompactionExperiment(experimentId)) {
+        compactionWrites.current = compactionWrites.current.then(persist);
+        return compactionWrites.current;
       }
+      return persist();
     },
     [apiState.api]
   );
@@ -252,9 +270,12 @@ export function ExperimentsProvider(props: { children: React.ReactNode }) {
       // legitimately be empty, so it must never clear overrides another client set.
       try {
         await Promise.all(
-          Object.entries(getExplicitLocalExperimentOverrides()).map(([experimentId, enabled]) =>
-            api.experiments.setOverride({ experimentId: experimentId as ExperimentId, enabled })
-          )
+          Object.entries(getExplicitLocalExperimentOverrides()).map(([id, enabled]) => {
+            const experimentId = id as ExperimentId;
+            return isCompactionExperiment(experimentId)
+              ? persistOverride(experimentId, enabled)
+              : api.experiments.setOverride({ experimentId, enabled });
+          })
         );
       } catch {
         // Best effort
@@ -311,7 +332,7 @@ export function ExperimentsProvider(props: { children: React.ReactNode }) {
       cancelled = true;
       controller.abort();
     };
-  }, [apiState.api]);
+  }, [apiState.api, persistOverride]);
 
   return (
     <ExperimentsContext.Provider value={{ setExperiment, backendOverrides, designRevision }}>

--- a/src/browser/features/Settings/Sections/ExperimentsSection.test.tsx
+++ b/src/browser/features/Settings/Sections/ExperimentsSection.test.tsx
@@ -1,6 +1,20 @@
 import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { GlobalWindow } from "happy-dom";
+import * as ActualAPIModule from "@/browser/contexts/API";
+import * as ActualExperimentsModule from "@/browser/contexts/ExperimentsContext";
+import * as ActualTelemetryModule from "@/browser/hooks/useTelemetry";
+
+// Snapshot values, not Bun's live module namespaces, before installing overrides.
+const actualAPI = { ...ActualAPIModule };
+const actualExperiments = { ...ActualExperimentsModule };
+const actualTelemetry = { ...ActualTelemetryModule };
+
+afterAll(() => {
+  void mock.module("@/browser/contexts/API", () => actualAPI);
+  void mock.module("@/browser/contexts/ExperimentsContext", () => actualExperiments);
+  void mock.module("@/browser/hooks/useTelemetry", () => actualTelemetry);
+});
 
 type PrereqStatus =
   | { available: true }
@@ -46,6 +60,7 @@ let experimentEnabled = false;
 let experimentValues: Record<string, boolean> = {};
 
 void mock.module("@/browser/contexts/API", () => ({
+  ...actualAPI,
   useAPI: () => ({
     api: mockApi,
     status: "connected" as const,
@@ -56,6 +71,7 @@ void mock.module("@/browser/contexts/API", () => ({
 }));
 
 void mock.module("@/browser/contexts/ExperimentsContext", () => ({
+  ...actualExperiments,
   useExperiment: (experimentId: string) => [
     experimentValues[experimentId] ?? experimentEnabled,
     (enabled: boolean) => {
@@ -66,6 +82,7 @@ void mock.module("@/browser/contexts/ExperimentsContext", () => ({
 }));
 
 void mock.module("@/browser/hooks/useTelemetry", () => ({
+  ...actualTelemetry,
   useTelemetry: () => ({
     experimentOverridden: mock(() => undefined),
   }),
@@ -165,6 +182,32 @@ describe("PortableDesktopExperimentWarning", () => {
     globalThis.setInterval = originalSetInterval;
     globalThis.clearInterval = originalClearInterval;
   });
+
+  test.each([false, true])(
+    "hides compaction switches even when their stored flags are %s",
+    (enabled) => {
+      experimentEnabled = false;
+      experimentValues = {
+        [EXPERIMENT_IDS.CONTINUOUS_COMPACTION]: enabled,
+        [EXPERIMENT_IDS.TOKEN_BUDGET]: enabled,
+      };
+      const view = render(<ExperimentsSection />);
+      expect(view.queryByLabelText("Toggle Continuous Compaction")).toBeNull();
+      expect(view.queryByLabelText("Toggle Token-budget context windows")).toBeNull();
+      for (const name of [
+        "Programmatic Tool Calling",
+        "Agent Memory",
+        "Multi-project workspaces",
+        "Workspace Heartbeats",
+      ]) {
+        expect(view.getByRole("switch", { name: `Toggle ${name}` })).toBeTruthy();
+      }
+      expect(experimentValues).toEqual({
+        [EXPERIMENT_IDS.CONTINUOUS_COMPACTION]: enabled,
+        [EXPERIMENT_IDS.TOKEN_BUDGET]: enabled,
+      });
+    }
+  );
 
   test("shows heartbeat defaults inline only when its experiment is enabled", async () => {
     // Goal defaults moved out of ExperimentsSection into the Goal tab

--- a/src/browser/features/Settings/Sections/GeneralSection.test.tsx
+++ b/src/browser/features/Settings/Sections/GeneralSection.test.tsx
@@ -1,8 +1,18 @@
 import React from "react";
-import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { ThemeProvider } from "@/browser/contexts/ThemeContext";
-import * as ActualSelectPrimitiveModule from "@/browser/components/SelectPrimitive/SelectPrimitive";
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { requireTestModule } from "@/browser/testUtils";
+import type * as APIModule from "@/browser/contexts/API";
+import type * as ExperimentsModule from "@/browser/contexts/ExperimentsContext";
+import type * as GeneralModule from "./GeneralSection";
+import {
+  EXPERIMENT_IDS,
+  getExperimentKey,
+  type ExperimentId,
+} from "@/common/constants/experiments";
 import { installDom } from "../../../../../tests/ui/dom";
 import { BASH_COLLAPSED_SUMMARY_MODE_KEY, SIDEBAR_FLAT_MODE_KEY } from "@/common/constants/storage";
 import {
@@ -21,7 +31,13 @@ interface MockConfig {
   llmDebugLogs: boolean;
 }
 
+type ExperimentOverrides = Partial<Record<ExperimentId, boolean>>;
+
 interface MockAPIClient {
+  experiments: {
+    getOverrides: () => Promise<ExperimentOverrides>;
+    setOverride: (input: { experimentId: ExperimentId; enabled: boolean }) => Promise<void>;
+  };
   config: {
     getConfig: () => Promise<MockConfig>;
     updateCoderPrefs: (input: {
@@ -43,7 +59,7 @@ interface MockAPIClient {
 
 let mockApi: MockAPIClient;
 
-void mock.module("@/browser/components/SelectPrimitive/SelectPrimitive", () => {
+const mockSelectPrimitive = (() => {
   const SelectContext = React.createContext<{
     value?: string;
     disabled?: boolean;
@@ -153,28 +169,72 @@ void mock.module("@/browser/components/SelectPrimitive/SelectPrimitive", () => {
     SelectContent,
     SelectItem,
   };
+})();
+
+let APIProvider: typeof APIModule.APIProvider;
+let ExperimentsProvider: typeof ExperimentsModule.ExperimentsProvider;
+let useExperiment: typeof ExperimentsModule.useExperiment;
+let GeneralSection: typeof GeneralModule.GeneralSection;
+let isolatedModuleDir: string;
+
+beforeAll(async () => {
+  // Isolate the real provider and its consumer from other suites' global hook mocks.
+  const root = join(process.cwd(), ".tmp");
+  await mkdir(root, { recursive: true });
+  isolatedModuleDir = await mkdtemp(join(root, "general-section-test-"));
+  await copyFile("src/browser/contexts/API.tsx", join(isolatedModuleDir, "API.tsx"));
+  for (const [sourcePath, filename] of [
+    ["src/browser/contexts/ExperimentsContext.tsx", "ExperimentsContext.tsx"],
+    ["src/browser/features/Settings/Sections/GeneralSection.tsx", "GeneralSection.tsx"],
+  ]) {
+    const source = await readFile(sourcePath, "utf8");
+    const isolatedSource = source
+      .replace('from "@/browser/contexts/API";', 'from "./API";')
+      .replace('from "@/browser/contexts/ExperimentsContext";', 'from "./ExperimentsContext";')
+      .replace('from "@/browser/components/SelectPrimitive/SelectPrimitive";', 'from "./Select";');
+    expect(isolatedSource).not.toBe(source);
+    await writeFile(join(isolatedModuleDir, filename), isolatedSource);
+  }
+  const selectPath = join(isolatedModuleDir, "Select.tsx");
+  await writeFile(selectPath, "export {};\n");
+  void mock.module(selectPath, () => mockSelectPrimitive);
+  ({ APIProvider } = requireTestModule<typeof APIModule>(join(isolatedModuleDir, "API.tsx")));
+  ({ ExperimentsProvider, useExperiment } = requireTestModule<typeof ExperimentsModule>(
+    join(isolatedModuleDir, "ExperimentsContext.tsx")
+  ));
+  ({ GeneralSection } = requireTestModule<typeof GeneralModule>(
+    join(isolatedModuleDir, "GeneralSection.tsx")
+  ));
 });
 
-void mock.module("@/browser/contexts/API", () => ({
-  useAPI: () => ({
-    api: mockApi,
-    status: "connected" as const,
-    error: null,
-    authenticate: () => undefined,
-    retry: () => undefined,
-  }),
-}));
+afterAll(async () => {
+  await rm(isolatedModuleDir, { recursive: true, force: true });
+});
 
-import { GeneralSection } from "./GeneralSection";
+function TestProviders(props: { children: React.ReactNode }) {
+  return (
+    <APIProvider client={mockApi as APIModule.APIClient}>
+      <ExperimentsProvider>
+        <ThemeProvider forcedTheme="dark">{props.children}</ThemeProvider>
+      </ExperimentsProvider>
+    </APIProvider>
+  );
+}
 
 interface RenderGeneralSectionOptions {
   coderWorkspaceArchiveBehavior?: CoderWorkspaceArchiveBehavior;
   worktreeArchiveBehavior?: WorktreeArchiveBehavior;
   chatTranscriptFullWidth?: boolean;
+  localOverrides?: ExperimentOverrides;
+  backendOverrides?: ExperimentOverrides;
+  children?: React.ReactNode;
 }
 
 interface MockAPISetup {
   api: MockAPIClient;
+  backendOverrides: ExperimentOverrides;
+  setOverrideMock: ReturnType<typeof mock<MockAPIClient["experiments"]["setOverride"]>>;
+  getOverridesMock: ReturnType<typeof mock<MockAPIClient["experiments"]["getOverrides"]>>;
   getConfigMock: ReturnType<typeof mock<() => Promise<MockConfig>>>;
   updateCoderPrefsMock: ReturnType<
     typeof mock<
@@ -189,7 +249,18 @@ interface MockAPISetup {
   >;
 }
 
-function createMockAPI(configOverrides: Partial<MockConfig> = {}): MockAPISetup {
+function createMockAPI(
+  configOverrides: Partial<MockConfig> = {},
+  experimentOverrides: ExperimentOverrides = {}
+): MockAPISetup {
+  const backendOverrides = { ...experimentOverrides };
+  const getOverridesMock = mock(() => Promise.resolve({ ...backendOverrides }));
+  const setOverrideMock = mock(
+    ({ experimentId, enabled }: { experimentId: ExperimentId; enabled: boolean }) => {
+      backendOverrides[experimentId] = enabled;
+      return Promise.resolve();
+    }
+  );
   const config: MockConfig = {
     coderWorkspaceArchiveBehavior: DEFAULT_CODER_ARCHIVE_BEHAVIOR,
     worktreeArchiveBehavior: DEFAULT_WORKTREE_ARCHIVE_BEHAVIOR,
@@ -219,6 +290,7 @@ function createMockAPI(configOverrides: Partial<MockConfig> = {}): MockAPISetup 
 
   return {
     api: {
+      experiments: { getOverrides: getOverridesMock, setOverride: setOverrideMock },
       config: {
         getConfig: getConfigMock,
         updateCoderPrefs: updateCoderPrefsMock,
@@ -238,6 +310,9 @@ function createMockAPI(configOverrides: Partial<MockConfig> = {}): MockAPISetup 
         setDefaultProjectDir: mock((_input: { path: string }) => Promise.resolve()),
       },
     },
+    backendOverrides,
+    setOverrideMock,
+    getOverridesMock,
     getConfigMock,
     updateCoderPrefsMock,
     updateChatTranscriptFullWidthMock,
@@ -254,29 +329,32 @@ describe("GeneralSection", () => {
   afterEach(() => {
     cleanup();
     mock.restore();
-    void mock.module(
-      "@/browser/components/SelectPrimitive/SelectPrimitive",
-      () => ActualSelectPrimitiveModule
-    );
     cleanupDom?.();
     cleanupDom = null;
   });
 
   function renderGeneralSection(options: RenderGeneralSectionOptions = {}) {
-    const { api, updateCoderPrefsMock, updateChatTranscriptFullWidthMock } = createMockAPI({
-      chatTranscriptFullWidth: options.chatTranscriptFullWidth,
-      coderWorkspaceArchiveBehavior: options.coderWorkspaceArchiveBehavior,
-      worktreeArchiveBehavior: options.worktreeArchiveBehavior,
-    });
-    mockApi = api;
+    for (const [id, enabled] of Object.entries(options.localOverrides ?? {})) {
+      window.localStorage.setItem(getExperimentKey(id as ExperimentId), JSON.stringify(enabled));
+    }
+    const setup = createMockAPI(
+      {
+        chatTranscriptFullWidth: options.chatTranscriptFullWidth,
+        coderWorkspaceArchiveBehavior: options.coderWorkspaceArchiveBehavior,
+        worktreeArchiveBehavior: options.worktreeArchiveBehavior,
+      },
+      options.backendOverrides
+    );
+    mockApi = setup.api;
 
     const view = render(
-      <ThemeProvider forcedTheme="dark">
+      <TestProviders>
         <GeneralSection />
-      </ThemeProvider>
+        {options.children}
+      </TestProviders>
     );
 
-    return { updateCoderPrefsMock, updateChatTranscriptFullWidthMock, view };
+    return { ...setup, view };
   }
 
   function getSelectTrigger(view: ReturnType<typeof render>, label: string): HTMLElement {
@@ -318,6 +396,170 @@ describe("GeneralSection", () => {
       expect(trigger.textContent).toContain(optionText);
     });
   }
+
+  const legacyStrategies = [
+    { continuous: false, budget: false, label: "Summarize" },
+    { continuous: true, budget: false, label: "Continuous" },
+    { continuous: false, budget: true, label: "Token Budget" },
+    { continuous: true, budget: true, label: "Continuous" },
+  ];
+
+  async function hydrateExperiments(setup: MockAPISetup) {
+    await act(async () => {
+      await waitFor(() => expect(setup.getOverridesMock).toHaveBeenCalledTimes(1));
+    });
+  }
+
+  for (const source of ["localOverrides", "backendOverrides"] as const) {
+    test.each(legacyStrategies)(
+      `displays ${source} continuous=$continuous budget=$budget without normalizing on mount`,
+      async ({ continuous, budget, label }) => {
+        const overrides = {
+          [EXPERIMENT_IDS.CONTINUOUS_COMPACTION]: continuous,
+          [EXPERIMENT_IDS.TOKEN_BUDGET]: budget,
+        };
+        const setup = renderGeneralSection({ [source]: overrides });
+        await hydrateExperiments(setup);
+        expect(setup.view.getByRole("combobox", { name: "Compaction strategy" }).textContent).toBe(
+          label
+        );
+        expect(setup.backendOverrides).toEqual(overrides);
+        // The provider uploads explicit local values; mounting the dropdown must add no writes.
+        if (source === "localOverrides") {
+          for (const [experimentId, enabled] of Object.entries(overrides)) {
+            expect(setup.setOverrideMock).toHaveBeenCalledWith({ experimentId, enabled });
+          }
+        }
+        expect(setup.setOverrideMock).toHaveBeenCalledTimes(source === "localOverrides" ? 2 : 0);
+        for (const [id, enabled] of Object.entries(overrides)) {
+          expect(window.localStorage.getItem(getExperimentKey(id as ExperimentId))).toBe(
+            source === "localOverrides" ? JSON.stringify(enabled) : null
+          );
+        }
+      }
+    );
+  }
+
+  test("defaults to Summarize without persisting an implicit choice", async () => {
+    const setup = renderGeneralSection();
+    await hydrateExperiments(setup);
+    expect(setup.view.getByRole("combobox", { name: "Compaction strategy" }).textContent).toBe(
+      "Summarize"
+    );
+    expect(setup.setOverrideMock).not.toHaveBeenCalled();
+    expect(setup.backendOverrides).toEqual({});
+    expect(
+      window.localStorage.getItem(getExperimentKey(EXPERIMENT_IDS.CONTINUOUS_COMPACTION))
+    ).toBeNull();
+    expect(window.localStorage.getItem(getExperimentKey(EXPERIMENT_IDS.TOKEN_BUDGET))).toBeNull();
+  });
+
+  test.each([
+    {
+      local: { [EXPERIMENT_IDS.CONTINUOUS_COMPACTION]: false },
+      backend: {
+        [EXPERIMENT_IDS.CONTINUOUS_COMPACTION]: true,
+        [EXPERIMENT_IDS.TOKEN_BUDGET]: true,
+      },
+      label: "Token Budget",
+    },
+    {
+      local: { [EXPERIMENT_IDS.TOKEN_BUDGET]: false },
+      backend: { [EXPERIMENT_IDS.TOKEN_BUDGET]: true },
+      label: "Summarize",
+    },
+    {
+      local: { [EXPERIMENT_IDS.TOKEN_BUDGET]: true },
+      backend: { [EXPERIMENT_IDS.CONTINUOUS_COMPACTION]: true },
+      label: "Continuous",
+    },
+  ])(
+    "resolves local overrides before backend values and defaults ($label)",
+    async ({ local, backend, label }) => {
+      const setup = renderGeneralSection({ localOverrides: local, backendOverrides: backend });
+      await hydrateExperiments(setup);
+      expect(setup.view.getByRole("combobox", { name: "Compaction strategy" }).textContent).toBe(
+        label
+      );
+      expect(setup.backendOverrides).toEqual({ ...backend, ...local });
+      expect(setup.setOverrideMock).toHaveBeenCalledTimes(Object.keys(local).length);
+    }
+  );
+
+  for (const initial of legacyStrategies) {
+    test.each(legacyStrategies.slice(0, 3).filter((next) => next.label !== initial.label))(
+      `selecting $label from continuous=${initial.continuous} budget=${initial.budget} persists both flags only`,
+      async ({ continuous, budget, label }) => {
+        const unrelated = {
+          [EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING]: true,
+          [EXPERIMENT_IDS.RLM]: true,
+          [EXPERIMENT_IDS.MEMORY]: true,
+        };
+        const setup = renderGeneralSection({
+          backendOverrides: {
+            ...unrelated,
+            [EXPERIMENT_IDS.CONTINUOUS_COMPACTION]: initial.continuous,
+            [EXPERIMENT_IDS.TOKEN_BUDGET]: initial.budget,
+          },
+        });
+        await hydrateExperiments(setup);
+        await chooseSelectOption(setup.view, "Compaction strategy", label);
+        await waitFor(() =>
+          expect(setup.backendOverrides).toEqual({
+            ...unrelated,
+            [EXPERIMENT_IDS.CONTINUOUS_COMPACTION]: continuous,
+            [EXPERIMENT_IDS.TOKEN_BUDGET]: budget,
+          })
+        );
+        expect(setup.setOverrideMock).toHaveBeenCalledTimes(2);
+        expect(
+          window.localStorage.getItem(getExperimentKey(EXPERIMENT_IDS.CONTINUOUS_COMPACTION))
+        ).toBe(JSON.stringify(continuous));
+        expect(window.localStorage.getItem(getExperimentKey(EXPERIMENT_IDS.TOKEN_BUDGET))).toBe(
+          JSON.stringify(budget)
+        );
+        expect(Boolean(setup.view.queryByRole("status"))).toBe(label === "Token Budget");
+      }
+    );
+  }
+
+  test("keeps Token Budget selectable and tracks live PTC/RLM conflicts without changing the strategy", async () => {
+    function ConflictToggles() {
+      const [ptc, setPtc] = useExperiment(EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING);
+      const [rlm, setRlm] = useExperiment(EXPERIMENT_IDS.RLM);
+      return (
+        <>
+          <button onClick={() => setPtc(!ptc)}>Toggle PTC fixture</button>
+          <button onClick={() => setRlm(!rlm)}>Toggle RLM fixture</button>
+        </>
+      );
+    }
+    const setup = renderGeneralSection({ children: <ConflictToggles /> });
+    await hydrateExperiments(setup);
+    await chooseSelectOption(setup.view, "Compaction strategy", "Token Budget");
+    const trigger = setup.view.getByRole("combobox", { name: "Compaction strategy" });
+    expect(setup.view.queryByRole("status")).toBeNull();
+    fireEvent.click(setup.view.getByRole("button", { name: "Toggle RLM fixture" }));
+    expect(setup.view.queryByRole("status")).toBeNull();
+    fireEvent.click(setup.view.getByRole("button", { name: "Toggle PTC fixture" }));
+    const warning = setup.view.getByRole("status");
+    expect(trigger.getAttribute("aria-describedby")).toBe(warning.id);
+    fireEvent.click(setup.view.getByRole("button", { name: "Toggle RLM fixture" }));
+    expect(setup.view.queryByRole("status")).toBeNull();
+    fireEvent.click(setup.view.getByRole("button", { name: "Toggle RLM fixture" }));
+    expect(setup.view.getByRole("status")).toBeTruthy();
+    fireEvent.click(setup.view.getByRole("button", { name: "Toggle PTC fixture" }));
+    expect(setup.view.queryByRole("status")).toBeNull();
+    expect(trigger.textContent).toBe("Token Budget");
+    await waitFor(() =>
+      expect(setup.backendOverrides).toEqual({
+        [EXPERIMENT_IDS.CONTINUOUS_COMPACTION]: false,
+        [EXPERIMENT_IDS.TOKEN_BUDGET]: true,
+        [EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING]: false,
+        [EXPERIMENT_IDS.RLM]: true,
+      })
+    );
+  });
 
   test("persists flat chat list mode from the Sidebar group", () => {
     const { view } = renderGeneralSection();
@@ -428,9 +670,9 @@ describe("GeneralSection", () => {
     mockApi = api;
 
     const view = render(
-      <ThemeProvider forcedTheme="dark">
+      <TestProviders>
         <GeneralSection />
-      </ThemeProvider>
+      </TestProviders>
     );
 
     await waitFor(() => {
@@ -479,9 +721,9 @@ describe("GeneralSection", () => {
     mockApi = api;
 
     const view = render(
-      <ThemeProvider forcedTheme="dark">
+      <TestProviders>
         <GeneralSection />
-      </ThemeProvider>
+      </TestProviders>
     );
 
     await waitFor(() => {
@@ -522,9 +764,9 @@ describe("GeneralSection", () => {
     mockApi = api;
 
     const view = render(
-      <ThemeProvider forcedTheme="dark">
+      <TestProviders>
         <GeneralSection />
-      </ThemeProvider>
+      </TestProviders>
     );
 
     await waitFor(() => {

--- a/src/browser/features/Settings/Sections/GeneralSection.test.tsx
+++ b/src/browser/features/Settings/Sections/GeneralSection.test.tsx
@@ -58,6 +58,9 @@ interface MockAPIClient {
 }
 
 let mockApi: MockAPIClient;
+const experimentOverriddenMock = mock<(experimentId: string, enabled: boolean) => void>(
+  () => undefined
+);
 
 const mockSelectPrimitive = (() => {
   const SelectContext = React.createContext<{
@@ -190,6 +193,7 @@ beforeAll(async () => {
     const source = await readFile(sourcePath, "utf8");
     const isolatedSource = source
       .replace('from "@/browser/contexts/API";', 'from "./API";')
+      .replace('from "@/browser/hooks/useTelemetry";', 'from "./Telemetry";')
       .replace('from "@/browser/contexts/ExperimentsContext";', 'from "./ExperimentsContext";')
       .replace('from "@/browser/components/SelectPrimitive/SelectPrimitive";', 'from "./Select";');
     expect(isolatedSource).not.toBe(source);
@@ -198,6 +202,11 @@ beforeAll(async () => {
   const selectPath = join(isolatedModuleDir, "Select.tsx");
   await writeFile(selectPath, "export {};\n");
   void mock.module(selectPath, () => mockSelectPrimitive);
+  const telemetryPath = join(isolatedModuleDir, "Telemetry.ts");
+  await writeFile(telemetryPath, "export {};\n");
+  void mock.module(telemetryPath, () => ({
+    useTelemetry: () => ({ experimentOverridden: experimentOverriddenMock }),
+  }));
   ({ APIProvider } = requireTestModule<typeof APIModule>(join(isolatedModuleDir, "API.tsx")));
   ({ ExperimentsProvider, useExperiment } = requireTestModule<typeof ExperimentsModule>(
     join(isolatedModuleDir, "ExperimentsContext.tsx")
@@ -324,6 +333,7 @@ describe("GeneralSection", () => {
 
   beforeEach(() => {
     cleanupDom = installDom();
+    experimentOverriddenMock.mockClear();
   });
 
   afterEach(() => {
@@ -424,6 +434,7 @@ describe("GeneralSection", () => {
           label
         );
         expect(setup.backendOverrides).toEqual(overrides);
+        expect(experimentOverriddenMock).not.toHaveBeenCalled();
         // The provider uploads explicit local values; mounting the dropdown must add no writes.
         if (source === "localOverrides") {
           for (const [experimentId, enabled] of Object.entries(overrides)) {
@@ -512,6 +523,12 @@ describe("GeneralSection", () => {
           })
         );
         expect(setup.setOverrideMock).toHaveBeenCalledTimes(2);
+        expect(experimentOverriddenMock).toHaveBeenCalledTimes(2);
+        expect(experimentOverriddenMock).toHaveBeenCalledWith(
+          EXPERIMENT_IDS.CONTINUOUS_COMPACTION,
+          continuous
+        );
+        expect(experimentOverriddenMock).toHaveBeenCalledWith(EXPERIMENT_IDS.TOKEN_BUDGET, budget);
         expect(
           window.localStorage.getItem(getExperimentKey(EXPERIMENT_IDS.CONTINUOUS_COMPACTION))
         ).toBe(JSON.stringify(continuous));

--- a/src/browser/features/Settings/Sections/GeneralSection.tsx
+++ b/src/browser/features/Settings/Sections/GeneralSection.tsx
@@ -10,6 +10,7 @@ import {
 import { Input } from "@/browser/components/Input/Input";
 import { Switch } from "@/browser/components/Switch/Switch";
 import { updatePersistedState, usePersistedState } from "@/browser/hooks/usePersistedState";
+import { useTelemetry } from "@/browser/hooks/useTelemetry";
 import { useTranscriptDensity } from "@/browser/hooks/useTranscriptDensity";
 import { useAPI } from "@/browser/contexts/API";
 import { useExperiment, useExperimentValue } from "@/browser/contexts/ExperimentsContext";
@@ -173,6 +174,7 @@ const isBrowserMode = typeof window !== "undefined" && !window.api;
 export function GeneralSection() {
   const { themePreference, setTheme } = useTheme();
   const { api } = useAPI();
+  const telemetry = useTelemetry();
   const [continuousCompaction, setContinuousCompaction] = useExperiment(
     EXPERIMENT_IDS.CONTINUOUS_COMPACTION
   );
@@ -220,6 +222,9 @@ export function GeneralSection() {
         return exhaustive;
       }
     }
+    // Retain the override events previously emitted by the individual experiment switches.
+    telemetry.experimentOverridden(EXPERIMENT_IDS.CONTINUOUS_COMPACTION, value === "continuous");
+    telemetry.experimentOverridden(EXPERIMENT_IDS.TOKEN_BUDGET, value === "token-budget");
   };
   const [launchBehavior, setLaunchBehavior] = usePersistedState<LaunchBehavior>(
     LAUNCH_BEHAVIOR_KEY,

--- a/src/browser/features/Settings/Sections/GeneralSection.tsx
+++ b/src/browser/features/Settings/Sections/GeneralSection.tsx
@@ -12,6 +12,9 @@ import { Switch } from "@/browser/components/Switch/Switch";
 import { updatePersistedState, usePersistedState } from "@/browser/hooks/usePersistedState";
 import { useTranscriptDensity } from "@/browser/hooks/useTranscriptDensity";
 import { useAPI } from "@/browser/contexts/API";
+import { useExperiment, useExperimentValue } from "@/browser/contexts/ExperimentsContext";
+import { EXPERIMENT_IDS } from "@/common/constants/experiments";
+import assert from "@/common/utils/assert";
 import { CUSTOM_EVENTS, createCustomEvent } from "@/common/constants/events";
 import {
   EDITOR_CONFIG_KEY,
@@ -101,6 +104,13 @@ function getTerminalFontAvailabilityWarning(config: TerminalFontConfig): string 
   return undefined;
 }
 
+const COMPACTION_STRATEGIES = [
+  { value: "summarize", label: "Summarize" },
+  { value: "continuous", label: "Continuous" },
+  { value: "token-budget", label: "Token Budget" },
+] as const;
+type CompactionStrategy = (typeof COMPACTION_STRATEGIES)[number]["value"];
+
 const EDITOR_OPTIONS: Array<{ value: EditorType; label: string }> = [
   { value: "vscode", label: "VS Code" },
   { value: "cursor", label: "Cursor" },
@@ -163,6 +173,54 @@ const isBrowserMode = typeof window !== "undefined" && !window.api;
 export function GeneralSection() {
   const { themePreference, setTheme } = useTheme();
   const { api } = useAPI();
+  const [continuousCompaction, setContinuousCompaction] = useExperiment(
+    EXPERIMENT_IDS.CONTINUOUS_COMPACTION
+  );
+  const [tokenBudget, setTokenBudget] = useExperiment(EXPERIMENT_IDS.TOKEN_BUDGET);
+  const ptc = useExperimentValue(EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING);
+  const rlm = useExperimentValue(EXPERIMENT_IDS.RLM);
+  // Preserve legacy both-enabled precedence without rewriting preferences on load.
+  const compactionStrategy: CompactionStrategy = continuousCompaction
+    ? "continuous"
+    : tokenBudget
+      ? "token-budget"
+      : "summarize";
+  const tokenBudgetInactive = compactionStrategy === "token-budget" && ptc && rlm;
+  const [compactionOpen, setCompactionOpen] = useState(false);
+  const sameStrategyActivation = useRef<CompactionStrategy | null>(null);
+  const markCompactionActivation = (value: CompactionStrategy) => {
+    if (value !== compactionStrategy) return;
+    // Radix omits onValueChange for an unchanged value. Only normalize if its
+    // activation also closes the menu, not on Escape or a typeahead-only Space.
+    sameStrategyActivation.current = value;
+    queueMicrotask(() => {
+      sameStrategyActivation.current = null;
+    });
+  };
+  const handleCompactionStrategyChange = (value: string) => {
+    assert(
+      value === "summarize" || value === "continuous" || value === "token-budget",
+      `Unexpected compaction strategy: ${value}`
+    );
+    switch (value) {
+      case "continuous":
+        setContinuousCompaction(true);
+        setTokenBudget(false);
+        break;
+      case "token-budget":
+        setTokenBudget(true);
+        setContinuousCompaction(false);
+        break;
+      case "summarize":
+        setTokenBudget(false);
+        setContinuousCompaction(false);
+        break;
+      default: {
+        const exhaustive: never = value;
+        return exhaustive;
+      }
+    }
+  };
   const [launchBehavior, setLaunchBehavior] = usePersistedState<LaunchBehavior>(
     LAUNCH_BEHAVIOR_KEY,
     "dashboard"
@@ -722,6 +780,58 @@ export function GeneralSection() {
             </Select>
           </div>
         </div>
+      </div>
+
+      <div className="border-border-light border-t pt-6">
+        <h3 className="text-foreground mb-4 text-sm font-medium">Compaction</h3>
+        <div className="flex items-center justify-between gap-4">
+          <div className="min-w-0 flex-1">
+            <div className="text-foreground text-sm">Compaction strategy</div>
+            <div className="text-muted text-xs">How to manage context as conversations grow.</div>
+          </div>
+          <Select
+            value={compactionStrategy}
+            onValueChange={handleCompactionStrategyChange}
+            open={compactionOpen}
+            onOpenChange={(open) => {
+              setCompactionOpen(open);
+              const activated = sameStrategyActivation.current;
+              sameStrategyActivation.current = null;
+              if (!open && activated) handleCompactionStrategyChange(activated);
+            }}
+          >
+            <SelectTrigger
+              aria-label="Compaction strategy"
+              aria-describedby={tokenBudgetInactive ? "token-budget-inactive" : undefined}
+              className="border-border-medium bg-background-secondary hover:bg-hover h-9 w-auto shrink-0 cursor-pointer rounded-md border px-3 text-sm transition-colors"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {COMPACTION_STRATEGIES.map((strategy) => (
+                <SelectItem
+                  key={strategy.value}
+                  value={strategy.value}
+                  onPointerUp={() => markCompactionActivation(strategy.value)}
+                  onClick={() => markCompactionActivation(strategy.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      markCompactionActivation(strategy.value);
+                    }
+                  }}
+                >
+                  {strategy.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        {tokenBudgetInactive && (
+          <div id="token-budget-inactive" role="status" className="text-warning mt-2 text-xs">
+            Token Budget is saved but inactive while Programmatic Tool Calling and RLM Mode are both
+            enabled. Disable either in Experiments to use it.
+          </div>
+        )}
       </div>
 
       <div className="border-border-light border-t pt-6">

--- a/src/browser/stories/App.compactionSettings.stories.tsx
+++ b/src/browser/stories/App.compactionSettings.stories.tsx
@@ -1,0 +1,190 @@
+import { expect, fn, userEvent, waitFor, within } from "@storybook/test";
+import { wrapAsyncIterator } from "@orpc/shared";
+import type { APIClient } from "@/browser/contexts/API";
+import { appMeta, AppWithMocks, type AppStory } from "./meta.js";
+import { expandLeftSidebar } from "./helpers/uiState";
+import { setupSettingsStory } from "@/browser/features/Settings/Sections/settingsStoryUtils";
+import { readPersistedState } from "@/browser/hooks/usePersistedState";
+import { EXPERIMENT_IDS, getExperimentKey } from "@/common/constants/experiments";
+
+export default { ...appMeta, title: "App/CompactionSettings" };
+
+const setOverride = fn<APIClient["experiments"]["setOverride"]>(() => Promise.resolve());
+const getOverrides = fn<APIClient["experiments"]["getOverrides"]>(() => Promise.resolve({}));
+
+function setupCompactionSettings(mode: "legacy" | "defaults" | "conflict" = "legacy") {
+  expandLeftSidebar();
+  setOverride.mockClear();
+  getOverrides.mockClear();
+  const client = setupSettingsStory({
+    experiments: {
+      ...(mode === "defaults"
+        ? {}
+        : {
+            [EXPERIMENT_IDS.CONTINUOUS_COMPACTION]: mode === "legacy",
+            [EXPERIMENT_IDS.TOKEN_BUDGET]: true,
+          }),
+      [EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING]: mode === "conflict",
+      [EXPERIMENT_IDS.RLM]: mode === "conflict",
+    },
+  });
+  client.experiments = {
+    setOverride,
+    getOverrides,
+    onDesignChange: () =>
+      Promise.resolve(
+        wrapAsyncIterator(
+          (async function* () {
+            yield await Promise.resolve({ enabled: false, revision: 0 });
+          })(),
+          {}
+        )
+      ),
+  };
+  return client;
+}
+
+async function openCompactionSettings(canvasElement: HTMLElement) {
+  const canvas = within(canvasElement);
+  await userEvent.click(await canvas.findByTestId("settings-button", {}, { timeout: 10000 }));
+  const trigger = await canvas.findByRole("combobox", { name: "Compaction strategy" });
+  trigger.scrollIntoView({ block: "center" });
+  // Initial local-override uploads belong to provider reconciliation, not a dropdown choice.
+  await waitFor(async () => expect(getOverrides).toHaveBeenCalled());
+  setOverride.mockClear();
+  return trigger;
+}
+
+async function expectPersistedStrategy(continuous: boolean, budget: boolean) {
+  await waitFor(async () => {
+    await expect(
+      readPersistedState(getExperimentKey(EXPERIMENT_IDS.CONTINUOUS_COMPACTION), undefined)
+    ).toBe(continuous);
+    await expect(readPersistedState(getExperimentKey(EXPERIMENT_IDS.TOKEN_BUDGET), undefined)).toBe(
+      budget
+    );
+  });
+}
+
+async function expectStrategyWrites(continuous: boolean, budget: boolean) {
+  await waitFor(async () => expect(setOverride).toHaveBeenCalledTimes(2));
+  await expect(setOverride).toHaveBeenCalledWith({
+    experimentId: EXPERIMENT_IDS.CONTINUOUS_COMPACTION,
+    enabled: continuous,
+  });
+  await expect(setOverride).toHaveBeenCalledWith({
+    experimentId: EXPERIMENT_IDS.TOKEN_BUDGET,
+    enabled: budget,
+  });
+}
+
+async function dismissWithoutChoosing(trigger: HTMLElement) {
+  await userEvent.click(trigger);
+  await userEvent.keyboard("{Escape}");
+  await expect(trigger).toHaveAttribute("aria-expanded", "false");
+  await expect(setOverride).not.toHaveBeenCalled();
+}
+
+async function selectStrategy(trigger: HTMLElement, name: string) {
+  setOverride.mockClear();
+  await userEvent.click(trigger);
+  const body = within(trigger.ownerDocument.body);
+  await userEvent.click(await body.findByRole("option", { name }));
+  await expect(trigger).toHaveTextContent(name);
+}
+
+async function exerciseCompactionSettings(canvasElement: HTMLElement) {
+  const trigger = await openCompactionSettings(canvasElement);
+  await expect(trigger).toHaveTextContent("Continuous");
+  await expectPersistedStrategy(true, true);
+  await dismissWithoutChoosing(trigger);
+
+  // Real Radix must commit an explicit choice even when legacy flags display that same value.
+  await selectStrategy(trigger, "Continuous");
+  await expectPersistedStrategy(true, false);
+  await expectStrategyWrites(true, false);
+  await selectStrategy(trigger, "Token Budget");
+  await expectPersistedStrategy(false, true);
+  await expectStrategyWrites(false, true);
+  await selectStrategy(trigger, "Summarize");
+  await expectPersistedStrategy(false, false);
+  await expectStrategyWrites(false, false);
+
+  // Leave the menu open to capture all three choices at desktop and phone widths.
+  await userEvent.click(trigger);
+  const body = within(trigger.ownerDocument.body);
+  const listbox = await body.findByRole("listbox");
+  await expect(within(listbox).getAllByRole("option")).toHaveLength(3);
+  for (const name of ["Summarize", "Continuous", "Token Budget"]) {
+    await expect(within(listbox).getByRole("option", { name })).toBeVisible();
+  }
+  // The Storybook runner ignores viewport globals; only assert phone bounds at narrow widths.
+  if (window.innerWidth < 768) {
+    await expect(trigger.getBoundingClientRect().right).toBeLessThanOrEqual(window.innerWidth);
+    await expect(listbox.getBoundingClientRect().left).toBeGreaterThanOrEqual(0);
+    await expect(listbox.getBoundingClientRect().right).toBeLessThanOrEqual(window.innerWidth);
+    await expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(window.innerWidth);
+  }
+}
+
+export const Desktop: AppStory = {
+  globals: { viewport: { value: "desktop", isRotated: false } },
+  parameters: { pixel: { matrix: { themes: ["dark", "light"], viewports: ["desktop"] } } },
+  render: () => <AppWithMocks setup={() => setupCompactionSettings()} />,
+  play: async ({ canvasElement }) => exerciseCompactionSettings(canvasElement),
+};
+
+export const Phone: AppStory = {
+  ...Desktop,
+  globals: { viewport: { value: "phone", isRotated: false } },
+  parameters: {
+    viewport: {
+      options: {
+        phone: {
+          name: "Phone",
+          styles: { width: "390px", height: "844px" },
+          type: "mobile",
+        },
+      },
+    },
+    pixel: { matrix: { themes: ["dark", "light"], viewports: ["phone"] } },
+  },
+  play: async ({ canvasElement }) => exerciseCompactionSettings(canvasElement),
+};
+
+export const ExplicitSummarize: AppStory = {
+  render: () => <AppWithMocks setup={() => setupCompactionSettings("defaults")} />,
+  play: async ({ canvasElement }) => {
+    const trigger = await openCompactionSettings(canvasElement);
+    await expect(trigger).toHaveTextContent("Summarize");
+    for (const id of [EXPERIMENT_IDS.CONTINUOUS_COMPACTION, EXPERIMENT_IDS.TOKEN_BUDGET]) {
+      await expect(readPersistedState(getExperimentKey(id), undefined)).toBeUndefined();
+    }
+    await dismissWithoutChoosing(trigger);
+    // Keyboard activation must commit the current default just like a pointer selection.
+    await userEvent.click(trigger);
+    const option = within(trigger.ownerDocument.body).getByRole("option", { name: "Summarize" });
+    option.focus();
+    await userEvent.keyboard("{Enter}");
+    await expect(trigger).toHaveAttribute("aria-expanded", "false");
+    await expectPersistedStrategy(false, false);
+    await expectStrategyWrites(false, false);
+  },
+};
+
+export const TokenBudgetConflict: AppStory = {
+  render: () => <AppWithMocks setup={() => setupCompactionSettings("conflict")} />,
+  play: async ({ canvasElement }) => {
+    const trigger = await openCompactionSettings(canvasElement);
+    const canvas = within(canvasElement);
+    await expect(trigger).toHaveTextContent("Token Budget");
+    const warning = canvas.getByRole("status");
+    await expect(warning).toBeVisible();
+    await expect(trigger).toHaveAttribute("aria-describedby", warning.id);
+    await selectStrategy(trigger, "Continuous");
+    await expect(canvas.queryByRole("status")).toBeNull();
+    await selectStrategy(trigger, "Token Budget");
+    await expectPersistedStrategy(false, true);
+    await expect(canvas.getByRole("status")).toBeVisible();
+  },
+};

--- a/src/browser/stories/App.tokenBudget.stories.tsx
+++ b/src/browser/stories/App.tokenBudget.stories.tsx
@@ -300,16 +300,16 @@ export const ExperimentSettings: AppStory = {
       await userEvent.click(canvas.getByRole("button", { name: "Open sidebar menu" }));
     }
     await userEvent.click(await canvas.findByTestId("settings-button"));
-    await userEvent.click(await canvas.findByRole("button", { name: "Experiments" }));
-    const toggle = await canvas.findByRole("switch", {
-      name: "Toggle Token-budget context windows",
-    });
-    toggle.scrollIntoView({ block: "center" });
-    await expect(toggle).toBeChecked();
-    await userEvent.click(toggle);
-    await expect(toggle).not.toBeChecked();
-    await userEvent.click(toggle);
-    await expect(toggle).toBeChecked();
+    const strategy = await canvas.findByRole("combobox", { name: "Compaction strategy" });
+    strategy.scrollIntoView({ block: "center" });
+    await expect(strategy).toHaveTextContent("Token Budget");
+    const page = within(canvasElement.ownerDocument.body);
+    await userEvent.click(strategy);
+    await userEvent.click(await page.findByRole("option", { name: "Summarize" }));
+    await expect(strategy).toHaveTextContent("Summarize");
+    await userEvent.click(strategy);
+    await userEvent.click(await page.findByRole("option", { name: "Token Budget" }));
+    await expect(strategy).toHaveTextContent("Token Budget");
   },
 };
 

--- a/src/common/constants/experiments.ts
+++ b/src/common/constants/experiments.ts
@@ -103,7 +103,8 @@ export const EXPERIMENTS: Record<ExperimentId, ExperimentDefinition> = {
     description:
       "Start fresh context windows instead of automatic summaries, with session_history for retrieval. Requires session_history; continuous compaction and RLM take precedence.",
     enabledByDefault: false,
-    showInSettings: true,
+    // Configured together with Continuous Compaction in Settings → General.
+    showInSettings: false,
   },
   [EXPERIMENT_IDS.CLAUDE_DESIGN_MCP]: {
     id: EXPERIMENT_IDS.CLAUDE_DESIGN_MCP,
@@ -118,7 +119,7 @@ export const EXPERIMENTS: Record<ExperimentId, ExperimentDefinition> = {
     name: "Continuous Compaction",
     description: "Compact older context between turns while preserving recent messages verbatim",
     enabledByDefault: false,
-    showInSettings: true,
+    showInSettings: false,
   },
   [EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING]: {
     id: EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING,

--- a/src/node/services/agentSkills/builtInSkillContent.generated.ts
+++ b/src/node/services/agentSkills/builtInSkillContent.generated.ts
@@ -8515,7 +8515,7 @@ export const BUILTIN_SKILL_FILES: Record<string, Record<string, string>> = {
       "description: Start fresh context windows without automatic summaries and retrieve earlier work on demand",
       "---",
       "",
-      "Enable **Token-budget context windows** in **Settings → Experiments** to replace usage-triggered automatic summaries with fresh context windows. The experiment is off by default.",
+      "Select **Token Budget** from **Compaction strategy** in **Settings → General** to replace usage-triggered automatic summaries with fresh context windows. The default strategy is **Summarize**.",
       "",
       "## Threshold and precedence",
       "",


### PR DESCRIPTION
## Summary
Move compaction selection into **Settings → General** as one dropdown: **Summarize**, **Continuous**, or **Token Budget**. Hide the two old Experiments switches; leave the composer, context-meter settings, and compaction algorithms unchanged.

## Compatibility and persistence
- Keep the existing global experiment flags. Legacy both-enabled state still displays Continuous; preferences are normalized only on an explicit choice, including reselecting the displayed choice.
- Serialize actual compaction writes in the app-root provider, including reconnect uploads, so successful rapid selections remain ordered across Settings navigation. Other experiments and Design-toggle behavior are unchanged.
- Keep Token Budget selectable under PTC + RLM and explain why the saved preference is inactive.

The queue is provider-local, not a cross-client transaction. Failed RPCs do not block later selections, but failed persistence or a hard reload cannot guarantee completion of a two-key update.

## Validation
- 136 targeted tests across the touched and neighboring settings, send-options, backend experiment, and compaction suites passed on the rebased commit.
- `make static-check` passed after rebase.
- 25 Storybook interactions across six affected suites passed at the standard timeout after warming Vite, including the existing token-budget stories, same-option normalization, exactly one pair of writes, Escape without writes, and the 390px Phone story. Verified the configured 390×844 viewport through the Storybook manager.
- Isolated browser dogfood independently inspected the experiments IPC: defaults, legacy both-enabled state, mouse/keyboard selection, rapid changes, Settings navigation, reload persistence, and PTC/RLM conflict changes. No live model calls.
- Current-head independent review and Codex code/security reviews are clean. All three initial findings were addressed with regression coverage and resolved.

### Evidence
![Desktop compaction dropdown](https://github.com/user-attachments/assets/5c053b76-8195-495a-a8c3-b94ff5e9a2e8)

![375px compaction preference and conflict notice](https://github.com/user-attachments/assets/014beeef-65a8-4551-bfcd-e6f75496492a)

Desktop interaction recording:

https://github.com/user-attachments/assets/31449482-8b94-4253-a8ab-80c058062b62

Fresh mobile layout recording:

https://github.com/user-attachments/assets/b6ecf8db-b351-415b-94d3-d788cb7d97be

### Validation limits
Native touch emulation was inconclusive, including on an existing unrelated dropdown. The idle draft composer was checked, but its context-meter dialog was unavailable without a conversation. General's pre-existing Terminal font input causes horizontal overflow at 375px; the new compaction row fits at the initial scroll position. Terminal layout was intentionally left unchanged.

---

<details>
<summary>📋 Implementation Plan</summary>

# Consolidate compaction in Settings → General

## Goal and placement
Replace the two compaction switches in **Settings → Experiments** with one **Compaction strategy** dropdown in **Settings → General**, the main settings page shown in the user's screenshot. **Do not add anything to the chat composer or context-meter dialog.**

## Recommended behavior
Use the existing General settings row and Select patterns, with exactly three choices:

| Choice | Continuous flag | Token Budget flag |
| --- | --- | --- |
| Summarize | off | off |
| Continuous | on | off |
| Token Budget | off | on |

Preserve the existing global experiment preference scope; do not introduce per-workspace storage. Preserve legacy state on load: when both flags are enabled, display Continuous, matching the current precedence; normalize only on an explicit selection.

## Verified implementation context
- `src/browser/features/Settings/Sections/GeneralSection.tsx` already uses shared `Select`, `SelectTrigger`, `SelectValue`, `SelectContent`, and `SelectItem`. Add a **Compaction** section between **Transcript** and **Terminal**.
- `src/common/constants/experiments.ts` registers both flags with `enabledByDefault: false`; absent overrides therefore resolve to Summarize. `ExperimentsSection.tsx` already filters `showInSettings: false` entries. Selecting Summarize writes explicit false values rather than clearing overrides.
- `ExperimentsContext.tsx` exposes resolved values and synchronous optimistic setters. Its app-root provider survives Settings navigation; `persistOverride` awaits the backend mutation and returns a success boolean. Standard setters currently launch writes concurrently.
- `experimentsService.ts` merges each override under a file lock and writes atomically, preventing distinct-key clobbering. The lock is not FIFO, so rapid same-key mutation ordering is not guaranteed. This is a code-level ordering gap, not a measured incident.
- `useAutoCompactionSettings.ts`, `agentSession.ts`, and `turnRequestBuilder.ts` implement precedence; `sendOptions.ts` carries experiment flags. PTC + RLM suppresses Token Budget, not Continuous. Retain these algorithms.
- The working tree was clean during investigation; preserve existing branch work.

## Delivery boundary
One small, independently usable change on the current branch: dropdown, hidden Settings switches, and required coverage together. No unrelated experiment cleanup, migrations, dependencies, or backend algorithm refactoring. No PR creation is authorized.

## Implementation steps and gates

### 1. Add the General setting and its persistence adapter
- In `GeneralSection.tsx`, add the **Compaction strategy** row under the new Compaction section. Reuse the shared Select and existing setting-row layout, labels, and keyboard behavior; no standalone picker component or custom shortcut system.
- Read resolved values via `useExperiment` (local override → backend override → default). Derive the selected strategy during render; use a three-value union and exhaustive handler, with an assertion for an unexpected Select value. Do not introduce a persisted enum, migration, single-use hook, or synchronization effect.
- On explicit selection, synchronously publish the canonical pair through existing setters. Enable the requested mechanism before clearing its competitor; for Summarize, clear Token Budget before Continuous. Never write or normalize on mount.
- In `ExperimentsContext.tsx`, add one provider-owned FIFO for **only these two experiment IDs**, enclosing their actual asynchronous `persistOverride` calls. Capture each requested ID/value and await completion before dispatching the next write. Preserve synchronous optimistic publication, the existing success/failure contract, and unrelated experiment/Design-toggle behavior. A failed/unavailable write must not poison the queue. Do not queue around the void-returning setter or inside GeneralSection.
- Keep all three choices selectable. If Token Budget is selected while PTC + RLM is active, show a short inline explanation that the saved preference is inactive until that combination is disabled. Do not change the preference or RLM itself.
- Hide the two old switches via `showInSettings: false`, retaining registry IDs, defaults, and backend plumbing. Leave the composer, threshold/idle dialog, and all other settings untouched.
- Comment briefly on legacy flag compatibility/precedence and why these paired mutations share an ordered persistence queue.

**Gate:** deterministic tests must show that, within one provider and without competing clients, the latest selected pair wins after successful queued writes, Settings navigation preserves ordering, and later selections still persist after failure. This does **not** promise transactional two-key updates, ordering between clients, successful persistence after failed RPCs, or queue completion across a hard reload.

### 2. Lock down behavior and layout
- Extend `GeneralSection.test.tsx`: all four legacy flag combinations; resolved defaults/backend overrides; no writes on mount; all strategy transitions; unchanged unrelated flags; and selectable Token Budget with an RLM warning that disappears when the conflict is removed. Test behavior, not descriptive prose.
- Extend `ExperimentsContext.test.tsx` with deferred backend completions proving FIFO dispatch, rapid latest-selection persistence, survival across General-section unmount/remount, and recovery after failed writes. Preserve existing Design-toggle coverage.
- Update `ExperimentsSection.test.tsx` to verify only the two compaction controls disappear.
- Add a full-app `src/browser/stories/App.compactionSettings.stories.tsx` using existing App-story setup patterns. Cover navigation to General, opening/selecting the dropdown, and desktop/phone layouts. Pin the phone Pixel viewport (390px) and matching local viewport; use a narrow wrapper or width-aware assertions for test-runner plays.
- Verify durable values through the existing experiments IPC in an isolated full-app/browser exercise after writes settle—not just localStorage or optimistic labels. Validate outgoing experiment flags with the existing `sendOptions` tests.

**Gate:** run the touched and neighboring suites:
```sh
bun test src/browser/features/Settings/Sections/GeneralSection.test.tsx \
  src/browser/features/Settings/Sections/ExperimentsSection.test.tsx \
  src/browser/contexts/ExperimentsContext.test.tsx \
  src/browser/hooks/useAutoCompactionSettings.test.tsx \
  src/browser/utils/messages/sendOptions.test.ts \
  src/node/services/experimentsService.test.ts \
  src/node/services/agentSession.continuousCompaction.test.ts
```
Run any additional existing sibling tests for touched production files and affected full-app Storybook interaction tests. After tests finish, run `make static-check` (lint, types, formatting). Fix failures and rerun affected gates before handoff.

## Dogfooding
1. Start an isolated instance using:
   ```sh
   make dev-server-sandbox DEV_SERVER_SANDBOX_ARGS="--clean-providers --clean-projects"
   ```
   Use its reported URL and a disposable project/workspace. Do not alter the user's running app or real preferences.
2. Load the `agent-browser` skill, open **Settings → General**, and record a video. Select Summarize → Continuous → Token Budget → Summarize; also make rapid successive selections and leave/reopen Settings. Wait for persistence, independently inspect backend overrides, then reload and confirm the last selection remains.
3. Visit **Settings → Experiments** and confirm the two switches are absent. Return to the chat and verify no new composer control appeared and threshold/idle settings remain unchanged. Test the General dropdown with Tab, Enter/Space, arrows, and Escape, including focus return.
4. Exercise seeded legacy both-enabled state and PTC/RLM combinations in the disposable sandbox. Verify the saved selection is preserved, Token Budget remains selectable, and the inline notice tracks the conflict. No live model calls are required; this change does not rewrite compaction algorithms.
5. Check desktop and approximately 375px-wide General settings layouts, including the open dropdown and right-edge overflow. Capture screenshots of both layouts and the conflict notice, plus the video; attach them for reviewer inspection. If GitHub publication is later requested, upload evidence with `gh ... --attach`.
6. Stop the owned dev server/browser recording, review the final diff, and report exact passed/failed/unavailable checks.

## Acceptance criteria
- **Settings → General** contains one Compaction strategy dropdown with exactly **Summarize**, **Continuous**, and **Token Budget**.
- **Settings → Experiments** no longer exposes the two switches. The composer, context-meter settings, and other experiments are unchanged.
- Existing resolved preferences and both-enabled precedence are preserved without migration or render-time writes. Explicit selection produces the canonical flag pair.
- Successful persistence reflects the latest selection within one provider, even during rapid changes or Settings navigation; write failures do not block later changes.
- PTC/RLM incompatibility is explained without disabling selection or changing backend algorithms.
- Keyboard/mobile checks, behavioral tests, static checks, screenshots, and video support the implementation handoff.

**Net product LoC estimate:** approximately **+80–120 lines**, excluding tests and stories: the General setting and small two-flag persistence queue, plus experiment metadata edits. No new backend API or standalone selector component.

**Review status:** **Advisor-approved after three review rounds**, with explicit full approval and no remaining design blockers. This approval covers the plan only; implementation and validation have not started. Proceed in Exec mode only after user approval.

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `coder:openai/gpt-6-astra` • Thinking: `xhigh` • Cost: `$28.68`_

<!-- mux-attribution: model=coder:openai/gpt-6-astra thinking=xhigh costs=28.68 -->
