### PR TITLE
🤖 ci: preserve all check-suite failures in the native-stack workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -665,8 +665,8 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Test comment classification
-        run: make test-codex-comments
+      - name: Test PR readiness gates
+        run: make test-codex-comments test-pr-checks
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/check_codex_comments.sh ${{ github.event.pull_request.number }}

--- a/Makefile
+++ b/Makefile
@@ -434,9 +434,12 @@ check-deadcode: node_modules/.installed ## Check for potential dead code (manual
 		|| echo "✓ No obvious dead code found"
 
 ## Testing
-.PHONY: test-codex-comments
+.PHONY: test-codex-comments test-pr-checks
 test-codex-comments: ## Test Codex comment gates with offline GitHub fixtures
 	@python3 scripts/check_codex_comments_test.py
+
+test-pr-checks: ## Test PR check discovery and readiness with offline GitHub fixtures
+	@python3 scripts/pr_checks_test.py
 
 test-integration: node_modules/.installed build-main ## Run all tests (unit + integration)
 	@bun test src

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -71,7 +71,7 @@ Core workflow:
 - When checking PR readiness, audit **all** PR reviews, review comments, and issue comments from every reviewer/bot (including `coder-agents-review`), not just Codex; address or explicitly resolve them before declaring readiness.
 - If a PR has `coder-agents-review` feedback, address it and reply before resolving: either reply inline on each finding or leave a PR comment that explicitly lists each finding and your response. Do not silently resolve those threads.
 - If a PR has Codex review comments, address + resolve them, then re-request review by commenting `@codex review` on the PR.
-- Prefer `gh` CLI for GitHub interactions over manual web/curl flows.
+- Prefer `gh` CLI for GitHub interactions over manual web/curl flows. Use `./scripts/wait_pr_ready.sh` for readiness: `gh pr checks` deduplicates names across check suites and can hide failures.
 - User preference: use `gh stack` to manage GitHub-native stacked PRs; keep every PR linked in the native stack, not just chained by base branches.
 
 - User preference: when work is already on an open PR, push branch updates at the end of each completed change set so the PR stays current.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -72,6 +72,7 @@ Core workflow:
 - If a PR has `coder-agents-review` feedback, address it and reply before resolving: either reply inline on each finding or leave a PR comment that explicitly lists each finding and your response. Do not silently resolve those threads.
 - If a PR has Codex review comments, address + resolve them, then re-request review by commenting `@codex review` on the PR.
 - Prefer `gh` CLI for GitHub interactions over manual web/curl flows.
+- User preference: use `gh stack` to manage GitHub-native stacked PRs; keep every PR linked in the native stack, not just chained by base branches.
 
 - User preference: when work is already on an open PR, push branch updates at the end of each completed change set so the PR stays current.
 - **PR creation gate:** Do **not** open/create a pull request unless the user explicitly asks (e.g., "open a PR", "create PR", "submit this"). By default, complete local validation, commit/push branch updates as requested, and let the user review before deciding whether to open a PR.

--- a/scripts/extract_pr_logs.sh
+++ b/scripts/extract_pr_logs.sh
@@ -50,13 +50,17 @@ if [[ "$INPUT" =~ ^[0-9]{1,5}$ ]]; then
   # Get the latest failed non-visual-review run for this PR. Pixel review statuses are
   # intentionally ignored for merge readiness, so they should not drive log extraction.
   JQ_DEFS=$(visual_check_jq_defs)
-  RUN_ID=$(gh pr checks "$PR_NUMBER" --json name,link,state,bucket,workflow,description --jq "$JQ_DEFS .[] | select((is_visual_review_check | not) and is_failed_check) | .link" | sed -nE 's|.*/runs/([0-9]+).*|\1|p' | head -1 || echo "")
+  if ! CHECKS=$(fetch_pr_checks "$PR_NUMBER"); then
+    echo "❌ Failed to get complete PR checks for PR #$PR_NUMBER" >&2
+    exit 1
+  fi
+  RUN_ID=$(jq -r "$JQ_DEFS [ .[] | select((is_visual_review_check | not) and is_failed_check) | .link | capture(\"/runs/(?<id>[0-9]+)\")? | .id ][0] // empty" <<<"$CHECKS")
 
   if [[ -z "$RUN_ID" ]]; then
     echo "❌ No failed non-visual-review runs found for PR #$PR_NUMBER" >&2
     echo "" >&2
     echo "Current non-visual-review check status:" >&2
-    gh pr checks "$PR_NUMBER" --json name,state,bucket,workflow,link,description --jq "$JQ_DEFS .[] | select(is_visual_review_check | not) | check_line" 2>&1 || true
+    jq -r "$JQ_DEFS .[] | select(is_visual_review_check | not) | check_line" <<<"$CHECKS" >&2
     exit 1
   fi
 
@@ -79,7 +83,7 @@ fi
 
 # Filter to failed jobs only (unless specific pattern requested)
 if [[ -z "$JOB_PATTERN" ]]; then
-  FAILED_JOBS=$(echo "$JOBS" | jq -r 'select(.conclusion == "FAILURE" or .conclusion == "TIMED_OUT" or .conclusion == "CANCELLED")')
+  FAILED_JOBS=$(echo "$JOBS" | jq -r 'select(.conclusion // "" | ascii_upcase | IN("FAILURE", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE", "STALE"))')
   if [[ -n "$FAILED_JOBS" ]]; then
     echo "🎯 Showing only failed jobs (use job_pattern to see others)" >&2
     JOBS="$FAILED_JOBS"
@@ -144,7 +148,7 @@ for JOB_ID in $JOB_IDS; do
 
   while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
     # Use gh api to fetch logs (works for individual completed jobs even if run is in progress)
-    if gh api "/repos/coder/mux/actions/jobs/$JOB_ID/logs" 2>/dev/null; then
+    if gh api "repos/{owner}/{repo}/actions/jobs/$JOB_ID/logs" 2>/dev/null; then
       break
     else
       RETRY_COUNT=$((RETRY_COUNT + 1))

--- a/scripts/lib/pr_check_filters.sh
+++ b/scripts/lib/pr_check_filters.sh
@@ -9,46 +9,98 @@ def is_visual_review_check:
   or (check_text("name") == "visual regression testing")
   or (check_text("name") | startswith("pixel /"))
   or (check_text("link") | contains("pixel.coder.com"));
-def is_unready_check:
-  (.bucket == "fail")
-  or (.bucket == "cancel")
-  or (.bucket == "pending")
-  or (.state == "FAILURE")
-  or (.state == "ERROR")
-  or (.state == "CANCELLED")
-  or (.state == "TIMED_OUT")
-  or (.state == "PENDING")
-  or (.state == "EXPECTED")
-  or (.state == "ACTION_REQUIRED")
-  or (.state == "QUEUED")
-  or (.state == "IN_PROGRESS")
-  or (.state == "REQUESTED")
-  or (.state == "WAITING");
 def is_failed_check:
-  (.bucket == "fail")
-  or (.bucket == "cancel")
-  or (.state == "FAILURE")
-  or (.state == "ERROR")
-  or (.state == "CANCELLED")
-  or (.state == "TIMED_OUT")
-  or (.state == "ACTION_REQUIRED");
+  (.bucket | IN("fail", "cancel"))
+  or (.state | IN("FAILURE", "ERROR", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED", "STARTUP_FAILURE", "STALE"));
 def is_pending_check:
   (.bucket == "pending")
-  or (.state == "PENDING")
-  or (.state == "EXPECTED")
-  or (.state == "QUEUED")
-  or (.state == "IN_PROGRESS")
-  or (.state == "REQUESTED")
-  or (.state == "WAITING");
+  or (.state | IN("PENDING", "EXPECTED", "QUEUED", "IN_PROGRESS", "REQUESTED", "WAITING"));
 def is_passing_check:
   (.bucket == "pass") or (.state == "SUCCESS");
+def is_unready_check: is_failed_check or is_pending_check;
 def check_line:
   [
     (.name // "<unnamed>"),
     (.bucket // "<unknown>"),
     (.state // "<unknown>"),
     (.link // ""),
-    (.description // "")
+    (.description // ""),
+    (.commit // "")
   ] | @tsv;
 JQ
+}
+
+# gh pr checks deduplicates by display name, hiding a failed run behind another
+# suite's success. GitHub's rollup retains those independent runs but omits
+# superseded attempts. Pin both refs and paginate before making any readiness claim.
+# shellcheck disable=SC2016 # GraphQL/jq variables must not expand in the shell.
+fetch_pr_checks() {
+  local pr refs oid pages normalized checks='[]'
+  pr=$(gh api graphql -F owner='{owner}' -F name='{repo}' -F number="$1" -f query='
+    query($owner: String!, $name: String!, $number: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) { headRefOid potentialMergeCommit { oid } }
+      }
+    }') || return 1
+  refs=$(jq -er '
+    .data.repository.pullRequest
+    | if (.headRefOid | type) != "string" or .headRefOid == ""
+        or (has("potentialMergeCommit") | not)
+        or (.potentialMergeCommit != null and ((.potentialMergeCommit.oid | type) != "string" or .potentialMergeCommit.oid == ""))
+      then error("Missing PR refs")
+      else [.headRefOid, .potentialMergeCommit.oid] | map(select(. != null)) | unique[] end
+  ' <<<"$pr") || return 1
+
+  for oid in $refs; do
+    pages=$(gh api graphql --paginate --slurp -F owner='{owner}' -F name='{repo}' -f oid="$oid" -f query='
+      query($owner: String!, $name: String!, $oid: GitObjectID!, $endCursor: String) {
+        repository(owner: $owner, name: $name) {
+          object(oid: $oid) {
+            ... on Commit {
+              oid
+              statusCheckRollup {
+                contexts(first: 100, after: $endCursor) {
+                  pageInfo { hasNextPage endCursor }
+                  nodes {
+                    __typename
+                    ... on CheckRun {
+                      id name status conclusion detailsUrl
+                      checkSuite { id workflowRun { workflow { name } } }
+                    }
+                    ... on StatusContext { id context state targetUrl description }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }') || return 1
+    normalized=$(jq -cer --arg oid "$oid" "$(visual_check_jq_defs)"'
+      if type != "array" or length == 0
+        or any(.[]; ((.errors // []) | length) > 0 or .data.repository.object.oid != $oid
+          or (.data.repository.object | has("statusCheckRollup") | not))
+      then error("Missing check snapshot")
+      elif any(.[]; .data.repository.object.statusCheckRollup |
+        . != null and ((.contexts.nodes | type) != "array" or (.contexts.pageInfo.hasNextPage | type) != "boolean"))
+        or (.[-1].data.repository.object.statusCheckRollup |
+          . != null and .contexts.pageInfo.hasNextPage != false)
+      then error("Incomplete check pagination")
+      else [ .[].data.repository.object.statusCheckRollup.contexts.nodes[]? |
+        if .__typename == "CheckRun" then
+          {id, name, state: (if .status == "COMPLETED" then .conclusion // "PENDING" else .status end),
+           link: .detailsUrl, description: "", workflow: (.checkSuite.workflowRun.workflow.name // ""),
+           suite: .checkSuite.id}
+        elif .__typename == "StatusContext" then
+          {id, name: .context, state, link: .targetUrl, description, workflow: ""}
+        else error("Unknown check context") end
+        | .commit = $oid
+        | .bucket = (if .state == "CANCELLED" then "cancel"
+          elif is_failed_check then "fail" elif is_passing_check then "pass"
+          elif .state == "SKIPPED" or .state == "NEUTRAL" then "skipping"
+          else "pending" end)
+      ] end
+    ' <<<"$pages") || return 1
+    checks=$(printf '%s\n%s\n' "$checks" "$normalized" | jq -cs 'add') || return 1
+  done
+  printf '%s\n' "$checks"
 }

--- a/scripts/lib/pr_check_filters.sh
+++ b/scripts/lib/pr_check_filters.sh
@@ -30,26 +30,41 @@ def check_line:
 JQ
 }
 
-# gh pr checks deduplicates by display name, hiding a failed run behind another
-# suite's success. GitHub's rollup retains those independent runs but omits
-# superseded attempts. Pin both refs and paginate before making any readiness claim.
-# shellcheck disable=SC2016 # GraphQL/jq variables must not expand in the shell.
-fetch_pr_checks() {
-  local pr refs oid pages normalized checks='[]'
+# shellcheck disable=SC2016 # These are GraphQL variables, not shell variables.
+fetch_pr_check_state() {
+  local pr
   pr=$(gh api graphql -F owner='{owner}' -F name='{repo}' -F number="$1" -f query='
     query($owner: String!, $name: String!, $number: Int!) {
       repository(owner: $owner, name: $name) {
-        pullRequest(number: $number) { headRefOid potentialMergeCommit { oid } }
+        pullRequest(number: $number) {
+          state mergeable mergeStateStatus reviewDecision headRefOid potentialMergeCommit { oid }
+        }
       }
     }') || return 1
-  refs=$(jq -er '
+  jq -cSe '
     .data.repository.pullRequest
     | if (.headRefOid | type) != "string" or .headRefOid == ""
         or (has("potentialMergeCommit") | not)
         or (.potentialMergeCommit != null and ((.potentialMergeCommit.oid | type) != "string" or .potentialMergeCommit.oid == ""))
       then error("Missing PR refs")
-      else [.headRefOid, .potentialMergeCommit.oid] | map(select(. != null)) | unique[] end
-  ' <<<"$pr") || return 1
+      else .reviewDecision = (.reviewDecision // "") end
+  ' <<<"$pr"
+}
+
+# gh pr checks deduplicates by display name, hiding a failed run behind another
+# suite's success. GitHub's rollup retains those independent runs but omits
+# superseded attempts. Return 10 if a push/base update invalidates the snapshot.
+# shellcheck disable=SC2016 # GraphQL/jq variables must not expand in the shell.
+fetch_pr_checks() {
+  local pr latest expected refs oid pages normalized checks='[]'
+  pr=$(fetch_pr_check_state "$1") || return 1
+  if [ "$#" -gt 1 ]; then
+    # Do not combine an earlier CLEAN verdict with checks for a different head.
+    expected=$(jq -cS . <<<"$2") || return 1
+    latest=$(jq -cS 'del(.potentialMergeCommit)' <<<"$pr") || return 1
+    [ "$latest" = "$expected" ] || return 10
+  fi
+  refs=$(jq -r '[.headRefOid, .potentialMergeCommit.oid] | map(select(. != null)) | unique[]' <<<"$pr") || return 1
 
   for oid in $refs; do
     pages=$(gh api graphql --paginate --slurp -F owner='{owner}' -F name='{repo}' -f oid="$oid" -f query='
@@ -102,5 +117,8 @@ fetch_pr_checks() {
     ' <<<"$pages") || return 1
     checks=$(printf '%s\n%s\n' "$checks" "$normalized" | jq -cs 'add') || return 1
   done
+  # A passing old commit is not evidence that a concurrently pushed PR is ready.
+  latest=$(fetch_pr_check_state "$1") || return 1
+  [ "$latest" = "$pr" ] || return 10
   printf '%s\n' "$checks"
 }

--- a/scripts/pr_checks_test.py
+++ b/scripts/pr_checks_test.py
@@ -1,0 +1,249 @@
+"""Offline PR check-discovery regressions: python3 scripts/pr_checks_test.py."""
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent
+HEAD = "1" * 40
+MERGE = "2" * 40
+
+
+def check(name="Required", conclusion="SUCCESS", suite=1, status="COMPLETED"):
+    return {
+        "__typename": "CheckRun",
+        "id": f"check-{suite}",
+        "name": name,
+        "status": status,
+        "conclusion": conclusion,
+        "detailsUrl": f"https://github.com/fixture/repo/actions/runs/{suite}/job/{suite}",
+        "checkSuite": {"id": f"suite-{suite}", "workflowRun": {"workflow": {"name": "PR"}}},
+    }
+
+
+def pixel():
+    return {
+        "__typename": "StatusContext",
+        "id": "pixel",
+        "context": "Pixel / Review",
+        "state": "PENDING",
+        "targetUrl": "https://pixel.coder.com/builds/1",
+        "description": "Awaiting visual review",
+    }
+
+
+def page(oid, nodes=None, more=False):
+    rollup = None if nodes is None else {
+        "contexts": {
+            "nodes": nodes,
+            "pageInfo": {"hasNextPage": more, "endCursor": "next" if more else None},
+        }
+    }
+    return {"data": {"repository": {"object": {"oid": oid, "statusCheckRollup": rollup}}}}
+
+
+def fixture(nodes=None, merge_state="CLEAN"):
+    return {
+        "pr": {"state": "OPEN", "mergeable": "MERGEABLE", "mergeStateStatus": merge_state, "reviewDecision": ""},
+        "refs": {"headRefOid": HEAD, "potentialMergeCommit": {"oid": MERGE}},
+        "pages": {HEAD: [page(HEAD, nodes)], MERGE: [page(MERGE)]},
+    }
+
+
+class PrChecksTest(unittest.TestCase):
+    def setUp(self):
+        directory = tempfile.TemporaryDirectory(prefix="pr-checks-test-")
+        self.addCleanup(directory.cleanup)
+        self.directory = Path(directory.name)
+        gh = self.directory / "gh"
+        # Strict protocol double: no path falls through to the real gh/network.
+        # Paginated fixtures model GitHub's current rollup, not historical attempts.
+        gh.write_text("""#!/usr/bin/env python3
+import json, os, pathlib, sys
+args = sys.argv[1:]
+fixture = json.loads(pathlib.Path(os.environ['PR_CHECK_FIXTURE']).read_text())
+with open(os.environ['PR_CHECK_CALLS'], 'a') as calls:
+    calls.write(json.dumps(args) + '\\n')
+if args[:2] == ['pr', 'view']:
+    print(json.dumps(fixture['pr']))
+elif args[:2] == ['api', 'graphql']:
+    query = next(arg[6:] for arg in args if arg.startswith('query='))
+    if 'potentialMergeCommit' in query:
+        print(json.dumps({'data': {'repository': {'pullRequest': fixture['refs']}}}))
+    elif 'statusCheckRollup' in query:
+        assert '--paginate' in args and '--slurp' in args, args
+        assert '$endCursor' in query and 'after: $endCursor' in query, query
+        oid = next(arg[4:] for arg in args if arg.startswith('oid='))
+        print(json.dumps(fixture['pages'][oid]))
+        if fixture.get('fail_ref') == oid:
+            print('API page request failed', file=sys.stderr)
+            sys.exit(1)
+    elif 'reviewThreads' in query:
+        print(json.dumps({'data': {'repository': {'pullRequest': {'reviewThreads': {
+            'nodes': [], 'pageInfo': {'hasNextPage': False, 'endCursor': None}
+        }}}}}))
+    else:
+        raise AssertionError(query)
+elif args[:2] == ['run', 'view']:
+    assert args[2] == '2', args
+    for job in fixture['jobs']:
+        print(json.dumps(job))
+elif args[0] == 'api' and args[1].endswith('/logs'):
+    print('downloaded job ' + args[1].split('/')[-2])
+else:
+    raise AssertionError(args)
+""")
+        gh.chmod(0o755)
+
+    def run_script(self, data, script="wait_pr_checks.sh"):
+        path = self.directory / "fixture.json"
+        path.write_text(json.dumps(data))
+        calls = self.directory / "calls.jsonl"
+        calls.write_text("")
+        env = {
+            key: value for key, value in os.environ.items()
+            if not key.startswith(("MUX_", "GH_", "GITHUB_"))
+        }
+        env.update({
+            "PATH": str(self.directory) + os.pathsep + os.environ["PATH"],
+            "PR_CHECK_FIXTURE": str(path),
+            "PR_CHECK_CALLS": str(calls),
+            "MUX_SKIP_FETCH_SYNC": "1",
+            "MUX_GH_OWNER": "fixture",
+            "MUX_GH_REPO": "repo",
+        })
+        args = ["bash", str(SCRIPTS / script), "4194"]
+        if script == "wait_pr_checks.sh":
+            args.append("--once")
+        result = subprocess.run(args, env=env, text=True, capture_output=True, timeout=15, check=False)
+        self.calls = [json.loads(line) for line in calls.read_text().splitlines()]
+        return result
+
+    def assert_gate(self, expected, data):
+        result = self.run_script(data)
+        self.assertEqual(result.returncode, expected, result.stdout + result.stderr)
+        return result
+
+    def test_independent_same_name_failure_is_not_hidden_by_success_or_pixel(self):
+        failed = check(conclusion="FAILURE", suite=2)
+        result = self.assert_gate(1, fixture([check(), failed, pixel()], "BLOCKED"))
+        self.assertIn(failed["detailsUrl"], result.stdout)
+        self.assertNotIn(check()["detailsUrl"], result.stdout)
+
+    def test_later_page_failure_is_reported(self):
+        data = fixture()
+        failed = check(conclusion="FAILURE", suite=2)
+        data["pages"][HEAD] = [page(HEAD, [check()], more=True), page(HEAD, [failed])]
+        result = self.assert_gate(1, data)
+        self.assertIn(failed["detailsUrl"], result.stdout)
+
+    def test_merge_ref_failure_is_reported_with_commit_identity(self):
+        data = fixture([check()])
+        failed = check(conclusion="FAILURE", suite=2)
+        data["pages"][MERGE] = [page(MERGE, [failed])]
+        result = self.assert_gate(1, data)
+        self.assertIn(failed["detailsUrl"], result.stdout)
+        self.assertIn(MERGE, result.stdout)
+
+    def test_current_success_with_no_merge_checks_passes(self):
+        self.assert_gate(0, fixture([check(suite=2)]))
+
+    def test_multiple_successful_pages_pass(self):
+        data = fixture()
+        data["pages"][HEAD] = [page(HEAD, [check()], more=True), page(HEAD, [check(suite=2)])]
+        self.assert_gate(0, data)
+
+    def test_no_merge_ref_still_checks_head(self):
+        data = fixture([check()])
+        data["refs"]["potentialMergeCommit"] = None
+        self.assert_gate(0, data)
+        self.assertFalse(any(f"oid={MERGE}" in args for args in self.calls))
+
+    def test_blocked_is_not_explained_by_pixel_alone(self):
+        self.assert_gate(10, fixture([check(), pixel()], "BLOCKED"))
+
+    def test_unstable_from_optional_pixel_can_pass(self):
+        self.assert_gate(0, fixture([check(), pixel()], "UNSTABLE"))
+
+    def test_empty_skipped_and_pixel_only_are_pending(self):
+        for nodes in (None, [], [check(conclusion="SKIPPED")], [pixel()]):
+            with self.subTest(nodes=nodes):
+                self.assert_gate(10, fixture(nodes))
+
+    def test_pending_or_unknown_state_cannot_be_hidden_by_success(self):
+        for status in ("QUEUED", "IN_PROGRESS", "WAITING", "FUTURE_STATUS"):
+            with self.subTest(status=status):
+                self.assert_gate(10, fixture([check(), check(suite=2, status=status)]))
+
+    def test_failure_conclusions_remain_blocking(self):
+        for conclusion in ("FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED", "STARTUP_FAILURE", "STALE"):
+            with self.subTest(conclusion=conclusion):
+                self.assert_gate(1, fixture([check(), check(suite=2, conclusion=conclusion)]))
+
+    def test_api_failure_after_a_successful_page_fails_closed(self):
+        data = fixture([check()])
+        data["fail_ref"] = MERGE
+        result = self.assert_gate(1, data)
+        self.assertIn("API page request failed", result.stdout + result.stderr)
+
+    def test_incomplete_pagination_fails_closed(self):
+        data = fixture()
+        data["pages"][HEAD] = [page(HEAD, [check()], more=True)]
+        self.assert_gate(1, data)
+
+    def test_missing_or_malformed_commit_data_fails_closed(self):
+        for response in (
+            {"data": {"repository": {"object": None}}},
+            {"data": {"repository": {"object": {"oid": MERGE}}}},
+            page("wrong", [check()]),
+            {},
+        ):
+            with self.subTest(response=response):
+                data = fixture([check()])
+                data["pages"][MERGE] = [response]
+                self.assert_gate(1, data)
+
+    def test_legacy_status_failure_cannot_be_hidden_by_a_same_name_check(self):
+        status = pixel()
+        status.update(context="Required", state="ERROR", targetUrl="https://ci.example/failed")
+        result = self.assert_gate(1, fixture([check(), status]))
+        self.assertIn(status["targetUrl"], result.stdout)
+
+    def test_malformed_contexts_fail_closed(self):
+        for nodes in ("invalid", [{"__typename": "UnknownCheck"}]):
+            with self.subTest(nodes=nodes):
+                data = fixture([check()])
+                data["pages"][MERGE] = [page(MERGE, nodes)]
+                self.assert_gate(1, data)
+
+    def test_missing_pr_refs_fail_closed(self):
+        for refs in (None, {"headRefOid": HEAD}, {"headRefOid": HEAD, "potentialMergeCommit": {}}):
+            with self.subTest(refs=refs):
+                data = fixture([check()])
+                data["refs"] = refs
+                self.assert_gate(1, data)
+
+    def test_log_extractor_finds_failed_suite_and_downloads_only_failed_jobs(self):
+        data = fixture([check(), check(conclusion="FAILURE", suite=2), pixel()])
+        data["jobs"] = [
+            {"databaseId": 21, "name": "Required", "conclusion": "failure"},
+            {"databaseId": 22, "name": "Lint", "conclusion": "success"},
+        ]
+        result = self.run_script(data, "extract_pr_logs.sh")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("downloaded job 21", result.stdout)
+        self.assertNotIn("downloaded job 22", result.stdout)
+
+    def test_log_extractor_does_not_select_a_pixel_failure(self):
+        visual = pixel()
+        visual["state"] = "FAILURE"
+        result = self.run_script(fixture([check(), visual]), "extract_pr_logs.sh")
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertFalse(any(args[:2] == ["run", "view"] for args in self.calls))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/pr_checks_test.py
+++ b/scripts/pr_checks_test.py
@@ -47,7 +47,7 @@ def page(oid, nodes=None, more=False):
 
 def fixture(nodes=None, merge_state="CLEAN"):
     return {
-        "pr": {"state": "OPEN", "mergeable": "MERGEABLE", "mergeStateStatus": merge_state, "reviewDecision": ""},
+        "pr": {"state": "OPEN", "mergeable": "MERGEABLE", "mergeStateStatus": merge_state, "reviewDecision": "", "headRefOid": HEAD},
         "refs": {"headRefOid": HEAD, "potentialMergeCommit": {"oid": MERGE}},
         "pages": {HEAD: [page(HEAD, nodes)], MERGE: [page(MERGE)]},
     }
@@ -72,7 +72,13 @@ if args[:2] == ['pr', 'view']:
 elif args[:2] == ['api', 'graphql']:
     query = next(arg[6:] for arg in args if arg.startswith('query='))
     if 'potentialMergeCommit' in query:
-        print(json.dumps({'data': {'repository': {'pullRequest': fixture['refs']}}}))
+        calls = [json.loads(line) for line in pathlib.Path(os.environ['PR_CHECK_CALLS']).read_text().splitlines()]
+        recheck = sum(any(arg.startswith('query=') and 'potentialMergeCommit' in arg for arg in call) for call in calls) > 1
+        if recheck and fixture.get('fail_recheck'):
+            sys.exit(1)
+        refs = fixture.get('refs_after', fixture['refs']) if recheck else fixture['refs']
+        state = dict(fixture['pr'], **refs) if refs is not None else None
+        print(json.dumps({'data': {'repository': {'pullRequest': state}}}))
     elif 'statusCheckRollup' in query:
         assert '--paginate' in args and '--slurp' in args, args
         assert '$endCursor' in query and 'after: $endCursor' in query, query
@@ -161,6 +167,29 @@ else:
         data["refs"]["potentialMergeCommit"] = None
         self.assert_gate(0, data)
         self.assertFalse(any(f"oid={MERGE}" in args for args in self.calls))
+
+    def test_ref_or_state_change_during_discovery_returns_pending(self):
+        for changed in (
+            {"headRefOid": "3" * 40},
+            {"potentialMergeCommit": {"oid": "3" * 40}},
+            {"mergeStateStatus": "BLOCKED"},
+        ):
+            with self.subTest(changed=changed):
+                data = fixture([check()])
+                data["refs_after"] = dict(data["refs"], **changed)
+                result = self.assert_gate(10, data)
+                self.assertNotIn(check()["detailsUrl"], result.stdout)
+
+    def test_head_change_between_status_and_discovery_returns_pending(self):
+        data = fixture([check()])
+        data["refs"]["headRefOid"] = "3" * 40
+        self.assert_gate(10, data)
+        self.assertFalse(any(any(arg.startswith("oid=") for arg in args) for args in self.calls))
+
+    def test_failed_final_snapshot_read_cannot_accept_passing_checks(self):
+        data = fixture([check()])
+        data["fail_recheck"] = True
+        self.assert_gate(1, data)
 
     def test_blocked_is_not_explained_by_pixel_alone(self):
         self.assert_gate(10, fixture([check(), pixel()], "BLOCKED"))

--- a/scripts/wait_pr_checks.sh
+++ b/scripts/wait_pr_checks.sh
@@ -184,8 +184,7 @@ CHECK_PR_CHECKS_ONCE() {
   local ignored_unready_count
   local ignored_unready_checks
 
-  checks_json=$(gh pr checks "$PR_NUMBER" --json name,state,bucket,workflow,link,description 2>&1) || true
-  if ! echo "$checks_json" | jq -e 'type == "array"' >/dev/null 2>&1; then
+  if ! checks_json=$(fetch_pr_checks "$PR_NUMBER" 2>&1); then
     echo "❌ Failed to get PR checks for PR #$PR_NUMBER" >&2
     echo "$checks_json" >&2
     return 1
@@ -231,7 +230,7 @@ CHECK_PR_CHECKS_ONCE() {
   if [ "$has_fail" -eq 1 ]; then
     echo "❌ Some non-visual-review checks failed:"
     echo ""
-    echo "$checks"
+    echo "$filtered_checks" | jq -r "$jq_defs .[] | select(is_failed_check) | check_line"
     if [ "$ignored_unready_count" -gt 0 ]; then
       echo ""
       echo "ℹ️ Ignoring visual-review unready checks:"
@@ -265,16 +264,9 @@ CHECK_PR_CHECKS_ONCE() {
       return 1
     fi
 
-    # If a Pixel review status is required in branch protection, GitHub reports
-    # the aggregate merge state as BLOCKED. At this point non-visual-review checks,
-    # review-thread checks, and GitHub's reviewDecision gate have passed, so an
-    # ignored unready status is the only remaining blocker this script can see.
-    local merge_state_blocked_by_ignored_visual=0
-    if { [ "$merge_state" = "UNSTABLE" ] || [ "$merge_state" = "BLOCKED" ]; } && [ "$ignored_unready_count" -gt 0 ]; then
-      merge_state_blocked_by_ignored_visual=1
-    fi
-
-    if [ "$merge_state" = "CLEAN" ] || [ "$merge_state_blocked_by_ignored_visual" -eq 1 ]; then
+    # Optional visual checks can explain UNSTABLE, but their presence does not
+    # prove why GitHub is BLOCKED (for example, an unsatisfied repository rule).
+    if [ "$merge_state" = "CLEAN" ] || { [ "$merge_state" = "UNSTABLE" ] && [ "$ignored_unready_count" -gt 0 ]; }; then
       echo "✅ All non-visual-review checks passed!"
       echo ""
       echo "$checks"

--- a/scripts/wait_pr_checks.sh
+++ b/scripts/wait_pr_checks.sh
@@ -88,7 +88,7 @@ CHECK_PR_CHECKS_ONCE() {
   local reviews_output
 
   # Get PR status
-  status=$(gh pr view "$PR_NUMBER" --json mergeable,mergeStateStatus,reviewDecision,state 2>/dev/null || echo "error")
+  status=$(gh pr view "$PR_NUMBER" --json mergeable,mergeStateStatus,reviewDecision,state,headRefOid 2>/dev/null || echo "error")
 
   if [ "$status" = "error" ]; then
     echo "❌ Failed to get PR status. Does PR #$PR_NUMBER exist?"
@@ -184,11 +184,16 @@ CHECK_PR_CHECKS_ONCE() {
   local ignored_unready_count
   local ignored_unready_checks
 
-  if ! checks_json=$(fetch_pr_checks "$PR_NUMBER" 2>&1); then
+  checks_json=$(fetch_pr_checks "$PR_NUMBER" "$status" 2>&1) || {
+    local fetch_status=$?
+    if [ "$fetch_status" -eq 10 ]; then
+      echo "PR state changed while collecting checks; retrying."
+      return 10
+    fi
     echo "❌ Failed to get PR checks for PR #$PR_NUMBER" >&2
     echo "$checks_json" >&2
     return 1
-  fi
+  }
 
   jq_defs=$(visual_check_jq_defs)
   filtered_checks=$(echo "$checks_json" | jq "$jq_defs [ .[] | select(is_visual_review_check | not) ]")

--- a/src/node/services/agentSkills/builtInSkillContent.generated.ts
+++ b/src/node/services/agentSkills/builtInSkillContent.generated.ts
@@ -1762,7 +1762,7 @@ export const BUILTIN_SKILL_FILES: Record<string, Record<string, string>> = {
       "- When checking PR readiness, audit **all** PR reviews, review comments, and issue comments from every reviewer/bot (including `coder-agents-review`), not just Codex; address or explicitly resolve them before declaring readiness.",
       "- If a PR has `coder-agents-review` feedback, address it and reply before resolving: either reply inline on each finding or leave a PR comment that explicitly lists each finding and your response. Do not silently resolve those threads.",
       "- If a PR has Codex review comments, address + resolve them, then re-request review by commenting `@codex review` on the PR.",
-      "- Prefer `gh` CLI for GitHub interactions over manual web/curl flows.",
+      "- Prefer `gh` CLI for GitHub interactions over manual web/curl flows. Use `./scripts/wait_pr_ready.sh` for readiness: `gh pr checks` deduplicates names across check suites and can hide failures.",
       "- User preference: use `gh stack` to manage GitHub-native stacked PRs; keep every PR linked in the native stack, not just chained by base branches.",
       "",
       "- User preference: when work is already on an open PR, push branch updates at the end of each completed change set so the PR stays current.",

--- a/src/node/services/agentSkills/builtInSkillContent.generated.ts
+++ b/src/node/services/agentSkills/builtInSkillContent.generated.ts
@@ -1763,6 +1763,7 @@ export const BUILTIN_SKILL_FILES: Record<string, Record<string, string>> = {
       "- If a PR has `coder-agents-review` feedback, address it and reply before resolving: either reply inline on each finding or leave a PR comment that explicitly lists each finding and your response. Do not silently resolve those threads.",
       "- If a PR has Codex review comments, address + resolve them, then re-request review by commenting `@codex review` on the PR.",
       "- Prefer `gh` CLI for GitHub interactions over manual web/curl flows.",
+      "- User preference: use `gh stack` to manage GitHub-native stacked PRs; keep every PR linked in the native stack, not just chained by base branches.",
       "",
       "- User preference: when work is already on an open PR, push branch updates at the end of each completed change set so the PR stays current.",
       '- **PR creation gate:** Do **not** open/create a pull request unless the user explicitly asks (e.g., "open a PR", "create PR", "submit this"). By default, complete local validation, commit/push branch updates as requested, and let the user review before deciding whether to open a PR.',


### PR DESCRIPTION
## Summary

Make PR readiness use GitHub's complete check rollup instead of the name-deduplicated `gh pr checks` projection, and record the preference for `gh stack` to manage native stacked PRs.

## Background

On #4194, successful `Required` and `Codex Comments` checks from one workflow run hid two still-failing checks with the same names in another run. The previous readiness workflow incorrectly reported success. The new discovery path was tested against that live failure and returns exit 1 with both failing job URLs.

## Implementation

- Share paginated, commit-pinned head/merge check discovery between the readiness waiter and log extractor; retain independent suite results while relying on GitHub's rollup to exclude superseded attempts.
- Fail closed on API errors or incomplete pagination, and keep unknown check states pending. Revalidate PR refs and merge/review state before accepting collected checks; a concurrent push or base update returns pending.
- Do not infer that a pending Pixel status explains GitHub's `BLOCKED` state. Failure output prioritizes failing checks and identifies their commits.
- Run offline behavioral regressions in CI and update AGENTS.md plus its generated skill copy.

## Stack

Only remaining open PR in native stack #4174, now based on main after #4172, #4173, and #4194 merged.

## Validation

- 22 new PR-check regressions and 12 existing Codex-gate tests passed.
- Shellcheck, `make static-check`, and `git diff --check` passed.
- Live reproduction on #4194 surfaced both hidden failures from run `34385271008`; retrying that exact run subsequently passed.

## Risks

Readiness becomes intentionally stricter: independent failures and unexplained GitHub blockers can no longer be masked by same-name successes or optional Pixel statuses.

## Production ledger

Workflow scripts/config: +125 / −51 (net +74), excluding tests and documentation. Removed repeated state predicates, duplicated discovery, and the unsafe Pixel/BLOCKED shortcut; added complete paginated discovery and validation.

---

_Generated with `xum` • Model: `openai:gpt-6-astra` • Thinking: `xhigh` • Cost: `$591.32`_

<!-- mux-attribution: model=openai:gpt-6-astra thinking=xhigh costs=591.32 -->
