### PR TITLE
🤖 fix: clarify code execution string escaping

### DIFF
--- a/src/constants/codeExecution.ts
+++ b/src/constants/codeExecution.ts
@@ -1,0 +1,8 @@
+// Heredocs still live inside JavaScript strings. Teach the same quoting rules before
+// execution and on parse failure rather than guessing repairs that could change a command.
+export const CODE_EXECUTION_STRING_GUIDANCE =
+  "For multiline strings (shell scripts, SQL, file contents), use a backtick template literal " +
+  "or escaped \\n sequences in single/double quotes; raw newlines are invalid in quoted strings. " +
+  "Escape matching quotes and backslashes. In template literals, also escape embedded backticks " +
+  "and literal ${...} (e.g. shell variables) to avoid JavaScript interpolation. " +
+  "When sending tool-call JSON, JSON-escape the entire code value as well.";

--- a/src/node/services/ptc/staticAnalysis.test.ts
+++ b/src/node/services/ptc/staticAnalysis.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, test, expect, afterAll } from "bun:test";
 import { analyzeCode, disposeAnalysisContext } from "./staticAnalysis";
+import { CODE_EXECUTION_STRING_GUIDANCE } from "@/constants/codeExecution";
 
 afterAll(() => {
   disposeAnalysisContext();
@@ -46,6 +47,27 @@ describe("staticAnalysis", () => {
       `);
       expect(result.valid).toBe(false);
       expect(result.errors[0].type).toBe("syntax");
+    });
+
+    test.each([
+      'return "first\nsecond";',
+      "return 'first\nsecond';",
+      'return "first\r\nsecond";',
+      'return "unfinished',
+    ])("adds quoting guidance to unterminated strings: %j", async (code) => {
+      const result = await analyzeCode(code);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toMatchObject({ type: "syntax", line: 1 });
+      // Test diagnostic routing, not the wording of the shared guidance.
+      expect(result.errors[0].message).toContain(CODE_EXECUTION_STRING_GUIDANCE);
+    });
+
+    test("does not add string guidance to unrelated syntax errors", async () => {
+      const result = await analyzeCode('const s = "valid string";\nreturn @;');
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toMatchObject({ type: "syntax", line: 2 });
+      expect(result.errors[0].message).not.toContain(CODE_EXECUTION_STRING_GUIDANCE);
     });
 
     test("await expression gives clear error message", async () => {

--- a/src/node/services/ptc/staticAnalysis.ts
+++ b/src/node/services/ptc/staticAnalysis.ts
@@ -10,6 +10,7 @@
  */
 
 import ts from "typescript";
+import { CODE_EXECUTION_STRING_GUIDANCE } from "@/constants/codeExecution";
 import {
   newQuickJSAsyncWASMModuleFromVariant,
   type QuickJSAsyncContext,
@@ -166,6 +167,12 @@ async function validateSyntax(code: string): Promise<AnalysisError | null> {
       typeof errorObj.message === "string" ? errorObj.message : JSON.stringify(errorObj);
 
     const rawLine = typeof errorObj.lineNumber === "number" ? errorObj.lineNumber : undefined;
+
+    // QuickJS stops at the first raw newline in a quoted script. Keep rejecting
+    // malformed code, but explain how to retry without silently rewriting shell text.
+    if (message === "unexpected end of string") {
+      message += `. Unterminated JavaScript string. ${CODE_EXECUTION_STRING_GUIDANCE}`;
+    }
 
     // Enhance obtuse "expecting ';'" error when await expression is detected.
     // In non-async context, `await foo()` parses as identifier `await` + stray `foo()`,

--- a/src/node/services/tools/code_execution.test.ts
+++ b/src/node/services/tools/code_execution.test.ts
@@ -18,6 +18,7 @@ import { createKernelFileLoader } from "@/node/services/tools/kernelFileLoad";
 import { LocalRuntime } from "@/node/runtime/LocalRuntime";
 import { RESULT_HANDLE_VARS_CAP_BYTES, VARS_SNAPSHOT_MAX_BYTES } from "@/constants/resultHandles";
 import { KERNEL_RETAINED_MEDIA_BUDGET_BYTES } from "@/constants/kernelOutput";
+import { CODE_EXECUTION_STRING_GUIDANCE } from "@/constants/codeExecution";
 import * as fs from "node:fs/promises";
 import * as nodePath from "node:path";
 
@@ -202,6 +203,60 @@ describe("createCodeExecutionTool", () => {
   });
 
   describe("static analysis", () => {
+    it("rejects raw heredoc strings without side effects and accepts a correctly quoted retry", async () => {
+      const executeBash = mock(() => mockResults.bash);
+      const tool = await createCodeExecutionTool(
+        runtimeFactory,
+        new ToolBridge({
+          bash: createMockTool("bash", z.object({ script: z.string() }), executeBash),
+        })
+      );
+      const script = [
+        "cat > /tmp/query.sql <<'SQL'",
+        "SELECT JSON_VALUE(report, '$.event_ticker') FROM `project.dataset.table`",
+        "SQL",
+        'bq.sh "$(cat /tmp/query.sql)" --label="${USER}"',
+        "printf '%s\\n' done",
+      ].join("\n");
+
+      const invalid = (await tool.execute!(
+        {
+          code: 'xum.bash({script: "must not run"});\nreturn xum.bash({script: "' + script + '"});',
+        },
+        mockToolCallOptions
+      )) as PTCExecutionResult;
+      expect(invalid.success).toBe(false);
+      expect(invalid.error).toContain(CODE_EXECUTION_STRING_GUIDANCE);
+      expect(invalid.error).toContain("(line 2)");
+      expect(invalid.toolCalls).toHaveLength(0);
+      expect(executeBash).not.toHaveBeenCalled();
+
+      const valid = (await tool.execute!(
+        { code: "return xum.bash({script: " + JSON.stringify(script) + "});" },
+        mockToolCallOptions
+      )) as PTCExecutionResult;
+      expect(valid.success).toBe(true);
+      expect(valid.result).toEqual(mockResults.bash);
+      expect(executeBash).toHaveBeenCalledTimes(1);
+      expect(executeBash).toHaveBeenCalledWith({ script });
+
+      // Template literals need their own escaping even inside a shell heredoc.
+      const templateCode = [
+        "return xum.bash({script: `cat > /tmp/query.sql <<'SQL'",
+        "SELECT JSON_VALUE(report, '$.event_ticker') FROM \\`project.dataset.table\\`",
+        "SQL",
+        'bq.sh "$(cat /tmp/query.sql)" --label="\\${USER}"',
+        "printf '%s\\\\n' done`});",
+      ].join("\n");
+      const templateResult = (await tool.execute!(
+        { code: templateCode },
+        mockToolCallOptions
+      )) as PTCExecutionResult;
+      expect(templateResult.success).toBe(true);
+      expect(executeBash).toHaveBeenCalledTimes(2);
+      expect(executeBash).toHaveBeenLastCalledWith({ script });
+    });
+
     it("rejects code with syntax errors", async () => {
       const tool = await createCodeExecutionTool(runtimeFactory, new ToolBridge({}));
 

--- a/src/node/services/tools/code_execution.ts
+++ b/src/node/services/tools/code_execution.ts
@@ -23,6 +23,7 @@ import {
 import type { KernelFileLoader } from "@/node/services/tools/kernelFileLoad";
 
 import { analyzeCode } from "@/node/services/ptc/staticAnalysis";
+import { CODE_EXECUTION_STRING_GUIDANCE } from "@/constants/codeExecution";
 import { log } from "@/node/services/log";
 import { getCachedXumTypes, clearTypeCache } from "@/node/services/ptc/typeGenerator";
 import {
@@ -575,7 +576,8 @@ ${xumTypes}
         .string()
         .min(1)
         .describe(
-          "JavaScript code to execute. xum.* calls are synchronous—do not use await. mux.* is a compatibility alias. Use 'return' for final result."
+          "JavaScript code to execute. xum.* calls are synchronous—do not use await. mux.* is a compatibility alias. Use 'return' for final result. " +
+            CODE_EXECUTION_STRING_GUIDANCE
         ),
       timeout_secs: z
         .number()


### PR DESCRIPTION
## Summary

Reduce recurring code-execution string syntax failures by teaching JavaScript quoting in the `code` schema and returning actionable retry guidance for QuickJS's `unexpected end of string` error.

## Background

Multiline shell heredocs and SQL were being placed inside ordinary quoted JavaScript strings. Raw newlines are illegal there; shell quotes and SQL backticks also need escaping at the JavaScript layer. The old error did not explain that distinction.

## Implementation

- Share quoting guidance between the input schema and unterminated-string diagnostic.
- Cover quoted strings, template literals, embedded backticks, literal shell interpolation, and outer JSON escaping.
- Preserve syntax rejection and line numbers. Do not automatically rewrite ambiguous shell commands.

## Validation

- `make static-check` passed (~1 minute).
- `bun test src/node/services/ptc/staticAnalysis.test.ts`: 49 passed (~0.2 seconds).
- `bun test src/node/services/tools/code_execution.test.ts`: 86 passed (~4.4 seconds).
- Regression coverage checks LF/CRLF, both quote styles, EOF, unrelated syntax errors, and no tool side effects on invalid code. Correctly escaped quoted and template-literal retries preserve heredoc contents, SQL backticks, shell substitution, and backslashes exactly.

## Risks

Low: changes guidance and diagnostic text only, not parsing or execution semantics. Malformed JavaScript remains rejected; guidance improves generation and recovery rather than guaranteeing every model emits valid code.

## Pains

The combined Bun test invocation hit a QuickJS/WASM error and then a Bun crash on retry. Both complete test files passed when run in separate processes.

---

_Generated with `xum` • Model: `openai:gpt-6-astra` • Thinking: `medium` • Cost: unavailable_

<!-- mux-attribution: model=openai:gpt-6-astra thinking=medium costs=unavailable -->
