### PR TITLE
[xum] 🤖 fix: preserve delegated execution stop causes

### DIFF
--- a/src/browser/features/Messages/SubagentFailureMessageContent.tsx
+++ b/src/browser/features/Messages/SubagentFailureMessageContent.tsx
@@ -6,6 +6,7 @@ export function SubagentFailureMessageContent(props: { failure: SubagentFailureE
   // A superseded turn stops reporting, but its workspace keeps running under the new input.
   // Present that handoff without the alarming failure protocol or a misleading workspace error.
   const isSuperseded = props.failure.errorType === "workspace_turn_superseded";
+  const isIncomplete = props.failure.errorType === "workspace_turn_incomplete";
   const StatusIcon = isSuperseded ? ArrowRightLeft : CircleAlert;
   const metadata = [
     ["Task ID", props.failure.taskId],
@@ -23,7 +24,11 @@ export function SubagentFailureMessageContent(props: { failure: SubagentFailureE
       <div className="min-w-0 flex-1 text-sm text-[var(--color-user-text)]">
         <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
           <span className="font-medium">
-            {isSuperseded ? "New input took over" : "Subagent task failed"}
+            {isSuperseded
+              ? "New input took over"
+              : isIncomplete
+                ? "Workspace turn incomplete"
+                : "Subagent task failed"}
           </span>
           <span className="text-muted text-xs [overflow-wrap:anywhere]">
             {props.failure.agentType}

--- a/src/browser/stories/helpers/subagentReportStory.tsx
+++ b/src/browser/stories/helpers/subagentReportStory.tsx
@@ -99,6 +99,13 @@ export function setupSubagentFailureStory() {
             "Workspace turn superseded by new input in the target workspace; the workspace continues under that input and this delegated turn will not report",
         },
         {
+          taskId: "6f492837ac",
+          agentType: "exec",
+          errorType: "workspace_turn_incomplete",
+          errorMessage:
+            "Workspace turn incomplete: unknown stop cause; no correlated continuation found.",
+        },
+        {
           taskId: "28a75e1b09",
           agentType: "explore",
           errorType: "process_exit",

--- a/src/common/orpc/schemas/message.ts
+++ b/src/common/orpc/schemas/message.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { StreamStopCauseSchema } from "@/common/types/streamStopCause";
 import { CONTEXT_BOUNDARY_KINDS } from "@/common/constants/contextBoundary";
 import { ThinkingLevelSchema } from "../../types/thinking";
 import { AgentIdSchema } from "./agentDefinition";
@@ -177,6 +178,7 @@ export const MuxMessageSchema = z.object({
       contextUsage: z.any().optional(),
       providerMetadata: z.record(z.string(), z.unknown()).optional(),
       contextProviderMetadata: z.record(z.string(), z.unknown()).optional(),
+      stopCause: StreamStopCauseSchema.optional().catch(undefined),
       duration: z.number().optional(),
       ttftMs: z.number().optional(),
       systemMessageTokens: z.number().optional(),

--- a/src/common/orpc/schemas/stream.ts
+++ b/src/common/orpc/schemas/stream.ts
@@ -1,3 +1,4 @@
+import { StreamStopCauseSchema } from "@/common/types/streamStopCause";
 import { z } from "zod";
 import { AgentDefinitionScopeSchema, AgentIdSchema } from "./agentDefinition";
 import { OpenAIReasoningModeSchema, ThinkingLevelSchema } from "../../types/thinking";
@@ -273,6 +274,7 @@ export const StreamEndEventSchema = z.object({
       // Last step's provider metadata (for context window cache display)
       contextProviderMetadata: z.record(z.string(), z.unknown()).optional(),
       finishReason: z.string().optional(),
+      stopCause: StreamStopCauseSchema.optional(),
       duration: z.number().optional(),
       ttftMs: z.number().optional(),
       systemMessageTokens: z.number().optional(),

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -1,3 +1,4 @@
+import type { StreamStopCause } from "@/common/types/streamStopCause";
 import type { ModelMessage, UIMessage } from "ai";
 import type { LanguageModelV2Usage } from "@ai-sdk/provider";
 import type { StreamErrorType } from "./errors";
@@ -968,6 +969,7 @@ export interface MuxMetadata {
   duration?: number;
   ttftMs?: number; // Time-to-first-token measured from stream start; omitted when unavailable
   finishReason?: string; // Provider/model finish reason for the final step (e.g. stop, length)
+  stopCause?: StreamStopCause;
   /** @deprecated Legacy base mode derived from agent definition. */
   mode?: AgentMode;
   timestamp?: number;

--- a/src/common/types/streamStopCause.ts
+++ b/src/common/types/streamStopCause.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+// Capture the decision before queue dispatch or removal can change its attribution.
+export const StreamStopCauseSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("queued-input"),
+    entryId: z.string().min(1),
+    muxMetadata: z.unknown().optional(),
+  }),
+  z.object({ kind: z.literal("context-budget"), decision: z.enum(["warn", "rollover", "block"]) }),
+  z.object({ kind: z.literal("required-tool") }),
+  z.object({ kind: z.literal("step-limit") }),
+]);
+
+export type StreamStopCause = z.infer<typeof StreamStopCauseSchema>;
+export type QueuedInputStopCause = Extract<StreamStopCause, { kind: "queued-input" }>;

--- a/src/common/utils/subagentFailureEnvelope.test.ts
+++ b/src/common/utils/subagentFailureEnvelope.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { formatSubagentFailureUserMessage } from "@/node/services/taskWorkspaceSeam";
-import { parseSubagentFailureEnvelope } from "./subagentFailureEnvelope";
+import {
+  parseSubagentFailureEnvelope,
+  SUBAGENT_FAILURE_FOOTER,
+  WORKSPACE_TURN_FAILURE_FOOTER,
+} from "./subagentFailureEnvelope";
 
 const failure = {
   childWorkspaceId: "task-123",
@@ -28,6 +32,25 @@ describe("parseSubagentFailureEnvelope", () => {
       });
     }
   });
+
+  test.each(["workspace_turn_incomplete", "workspace_turn_superseded", "process_exit"])(
+    "accepts current and legacy footers for %s without changing the diagnostic",
+    (errorType) => {
+      const current = formatSubagentFailureUserMessage({ ...failure, errorType });
+      const legacy = current.replace(WORKSPACE_TURN_FAILURE_FOOTER, SUBAGENT_FAILURE_FOOTER);
+      const expected = {
+        taskId: failure.childWorkspaceId,
+        agentType: failure.agentType,
+        errorType,
+        errorMessage: failure.errorMessage,
+      };
+      expect(parseSubagentFailureEnvelope(current)).toEqual(expected);
+      expect(parseSubagentFailureEnvelope(legacy)).toEqual(expected);
+      expect(
+        parseSubagentFailureEnvelope(legacy.replace(SUBAGENT_FAILURE_FOOTER, "Unknown footer"))
+      ).toBeNull();
+    }
+  );
 
   test("preserves delimiter examples and whitespace inside error messages", () => {
     const errorMessage = `    Diagnostic:\n${formatSubagentFailureUserMessage(failure)}\n  trailing  `;

--- a/src/common/utils/subagentFailureEnvelope.test.ts
+++ b/src/common/utils/subagentFailureEnvelope.test.ts
@@ -36,8 +36,8 @@ describe("parseSubagentFailureEnvelope", () => {
   test.each(["workspace_turn_incomplete", "workspace_turn_superseded", "process_exit"])(
     "accepts current and legacy footers for %s without changing the diagnostic",
     (errorType) => {
-      const current = formatSubagentFailureUserMessage({ ...failure, errorType });
-      const legacy = current.replace(WORKSPACE_TURN_FAILURE_FOOTER, SUBAGENT_FAILURE_FOOTER);
+      const legacy = formatSubagentFailureUserMessage({ ...failure, errorType });
+      const current = legacy.replace(SUBAGENT_FAILURE_FOOTER, WORKSPACE_TURN_FAILURE_FOOTER);
       const expected = {
         taskId: failure.childWorkspaceId,
         agentType: failure.agentType,

--- a/src/common/utils/subagentFailureEnvelope.ts
+++ b/src/common/utils/subagentFailureEnvelope.ts
@@ -1,3 +1,9 @@
+// Keep the producer and parser compatible with both persisted protocol versions.
+export const SUBAGENT_FAILURE_FOOTER =
+  "This sub-agent task failed terminally and will not produce a report. Do not re-await it.";
+export const WORKSPACE_TURN_FAILURE_FOOTER =
+  "This delegated workspace turn ended without a final report. Do not re-await this execution. Other workspace activity can continue.";
+
 export interface SubagentFailureEnvelope {
   taskId: string;
   agentType: string;
@@ -12,12 +18,14 @@ export function parseSubagentFailureEnvelope(content: string): SubagentFailureEn
   // Match the entire producer envelope so malformed or mixed-content messages remain visible as-is.
   // The error body is greedy: embedded protocol examples must not truncate the actual diagnostic.
   const match =
-    /^<mux_subagent_failure>\n<task_id>([^\n<>]+)<\/task_id>\n(?:<execution_version>([^\n<>]+)<\/execution_version>\n)?(?:<execution_id>([^\n<>]+)<\/execution_id>\n)?<agent_type>([^\n<>]+)<\/agent_type>\n<error_type>([^\n<>]+)<\/error_type>\n<error_message>\n([\s\S]+)\n<\/error_message>\nThis sub-agent task failed terminally and will not produce a report\. Do not re-await it\.\n<\/mux_subagent_failure>$/.exec(
+    /^<mux_subagent_failure>\n<task_id>([^\n<>]+)<\/task_id>\n(?:<execution_version>([^\n<>]+)<\/execution_version>\n)?(?:<execution_id>([^\n<>]+)<\/execution_id>\n)?<agent_type>([^\n<>]+)<\/agent_type>\n<error_type>([^\n<>]+)<\/error_type>\n<error_message>\n([\s\S]+)\n<\/error_message>\n([^\n]+)\n<\/mux_subagent_failure>$/.exec(
       content
     );
   if (!match) return null;
 
-  const [, taskId, executionVersion, executionId, agentType, errorType, errorMessage] = match;
+  const [, taskId, executionVersion, executionId, agentType, errorType, errorMessage, footer] =
+    match;
+  if (footer !== SUBAGENT_FAILURE_FOOTER && footer !== WORKSPACE_TURN_FAILURE_FOOTER) return null;
   if (![taskId, agentType, errorType, errorMessage].every((field) => field.trim().length > 0)) {
     return null;
   }

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -1,3 +1,4 @@
+import type { QueuedInputStopCause } from "@/common/types/streamStopCause";
 import { raceWithAbortAndTimeout } from "@/node/utils/concurrency/withTimeout";
 import { STARTUP_RECOVERY_PROBE_TIMEOUT_MS } from "@/constants/startupRecovery";
 import type { AIService } from "./aiService";
@@ -5559,6 +5560,7 @@ export class AgentSession {
         disableWorkspaceAgents: options?.disableWorkspaceAgents,
         strictAgentResolution: options?.strictAgentResolution,
         hasQueuedMessages: this.hasQueuedMessages.bind(this),
+        getQueuedInputStopCause: this.getQueuedInputStopCause.bind(this),
         contextBudgetRolloverAvailable:
           this.isTokenBudgetActive(options) && this.compactionMonitor.getThreshold() < 1,
         onStepSettled: (step) => this.onContextBudgetStepSettled(step),
@@ -7467,6 +7469,7 @@ export class AgentSession {
         disableWorkspaceAgents: options?.disableWorkspaceAgents,
         strictAgentResolution: options?.strictAgentResolution,
         hasQueuedMessages: this.hasQueuedMessages.bind(this),
+        getQueuedInputStopCause: this.getQueuedInputStopCause.bind(this),
         contextBudgetRolloverAvailable:
           this.isTokenBudgetActive(options) && this.compactionMonitor.getThreshold() < 1,
         requestAssemblySnapshot: requestAssemblySnapshot ?? resumedFlushSnapshot,
@@ -9344,6 +9347,21 @@ export class AgentSession {
     );
     this.notifyQueuedMessageCleared(callbacks, cancelReason);
     return true;
+  }
+
+  getQueuedInputStopCause(): QueuedInputStopCause | undefined {
+    const candidate = this.messageQueue.getNextQueueCutCandidate();
+    if (candidate?.dispatchMode !== "tool-end") return undefined;
+    return {
+      kind: "queued-input",
+      entryId: candidate.entryId,
+      // Monitor wakes acquire this execution correlation when they dispatch.
+      muxMetadata: structuredClone(
+        this.messageQueue.isNextEntryBashMonitorWake()
+          ? (this.activeStreamContext?.workspaceTurnMetadata ?? candidate.muxMetadata)
+          : candidate.muxMetadata
+      ),
+    };
   }
 
   /** Pending work only: withdrawn (aborted) entries still occupy the queue but never start a turn. */

--- a/src/node/services/messageQueue.test.ts
+++ b/src/node/services/messageQueue.test.ts
@@ -863,7 +863,7 @@ describe("MessageQueue", () => {
               ? { type: "bash-monitor-wake" as const, records: [] }
               : undefined;
         queue.add("live", { ...options, muxMetadata: liveMetadata, queueDispatchMode: "turn-end" });
-        expect(queue.getNextQueueCutCandidate()).toEqual({
+        expect(queue.getNextQueueCutCandidate()).toMatchObject({
           muxMetadata: liveMetadata,
           dispatchMode: "turn-end",
         });

--- a/src/node/services/messageQueue.ts
+++ b/src/node/services/messageQueue.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { GoalSyntheticMessageKind } from "@/constants/goals";
 import assert from "@/common/utils/assert";
 import type { FilePart, SendMessageOptions } from "@/common/orpc/types";
@@ -178,6 +179,7 @@ type QueueClearCallbacks = Pick<
  * exactly one dispatch.
  */
 interface QueueEntry {
+  entryId: string;
   goalKind?: GoalSyntheticMessageKind;
   goalId?: string;
   messages: string[];
@@ -387,13 +389,17 @@ export class MessageQueue {
    * metadata.
    */
   getNextQueueCutCandidate():
-    | { muxMetadata: unknown; dispatchMode: QueueDispatchMode }
+    | { entryId: string; muxMetadata: unknown; dispatchMode: QueueDispatchMode }
     | undefined {
     const head = this.nextDispatchableEntry();
     if (head == null) {
       return undefined;
     }
-    return { muxMetadata: head.muxMetadata, dispatchMode: head.dispatchMode };
+    return {
+      entryId: head.entryId,
+      muxMetadata: head.muxMetadata,
+      dispatchMode: head.dispatchMode,
+    };
   }
 
   /**
@@ -616,6 +622,7 @@ export class MessageQueue {
       }
     } else {
       entry = {
+        entryId: randomUUID(),
         messages: [],
         fileParts: [],
         dedupeKeys: new Set<string>(),

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -1,4 +1,6 @@
 import { describe, test, expect, afterEach, beforeEach, mock, spyOn } from "bun:test";
+import type { QueuedInputStopCause, StreamStopCause } from "@/common/types/streamStopCause";
+import { MuxMessageSchema } from "@/common/orpc/schemas/message";
 import * as fs from "node:fs/promises";
 import { existsSync } from "node:fs";
 import * as path from "node:path";
@@ -1850,6 +1852,8 @@ describe("StreamManager - engine supervision (AppFiberScope occupant)", () => {
 describe("StreamManager - stopWhen configuration", () => {
   type StopWhenCondition = (options: { steps: unknown[] }) => boolean | Promise<boolean>;
   type BuildStopWhenCondition = (request: {
+    stopCause?: StreamStopCause;
+    getQueuedInputStopCause?: () => QueuedInputStopCause | undefined;
     hasQueuedMessages?: (dispatchMode?: "tool-end" | "turn-end") => boolean;
     toolPolicy?: ToolPolicy;
     onStepSettled?: TurnExecutionOptions["onStepSettled"];
@@ -1876,6 +1880,80 @@ describe("StreamManager - stopWhen configuration", () => {
   function stepsWithToolResult(toolName: string, output: unknown): { steps: unknown[] } {
     return { steps: [{ toolResults: [{ toolName, output }] }] };
   }
+
+  test("persists the queue stop decision after the session clears the cutter", async () => {
+    const { session, cleanup } = await createAgentSessionHarness({ workspaceId: "stop-decision" });
+    const manager = new StreamManager(historyService);
+    const request: Parameters<BuildStopWhenCondition>[0] & {
+      model: LanguageModel;
+      messages: never[];
+    } = {
+      model: createTestLanguageModel(),
+      messages: [],
+      getQueuedInputStopCause: session.getQueuedInputStopCause.bind(session),
+    };
+    try {
+      const correlation = {
+        type: "workspace-turn-task" as const,
+        taskHandleId: "wst_test",
+        ownerWorkspaceId: "owner",
+        turnId: "execution",
+      };
+      session.queueMessage("continue", {
+        model: TEST_STREAM_MODEL_ID,
+        agentId: "exec",
+        muxMetadata: correlation,
+      });
+      const [, stop] = buildStopWhenForTests(manager)(request);
+      expect(await stop({ steps: [] })).toBe(true);
+      const cause = request.stopCause;
+      expect(cause?.kind).toBe("queued-input");
+      session.clearQueue();
+      session.queueMessage("replacement");
+      expect(session.getQueuedInputStopCause()?.entryId).not.toBe(
+        cause?.kind === "queued-input" ? cause.entryId : undefined
+      );
+      expect(request.stopCause).toMatchObject({ muxMetadata: correlation });
+      const messageId = "stop-decision-message";
+      await appendPartialAssistantForTests("stop-decision", messageId, 1);
+      const events: unknown[] = [];
+      onTurnEngineEvent(manager, "stream-end", (event) => events.push(event));
+      const info = createStreamInfoForTests({
+        messageId,
+        request,
+        parts: [{ type: "text", text: "Intermediate result" }],
+        streamResult: createStreamResultForTests(
+          (async function* () {
+            await Promise.resolve();
+            yield { type: "finish", finishReason: "tool-calls" };
+          })()
+        ),
+      });
+      await getProcessStreamWithCleanupForTests(manager).call(manager, "stop-decision", info, 1);
+      expect(events).toHaveLength(1);
+      expect(StreamEndEventSchema.parse(events[0]).metadata.stopCause).toEqual(cause);
+      const history = await historyService.getHistoryFromLatestBoundary("stop-decision");
+      expect(history.success).toBe(true);
+      if (!history.success) throw new Error(history.error);
+      expect(MuxMessageSchema.parse(history.data.at(-1)).metadata?.stopCause).toEqual(cause);
+    } finally {
+      session.clearQueue();
+      await session.dispose();
+      await cleanup();
+    }
+  });
+
+  test("records required-tool completion instead of a queued replacement", async () => {
+    const request: Parameters<BuildStopWhenCondition>[0] = {
+      toolPolicy: [{ regex_match: "agent_report", action: "require" }],
+      getQueuedInputStopCause: () => ({ kind: "queued-input", entryId: "replacement" }),
+    };
+    const [, queueStop, requiredStop] = buildStopWhenForTests()(request);
+    const step = stepsWithToolResult("agent_report", { success: true });
+    expect(await queueStop(step)).toBe(false);
+    expect(await requiredStop(step)).toBe(true);
+    expect(request.stopCause?.kind).toBe("required-tool");
+  });
 
   test("returns step-cap and queued-message conditions with no policy", async () => {
     let queued = false;

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -1943,6 +1943,38 @@ describe("StreamManager - stopWhen configuration", () => {
     }
   });
 
+  test.each([
+    { cause: { kind: "required-tool" } as const, expected: "stop" },
+    {
+      cause: { kind: "queued-input", entryId: "pending-input" } as const,
+      expected: "tool-calls",
+    },
+  ])("persists a downgrade-compatible finish for $cause.kind", async ({ cause, expected }) => {
+    const manager = new StreamManager(historyService);
+    const workspaceId = "finish-compatibility";
+    const messageId = "finished-message";
+    await appendPartialAssistantForTests(workspaceId, messageId, 1);
+    const events: unknown[] = [];
+    onTurnEngineEvent(manager, "stream-end", (event) => events.push(event));
+    const info = createStreamInfoForTests({
+      messageId,
+      request: { model: createTestLanguageModel(), messages: [], stopCause: cause },
+      parts: [{ type: "text", text: "Tool result" }],
+      streamResult: createStreamResultForTests(
+        (async function* () {
+          await Promise.resolve();
+          yield { type: "finish", finishReason: "tool-calls" };
+        })()
+      ),
+    });
+    await getProcessStreamWithCleanupForTests(manager).call(manager, workspaceId, info, 1);
+    expect(StreamEndEventSchema.parse(events[0]).metadata.finishReason).toBe(expected);
+    const history = await historyService.getHistoryFromLatestBoundary(workspaceId);
+    if (!history.success) throw new Error(history.error);
+    expect(history.data.at(-1)?.metadata?.finishReason).toBe(expected);
+    expect(history.data.at(-1)?.metadata?.stopCause).toEqual(cause);
+  });
+
   test("records required-tool completion instead of a queued replacement", async () => {
     const request: Parameters<BuildStopWhenCondition>[0] = {
       toolPolicy: [{ regex_match: "agent_report", action: "require" }],

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -1,3 +1,4 @@
+import type { QueuedInputStopCause, StreamStopCause } from "@/common/types/streamStopCause";
 import { estimateToolResultSize } from "@/common/utils/compaction/contextBudget";
 import { ContextBudgetExceededError, ContextBudgetBlockedError } from "./contextBudgetError";
 import {
@@ -17,7 +18,7 @@ import { PlatformPaths } from "@/common/utils/paths";
 import { eventSpine } from "@/node/services/events/eventSpine";
 import {
   streamText,
-  stepCountIs,
+  type stepCountIs,
   type ModelMessage,
   type SystemModelMessage,
   type LanguageModel,
@@ -282,6 +283,7 @@ interface StreamRequestOptions {
   callSettingsOverrides?: ResolvedCallSettingsOverrides;
   toolPolicy?: ToolPolicy;
   hasQueuedMessages?: (dispatchMode?: "tool-end" | "turn-end") => boolean;
+  getQueuedInputStopCause?: () => QueuedInputStopCause | undefined;
   headers?: Record<string, string | undefined>;
   onChunk?: StreamTextOnChunk;
   onStepMessages?: (messages: ModelMessage[]) => void;
@@ -324,6 +326,7 @@ interface StepMessageTracker {
   latestMessages?: ModelMessage[];
 }
 interface StreamRequestConfig {
+  stopCause?: StreamStopCause;
   cacheEnabled?: boolean;
   budgetMetadataModel?: string;
   model: LanguageModel;
@@ -338,6 +341,7 @@ interface StreamRequestConfig {
   maxOutputTokens?: number;
   streamCallSettings?: Omit<ResolvedCallSettingsOverrides, "maxOutputTokens">;
   hasQueuedMessages?: (dispatchMode?: "tool-end" | "turn-end") => boolean;
+  getQueuedInputStopCause?: () => QueuedInputStopCause | undefined;
   /** Optional hook for callers that need chunk-level visibility during streaming. */
   onChunk?: StreamTextOnChunk;
   /** Optional hook for callers that need the live prepared step transcript. */
@@ -2295,6 +2299,7 @@ export class StreamManager {
       callSettingsOverrides,
       toolPolicy,
       hasQueuedMessages,
+      getQueuedInputStopCause,
       headers,
       onChunk,
       onStepMessages,
@@ -2351,6 +2356,7 @@ export class StreamManager {
       streamCallSettings:
         Object.keys(streamCallSettings).length > 0 ? streamCallSettings : undefined,
       hasQueuedMessages,
+      getQueuedInputStopCause,
       onChunk,
       onStepMessages,
       onStepSettled,
@@ -2369,6 +2375,8 @@ export class StreamManager {
     request: Pick<
       StreamRequestConfig,
       | "hasQueuedMessages"
+      | "getQueuedInputStopCause"
+      | "stopCause"
       | "toolPolicy"
       | "onStepSettled"
       | "modelString"
@@ -2402,7 +2410,9 @@ export class StreamManager {
 
     const requiredPatterns = buildRequiredToolPatterns(request.toolPolicy);
 
-    const hasSuccessfulRequiredToolResult: ReturnType<typeof stepCountIs> = ({ steps }) => {
+    const hasSuccessfulRequiredToolResult = ({
+      steps,
+    }: Parameters<ReturnType<typeof stepCountIs>>[0]): boolean => {
       if (requiredPatterns.length === 0) {
         return false;
       }
@@ -2421,13 +2431,17 @@ export class StreamManager {
     };
 
     return [
-      stepCountIs(100000),
+      ({ steps }) => {
+        if (steps.length < 100000) return false;
+        request.stopCause ??= { kind: "step-limit" };
+        return true;
+      },
       // The SDK evaluates stop conditions only after every sibling tool result in the
       // model's current step settles. Do not move this to individual tool-call-end events:
       // that would abort the remaining calls the model emitted in the same batch.
       async ({ steps }) => {
         const step = steps.at(-1);
-        if (request.onStepSettled && step && !(await hasSuccessfulRequiredToolResult({ steps }))) {
+        if (request.onStepSettled && step && !hasSuccessfulRequiredToolResult({ steps })) {
           const outputs = step.toolResults.map((result) => result.output);
           const size = estimateToolResultSize(outputs);
           const toolResultTokens = await estimateToolResultTokensForModel(outputs, {
@@ -2447,6 +2461,9 @@ export class StreamManager {
             ),
           });
           // All siblings have settled: stop before another provider step without discarding results.
+          if (decision !== "continue") {
+            request.stopCause ??= { kind: "context-budget", decision };
+          }
           if (decision === "block")
             throw new ContextBudgetBlockedError(
               "The settled tool results exceed the context budget. Use /compact or start a new context before continuing."
@@ -2454,9 +2471,19 @@ export class StreamManager {
           // Budget stops are authoritative even when only a turn-end message is queued.
           if (decision !== "continue") return true;
         }
+        if (hasSuccessfulRequiredToolResult({ steps })) return false;
+        const queuedInput = request.getQueuedInputStopCause?.();
+        if (queuedInput != null) {
+          request.stopCause ??= queuedInput;
+          return true;
+        }
         return request.hasQueuedMessages?.("tool-end") ?? false;
       },
-      hasSuccessfulRequiredToolResult,
+      (options) => {
+        if (!hasSuccessfulRequiredToolResult(options)) return false;
+        request.stopCause ??= { kind: "required-tool" };
+        return true;
+      },
     ];
   }
 
@@ -2590,6 +2617,8 @@ export class StreamManager {
     abortController: AbortController,
     stepTracker?: StepMessageTracker
   ): Awaited<ReturnType<typeof streamText>> {
+    // Retries can reuse the request, but each stream makes its own stop decision.
+    delete request.stopCause;
     // Explicit <ToolSet> pins RUNTIME_CONTEXT to its default: mux tools use
     // Tool's `any` context, which would otherwise infect the inferred result
     // type (no-unsafe-return).
@@ -3592,6 +3621,7 @@ export class StreamManager {
       callSettingsOverrides: prepared.data.callSettingsOverrides,
       toolPolicy: streamInfo.request.toolPolicy,
       hasQueuedMessages: streamInfo.request.hasQueuedMessages,
+      getQueuedInputStopCause: streamInfo.request.getQueuedInputStopCause,
       headers: prepared.data.headers,
       onChunk: streamInfo.request.onChunk,
       onStepMessages: streamInfo.request.onStepMessages,
@@ -4425,6 +4455,12 @@ export class StreamManager {
             const contextProviderMetadata =
               streamMeta.contextProviderMetadata ?? streamInfo.lastStepProviderMetadata;
             const finishReason = streamInfo.terminalFinishReason ?? streamMeta.finishReason;
+            if (finishReason === "tool-calls" && streamInfo.request.stopCause == null) {
+              workspaceLog.warn("Tool-calls stream ended without a recorded stop cause", {
+                messageId: streamInfo.messageId,
+                muxMetadata: streamInfo.initialMetadata?.muxMetadata,
+              });
+            }
             const duration = streamMeta.duration;
             const ttftMs = this.resolveTtftMsForStreamEnd(streamInfo);
             // Aggregated provider metadata across all steps (for cost calculation with cache tokens)
@@ -4463,6 +4499,9 @@ export class StreamManager {
                 contextProviderMetadata, // Last step (for context window display)
                 ...(toolModelUsages != null ? { toolModelUsages } : {}),
                 ...(finishReason !== undefined && { finishReason }),
+                ...(streamInfo.request.stopCause != null && {
+                  stopCause: streamInfo.request.stopCause,
+                }),
                 historySequence: streamInfo.historySequence,
                 duration,
                 ...(ttftMs !== undefined && { ttftMs }),

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -4454,7 +4454,12 @@ export class StreamManager {
             const contextUsage = streamMeta.contextUsage ?? streamInfo.lastStepUsage;
             const contextProviderMetadata =
               streamMeta.contextProviderMetadata ?? streamInfo.lastStepProviderMetadata;
-            const finishReason = streamInfo.terminalFinishReason ?? streamMeta.finishReason;
+            // Required-tool completion must remain successful after downgrade or crash recovery.
+            // Keep the internal stop cause, but persist the legacy-compatible terminal signal.
+            const finishReason =
+              streamInfo.request.stopCause?.kind === "required-tool"
+                ? "stop"
+                : (streamInfo.terminalFinishReason ?? streamMeta.finishReason);
             if (finishReason === "tool-calls" && streamInfo.request.stopCause == null) {
               workspaceLog.warn("Tool-calls stream ended without a recorded stop cause", {
                 messageId: streamInfo.messageId,
@@ -5335,17 +5340,11 @@ export class StreamManager {
       });
     }
 
-    // Get or create mutex for this workspace
-    if (!this.streamLocks.has(typedWorkspaceId)) {
-      this.streamLocks.set(typedWorkspaceId, new AsyncMutex());
-    }
-    const mutex = this.streamLocks.get(typedWorkspaceId)!;
-
     let registeredStream: WorkspaceStreamInfo | undefined;
     try {
       // Acquire lock - guarantees only one startStream per workspace
       // Lock is automatically released when scope exits via Symbol.asyncDispose
-      await using _lock = await mutex.acquire();
+      await using _lock = await this.acquireStreamStartLock(workspaceId);
 
       // DEBUG: Log stream start
       log.debug(
@@ -5816,10 +5815,20 @@ export class StreamManager {
     return Array.from(this.workspaceStreams.keys()).map((id) => id as string);
   }
 
+  /** Serialize idle recovery with stream startup, including terminal persistence. */
+  async acquireStreamStartLock(workspaceId: string) {
+    const id = workspaceId as WorkspaceId;
+    let mutex = this.streamLocks.get(id);
+    if (mutex == null) {
+      mutex = new AsyncMutex();
+      this.streamLocks.set(id, mutex);
+    }
+    return mutex.acquire();
+  }
+
   /**
-   * Gets the current stream info for a workspace if actively streaming
-   * Returns undefined if no active stream exists
-   * Used to re-establish streaming context on frontend reconnection
+   * Gets the current stream info for a workspace if actively streaming.
+   * Include finalizing streams when checking whether recovery can proceed.
    */
   getStreamInfo(
     workspaceId: string,

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -27456,8 +27456,8 @@ describe("TaskService", () => {
       status: "error",
       workspaceId: "childworkspace",
       messageId: "msg_tool_calls_terminal",
-      error: "Workspace turn ended before completion (finishReason: tool-calls)",
     });
+    expect(snapshot?.error).toContain("unknown stop cause");
   });
 
   test("parent stream-end auto-resumes for active background workspace turns", async () => {

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -27346,11 +27346,16 @@ describe("TaskService", () => {
     const internal = taskService as unknown as {
       handleStreamEnd: (event: StreamEndEvent) => Promise<void>;
     };
-    await internal.handleStreamEnd(
-      workspaceTurnStreamEndEvent(parentId, "msg_truncated_direct_parent", "Truncated", {
+    const truncated = workspaceTurnStreamEndEvent(
+      parentId,
+      "msg_truncated_direct_parent",
+      "Truncated",
+      {
         finishReason: "length",
-      })
+      }
     );
+    truncated.metadata.historySequence = 1;
+    await internal.handleStreamEnd(truncated);
     const errored = await taskHandleStore.getWorkspaceTurn(parentId, "wst_handle");
     assert(errored, "errored handle must exist");
     expect(errored.status).toBe("error");
@@ -27371,7 +27376,10 @@ describe("TaskService", () => {
     workspaceMocks.getQueueCutCutter.mockImplementation(() =>
       ownerFollowUpCutter(parentId, "wst_successor")
     );
-    await internal.handleStreamEnd(ownerFollowUpCutEvent(parentId, "msg_quiet_direct_parent_cut"));
+    const successor = ownerFollowUpCutEvent(parentId, "msg_quiet_direct_parent_cut");
+    // Durable ordering proves this cut follows the truncated response.
+    successor.metadata.historySequence = 2;
+    await internal.handleStreamEnd(successor);
 
     const resettled = await taskHandleStore.getWorkspaceTurn(parentId, "wst_handle");
     assert(resettled, "resettled handle must exist");

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -27166,11 +27166,11 @@ describe("TaskService", () => {
     };
 
     // Length-truncated correlated final settles the handle as error and arms a wake.
-    await internal.handleStreamEnd(
-      workspaceTurnStreamEndEvent(parentId, "msg_truncated_error", "Truncated", {
-        finishReason: "length",
-      })
-    );
+    const truncated = workspaceTurnStreamEndEvent(parentId, "msg_truncated_error", "Truncated", {
+      finishReason: "length",
+    });
+    truncated.metadata.historySequence = 1;
+    await internal.handleStreamEnd(truncated);
     const errored = await taskHandleStore.getWorkspaceTurn(parentId, "wst_handle");
     assert(errored, "errored handle must exist");
     expect(errored.status).toBe("error");
@@ -27186,7 +27186,9 @@ describe("TaskService", () => {
     workspaceMocks.getQueueCutCutter.mockImplementation(() =>
       ownerFollowUpCutter(parentId, "wst_successor")
     );
-    await internal.handleStreamEnd(ownerFollowUpCutEvent(parentId, "msg_quiet_resettle_cut"));
+    const cut = ownerFollowUpCutEvent(parentId, "msg_quiet_resettle_cut");
+    cut.metadata.historySequence = 2;
+    await internal.handleStreamEnd(cut);
 
     const resettled = await taskHandleStore.getWorkspaceTurn(parentId, "wst_handle");
     assert(resettled, "resettled handle must exist");

--- a/src/node/services/taskService.testHarness.ts
+++ b/src/node/services/taskService.testHarness.ts
@@ -275,6 +275,7 @@ export function createAIServiceMocks(
       getStreamInfo,
       getProvidersConfig,
       replayStream,
+      acquireStreamStartLock: mock(() => Promise.resolve(undefined)),
       on,
       off,
     } as unknown as AIService,

--- a/src/node/services/taskService.testHarness.ts
+++ b/src/node/services/taskService.testHarness.ts
@@ -298,6 +298,8 @@ export function createWorkspaceServiceMocks(overrides: WorkspaceHostMockOverride
   const isWorkflowInvocationCurrent =
     overrides.isWorkflowInvocationCurrent ?? mock(() => Promise.resolve(true));
   const mocks = {
+    acquireIdleTurnExclusion:
+      overrides.acquireIdleTurnExclusion ?? mock(() => Ok({ [Symbol.dispose]: () => undefined })),
     sendMessage:
       overrides.sendMessage ?? mock((): Promise<Result<void>> => Promise.resolve(Ok(undefined))),
     resumeStream:

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -1829,12 +1829,8 @@ export class TaskService implements AgentTaskIntegration {
     this.aiService.on("stream-end", (payload: unknown) => {
       if (!isStreamEndEvent(payload)) return;
 
-      // Captured synchronously at event time, BEFORE the workspace event lock:
-      // another operation holding the lock would otherwise let the session
-      // drain the real (manual/cross-owner) cutter and engage a later
-      // same-owner follow-up during the wait, misattributing the cut and
-      // wrongly suppressing the real cutter's wake (see
-      // QueueCutAttributionSnapshot).
+      // New streams persist attribution at the stop decision. Keep this snapshot for legacy events
+      // and disposable ownership transfer, before the event lock lets another input enter the queue.
       const queueCutSnapshot = this.getWorkspaceTurnManager().captureQueueCutAttributionSnapshot(
         payload.workspaceId
       );

--- a/src/node/services/taskWorkspaceSeam.testUtils.ts
+++ b/src/node/services/taskWorkspaceSeam.testUtils.ts
@@ -15,6 +15,7 @@ export function makeWorkspaceHostFake(overrides: Partial<WorkspaceHost> = {}): W
     waitForPendingStreamErrorRecoveryDecision: () => Promise.resolve(undefined),
     getStartupRecoveryState: () => Promise.resolve("interrupted"),
     dispatchPendingCompactionFollowUp: () => Promise.resolve(Ok(false)),
+    acquireIdleTurnExclusion: () => Ok({ [Symbol.dispose]: () => undefined }),
     isBusyForMessage: () => false,
     hasQueuedMessages: () => false,
     hasPendingQueuedOrPreparingTurn: () => false,

--- a/src/node/services/taskWorkspaceSeam.ts
+++ b/src/node/services/taskWorkspaceSeam.ts
@@ -1,3 +1,7 @@
+import {
+  SUBAGENT_FAILURE_FOOTER,
+  WORKSPACE_TURN_FAILURE_FOOTER,
+} from "@/common/utils/subagentFailureEnvelope";
 import type { StartupRecoveryState } from "./startupRecovery";
 import type { CoderWorkspaceArchiveBehavior } from "@/common/config/coderArchiveBehavior";
 import type { WorktreeArchiveBehavior } from "@/common/config/worktreeArchiveBehavior";
@@ -193,8 +197,8 @@ export function formatSubagentFailureUserMessage(params: {
     params.errorMessage,
     "</error_message>",
     params.errorType.startsWith("workspace_turn_")
-      ? "This delegated workspace turn ended without a final report. Do not re-await this execution. Other workspace activity can continue."
-      : "This sub-agent task failed terminally and will not produce a report. Do not re-await it.",
+      ? WORKSPACE_TURN_FAILURE_FOOTER
+      : SUBAGENT_FAILURE_FOOTER,
     "</mux_subagent_failure>",
   ].join("\n");
 }

--- a/src/node/services/taskWorkspaceSeam.ts
+++ b/src/node/services/taskWorkspaceSeam.ts
@@ -192,7 +192,9 @@ export function formatSubagentFailureUserMessage(params: {
     "<error_message>",
     params.errorMessage,
     "</error_message>",
-    "This sub-agent task failed terminally and will not produce a report. Do not re-await it.",
+    params.errorType.startsWith("workspace_turn_")
+      ? "This delegated workspace turn ended without a final report. Do not re-await this execution. Other workspace activity can continue."
+      : "This sub-agent task failed terminally and will not produce a report. Do not re-await it.",
     "</mux_subagent_failure>",
   ].join("\n");
 }

--- a/src/node/services/taskWorkspaceSeam.ts
+++ b/src/node/services/taskWorkspaceSeam.ts
@@ -420,6 +420,7 @@ export interface WorkspaceTurnHost {
 }
 
 export interface TurnAdmissionHost {
+  acquireIdleTurnExclusion(workspaceId: string): Result<Disposable>;
   getStartupRecoveryState(workspaceId: string): Promise<StartupRecoveryState>;
   dispatchPendingCompactionFollowUp(workspaceId: string): Promise<Result<boolean>>;
   isBusyForMessage(workspaceId: string): boolean;

--- a/src/node/services/taskWorkspaceSeam.ts
+++ b/src/node/services/taskWorkspaceSeam.ts
@@ -1,7 +1,4 @@
-import {
-  SUBAGENT_FAILURE_FOOTER,
-  WORKSPACE_TURN_FAILURE_FOOTER,
-} from "@/common/utils/subagentFailureEnvelope";
+import { SUBAGENT_FAILURE_FOOTER } from "@/common/utils/subagentFailureEnvelope";
 import type { StartupRecoveryState } from "./startupRecovery";
 import type { CoderWorkspaceArchiveBehavior } from "@/common/config/coderArchiveBehavior";
 import type { WorktreeArchiveBehavior } from "@/common/config/worktreeArchiveBehavior";
@@ -196,9 +193,8 @@ export function formatSubagentFailureUserMessage(params: {
     "<error_message>",
     params.errorMessage,
     "</error_message>",
-    params.errorType.startsWith("workspace_turn_")
-      ? WORKSPACE_TURN_FAILURE_FOOTER
-      : SUBAGENT_FAILURE_FOOTER,
+    // Older clients require this exact terminator to render persisted failures.
+    SUBAGENT_FAILURE_FOOTER,
     "</mux_subagent_failure>",
   ].join("\n");
 }

--- a/src/node/services/turnRequestBuilder.ts
+++ b/src/node/services/turnRequestBuilder.ts
@@ -1,3 +1,4 @@
+import type { QueuedInputStopCause } from "@/common/types/streamStopCause";
 import { execBuffered } from "@/node/utils/runtime/helpers";
 import { shellQuote } from "@/common/utils/shell";
 import type { OnStepSettled } from "./streamManager";
@@ -314,6 +315,7 @@ export interface StreamMessageOptions {
   prospectiveGoalStatusForToolAvailability?: GoalRecordV1["status"] | null;
   disableWorkspaceAgents?: boolean;
   hasQueuedMessages?: (dispatchMode?: "tool-end" | "turn-end") => boolean;
+  getQueuedInputStopCause?: () => QueuedInputStopCause | undefined;
   onStepSettled?: OnStepSettled;
   /**
    * Whether a token-budget rollover could actually be sealed for this request (mode active and
@@ -865,6 +867,7 @@ export class TurnRequestBuilder {
       workspaceGoalService,
       disableWorkspaceAgents,
       hasQueuedMessages,
+      getQueuedInputStopCause,
       onStepSettled,
       contextBudgetRolloverAvailable,
       requestAssemblySnapshot,
@@ -3207,6 +3210,7 @@ export class TurnRequestBuilder {
         toolPolicy: effectiveToolPolicy,
         providedStreamToken: streamToken,
         hasQueuedMessages,
+        getQueuedInputStopCause,
         onStepSettled,
         workspaceName: metadata.name,
         thinkingLevel: streamThinkingLevel,

--- a/src/node/services/workspaceTurnManager.test.ts
+++ b/src/node/services/workspaceTurnManager.test.ts
@@ -4650,6 +4650,218 @@ describe("WorkspaceTurnManager", () => {
     expect(followUp.data.maySupersedeTaskId).toBeUndefined();
   });
 
+  function intermediateStopEvent(parentId: string): StreamEndEvent {
+    const muxMetadata = workspaceTurnMuxMetadata(parentId);
+    return {
+      type: "stream-end",
+      workspaceId: "childworkspace",
+      messageId: "intermediate-stop",
+      metadata: {
+        model: "anthropic:claude-opus-4-6",
+        finishReason: "tool-calls",
+        muxMetadata,
+        stopCause: { kind: "queued-input", entryId: "continuation-entry", muxMetadata },
+      },
+      parts: [{ type: "text", text: "Work in progress" }],
+    };
+  }
+
+  async function persistStopEvent(history: HistoryService, event: StreamEndEvent): Promise<void> {
+    const result = await history.appendToHistory(event.workspaceId, {
+      id: event.messageId,
+      role: "assistant",
+      metadata: event.metadata,
+      parts: event.parts,
+    });
+    expect(result.success).toBe(true);
+  }
+
+  test("queue stop attribution survives queue removal before finalization and recovery", async () => {
+    const { config, parentId, taskService, historyService } = await startWorkspaceTurnForTest();
+    const event = intermediateStopEvent(parentId);
+    event.metadata.stopCause = { kind: "queued-input", entryId: "manual-entry" };
+    await persistStopEvent(historyService, event);
+    const store = new TaskHandleStore(config);
+    const record = await store.getWorkspaceTurn(parentId, "wst_handle");
+    assert(record);
+    const internal = taskService as unknown as {
+      recoverTerminalWorkspaceTurnFromHistory(
+        record: WorkspaceTurnTaskHandleRecord
+      ): Promise<WorkspaceTurnTaskHandleRecord | null>;
+    };
+    const recovered = await internal.recoverTerminalWorkspaceTurnFromHistory(record);
+    expect(recovered?.status).toBe("interrupted");
+    await finalizeWorkspaceTurnStreamEndForTest(taskService, event);
+    expect(await store.getWorkspaceTurn(parentId, "wst_handle")).toMatchObject({
+      status: "interrupted",
+      error: recovered?.error,
+    });
+  });
+
+  test.each([false, true])(
+    "continuation starts and finishes during finalization await (legacy=%s)",
+    async (legacy) => {
+      const { config, parentId, taskService, historyService } = await startWorkspaceTurnForTest();
+      const event = intermediateStopEvent(parentId);
+      if (legacy) delete event.metadata.stopCause;
+      await persistStopEvent(historyService, event);
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const readHistory = historyService.getHistoryFromLatestBoundary.bind(historyService);
+      spyOn(historyService, "getHistoryFromLatestBoundary").mockImplementationOnce(
+        async (...args) => {
+          entered.resolve();
+          await release.promise;
+          return readHistory(...args);
+        }
+      );
+      const finalizing = finalizeWorkspaceTurnStreamEndForTest(taskService, event);
+      await entered.promise;
+      const successor: StreamEndEvent = {
+        ...event,
+        messageId: "finished-continuation",
+        metadata: { ...event.metadata, finishReason: "stop", stopCause: undefined },
+        parts: [{ type: "text", text: "Completed result" }],
+      };
+      await persistStopEvent(historyService, successor);
+      release.resolve();
+      await finalizing;
+      expect(
+        await new TaskHandleStore(config).getWorkspaceTurn(parentId, "wst_handle")
+      ).toMatchObject({
+        status: "completed",
+        messageId: successor.messageId,
+        reportMarkdown: "Completed result",
+      });
+      const store = new TaskHandleStore(config);
+      const completed = await store.getWorkspaceTurn(parentId, "wst_handle");
+      await finalizeWorkspaceTurnStreamEndForTest(taskService, successor);
+      expect(await store.getWorkspaceTurn(parentId, "wst_handle")).toEqual(completed);
+    }
+  );
+
+  test.each([false, true])(
+    "recovery preserves pending same-execution continuation (legacy=%s)",
+    async (legacy) => {
+      const { config, parentId, taskService, historyService } = await startWorkspaceTurnForTest({
+        hasPendingWorkspaceTurnContinuation: mock(() => true),
+      });
+      const event = intermediateStopEvent(parentId);
+      if (legacy) delete event.metadata.stopCause;
+      await persistStopEvent(historyService, event);
+      const store = new TaskHandleStore(config);
+      const record = await store.getWorkspaceTurn(parentId, "wst_handle");
+      assert(record);
+      const internal = taskService as unknown as {
+        recoverTerminalWorkspaceTurnFromHistory(
+          record: WorkspaceTurnTaskHandleRecord
+        ): Promise<WorkspaceTurnTaskHandleRecord | null>;
+      };
+      expect(await internal.recoverTerminalWorkspaceTurnFromHistory(record)).toBeNull();
+      await finalizeWorkspaceTurnStreamEndForTest(taskService, event);
+      expect(await store.getWorkspaceTurn(parentId, "wst_handle")).toMatchObject({
+        status: "running",
+        deferredMessageIds: [event.messageId],
+      });
+    }
+  );
+
+  test.each(["interrupted", "error"] as const)(
+    "continuation %s survives a late intermediate finalization",
+    async (status) => {
+      const { config, parentId, taskService, historyService } = await startWorkspaceTurnForTest();
+      const event = intermediateStopEvent(parentId);
+      await persistStopEvent(historyService, event);
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const readHistory = historyService.getHistoryFromLatestBoundary.bind(historyService);
+      spyOn(historyService, "getHistoryFromLatestBoundary").mockImplementationOnce(
+        async (...args) => {
+          entered.resolve();
+          await release.promise;
+          return readHistory(...args);
+        }
+      );
+      const finalizing = finalizeWorkspaceTurnStreamEndForTest(taskService, event);
+      await entered.promise;
+      const error =
+        status === "interrupted"
+          ? "Continuation canceled by user"
+          : "Continuation dispatch failed: runtime unavailable";
+      await taskService.settleWorkspaceTurnContinuationFailure(
+        event.workspaceId,
+        workspaceTurnMuxMetadata(parentId),
+        status,
+        error
+      );
+      release.resolve();
+      await finalizing;
+      expect(
+        await new TaskHandleStore(config).getWorkspaceTurn(parentId, "wst_handle")
+      ).toMatchObject({ status, error });
+    }
+  );
+
+  test("finalizing continuation remains active until its history commit", async () => {
+    const { config, parentId, taskService } = await startWorkspaceTurnForTest();
+    const event = intermediateStopEvent(parentId);
+    const getStreamInfo = mock((_workspaceId: string, includeFinalizing?: boolean) =>
+      includeFinalizing
+        ? { messageId: "continuation-finalizing", muxMetadata: event.metadata.muxMetadata }
+        : undefined
+    );
+    expect(Reflect.set(taskService, "streamManager", { getStreamInfo })).toBe(true);
+    await finalizeWorkspaceTurnStreamEndForTest(taskService, event);
+    expect(getStreamInfo).toHaveBeenCalledWith(event.workspaceId, true);
+    expect(
+      await new TaskHandleStore(config).getWorkspaceTurn(parentId, "wst_handle")
+    ).toMatchObject({
+      status: "running",
+      deferredMessageIds: [event.messageId],
+    });
+  });
+
+  test.each([
+    { cause: { kind: "required-tool" } as const, status: "completed" },
+    { cause: { kind: "context-budget", decision: "rollover" } as const, status: "error" },
+    { cause: { kind: "step-limit" } as const, status: "error" },
+  ])(
+    "explicit $cause.kind stop does not borrow unrelated queue attribution",
+    async ({ cause, status }) => {
+      const { config, parentId, taskService } = await startWorkspaceTurnForTest({
+        getQueueCutCutter: mock(() => ({ stage: "queued", dispatchMode: "tool-end" })),
+      });
+      const event = intermediateStopEvent(parentId);
+      event.metadata.stopCause = cause;
+      await finalizeWorkspaceTurnStreamEndForTest(taskService, event);
+      expect(
+        (await new TaskHandleStore(config).getWorkspaceTurn(parentId, "wst_handle"))?.status
+      ).toBe(status);
+    }
+  );
+
+  test("legacy tool stop without continuation records an unknown cause", async () => {
+    const { config, parentId, taskService, historyService } = await startWorkspaceTurnForTest();
+    const event = intermediateStopEvent(parentId);
+    delete event.metadata.stopCause;
+    await persistStopEvent(historyService, event);
+    await finalizeWorkspaceTurnStreamEndForTest(taskService, event);
+    const record = await new TaskHandleStore(config).getWorkspaceTurn(parentId, "wst_handle");
+    expect(record?.status).toBe("error");
+    expect(record?.error).toContain("unknown stop cause");
+  });
+
+  test("lost continuation settles instead of remaining active after recovery", async () => {
+    const { config, parentId, taskService, historyService } = await startWorkspaceTurnForTest();
+    const event = intermediateStopEvent(parentId);
+    await persistStopEvent(historyService, event);
+    await finalizeWorkspaceTurnStreamEndForTest(taskService, event);
+    const record = await new TaskHandleStore(config).getWorkspaceTurn(parentId, "wst_handle");
+    expect(record?.status).toBe("error");
+    expect(record?.error).toContain("continuation unavailable");
+    expect(record?.error).toContain("continuation-entry");
+  });
+
   test("workspace-turn deferred stream-end does not finalize the handle", async () => {
     const { parentId, taskService } = await startWorkspaceTurnForTest();
     const event: StreamEndEvent = {

--- a/src/node/services/workspaceTurnManager.test.ts
+++ b/src/node/services/workspaceTurnManager.test.ts
@@ -4919,6 +4919,81 @@ describe("WorkspaceTurnManager", () => {
     });
   });
 
+  test.each([false, true])(
+    "required-tool completion repairs a transient failure (duringLookup=%s)",
+    async (duringLookup) => {
+      const { config, parentId, taskService, historyService } = await startWorkspaceTurnForTest();
+      const event = intermediateStopEvent(parentId);
+      event.metadata.stopCause = { kind: "required-tool" };
+      await persistStopEvent(historyService, event);
+      const store = (taskService as unknown as { taskHandleStore: TaskHandleStore })
+        .taskHandleStore;
+      const fail = () =>
+        taskService.settleWorkspaceTurnContinuationFailure(
+          event.workspaceId,
+          workspaceTurnMuxMetadata(parentId),
+          "error",
+          "Transient provider failure"
+        );
+      if (duringLookup) {
+        const readHandle = store.getWorkspaceTurn.bind(store);
+        spyOn(store, "getWorkspaceTurn").mockImplementationOnce(async (...args) => {
+          const snapshot = await readHandle(...args);
+          await fail();
+          return snapshot;
+        });
+      } else {
+        await fail();
+      }
+      await finalizeWorkspaceTurnStreamEndForTest(taskService, event);
+      expect(
+        await new TaskHandleStore(config).getWorkspaceTurn(parentId, "wst_handle")
+      ).toMatchObject({
+        status: "completed",
+        messageId: event.messageId,
+      });
+    }
+  );
+
+  test("stale recovery rereads history after a continuation commits and becomes idle", async () => {
+    const { config, parentId, taskService, historyService } = await startWorkspaceTurnForTest();
+    const event = intermediateStopEvent(parentId);
+    await taskService.markWorkspaceTurnStreamEndDeferred(event);
+    const record = await new TaskHandleStore(config).getWorkspaceTurn(parentId, "wst_handle");
+    assert(record);
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const readHistory = historyService.getHistoryFromLatestBoundary.bind(historyService);
+    spyOn(historyService, "getHistoryFromLatestBoundary").mockImplementationOnce(
+      async (...args) => {
+        const snapshot = await readHistory(...args);
+        entered.resolve();
+        await release.promise;
+        return snapshot;
+      }
+    );
+    const recovering = (
+      taskService as unknown as {
+        settleStaleWorkspaceTurn(record: WorkspaceTurnTaskHandleRecord): Promise<void>;
+      }
+    ).settleStaleWorkspaceTurn(record);
+    await entered.promise;
+    const completed: StreamEndEvent = {
+      ...event,
+      messageId: "continuation-committed",
+      metadata: { ...event.metadata, finishReason: "stop", stopCause: undefined },
+    };
+    await persistStopEvent(historyService, completed);
+    release.resolve();
+    await recovering;
+    expect(
+      await new TaskHandleStore(config).getWorkspaceTurn(parentId, "wst_handle")
+    ).toMatchObject({
+      status: "completed",
+      messageId: completed.messageId,
+    });
+  });
+
   test("unreadable history does not keep a deferred continuation active forever", async () => {
     const { config, parentId, taskService, historyService } = await startWorkspaceTurnForTest();
     const event = intermediateStopEvent(parentId);

--- a/src/node/services/workspaceTurnManager.test.ts
+++ b/src/node/services/workspaceTurnManager.test.ts
@@ -1,3 +1,4 @@
+import { StreamManager } from "./streamManager";
 import * as path from "path";
 import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
 import * as fsPromises from "fs/promises";
@@ -4955,23 +4956,21 @@ describe("WorkspaceTurnManager", () => {
     }
   );
 
-  test("stale recovery rereads history after a continuation commits and becomes idle", async () => {
+  test("stale recovery waits for an in-flight stream start before reading history", async () => {
     const { config, parentId, taskService, historyService } = await startWorkspaceTurnForTest();
+    const streams = new StreamManager(historyService);
+    Reflect.set(taskService, "streamManager", streams);
     const event = intermediateStopEvent(parentId);
     await taskService.markWorkspaceTurnStreamEndDeferred(event);
     const record = await new TaskHandleStore(config).getWorkspaceTurn(parentId, "wst_handle");
     assert(record);
+    const starting = await streams.acquireStreamStartLock(event.workspaceId);
     const entered = Promise.withResolvers<void>();
-    const release = Promise.withResolvers<void>();
-    const readHistory = historyService.getHistoryFromLatestBoundary.bind(historyService);
-    spyOn(historyService, "getHistoryFromLatestBoundary").mockImplementationOnce(
-      async (...args) => {
-        const snapshot = await readHistory(...args);
-        entered.resolve();
-        await release.promise;
-        return snapshot;
-      }
-    );
+    const acquire = streams.acquireStreamStartLock.bind(streams);
+    spyOn(streams, "acquireStreamStartLock").mockImplementationOnce((id) => {
+      entered.resolve();
+      return acquire(id);
+    });
     const recovering = (
       taskService as unknown as {
         settleStaleWorkspaceTurn(record: WorkspaceTurnTaskHandleRecord): Promise<void>;
@@ -4984,13 +4983,66 @@ describe("WorkspaceTurnManager", () => {
       metadata: { ...event.metadata, finishReason: "stop", stopCause: undefined },
     };
     await persistStopEvent(historyService, completed);
-    release.resolve();
+    await starting[Symbol.asyncDispose]();
     await recovering;
     expect(
       await new TaskHandleStore(config).getWorkspaceTurn(parentId, "wst_handle")
     ).toMatchObject({
       status: "completed",
       messageId: completed.messageId,
+    });
+  });
+
+  test("stale recovery blocks new starts through terminal persistence without blocking other workspaces", async () => {
+    const { config, parentId, taskService, historyService } = await startWorkspaceTurnForTest();
+    const streams = new StreamManager(historyService);
+    Reflect.set(taskService, "streamManager", streams);
+    const event = intermediateStopEvent(parentId);
+    event.metadata.finishReason = "stop";
+    delete event.metadata.stopCause;
+    await taskService.markWorkspaceTurnStreamEndDeferred(event);
+    await persistStopEvent(historyService, event);
+    const store = (taskService as unknown as { taskHandleStore: TaskHandleStore }).taskHandleStore;
+    const record = await store.getWorkspaceTurn(parentId, "wst_handle");
+    assert(record);
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const cleanup = spyOn(
+      taskService as unknown as {
+        cleanupDisposableWorkspaceTurn(record: WorkspaceTurnTaskHandleRecord): Promise<void>;
+      },
+      "cleanupDisposableWorkspaceTurn"
+    ).mockImplementation(async () => {
+      await using _cleanupStart = await streams.acquireStreamStartLock(event.workspaceId);
+    });
+    const persist = store.upsertWorkspaceTurn.bind(store);
+    spyOn(store, "upsertWorkspaceTurn").mockImplementationOnce(async (next) => {
+      entered.resolve();
+      await release.promise;
+      return persist(next);
+    });
+    const recovering = (
+      taskService as unknown as {
+        settleStaleWorkspaceTurn(record: WorkspaceTurnTaskHandleRecord): Promise<void>;
+      }
+    ).settleStaleWorkspaceTurn(record);
+    await entered.promise;
+    let started = false;
+    const starting = streams.acquireStreamStartLock(event.workspaceId).then(async (lock) => {
+      started = true;
+      await lock[Symbol.asyncDispose]();
+    });
+    await using _otherWorkspace = await streams.acquireStreamStartLock("other-workspace");
+    expect(started).toBe(false);
+    release.resolve();
+    await recovering;
+    await starting;
+    expect(cleanup).toHaveBeenCalled();
+    expect(
+      await new TaskHandleStore(config).getWorkspaceTurn(parentId, "wst_handle")
+    ).toMatchObject({
+      status: "completed",
+      messageId: event.messageId,
     });
   });
 

--- a/src/node/services/workspaceTurnManager.test.ts
+++ b/src/node/services/workspaceTurnManager.test.ts
@@ -4802,6 +4802,84 @@ describe("WorkspaceTurnManager", () => {
     }
   );
 
+  test.each(["error", "interrupted"] as const)(
+    "old replacement queue stop preserves newer %s during handle lookup",
+    async (status) => {
+      const { config, parentId, taskService } = await startWorkspaceTurnForTest();
+      const event = intermediateStopEvent(parentId);
+      event.metadata.stopCause = { kind: "queued-input", entryId: "replacement" };
+      const store = (taskService as unknown as { taskHandleStore: TaskHandleStore })
+        .taskHandleStore;
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const readHandle = store.getWorkspaceTurn.bind(store);
+      spyOn(store, "getWorkspaceTurn").mockImplementationOnce(async (...args) => {
+        const snapshot = await readHandle(...args);
+        entered.resolve();
+        await release.promise;
+        return snapshot;
+      });
+      const finalizing = finalizeWorkspaceTurnStreamEndForTest(taskService, event);
+      await entered.promise;
+      const error = status === "error" ? "Continuation dispatch failed" : "Continuation canceled";
+      await taskService.settleWorkspaceTurnContinuationFailure(
+        event.workspaceId,
+        workspaceTurnMuxMetadata(parentId),
+        status,
+        error
+      );
+      release.resolve();
+      await finalizing;
+      expect(
+        await new TaskHandleStore(config).getWorkspaceTurn(parentId, "wst_handle")
+      ).toMatchObject({ status, error });
+    }
+  );
+
+  test("old queue stop cannot replace a newer terminal message", async () => {
+    const { config, parentId, taskService } = await startWorkspaceTurnForTest();
+    const old = intermediateStopEvent(parentId);
+    old.metadata.stopCause = { kind: "queued-input", entryId: "old-replacement" };
+    old.metadata.historySequence = 10;
+    const newer: StreamEndEvent = {
+      ...old,
+      messageId: "newer-failure",
+      metadata: {
+        ...old.metadata,
+        stopCause: undefined,
+        finishReason: "length",
+        historySequence: 20,
+      },
+    };
+    await finalizeWorkspaceTurnStreamEndForTest(taskService, newer);
+    await finalizeWorkspaceTurnStreamEndForTest(taskService, old);
+    expect(
+      await new TaskHandleStore(config).getWorkspaceTurn(parentId, "wst_handle")
+    ).toMatchObject({
+      status: "error",
+      messageId: newer.messageId,
+    });
+  });
+
+  test("unreadable history does not keep a deferred continuation active forever", async () => {
+    const { config, parentId, taskService, historyService } = await startWorkspaceTurnForTest();
+    const event = intermediateStopEvent(parentId);
+    await taskService.markWorkspaceTurnStreamEndDeferred(event);
+    const record = await new TaskHandleStore(config).getWorkspaceTurn(parentId, "wst_handle");
+    assert(record);
+    spyOn(historyService, "getHistoryFromLatestBoundary").mockResolvedValueOnce(
+      Err("History unavailable")
+    );
+    await (
+      taskService as unknown as {
+        settleStaleWorkspaceTurn(record: WorkspaceTurnTaskHandleRecord): Promise<void>;
+      }
+    ).settleStaleWorkspaceTurn(record);
+    expect(
+      (await new TaskHandleStore(config).getWorkspaceTurn(parentId, "wst_handle"))?.status
+    ).toBe("interrupted");
+  });
+
   test("finalizing continuation remains active until its history commit", async () => {
     const { config, parentId, taskService } = await startWorkspaceTurnForTest();
     const event = intermediateStopEvent(parentId);
@@ -4863,7 +4941,7 @@ describe("WorkspaceTurnManager", () => {
   });
 
   test("workspace-turn deferred stream-end does not finalize the handle", async () => {
-    const { parentId, taskService } = await startWorkspaceTurnForTest();
+    const { config, parentId, taskService } = await startWorkspaceTurnForTest();
     const event: StreamEndEvent = {
       type: "stream-end",
       workspaceId: "childworkspace",
@@ -4884,14 +4962,16 @@ describe("WorkspaceTurnManager", () => {
     await internal.markWorkspaceTurnStreamEndDeferred(event);
     expect(await internal.finalizeWorkspaceTurnFromStreamEnd(event)).toBe(true);
 
-    expect(await workspaceTurnSnapshot(taskService, parentId)).toMatchObject({
+    expect(
+      await new TaskHandleStore(config).getWorkspaceTurn(parentId, "wst_handle")
+    ).toMatchObject({
       status: "running",
       deferredMessageIds: ["msg_deferred"],
     });
   });
 
   test("a final-flush stream-end is deferred even without a queued continuation", async () => {
-    const { parentId, taskService } = await startWorkspaceTurnForTest();
+    const { config, parentId, taskService } = await startWorkspaceTurnForTest();
     const event: StreamEndEvent = {
       type: "stream-end",
       workspaceId: "childworkspace",
@@ -4911,7 +4991,9 @@ describe("WorkspaceTurnManager", () => {
     // Nothing is queued (e.g. the user cleared the queue mid-flush): the housekeeping finish still
     // must not settle the delegated task.
     expect(await finalizeWorkspaceTurnStreamEndForTest(taskService, event)).toBe(true);
-    expect(await workspaceTurnSnapshot(taskService, parentId)).toMatchObject({
+    expect(
+      await new TaskHandleStore(config).getWorkspaceTurn(parentId, "wst_handle")
+    ).toMatchObject({
       status: "running",
       deferredMessageIds: ["msg_flush"],
     });

--- a/src/node/services/workspaceTurnManager.test.ts
+++ b/src/node/services/workspaceTurnManager.test.ts
@@ -4956,6 +4956,28 @@ describe("WorkspaceTurnManager", () => {
     }
   );
 
+  test("stale recovery defers while a send is in pre-admission", async () => {
+    const { config, parentId, taskService, historyService, workspaceMocks } =
+      await startWorkspaceTurnForTest();
+    const event = intermediateStopEvent(parentId);
+    await taskService.markWorkspaceTurnStreamEndDeferred(event);
+    const record = await new TaskHandleStore(config).getWorkspaceTurn(parentId, "wst_handle");
+    assert(record);
+    workspaceMocks.acquireIdleTurnExclusion.mockReturnValueOnce(Err("a send is being admitted"));
+    const readHistory = spyOn(historyService, "getHistoryFromLatestBoundary");
+    await (
+      taskService as unknown as {
+        settleStaleWorkspaceTurn(record: WorkspaceTurnTaskHandleRecord): Promise<void>;
+      }
+    ).settleStaleWorkspaceTurn(record);
+    expect(readHistory).not.toHaveBeenCalled();
+    expect(
+      await new TaskHandleStore(config).getWorkspaceTurn(parentId, "wst_handle")
+    ).toMatchObject({
+      status: "running",
+    });
+  });
+
   test("stale recovery waits for an in-flight stream start before reading history", async () => {
     const { config, parentId, taskService, historyService } = await startWorkspaceTurnForTest();
     const streams = new StreamManager(historyService);
@@ -4994,7 +5016,17 @@ describe("WorkspaceTurnManager", () => {
   });
 
   test("stale recovery blocks new starts through terminal persistence without blocking other workspaces", async () => {
-    const { config, parentId, taskService, historyService } = await startWorkspaceTurnForTest();
+    const { config, parentId, taskService, historyService, workspaceMocks } =
+      await startWorkspaceTurnForTest();
+    let admissionHeld = false;
+    workspaceMocks.acquireIdleTurnExclusion.mockImplementation(() => {
+      admissionHeld = true;
+      return Ok({
+        [Symbol.dispose]: () => {
+          admissionHeld = false;
+        },
+      });
+    });
     const streams = new StreamManager(historyService);
     Reflect.set(taskService, "streamManager", streams);
     const event = intermediateStopEvent(parentId);
@@ -5013,6 +5045,7 @@ describe("WorkspaceTurnManager", () => {
       },
       "cleanupDisposableWorkspaceTurn"
     ).mockImplementation(async () => {
+      expect(admissionHeld).toBe(false);
       await using _cleanupStart = await streams.acquireStreamStartLock(event.workspaceId);
     });
     const persist = store.upsertWorkspaceTurn.bind(store);
@@ -5034,6 +5067,7 @@ describe("WorkspaceTurnManager", () => {
     });
     await using _otherWorkspace = await streams.acquireStreamStartLock("other-workspace");
     expect(started).toBe(false);
+    expect(admissionHeld).toBe(true);
     release.resolve();
     await recovering;
     await starting;

--- a/src/node/services/workspaceTurnManager.test.ts
+++ b/src/node/services/workspaceTurnManager.test.ts
@@ -4741,6 +4741,64 @@ describe("WorkspaceTurnManager", () => {
   );
 
   test.each([false, true])(
+    "continuation arriving during history read keeps execution active (legacy=%s)",
+    async (legacy) => {
+      const pending = mock(() => false);
+      const { config, parentId, taskService, historyService } = await startWorkspaceTurnForTest({
+        hasPendingWorkspaceTurnContinuation: pending,
+      });
+      const event = intermediateStopEvent(parentId);
+      if (legacy) delete event.metadata.stopCause;
+      await persistStopEvent(historyService, event);
+      const entered = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const readHistory = historyService.getHistoryFromLatestBoundary.bind(historyService);
+      spyOn(historyService, "getHistoryFromLatestBoundary").mockImplementationOnce(
+        async (...args) => {
+          const snapshot = await readHistory(...args);
+          entered.resolve();
+          await release.promise;
+          return snapshot;
+        }
+      );
+      const finalizing = finalizeWorkspaceTurnStreamEndForTest(taskService, event);
+      await entered.promise;
+      pending.mockReturnValue(true);
+      release.resolve();
+      await finalizing;
+      expect(
+        await new TaskHandleStore(config).getWorkspaceTurn(parentId, "wst_handle")
+      ).toMatchObject({
+        status: "running",
+        deferredMessageIds: [event.messageId],
+      });
+    }
+  );
+
+  test.each([false, true])(
+    "settled repair honors explicit replacement cause (sameOwner=%s)",
+    async (sameOwner) => {
+      const { config, parentId, taskService, historyService } = await startWorkspaceTurnForTest();
+      const event = intermediateStopEvent(parentId);
+      event.metadata.stopCause = {
+        kind: "queued-input",
+        entryId: "replacement-entry",
+        ...(sameOwner ? { muxMetadata: workspaceTurnMuxMetadata(parentId, "wst_successor") } : {}),
+      };
+      await persistStopEvent(historyService, event);
+      await new TaskHandleStore(config).upsertWorkspaceTurn(
+        workspaceTurnRecord(parentId, "childworkspace", "wst_handle", "error", {
+          messageId: "earlier-error",
+          error: "Earlier provider failure",
+        })
+      );
+      const repaired = await workspaceTurnSnapshot(taskService, parentId);
+      expect(repaired).toMatchObject({ status: "interrupted", messageId: event.messageId });
+      if (sameOwner) expect(repaired?.error).toContain("wst_successor");
+    }
+  );
+
+  test.each([false, true])(
     "recovery preserves pending same-execution continuation (legacy=%s)",
     async (legacy) => {
       const { config, parentId, taskService, historyService } = await startWorkspaceTurnForTest({

--- a/src/node/services/workspaceTurnManager.ts
+++ b/src/node/services/workspaceTurnManager.ts
@@ -2280,6 +2280,10 @@ export class WorkspaceTurnManager {
         // actually changes the outcome (duplicate stream-end replays must stay idempotent).
         const resettleStaleTerminal =
           params.allowTerminalResettle === true &&
+          (params.next.finalMessage?.metadata?.finishReason !== "tool-calls" ||
+            (current.status === params.record.status &&
+              current.messageId === params.record.messageId &&
+              current.updatedAt === params.record.updatedAt)) &&
           this.isTerminalWorkspaceTurnStatus(current.status) &&
           current.status !== "completed" &&
           isSelfHealEligibleSettledWorkspaceTurn(current) &&
@@ -4029,7 +4033,19 @@ export class WorkspaceTurnManager {
     const active = this.activeWorkspaceTurnHandleByWorkspaceId.get(record.workspaceId);
     const hasRuntimeActivity =
       this.aiService.isStreaming(record.workspaceId) ||
-      this.workspaceService.hasPendingQueuedOrPreparingTurn(record.workspaceId);
+      this.workspaceService.hasPendingQueuedOrPreparingTurn(record.workspaceId) ||
+      this.workspaceService.hasPendingBashMonitorWakeContinuation(record.workspaceId) ||
+      this.hasSameTurnContinuation(
+        {
+          workspaceId: record.workspaceId,
+          messageId: record.deferredMessageIds?.at(-1) ?? record.messageId ?? "",
+        },
+        {
+          taskHandleId: record.handleId,
+          ownerWorkspaceId: record.ownerWorkspaceId,
+          turnId: record.turnId,
+        }
+      );
     if (hasRuntimeActivity) {
       return true;
     }
@@ -4068,18 +4084,9 @@ export class WorkspaceTurnManager {
       return;
     }
 
-    // Same-process deferred stream-ends can be observed before the final assistant message is
-    // readable from history. Keep the handle alive in that narrow window; after restart the active
-    // map is empty, so unrecoverable deferred handles still settle terminally instead of leaking.
-    const active = this.activeWorkspaceTurnHandleByWorkspaceId.get(record.workspaceId);
-    if (
-      (record.deferredMessageIds?.length ?? 0) > 0 &&
-      active?.handleId === record.handleId &&
-      active.ownerWorkspaceId === record.ownerWorkspaceId
-    ) {
-      return;
-    }
-
+    // Recovery reads can overlap a continuation start. Check live work again before the fallback.
+    if (await this.isLiveWorkspaceTurn(record)) return;
+    // No runtime work remains. A missing history row must not keep a deferred handle active forever.
     const next: WorkspaceTurnTaskHandleRecord = {
       ...record,
       status: "interrupted",
@@ -4624,7 +4631,7 @@ export class WorkspaceTurnManager {
    * Pending entries must carry the same correlation metadata as the ended stream.
    */
   private hasSameTurnContinuation(
-    event: StreamEndEvent,
+    event: Pick<StreamEndEvent, "workspaceId" | "messageId">,
     correlation: { taskHandleId: string; ownerWorkspaceId: string; turnId: string }
   ): boolean {
     if (
@@ -4899,8 +4906,11 @@ export class WorkspaceTurnManager {
       // An intermediate stop cannot replace a concrete continuation failure.
       allowTerminalResettle:
         event.metadata.finishReason !== "tool-calls" ||
-        next.status === "completed" ||
-        supersedeEvidence != null,
+        (record.messageId === event.messageId &&
+          record.finalMessage?.metadata?.finishReason === "tool-calls") ||
+        (typeof event.metadata.historySequence === "number" &&
+          typeof record.finalMessage?.metadata?.historySequence === "number" &&
+          event.metadata.historySequence > record.finalMessage.metadata.historySequence),
       disposableOwnershipTransferred,
     });
     return true;

--- a/src/node/services/workspaceTurnManager.ts
+++ b/src/node/services/workspaceTurnManager.ts
@@ -2151,7 +2151,9 @@ export class WorkspaceTurnManager {
             executionId: record.handleId,
             errorType: isSupersededWorkspaceTurnInterrupt(record)
               ? "workspace_turn_superseded"
-              : "workspace_turn_error",
+              : record.finalMessage?.metadata?.finishReason === "tool-calls"
+                ? "workspace_turn_incomplete"
+                : "workspace_turn_error",
             errorMessage: record.error ?? "Workspace turn failed",
           });
     if (!alreadyDelivered) {
@@ -4298,17 +4300,7 @@ export class WorkspaceTurnManager {
     const baseRecord = { ...record };
     delete baseRecord.error;
     delete baseRecord.deferredMessageIds;
-    // A "tool-calls" finish on a delegated turn backed by queue-dispatch
-    // evidence is a queue cut: some other queued input (a manual user message,
-    // /compact, the owner's own follow-up turn) dispatched at the tool boundary
-    // and superseded the turn (same-turn continuations were already deferred by
-    // the caller). The child keeps working under that new input, so this is a
-    // supersede — not a failure of the delegated work. Settle as interrupted
-    // with a human-readable reason instead of alarming the owner with an
-    // "error" and internal finishReason jargon. Without such evidence a
-    // "tool-calls" finish can come from other stop conditions (e.g. a
-    // successful required-tool result), so it falls through to the truncation
-    // branch.
+    // Persisted queue decisions remain authoritative after the cutter leaves the queue.
     if (event.metadata.finishReason === "tool-calls" && options.supersedeEvidence != null) {
       const evidence = options.supersedeEvidence;
       const error =
@@ -4331,13 +4323,20 @@ export class WorkspaceTurnManager {
       };
     }
     // Truncated/non-stop provider finishes are partial output, not a completed delegated turn.
-    if (event.metadata.finishReason != null && event.metadata.finishReason !== "stop") {
+    if (
+      event.metadata.finishReason != null &&
+      event.metadata.finishReason !== "stop" &&
+      event.metadata.stopCause?.kind !== "required-tool"
+    ) {
       return {
         ...baseRecord,
         status: "error",
         updatedAt: getIsoNow(),
         messageId: event.messageId,
-        error: `Workspace turn ended before completion (finishReason: ${event.metadata.finishReason})`,
+        error:
+          event.metadata.finishReason === "tool-calls"
+            ? this.describeIncompleteToolStop(event)
+            : `Workspace turn ended before completion (finishReason: ${event.metadata.finishReason})`,
         finalMessageRef: this.buildWorkspaceTurnFinalMessageRef(event),
         finalMessage: {
           messageId: event.messageId,
@@ -4357,6 +4356,25 @@ export class WorkspaceTurnManager {
         metadata: event.metadata,
       },
     };
+  }
+
+  private describeIncompleteToolStop(event: StreamEndEvent): string {
+    const cause = event.metadata.stopCause;
+    if (cause == null) {
+      log.warn("Workspace turn tool-calls stop has unknown cause", {
+        workspaceId: event.workspaceId,
+        messageId: event.messageId,
+        muxMetadata: event.metadata.muxMetadata,
+      });
+      return "Workspace turn incomplete: unknown stop cause; no correlated continuation found.";
+    }
+    if (cause.kind === "queued-input") {
+      return `Workspace turn continuation unavailable after queue stop (entryId: ${cause.entryId}).`;
+    }
+    if (cause.kind === "context-budget") {
+      return `Workspace turn incomplete: context budget ${cause.decision}; no continuation remains.`;
+    }
+    return "Workspace turn incomplete: step limit reached.";
   }
 
   private isDeferredWorkspaceTurnMessage(
@@ -4389,14 +4407,19 @@ export class WorkspaceTurnManager {
       }
       const event = this.buildWorkspaceTurnStreamEndEventFromHistory(record, message);
       if (event != null) {
-        // History order alone cannot prove a queue cut (a later unrelated user
-        // message is not causal evidence), so stale recovery conservatively
-        // settles tool-calls finals as errors. Genuine supersedes are
-        // classified live at stream-end; a crash-window misclassification here
-        // stays self-heal eligible for later correlated evidence.
-        return this.buildTerminalWorkspaceTurnRecordFromEvent(record, event, {
-          supersedeEvidence: null,
+        const supersedeEvidence = this.getQueueCutSupersedeEvidence(event, record, {
+          activeStream: undefined,
+          cutter: undefined,
+          hasPendingQueuedOrPreparingTurn: false,
         });
+        const correlation = this.getWorkspaceTurnMetadata(event);
+        if (
+          supersedeEvidence == null &&
+          correlation != null &&
+          this.hasSameTurnContinuation(event, correlation)
+        )
+          return null;
+        return this.buildTerminalWorkspaceTurnRecordFromEvent(record, event, { supersedeEvidence });
       }
     }
     return null;
@@ -4584,6 +4607,18 @@ export class WorkspaceTurnManager {
     });
   }
 
+  private matchesWorkspaceTurnRecord(
+    record: WorkspaceTurnTaskHandleRecord,
+    value: unknown
+  ): boolean {
+    const correlation = this.getWorkspaceTurnMetadataFromValue(value);
+    return (
+      correlation?.taskHandleId === record.handleId &&
+      correlation.ownerWorkspaceId === record.ownerWorkspaceId &&
+      correlation.turnId === record.turnId
+    );
+  }
+
   /**
    * Whether a continuation of this exact delegated turn is pending or streaming.
    * Pending entries must carry the same correlation metadata as the ended stream.
@@ -4600,7 +4635,7 @@ export class WorkspaceTurnManager {
     ) {
       return true;
     }
-    const activeStream = this.streamManager?.getStreamInfo(event.workspaceId);
+    const activeStream = this.streamManager?.getStreamInfo(event.workspaceId, true);
     if (activeStream == null || activeStream.messageId === event.messageId) {
       return false;
     }
@@ -4655,6 +4690,12 @@ export class WorkspaceTurnManager {
         ? { kind: "same_owner_follow_up", successorHandleId }
         : { kind: "other_input" };
     };
+    const cause = event.metadata.stopCause;
+    if (cause != null) {
+      if (cause.kind !== "queued-input") return null;
+      if (this.matchesWorkspaceTurnRecord(record, cause.muxMetadata)) return null;
+      return classifyMetadata(cause.muxMetadata);
+    }
     // Already streaming at the cut: the uncorrelated active stream is the
     // engaged cutter.
     const { activeStream, cutter } = snapshot;
@@ -4762,6 +4803,7 @@ export class WorkspaceTurnManager {
       return true;
     }
 
+    // Check runtime state before history. A finishing successor commits history before it disappears.
     // Parent guidance and report wake-ups continue the exact delegated turn. This includes
     // turn-end guidance: don't publish an early report before the queued guidance runs.
     // Uncorrelated bash-monitor wakes inherit only an open tool-boundary continuation;
@@ -4770,12 +4812,45 @@ export class WorkspaceTurnManager {
       (event.metadata.finishReason === "tool-calls" ||
         event.metadata.finishReason === "stop" ||
         event.metadata.finishReason == null) &&
+      (event.metadata.stopCause == null ||
+        this.getQueueCutSupersedeEvidence(event, record, queueCutSnapshot) == null) &&
       (this.hasSameTurnContinuation(event, metadata) ||
         (event.metadata.finishReason === "tool-calls" &&
           this.workspaceService.hasPendingBashMonitorWakeContinuation(event.workspaceId)))
     ) {
       await this.markWorkspaceTurnStreamEndDeferred(event);
       return true;
+    }
+
+    if (
+      event.metadata.finishReason === "tool-calls" &&
+      (event.metadata.stopCause == null ||
+        this.getQueueCutSupersedeEvidence(event, record, queueCutSnapshot) == null)
+    ) {
+      const history = await this.historyService.getHistoryFromLatestBoundary(event.workspaceId);
+      if (history.success) {
+        const index = history.data.findIndex((message) => message.id === event.messageId);
+        if (index >= 0) {
+          const successor = history.data
+            .slice(index + 1)
+            .findLast(
+              (message) =>
+                message.role === "assistant" &&
+                this.matchesWorkspaceTurnRecord(record, message.metadata?.muxMetadata)
+            );
+          if (successor != null) {
+            const successorEvent = this.buildWorkspaceTurnStreamEndEventFromHistory(
+              record,
+              successor
+            );
+            if (successorEvent != null) {
+              return this.finalizeWorkspaceTurnFromStreamEnd(successorEvent, queueCutSnapshot);
+            }
+            await this.markWorkspaceTurnStreamEndDeferred(event);
+            return true;
+          }
+        }
+      }
     }
 
     const supersedeEvidence = this.getQueueCutSupersedeEvidence(event, record, queueCutSnapshot);
@@ -4821,7 +4896,11 @@ export class WorkspaceTurnManager {
       // delegated turn's real outcome. A handle that settled interrupted/error from a
       // transient failure (provider error, restart) may have self-healed via auto-retry
       // of the same turn; let this settlement correct that stale record.
-      allowTerminalResettle: true,
+      // An intermediate stop cannot replace a concrete continuation failure.
+      allowTerminalResettle:
+        event.metadata.finishReason !== "tool-calls" ||
+        next.status === "completed" ||
+        supersedeEvidence != null,
       disposableOwnershipTransferred,
     });
     return true;

--- a/src/node/services/workspaceTurnManager.ts
+++ b/src/node/services/workspaceTurnManager.ts
@@ -2836,22 +2836,20 @@ export class WorkspaceTurnManager {
           });
         }
         const recovered = this.buildTerminalWorkspaceTurnRecordFromEvent(record, event, {
-          // Repair preserves — never invents — a supersede classification.
-          // History order is not causal queue-dispatch evidence (an unrelated
-          // later user message must not upgrade an error settlement), while the
-          // persisted supersede stays authoritative when rebuilding from the
-          // SAME correlated final that settled it: the superseding queued input
-          // may not have appended its user message yet, and that absence must
-          // not downgrade the supersede to a truncation error. Only a different
-          // correlated final (contradictory same-turn evidence) may resettle.
-          // "preserved" keeps whichever flavor (generic or owner follow-up) was
-          // persisted verbatim, so repair cannot downgrade the quiet flavor.
+          // Explicit stop causes survive recovery. Without one, preserve only the same final's
+          // existing supersession; later unrelated history cannot prove a queue stop.
           supersedeEvidence:
-            isSupersededWorkspaceTurnInterrupt(record) &&
-            event.messageId === record.messageId &&
-            record.error != null
-              ? { kind: "preserved", error: record.error }
-              : null,
+            event.metadata.stopCause != null
+              ? this.getQueueCutSupersedeEvidence(event, record, {
+                  activeStream: undefined,
+                  cutter: undefined,
+                  hasPendingQueuedOrPreparingTurn: false,
+                })
+              : isSupersededWorkspaceTurnInterrupt(record) &&
+                  event.messageId === record.messageId &&
+                  record.error != null
+                ? { kind: "preserved", error: record.error }
+                : null,
         });
         if (
           !options.repairFromHistory ||
@@ -4835,6 +4833,14 @@ export class WorkspaceTurnManager {
         this.getQueueCutSupersedeEvidence(event, record, queueCutSnapshot) == null)
     ) {
       const history = await this.historyService.getHistoryFromLatestBoundary(event.workspaceId);
+      // A continuation can start during the read before its assistant row reaches history.
+      if (
+        this.hasSameTurnContinuation(event, metadata) ||
+        this.workspaceService.hasPendingBashMonitorWakeContinuation(event.workspaceId)
+      ) {
+        await this.markWorkspaceTurnStreamEndDeferred(event);
+        return true;
+      }
       if (history.success) {
         const index = history.data.findIndex((message) => message.id === event.messageId);
         if (index >= 0) {

--- a/src/node/services/workspaceTurnManager.ts
+++ b/src/node/services/workspaceTurnManager.ts
@@ -2225,6 +2225,8 @@ export class WorkspaceTurnManager {
      * same turn, and the correlated stream-end proves the turn's real outcome.
      */
     allowTerminalResettle?: boolean;
+    /** Release startup exclusion after persistence, before cleanup can join pending sends. */
+    releaseRecoveryLock?: () => Promise<void>;
     /**
      * Only the settlement that itself moved disposable ownership to a
      * successor (transferDisposableWorkspaceToSuccessor) may clear
@@ -2428,6 +2430,7 @@ export class WorkspaceTurnManager {
             error: queuedProgressRemoval.error,
           });
         }
+        await params.releaseRecoveryLock?.();
         const foregroundWaiterWorkspaceIds = this.settleWorkspaceTurnWaiters(
           params.record.handleId,
           params.waiterSettlement
@@ -4068,16 +4071,27 @@ export class WorkspaceTurnManager {
     if (!isActiveWorkspaceTurnTaskStatus(record.status)) {
       return;
     }
-    let recovered = await this.recoverTerminalWorkspaceTurnFromHistory(record);
-    if (recovered == null) {
-      if (await this.isLiveWorkspaceTurn(record)) return;
-      // A continuation commits history before it becomes idle. Read again after the idle check
-      // so an earlier snapshot cannot turn its completed result into a restart interruption.
-      recovered = await this.recoverTerminalWorkspaceTurnFromHistory(record);
-    }
+    // Lock order: stream start, then handle settlement. Registration cannot race recovery writes.
+    let recoveryLock = await this.streamManager?.acquireStreamStartLock(record.workspaceId);
+    await using recoveryScope = {
+      [Symbol.asyncDispose]: () => {
+        const lock = recoveryLock;
+        recoveryLock = undefined;
+        return lock?.[Symbol.asyncDispose]() ?? Promise.resolve();
+      },
+    };
+    const releaseRecoveryLock = () => recoveryScope[Symbol.asyncDispose]();
+    // Preparing input stays visible until registration. Existing streams include finalization.
+    if (
+      this.streamManager?.getStreamInfo(record.workspaceId, true) != null ||
+      (await this.isLiveWorkspaceTurn(record))
+    )
+      return;
+    const recovered = await this.recoverTerminalWorkspaceTurnFromHistory(record);
     if (recovered != null) {
       await this.settleWorkspaceTurn({
         cause: { kind: "stale-history-recovery" },
+        releaseRecoveryLock,
         record,
         next: recovered,
         waiterSettlement:
@@ -4099,6 +4113,7 @@ export class WorkspaceTurnManager {
     };
     await this.settleWorkspaceTurn({
       cause: { kind: "stale-restart" },
+      releaseRecoveryLock,
       record,
       next,
       waiterSettlement: {

--- a/src/node/services/workspaceTurnManager.ts
+++ b/src/node/services/workspaceTurnManager.ts
@@ -2280,7 +2280,7 @@ export class WorkspaceTurnManager {
         // actually changes the outcome (duplicate stream-end replays must stay idempotent).
         const resettleStaleTerminal =
           params.allowTerminalResettle === true &&
-          (params.next.finalMessage?.metadata?.finishReason !== "tool-calls" ||
+          (!this.isIntermediateToolStop(params.next.finalMessage?.metadata) ||
             (current.status === params.record.status &&
               current.messageId === params.record.messageId &&
               current.updatedAt === params.record.updatedAt)) &&
@@ -4068,7 +4068,13 @@ export class WorkspaceTurnManager {
     if (!isActiveWorkspaceTurnTaskStatus(record.status)) {
       return;
     }
-    const recovered = await this.recoverTerminalWorkspaceTurnFromHistory(record);
+    let recovered = await this.recoverTerminalWorkspaceTurnFromHistory(record);
+    if (recovered == null) {
+      if (await this.isLiveWorkspaceTurn(record)) return;
+      // A continuation commits history before it becomes idle. Read again after the idle check
+      // so an earlier snapshot cannot turn its completed result into a restart interruption.
+      recovered = await this.recoverTerminalWorkspaceTurnFromHistory(record);
+    }
     if (recovered != null) {
       await this.settleWorkspaceTurn({
         cause: { kind: "stale-history-recovery" },
@@ -4361,6 +4367,12 @@ export class WorkspaceTurnManager {
         metadata: event.metadata,
       },
     };
+  }
+
+  private isIntermediateToolStop(
+    metadata: Pick<StreamEndEvent["metadata"], "finishReason" | "stopCause"> | undefined
+  ): boolean {
+    return metadata?.finishReason === "tool-calls" && metadata.stopCause?.kind !== "required-tool";
   }
 
   private describeIncompleteToolStop(event: StreamEndEvent): string {
@@ -4911,7 +4923,7 @@ export class WorkspaceTurnManager {
       // of the same turn; let this settlement correct that stale record.
       // An intermediate stop cannot replace a concrete continuation failure.
       allowTerminalResettle:
-        event.metadata.finishReason !== "tool-calls" ||
+        !this.isIntermediateToolStop(event.metadata) ||
         (record.messageId === event.messageId &&
           record.finalMessage?.metadata?.finishReason === "tool-calls") ||
         (typeof event.metadata.historySequence === "number" &&

--- a/src/node/services/workspaceTurnManager.ts
+++ b/src/node/services/workspaceTurnManager.ts
@@ -4071,16 +4071,23 @@ export class WorkspaceTurnManager {
     if (!isActiveWorkspaceTurnTaskStatus(record.status)) {
       return;
     }
-    // Lock order: stream start, then handle settlement. Registration cannot race recovery writes.
-    let recoveryLock = await this.streamManager?.acquireStreamStartLock(record.workspaceId);
+    // Admission exclusion also covers sends whose user row is not durable yet.
+    const admission = this.workspaceService.acquireIdleTurnExclusion(record.workspaceId);
+    if (!admission.success) return;
+    let admissionHold: Disposable | undefined = admission.data;
+    let recoveryLock: AsyncDisposable | undefined;
     await using recoveryScope = {
       [Symbol.asyncDispose]: () => {
+        admissionHold?.[Symbol.dispose]();
+        admissionHold = undefined;
         const lock = recoveryLock;
         recoveryLock = undefined;
-        return lock?.[Symbol.asyncDispose]() ?? Promise.resolve();
+        return Promise.resolve(lock?.[Symbol.asyncDispose]());
       },
     };
     const releaseRecoveryLock = () => recoveryScope[Symbol.asyncDispose]();
+    // Lock order: admission, stream start, then handle settlement.
+    recoveryLock = await this.streamManager?.acquireStreamStartLock(record.workspaceId);
     // Preparing input stays visible until registration. Existing streams include finalization.
     if (
       this.streamManager?.getStreamInfo(record.workspaceId, true) != null ||


### PR DESCRIPTION
## Summary
Preserve stream stop causes so intermediate tool boundaries do not appear as failed child executions.

## Background
Parents can receive a workspace-turn failure while a child handles continuation input. Later queue inspection can lose the original stop cause. The original incident remains unproven, but deterministic tests reproduce lifecycle gaps.

## Implementation
- Capture queued-input identity and correlation when the stream stops. Persist the cause with assistant metadata.
- Use explicit causes during finalization, recovery, and settled-handle repair.
- Exclude send admission and serialize stream startup during idle recovery through terminal persistence. Release the lock before cleanup and notifications.
- Preserve legacy failure terminators and successful completion signals for downgrade recovery.
- Keep recognized continuations active. Preserve concrete cancellation and dispatch failures.
- Prevent old stream events from replacing newer outcomes.
- Show incomplete workspace turns separately from generic subagent failures.
- Add controlled-promise regression cases for queue removal, history-read races, recovery, and terminal ordering.

## Risks
This changes delegated execution settlement across live and recovery paths. Incorrect correlation could delay a report or classify it incorrectly. Legacy records retain fallback handling, and abandoned continuations still settle.
Idle recovery briefly blocks same-workspace stream starts while it reads and persists the outcome. Other workspaces remain independent.
A send racing recovery can receive the existing admission-blocked response and require a retry.

## Personal deployment validation
No personal deployment validation.

---

_Generated with `xum` • Model: `openai:gpt-6-astra` • Thinking: `medium` • Cost: `$26.38`_

<!-- mux-attribution: model=openai:gpt-6-astra thinking=medium costs=26.38 -->


