### PR TITLE
🤖 fix: preserve optional MCP arguments under OpenAI strict mode

### DIFF
--- a/src/common/utils/tools/schemaSanitizer.test.ts
+++ b/src/common/utils/tools/schemaSanitizer.test.ts
@@ -32,6 +32,7 @@ describe("schemaSanitizer", () => {
           properties: {
             content: { type: "string", minLength: 1 },
           },
+          required: ["content"],
         },
       } as unknown as Tool;
 
@@ -51,6 +52,7 @@ describe("schemaSanitizer", () => {
             name: { type: "string", minLength: 1, maxLength: 100, pattern: "^[a-z]+$" },
             age: { type: "number", minimum: 0, maximum: 150, default: 25 },
           },
+          required: ["name", "age"],
         },
       } as unknown as Tool;
 
@@ -72,8 +74,10 @@ describe("schemaSanitizer", () => {
               properties: {
                 email: { type: "string", format: "email", minLength: 5 },
               },
+              required: ["email"],
             },
           },
+          required: ["user"],
         },
       } as unknown as Tool;
 
@@ -149,6 +153,89 @@ describe("schemaSanitizer", () => {
       expect(params.required).toEqual(["content"]);
     });
 
+    it("widens optional properties to nullable so strict mode can omit them", () => {
+      // Linear-style: statusUpdateType is an optional enum. Without a null
+      // option, OpenAI strict mode forces the model to invent a member.
+      const tool = {
+        description: "Test tool",
+        parameters: {
+          type: "object",
+          properties: {
+            title: { type: "string" },
+            statusUpdateType: { type: "string", enum: ["onTrack", "atRisk", "offTrack"] },
+            priority: { type: "integer", description: "1-4" },
+            assignee: { type: ["string", "null"] },
+            labels: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: { name: { type: "string" }, color: { type: "string" } },
+                required: ["name"],
+              },
+            },
+            project: {
+              type: "object",
+              properties: { id: { type: "string" }, slug: { type: "string" } },
+              required: ["id"],
+            },
+            filter: {
+              anyOf: [{ type: "string" }, { type: "number" }],
+            },
+            either: {
+              anyOf: [
+                { type: "object", properties: { a: { type: "string" } } },
+                { type: "string" },
+              ],
+            },
+          },
+          required: ["title"],
+        },
+      } as unknown as Tool;
+
+      const params = getParams(sanitizeToolSchemaForOpenAI(tool));
+
+      expect(params.required).toEqual(["title"]);
+      expect(params.properties.title).toEqual({ type: "string" });
+      expect(params.properties.statusUpdateType).toEqual({
+        type: ["string", "null"],
+        enum: ["onTrack", "atRisk", "offTrack", null],
+      });
+      expect(params.properties.priority).toEqual({ type: ["integer", "null"], description: "1-4" });
+      // Already nullable: unchanged, no duplicate "null".
+      expect(params.properties.assignee).toEqual({ type: ["string", "null"] });
+      // Nested object properties and array item properties get the same treatment.
+      expect(params.properties.labels.items.properties).toEqual({
+        name: { type: "string" },
+        color: { type: ["string", "null"] },
+      });
+      expect(params.properties.project.properties).toEqual({
+        id: { type: "string" },
+        slug: { type: ["string", "null"] },
+      });
+      expect(params.properties.filter).toEqual({
+        anyOf: [{ type: "string" }, { type: "number" }, { type: "null" }],
+      });
+      // Properties inside composition branches are left alone: the argument
+      // strip could not tell which branch the model chose.
+      expect(params.properties.either.anyOf[0].properties.a).toEqual({ type: "string" });
+    });
+
+    it("treats properties required via allOf as required when widening", () => {
+      const tool = {
+        description: "Test tool",
+        parameters: {
+          type: "object",
+          properties: { a: { type: "string" }, b: { type: "string" } },
+          allOf: [{ required: ["a"] }],
+        },
+      } as unknown as Tool;
+
+      const params = getParams(sanitizeToolSchemaForOpenAI(tool));
+
+      expect(params.properties.a).toEqual({ type: "string" });
+      expect(params.properties.b).toEqual({ type: ["string", "null"] });
+    });
+
     it("should return tool as-is if no parameters", () => {
       const tool = {
         description: "Test tool",
@@ -185,7 +272,7 @@ describe("schemaSanitizer", () => {
           content: { type: "string", minLength: 1, maxLength: 100 },
           count: { type: "number", minimum: 0, maximum: 10 },
         },
-        required: ["content"],
+        required: ["content", "count"],
       };
 
       const mcpTool = {
@@ -208,7 +295,7 @@ describe("schemaSanitizer", () => {
       expect(schema.properties.count).toEqual({ type: "number" });
       // Supported properties should be preserved
       expect(schema.type).toBe("object");
-      expect(schema.required).toEqual(["content"]);
+      expect(schema.required).toEqual(["content", "count"]);
     });
 
     it("should not mutate the original MCP tool inputSchema", () => {
@@ -303,6 +390,7 @@ describe("schemaSanitizer", () => {
             properties: {
               content: { type: "string", minLength: 1 },
             },
+            required: ["content"],
           },
         },
         tool2: {
@@ -312,6 +400,7 @@ describe("schemaSanitizer", () => {
             properties: {
               count: { type: "number", minimum: 0 },
             },
+            required: ["count"],
           },
         },
       } as unknown as Record<string, Tool>;

--- a/src/common/utils/tools/schemaSanitizer.ts
+++ b/src/common/utils/tools/schemaSanitizer.ts
@@ -1,4 +1,5 @@
 import { type Tool } from "ai";
+import { isPlainObject } from "@/common/utils/isPlainObject";
 
 /**
  * JSON Schema properties that are not permitted by OpenAI's Responses API.
@@ -98,11 +99,131 @@ function stripUnsupportedProperties(schema: unknown): void {
 }
 
 /**
- * Return a sanitized clone of a JSON Schema for OpenAI Responses API compatibility.
+ * Whether a schema admits `null` under every constraint it declares (`type`,
+ * `enum`, `anyOf`/`oneOf`). A schema with none of those constraints reports
+ * false so that makeNullable and its inverse in mcpServerManager agree.
+ */
+export function schemaAcceptsNull(schema: unknown): boolean {
+  if (!isPlainObject(schema)) {
+    return false;
+  }
+  const checks: boolean[] = [];
+  if (schema.type !== undefined) {
+    checks.push(
+      schema.type === "null" || (Array.isArray(schema.type) && schema.type.includes("null"))
+    );
+  }
+  if (Array.isArray(schema.enum)) {
+    checks.push(schema.enum.includes(null));
+  }
+  for (const keyword of ["anyOf", "oneOf"] as const) {
+    const options = schema[keyword];
+    if (Array.isArray(options)) {
+      checks.push(options.some(schemaAcceptsNull));
+    }
+  }
+  return checks.length > 0 && checks.every(Boolean);
+}
+
+/**
+ * Widen a schema so it also admits `null`, mutating and returning it. Every
+ * declared constraint is widened together (e.g. `{ type: "string", enum }`
+ * needs both `"null"` in `type` and `null` in `enum`), otherwise strict-mode
+ * validation still rejects the null.
+ */
+export function makeNullable(schema: unknown): unknown {
+  if (schemaAcceptsNull(schema)) {
+    return schema;
+  }
+  if (!isPlainObject(schema)) {
+    return { anyOf: [schema, { type: "null" }] };
+  }
+  let widened = false;
+  const types: unknown[] | undefined = Array.isArray(schema.type) ? schema.type : undefined;
+  if (typeof schema.type === "string") {
+    schema.type = [schema.type, "null"];
+    widened = true;
+  } else if (types !== undefined && !types.includes("null")) {
+    schema.type = [...types, "null"];
+    widened = true;
+  }
+  const enumValues: unknown[] | undefined = Array.isArray(schema.enum) ? schema.enum : undefined;
+  if (enumValues !== undefined && !enumValues.includes(null)) {
+    schema.enum = [...enumValues, null];
+    widened = true;
+  }
+  for (const keyword of ["anyOf", "oneOf"] as const) {
+    const options: unknown[] | undefined = Array.isArray(schema[keyword])
+      ? schema[keyword]
+      : undefined;
+    if (options !== undefined && !options.some(schemaAcceptsNull)) {
+      schema[keyword] = [...options, { type: "null" }];
+      widened = true;
+    }
+  }
+  return widened ? schema : { anyOf: [schema, { type: "null" }] };
+}
+
+/** Property names an object schema requires, including those declared in `allOf` branches. */
+export function requiredPropertyNames(schema: unknown): Set<string> {
+  const required = new Set<string>();
+  if (!isPlainObject(schema)) {
+    return required;
+  }
+  if (Array.isArray(schema.required)) {
+    for (const key of schema.required) {
+      if (typeof key === "string") {
+        required.add(key);
+      }
+    }
+  }
+  if (Array.isArray(schema.allOf)) {
+    for (const subSchema of schema.allOf) {
+      for (const key of requiredPropertyNames(subSchema)) {
+        required.add(key);
+      }
+    }
+  }
+  return required;
+}
+
+/**
+ * Widen every optional property to accept `null`, recursing through nested
+ * object properties and array items. Mutates in place.
+ *
+ * OpenAI's Responses API normalizes function tools into strict mode, which
+ * forces every property into `required`; a model then has to fabricate a
+ * value for a parameter it would otherwise omit (an enum property gets an
+ * invented member, not an empty string). `null` as a type option is OpenAI's
+ * documented escape hatch, and mcpServerManager drops those nulls again
+ * before the call reaches the server. Composition branches (anyOf/oneOf/allOf)
+ * are left as-is because that inverse could not tell which branch the model
+ * chose.
+ */
+function widenOptionalProperties(schema: unknown): void {
+  if (!isPlainObject(schema)) {
+    return;
+  }
+  if (isPlainObject(schema.properties)) {
+    const required = requiredPropertyNames(schema);
+    for (const [name, propSchema] of Object.entries(schema.properties)) {
+      widenOptionalProperties(propSchema);
+      if (!required.has(name)) {
+        schema.properties[name] = makeNullable(propSchema);
+      }
+    }
+  }
+  widenOptionalProperties(schema.items);
+}
+
+/**
+ * Return a sanitized clone of a JSON Schema for OpenAI Responses API
+ * compatibility: unsupported keywords stripped, optional properties nullable.
  */
 export function sanitizeJsonSchemaForOpenAI<T>(schema: T): T {
   const clonedSchema = JSON.parse(JSON.stringify(schema)) as T;
   stripUnsupportedProperties(clonedSchema);
+  widenOptionalProperties(clonedSchema);
   return clonedSchema;
 }
 
@@ -136,68 +257,6 @@ export function sanitizeWorkflowAgentReportSchemaForOpenAI<T>(schema: T): T {
   const clonedSchema = JSON.parse(JSON.stringify(schema)) as T;
   sanitizeWorkflowAgentReportSchemaNode(clonedSchema);
   return clonedSchema;
-}
-
-function makeWorkflowReportPropertyNullable(schema: unknown): unknown {
-  if (typeof schema !== "object" || schema === null || Array.isArray(schema)) {
-    return { anyOf: [schema, { type: "null" }] };
-  }
-
-  const obj = schema as Record<string, unknown>;
-  if (Array.isArray(obj.enum)) {
-    const values: unknown[] = obj.enum;
-    if (!values.includes(null)) {
-      obj.enum = [...values, null];
-    }
-    return obj;
-  }
-  if (typeof obj.type === "string") {
-    if (obj.type !== "null") {
-      obj.type = [obj.type, "null"];
-    }
-    return obj;
-  }
-  if (Array.isArray(obj.type)) {
-    const types: unknown[] = obj.type;
-    if (!types.includes("null")) {
-      obj.type = [...types, "null"];
-    }
-    return obj;
-  }
-  if (Array.isArray(obj.anyOf)) {
-    const options: unknown[] = obj.anyOf;
-    const hasNullOption = options.some(
-      (option) =>
-        option != null &&
-        typeof option === "object" &&
-        !Array.isArray(option) &&
-        (option as { type?: unknown }).type === "null"
-    );
-    if (!hasNullOption) {
-      obj.anyOf = [...options, { type: "null" }];
-    }
-    return obj;
-  }
-  return { anyOf: [obj, { type: "null" }] };
-}
-
-function getWorkflowReportRequiredProperties(schema: Record<string, unknown>): Set<string> {
-  const required = new Set(
-    Array.isArray(schema.required)
-      ? schema.required.filter((key): key is string => typeof key === "string")
-      : []
-  );
-  if (Array.isArray(schema.allOf)) {
-    for (const subSchema of schema.allOf) {
-      if (subSchema == null || typeof subSchema !== "object" || Array.isArray(subSchema)) {
-        continue;
-      }
-      for (const key of getWorkflowReportRequiredProperties(subSchema as Record<string, unknown>)) {
-        required.add(key);
-      }
-    }
-  }
-  return required;
 }
 
 function mergeSchemaRecords(left: unknown, right: unknown): unknown {
@@ -246,7 +305,7 @@ function mergeAllOfObjectProperties(schema: Record<string, unknown>): void {
       }
     }
   }
-  const required = getWorkflowReportRequiredProperties(schema);
+  const required = requiredPropertyNames(schema);
   if (required.size > 0) {
     schema.required = [...required];
   }
@@ -259,7 +318,7 @@ function sanitizeWorkflowAgentReportSchemaNode(schema: unknown): void {
 
   const obj = schema as Record<string, unknown>;
   mergeAllOfObjectProperties(obj);
-  const requiredBeforeSanitizing = getWorkflowReportRequiredProperties(obj);
+  const requiredBeforeSanitizing = requiredPropertyNames(obj);
   for (const prop of OPENAI_WORKFLOW_REPORT_UNSUPPORTED_SCHEMA_PROPERTIES) {
     if (prop in obj) {
       delete obj[prop];
@@ -286,7 +345,7 @@ function sanitizeWorkflowAgentReportSchemaNode(schema: unknown): void {
     for (const [propertyName, propSchema] of Object.entries(properties)) {
       sanitizeWorkflowAgentReportSchemaNode(propSchema);
       if (!originallyRequired.has(propertyName)) {
-        properties[propertyName] = makeWorkflowReportPropertyNullable(propSchema);
+        properties[propertyName] = makeNullable(propSchema);
       }
     }
   } else if (obj.type === "object") {

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -7455,7 +7455,7 @@ describe("wrapMCPTools", () => {
             assignee_id: { type: "string" },
             search: { type: "string" },
             labels: { type: "array" },
-            milestone: { type: "string" },
+            milestone: { type: ["string", "null"] },
           },
           required,
           additionalProperties: false,
@@ -7473,7 +7473,7 @@ describe("wrapMCPTools", () => {
       );
 
       expect(executeMock).toHaveBeenCalledTimes(1);
-      // null and [] pass through untouched; only optional "" is dropped.
+      // A server-declared nullable null and [] pass through; optional "" is dropped.
       expect(executeMock.mock.calls[0][0]).toEqual({
         project_id: "42332",
         labels: [],
@@ -7490,14 +7490,113 @@ describe("wrapMCPTools", () => {
       expect(executeMock.mock.calls[0][0]).toEqual({ project_id: "" });
     });
 
-    test("passes args through unchanged when no empty strings are present", async () => {
+    test("passes args through unchanged when nothing needs stripping", async () => {
       const executeMock = makeExecuteMock();
       const wrapped = wrapMCPTools({ myTool: makeTool(executeMock) });
 
       const args = { project_id: "42332", search: "bug" };
       await wrapped.myTool.execute!(args, {} as never);
 
-      expect(executeMock.mock.calls[0][0]).toBe(args);
+      expect(executeMock.mock.calls[0][0]).toEqual(args);
+    });
+
+    test("drops null for optional params whose schema does not accept null", async () => {
+      // schemaSanitizer widens optional MCP properties to nullable for OpenAI
+      // strict mode; the model then sends null for parameters it would have
+      // omitted. That null is xum's artifact, so it never reaches the server.
+      const executeMock = makeExecuteMock();
+      const tool = {
+        inputSchema: jsonSchema({
+          type: "object",
+          properties: {
+            title: { type: "string" },
+            statusUpdateType: { type: "string", enum: ["onTrack", "atRisk"] },
+            assigneeId: { type: ["string", "null"] },
+            dueDate: { anyOf: [{ type: "string" }, { type: "null" }] },
+            priority: { type: "integer" },
+          },
+          required: ["title", "priority"],
+          additionalProperties: false,
+        }),
+        execute: executeMock,
+      } as unknown as Tool;
+      const wrapped = wrapMCPTools({ myTool: tool });
+
+      await wrapped.myTool.execute!(
+        { title: "Fix", statusUpdateType: null, assigneeId: null, dueDate: null, priority: null },
+        {} as never
+      );
+
+      expect(executeMock.mock.calls[0][0]).toEqual({
+        title: "Fix",
+        // Server-declared nullable: null passes through ("clear this field").
+        assigneeId: null,
+        dueDate: null,
+        // Required: never dropped, even when null.
+        priority: null,
+      });
+    });
+
+    test("keeps null when the tool has no readable schema or the key is undeclared", async () => {
+      const executeMock = makeExecuteMock();
+      const wrapped = wrapMCPTools({
+        noSchema: { execute: executeMock } as unknown as Tool,
+        withSchema: makeTool(executeMock),
+      });
+
+      await wrapped.noSchema.execute!({ search: null }, {} as never);
+      await wrapped.withSchema.execute!({ undeclared: null }, {} as never);
+
+      expect(executeMock.mock.calls[0][0]).toEqual({ search: null });
+      expect(executeMock.mock.calls[1][0]).toEqual({ undeclared: null });
+    });
+
+    test("strips nested optional nulls and empty strings alongside the schema", async () => {
+      const executeMock = makeExecuteMock();
+      const tool = {
+        inputSchema: jsonSchema({
+          type: "object",
+          properties: {
+            project: {
+              type: "object",
+              properties: { id: { type: "string" }, slug: { type: "string" } },
+              required: ["id"],
+            },
+            labels: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: { name: { type: "string" }, color: { type: "string" } },
+                required: ["name"],
+              },
+            },
+            meta: { type: "object" },
+          },
+          required: ["project"],
+          additionalProperties: false,
+        }),
+        execute: executeMock,
+      } as unknown as Tool;
+      const wrapped = wrapMCPTools({ myTool: tool });
+
+      await wrapped.myTool.execute!(
+        {
+          project: { id: "", slug: null },
+          labels: [
+            { name: "bug", color: null },
+            { name: "", color: "" },
+          ],
+          // Declared without properties: values below it are not touched.
+          meta: { note: null, tag: "" },
+        },
+        {} as never
+      );
+
+      expect(executeMock.mock.calls[0][0]).toEqual({
+        project: { id: "" },
+        labels: [{ name: "bug" }, { name: "" }],
+        meta: { note: null, tag: "" },
+      });
     });
 
     test("strips empty strings when the tool has no readable schema", async () => {

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -24,6 +24,7 @@ import type {
 } from "@/common/types/mcp";
 import assert from "@/common/utils/assert";
 import { shellQuote } from "@/common/utils/shell";
+import { requiredPropertyNames, schemaAcceptsNull } from "@/common/utils/tools/schemaSanitizer";
 import type { Runtime } from "@/node/runtime/Runtime";
 import { DevcontainerRuntime } from "@/node/runtime/DevcontainerRuntime";
 import { RemoteRuntime } from "@/node/runtime/RemoteRuntime";
@@ -203,46 +204,70 @@ function shouldRecycleClientAfterToolError(error: unknown): boolean {
 }
 
 /**
- * Top-level parameter names the tool's input schema marks as required.
+ * Drop arguments the model emitted to mean "not provided" for optional
+ * parameters, walking nested objects and arrays alongside the server's schema.
  *
- * MCP tools built by mcpClient carry their server-declared JSON schema via
- * the AI SDK's jsonSchema() wrapper ({ jsonSchema: <raw schema> }); anything
- * else (or a malformed schema) yields an empty set.
+ * - "": LLMs often fill optional parameters with "" instead of omitting them,
+ *   and strict REST-backed MCP servers (e.g. GitLab) treat present-but-empty
+ *   as invalid and reject the call with 400 (#2887).
+ * - null the schema does not accept: schemaSanitizer widens optional
+ *   properties to nullable so OpenAI strict mode can omit them, so this null
+ *   is our own artifact, never a value the server can take. A null the schema
+ *   does accept passes through: servers may mean "clear this field".
+ *
+ * A required parameter keeps its value so a genuinely intended empty value is
+ * never silently dropped. Empty arrays pass through ("no filter").
  */
-function requiredParamsFromSchema(inputSchema: unknown): ReadonlySet<string> {
-  if (inputSchema !== null && typeof inputSchema === "object" && "jsonSchema" in inputSchema) {
-    const raw = (inputSchema as { jsonSchema: unknown }).jsonSchema;
-    if (raw !== null && typeof raw === "object" && "required" in raw) {
-      const required = (raw as { required: unknown }).required;
-      if (Array.isArray(required)) {
-        return new Set(required.filter((entry): entry is string => typeof entry === "string"));
+function sanitizeMCPToolArgs(args: unknown, schema: unknown): unknown {
+  if (!isPlainObject(args)) {
+    return args;
+  }
+  const required = requiredPropertyNames(schema);
+  const properties =
+    isPlainObject(schema) && isPlainObject(schema.properties) ? schema.properties : undefined;
+  const entries: Array<[string, unknown]> = [];
+  for (const [key, value] of Object.entries(args)) {
+    const propertySchema =
+      properties !== undefined && Object.hasOwn(properties, key) ? properties[key] : undefined;
+    if (!required.has(key)) {
+      if (value === "") {
+        continue;
+      }
+      if (value === null && propertySchema !== undefined && !schemaAcceptsNull(propertySchema)) {
+        continue;
       }
     }
+    entries.push([key, sanitizeNestedMCPToolArgs(value, propertySchema)]);
   }
-  return new Set();
+  return Object.fromEntries(entries);
 }
 
 /**
- * Drop top-level empty-string arguments the model emitted for optional
- * parameters.
- *
- * LLMs often fill optional parameters with "" instead of omitting them, and
- * strict REST-backed MCP servers (e.g. GitLab) treat present-but-empty as
- * invalid and reject the call with 400 (#2887). A required parameter keeps
- * its "" so a genuinely intended empty value is never silently dropped.
- * Explicit null and empty arrays pass through untouched: servers may assign
- * them meaning ("clear this field" / "no filter").
+ * Descend into arrays via `items` and into objects only when the schema
+ * declares `properties`; a free-form object (env vars, labels) keeps every
+ * value the model chose.
  */
-function sanitizeMCPToolArgs(args: unknown, inputSchema: unknown): unknown {
-  if (args === null || typeof args !== "object" || Array.isArray(args)) {
-    return args;
+function sanitizeNestedMCPToolArgs(value: unknown, schema: unknown): unknown {
+  if (!isPlainObject(schema)) {
+    return value;
   }
-  const entries = Object.entries(args as Record<string, unknown>);
-  if (!entries.some(([, value]) => value === "")) {
-    return args;
+  if (Array.isArray(value)) {
+    const items = schema.items;
+    return isPlainObject(items)
+      ? value.map((item) => sanitizeNestedMCPToolArgs(item, items))
+      : value;
   }
-  const required = requiredParamsFromSchema(inputSchema);
-  return Object.fromEntries(entries.filter(([key, value]) => value !== "" || required.has(key)));
+  return isPlainObject(schema.properties) ? sanitizeMCPToolArgs(value, schema) : value;
+}
+
+/**
+ * MCP tools built by mcpClient carry their server-declared JSON schema via
+ * the AI SDK's jsonSchema() wrapper ({ jsonSchema: <raw schema> }); anything
+ * else yields undefined, and sanitizeMCPToolArgs then only applies the
+ * schema-free "" rule.
+ */
+function rawInputSchema(inputSchema: unknown): unknown {
+  return isPlainObject(inputSchema) ? inputSchema.jsonSchema : undefined;
 }
 
 /**
@@ -276,7 +301,7 @@ export function wrapMCPTools(
               ? (context as { abortSignal?: AbortSignal }).abortSignal
               : undefined;
 
-          const sanitizedArgs = sanitizeMCPToolArgs(args, tool.inputSchema);
+          const sanitizedArgs = sanitizeMCPToolArgs(args, rawInputSchema(tool.inputSchema));
           const result: unknown = await runMCPToolWithDeadline(
             () => Promise.resolve(originalExecute(sanitizedArgs, context)) as Promise<unknown>,
             { toolName, timeoutMs: MCP_TOOL_CALL_TIMEOUT_MS, signal: abortSignal }

--- a/src/node/services/turnEnvelope.test.ts
+++ b/src/node/services/turnEnvelope.test.ts
@@ -176,11 +176,13 @@ describe("buildToolsetManifest", () => {
     const unsanitized: JSONSchema7 = {
       type: "object",
       properties: { count: { type: "number", minimum: 1 } },
+      required: ["count"],
       additionalProperties: false,
     };
     const stripped: JSONSchema7 = {
       type: "object",
       properties: { count: { type: "number" } },
+      required: ["count"],
       additionalProperties: false,
     };
 


### PR DESCRIPTION
## Summary

OpenAI's Responses API normalizes function tools into strict mode, which forces every property into `required`. An optional MCP parameter with no `null` type option therefore has to be filled, and for an enum the model invents a member. This PR widens optional MCP properties to nullable in the OpenAI schema sanitizer and drops those nulls again at the MCP boundary before the call reaches the server.

## Background

Reported with Linear's `create_issue`: the model sent `statusUpdateType: "onTrack"` with no `statusUpdateId`, and Linear rejected the call. #3893 (closing #2887) drops top-level `""` on optional parameters, which covers string fields, but an enum property under strict mode gets a valid member instead of `""`, and a numeric field gets `0`. OpenAI documents the escape hatch: [in Responses, omitting `strict` attempts strict mode, and optional fields are denoted by adding `null` as a type option](https://developers.openai.com/api/docs/guides/function-calling). xum already applies this contract to its own tools via `.nullish()` (see the `toolDefinitions.ts` header comment from #2250); MCP tools were sent to OpenAI with the server's schema unchanged.

Replaces #3821, which grew far beyond this fix.

## Implementation

`schemaSanitizer.ts` already contained the optional-to-nullable logic for workflow reports (`makeWorkflowReportPropertyNullable`, `getWorkflowReportRequiredProperties`). Those become the shared `makeNullable`, `requiredPropertyNames`, and `schemaAcceptsNull`, used by both sanitizers. `makeNullable` now widens every declared constraint together, since `{ type: "string", enum: [...] }` needs `"null"` in `type` and `null` in `enum` or strict mode still rejects the null.

The OpenAI MCP sanitizer (`sanitizeJsonSchemaForOpenAI`, applied only on the `openai` provider path in `tools.ts`) widens optional properties, recursing through `properties` and `items`. Composition branches (`anyOf`/`oneOf`/`allOf`) are left untouched, because the inverse below could not tell which branch the model chose.

`sanitizeMCPToolArgs` in `mcpServerManager.ts` is that inverse. It drops `null` on an optional property only when the source schema does not accept `null`, so a server-declared nullable ("clear this field") still passes through, and it follows the same `properties`/`items` walk. It descends into an object only when its schema declares `properties`; free-form maps (env vars, labels) keep every value. The #3893 `""` rule is unchanged. `wrapMCPTools` runs at load time and closes over the raw schema, while OpenAI sanitization runs later in `tools.ts`, so the strip always sees the server's schema, never the widened one.

## Validation

Ran the real pipeline (`dynamicTool` + `jsonSchema` as `mcpClient` builds it → `wrapMCPTools` → `sanitizeToolSchemaForOpenAI` → Responses API → strip) against `gpt-5.6-sol` with a Linear-shaped schema (`title` required; `description`, `statusUpdateType` enum, `statusUpdateId`, `priority` optional) and the prompt "Create a Linear issue titled \"Probe issue\". Set only the title, nothing else."

| | Model emitted | Server received |
|---|---|---|
| `main` | `{"title":"Probe issue","description":"","statusUpdateType":"onTrack","statusUpdateId":"","priority":0}` | `{"title":"Probe issue","statusUpdateType":"onTrack","priority":0}` |
| this PR | `{"title":"Probe issue","description":null,"statusUpdateType":null,"statusUpdateId":null,"priority":null}` | `{"title":"Probe issue"}` |

## Risks

Low, scoped to MCP tool calls. On the OpenAI path the model-visible schema for optional properties changes from `T` to `T | null`; this is the shape xum already sends for its own tools. On every provider path, a `null` the model sends for an optional property that the server's schema does not accept is now dropped instead of forwarded; such a null was never valid for the server. Nulls on required properties, on server-declared nullable properties, on undeclared keys, and inside free-form objects are unchanged.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh -->
