### PR TITLE
🤖 ci: accept resolved Codex advisories on the review summary board

### DIFF
--- a/scripts/check_codex_comments_test.py
+++ b/scripts/check_codex_comments_test.py
@@ -169,11 +169,20 @@ else:
             .replace('"status":"running"', '"status":"completed"')
             .replace("🔄 **Running** since", "✅ **Completed**")
         )
+        # Codex keeps resolved advisories on the board; only its own Resolved marker,
+        # not a bare bullet, an unknown section, or a non-thread link, is informational.
+        resolved_findings = completed_findings.replace(
+            ") · **Medium**", ") · **Medium** · **Resolved**"
+        )
         for body, expected in (
             (completed.replace('"status":"completed"', '"status":"running"'), 1),
             (completed.replace("✅ **Completed**", "🔄 **Running** since", 1), 1),
             (completed_pr_opened, 0),
             (completed_findings, 1),
+            (resolved_findings, 0),
+            (resolved_findings.replace("#### Advisory findings", "#### Blocking findings"), 1),
+            (resolved_findings.replace("#discussion_r3960253571", "#issuecomment-1"), 1),
+            (resolved_findings.replace("· **Resolved**", "· **Resolved** see below"), 1),
         ):
             for cached in (False, True):
                 with self.subTest(body=body, cached=cached):

--- a/scripts/lib/codex_comments.jq
+++ b/scripts/lib/codex_comments.jq
@@ -45,6 +45,13 @@ def codex_comment_is_informational($bot):
                 + "[^[:alnum:]|]*\\*\\*Completed\\*\\*"
                 + "( <relative-time datetime=\"[0-9TZ:.+-]+\">[0-9TZ:.+-]+</relative-time>)? "
                 + "\\| `[0-9a-f]+` \\| (Manual request|New commits|Draft marked ready|PR opened) \\|$")
+              # Security advisories stay listed after their review threads are resolved, and
+              # Codex adds the Resolved marker only when a later review completes. A bullet
+              # without it is a live finding and keeps blocking; other sections stay unknown.
+              or . == "### Security findings"
+              or test("^#### Advisory findings \\([0-9]+\\)$")
+              or test("^- [^[:alnum:]|\\[]*\\[[^\\]]+\\]\\(https://github\\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/[0-9]+#discussion_r[0-9]+\\)"
+                + " · \\*\\*[A-Za-z]+\\*\\* · \\*\\*Resolved\\*\\*$")
             ))
         ) catch false) // false
       else


### PR DESCRIPTION
## Summary

The `Codex Comments` gate treats Codex's review summary board as a blocking comment whenever it carries a "Security findings" section, even after every advisory thread is resolved and both reviews are complete. This whitelists the section when each advisory bullet carries Codex's own **Resolved** marker, so PRs that once had a security advisory can pass `Required` again. Unblocks #4211.

## Background

Codex keeps resolved security advisories listed on the board and only adds the `· **Resolved**` marker when a later review completes (verified from the board's edit history on #4211: the marker appeared at the next review completion, not when the thread was resolved). The gate's line whitelist (#4149, #4158) does not know the section, so a completed board with resolved advisories is reported as an unresolved Codex comment and `Required` can never go green. On #4211 the gate log at 17:24Z shows exactly that: `status: completed`, both rows Completed, two `**Resolved**` advisories, still counted as blocking. The two most recent merged PRs with such boards (#4170, #4176) only passed because the section was added after their last gate run.

## Implementation

`scripts/lib/codex_comments.jq` accepts three more line shapes inside a completed board: `### Security findings`, `#### Advisory findings (N)`, and a bullet that links a review thread on a PR (`.../pull/N#discussion_r<id>`), names a severity, and ends with `· **Resolved**`. A bullet without the marker is a live finding and keeps blocking, as do unknown sections, non-thread links, and trailing text.

## Validation

- `python3 scripts/check_codex_comments_test.py`: the existing unresolved-advisory case still expects blocking; new cases cover the resolved board (informational) and three malformed variants (still blocking). Red without the jq change: the resolved case fails `1 != 0`.
- The new jq evaluated against real boards: #4211's completed board with two resolved advisories is informational; its running board and #4176's board (unresolved advisory) stay blocking.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$16.42`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=16.42 -->
