### PR TITLE
🤖 fix: keep workspace forks valid during checkout hooks

### DIFF
--- a/src/node/worktree/WorktreeManager.test.ts
+++ b/src/node/worktree/WorktreeManager.test.ts
@@ -635,6 +635,355 @@ describe("WorktreeManager.createWorkspace", () => {
     }
   }, 20_000);
 
+  it("forks at the hook boundary without exposing an unborn source branch", async () => {
+    const fixture = await createWorktreeManagerFixture();
+    const branchName = "source-hook-boundary";
+    const workspacePath = fixture.manager.getWorkspacePath(fixture.projectPath, branchName);
+    const realExec = disposableExec.execFileAsync;
+    let forkResult: Awaited<ReturnType<WorktreeManager["forkWorkspace"]>> | undefined;
+    const execSpy = spyOn(disposableExec, "execFileAsync").mockImplementation(
+      (file, args, options) => {
+        const proc = realExec(file, args, options);
+        // Both implementations reach this boundary after populating files, before creation
+        // settles. The old symbolic-ref path exposes an invalid branch to this same fork.
+        if (
+          file === "git" &&
+          args[1] === workspacePath &&
+          ((args.includes("symbolic-ref") &&
+            args.some((a) => a.startsWith("refs/heads/xum-unborn-"))) ||
+            (args.includes("hook") && args.includes("run")))
+        ) {
+          Object.defineProperty(proc, "result", {
+            value: proc.result.then(async (output) => {
+              forkResult = await fixture.manager.forkWorkspace({
+                projectPath: fixture.projectPath,
+                sourceWorkspaceName: branchName,
+                newWorkspaceName: "fork-at-hook",
+                trusted: true,
+                initLogger: fixture.initLogger,
+              });
+              return output;
+            }),
+          });
+        }
+        return proc;
+      }
+    );
+    try {
+      const result = await fixture.manager.createWorkspace({
+        projectPath: fixture.projectPath,
+        branchName,
+        trunkBranch: "main",
+        skipRemoteSync: true,
+        trusted: true,
+        initLogger: fixture.initLogger,
+        deferMaterialization: true,
+      });
+      expect(result.success).toBe(true);
+      if (!result.success || !result.workspacePath || !result.pendingMaterialization)
+        throw new Error("Expected reservation");
+      await fixture.manager.materializeWorkspace(
+        {
+          projectPath: fixture.projectPath,
+          workspacePath,
+          branchName,
+          trunkBranch: "main",
+          trusted: true,
+          initLogger: fixture.initLogger,
+        },
+        result.pendingMaterialization
+      );
+      expect(forkResult).toMatchObject({ success: true, sourceBranch: branchName });
+    } finally {
+      execSpy.mockRestore();
+      await fixture.cleanup();
+    }
+  }, 20_000);
+
+  // The portable hook-boundary regression above also runs on Windows.
+  it.skipIf(process.platform === "win32")(
+    "keeps the source branch claimed and forkable while its trusted checkout hook is running",
+    async () => {
+      const fixture = await createWorktreeManagerFixture();
+      const branchName = "source-held-hook";
+      const workspacePath = fixture.manager.getWorkspacePath(fixture.projectPath, branchName);
+      const fifo = path.join(fixture.rootDir, "release-hook");
+      execFileSync("mkfifo", [fifo]);
+      const hook = path.join(fixture.projectPath, ".git", "hooks", "post-checkout");
+      await fsPromises.writeFile(
+        hook,
+        `#!/bin/sh\nif [ "$PWD" = "${workspacePath}" ]; then\nprintf 'source-hook-entered\\n' >&2\nread release < "${fifo}"\nfi\n`
+      );
+      await fsPromises.chmod(hook, 0o755);
+      const entered = Promise.withResolvers<void>();
+      const realExec = disposableExec.execFileAsync;
+      const execSpy = spyOn(disposableExec, "execFileAsync").mockImplementation(
+        (file, args, options) =>
+          realExec(file, args, {
+            ...options,
+            onStderrData: (chunk) => {
+              options?.onStderrData?.(chunk);
+              if (args[1] === workspacePath && chunk.includes("source-hook-entered"))
+                entered.resolve();
+            },
+          })
+      );
+      let materialize: Promise<void> | undefined;
+      const controller = new AbortController();
+      try {
+        const result = await fixture.manager.createWorkspace({
+          projectPath: fixture.projectPath,
+          branchName,
+          trunkBranch: "main",
+          skipRemoteSync: true,
+          trusted: true,
+          initLogger: fixture.initLogger,
+          deferMaterialization: true,
+        });
+        if (!result.success || !result.pendingMaterialization)
+          throw new Error("Expected reservation");
+        materialize = fixture.manager.materializeWorkspace(
+          {
+            projectPath: fixture.projectPath,
+            workspacePath,
+            branchName,
+            trunkBranch: "main",
+            trusted: true,
+            abortSignal: controller.signal,
+            initLogger: fixture.initLogger,
+          },
+          result.pendingMaterialization
+        );
+        await Promise.race([
+          entered.promise,
+          materialize.then(() => {
+            throw new Error("Hook settled without entering its gate");
+          }),
+        ]);
+        expect(() =>
+          execFileSync(
+            "git",
+            ["worktree", "add", "--no-checkout", path.join(fixture.rootDir, "rival"), branchName],
+            { cwd: fixture.projectPath, stdio: "pipe" }
+          )
+        ).toThrow(/already (checked out|used by worktree)/);
+        const fork = await fixture.manager.forkWorkspace({
+          projectPath: fixture.projectPath,
+          sourceWorkspaceName: branchName,
+          newWorkspaceName: "fork-with-hook-running",
+          trusted: true,
+          initLogger: fixture.initLogger,
+        });
+        expect(fork).toMatchObject({ success: true, sourceBranch: branchName });
+        await fsPromises.writeFile(fifo, "release\n");
+        await materialize;
+      } finally {
+        controller.abort();
+        await materialize?.catch(() => undefined);
+        execSpy.mockRestore();
+        await fixture.cleanup();
+      }
+    },
+    20_000
+  );
+
+  it.each([
+    ["git version 2.35.7", true, false],
+    ["unrecognized git version", true, false],
+    [null, true, false],
+    ["git version 2.35.7", false, true],
+  ] as const)(
+    "keeps deferred creation safe with version %s and trusted=%s",
+    async (version, trusted, deferred) => {
+      const fixture = await createWorktreeManagerFixture();
+      const realExec = disposableExec.execFileAsync;
+      const execSpy = spyOn(disposableExec, "execFileAsync").mockImplementation(
+        (file, args, options) => {
+          const proc = realExec(file, args, options);
+          if (file === "git" && args[0] === "--version") {
+            Object.defineProperty(proc, "result", {
+              value: proc.result.then((output) => {
+                if (version === null) throw new Error("version probe failed");
+                return { ...output, stdout: version + "\n" };
+              }),
+            });
+          }
+          return proc;
+        }
+      );
+      try {
+        const result = await fixture.manager.createWorkspace({
+          projectPath: fixture.projectPath,
+          branchName: "compat-source",
+          trunkBranch: "main",
+          skipRemoteSync: true,
+          trusted,
+          initLogger: fixture.initLogger,
+          deferMaterialization: true,
+        });
+        expect(result.success).toBe(true);
+        if (!result.success || !result.workspacePath) throw new Error("Expected creation");
+        expect(result.pendingMaterialization !== undefined).toBe(deferred);
+        expect(existsSync(path.join(result.workspacePath, "README.md"))).toBe(!deferred);
+        const fork = await fixture.manager.forkWorkspace({
+          projectPath: fixture.projectPath,
+          sourceWorkspaceName: "compat-source",
+          newWorkspaceName: "compat-fork",
+          trusted,
+          initLogger: fixture.initLogger,
+        });
+        expect(fork).toMatchObject({ success: true, sourceBranch: "compat-source" });
+      } finally {
+        execSpy.mockRestore();
+        await fixture.cleanup();
+      }
+    }
+  );
+
+  it("honors cancellation during capability detection instead of starting legacy checkout", async () => {
+    const fixture = await createWorktreeManagerFixture();
+    const controller = new AbortController();
+    const realExec = disposableExec.execFileAsync;
+    const execSpy = spyOn(disposableExec, "execFileAsync").mockImplementation(
+      (file, args, options) => {
+        const proc = realExec(file, args, options);
+        if (file === "git" && args[0] === "--version") {
+          Object.defineProperty(proc, "result", {
+            value: proc.result.then((output) => {
+              controller.abort();
+              return output;
+            }),
+          });
+        }
+        return proc;
+      }
+    );
+    try {
+      const result = await fixture.manager.createWorkspace({
+        projectPath: fixture.projectPath,
+        branchName: "cancelled-capability",
+        trunkBranch: "main",
+        trusted: true,
+        skipRemoteSync: true,
+        initLogger: fixture.initLogger,
+        deferMaterialization: true,
+        abortSignal: controller.signal,
+      });
+      expect(result.success).toBe(false);
+      expect(
+        existsSync(fixture.manager.getWorkspacePath(fixture.projectPath, "cancelled-capability"))
+      ).toBe(false);
+    } finally {
+      execSpy.mockRestore();
+      await fixture.cleanup();
+    }
+  });
+
+  it("preserves configured checkout-hook arguments and environment in a SHA-256 repository", async () => {
+    const fixture = await createWorktreeManagerFixture();
+    try {
+      await fsPromises.rm(path.join(fixture.projectPath, ".git"), { recursive: true, force: true });
+      const git = (...args: string[]) =>
+        execFileSync("git", args, { cwd: fixture.projectPath, stdio: "pipe" }).toString().trim();
+      git("init", "-b", "main", "--object-format=sha256");
+      git("config", "user.name", "test");
+      git("config", "user.email", "test@example.com");
+      git("config", "commit.gpgsign", "false");
+      git("add", "README.md");
+      git("commit", "-qm", "init");
+      const hooks = path.join(fixture.rootDir, "configured hooks");
+      await fsPromises.mkdir(hooks);
+      const log = path.join(fixture.rootDir, "hook-contract");
+      const hook = path.join(hooks, "post-checkout");
+      await fsPromises.writeFile(
+        hook,
+        `#!/bin/sh\nprintf '%s\\n' "$1" "$2" "$3" "$PWD" "$GIT_DIR" > "${log}"\n`
+      );
+      await fsPromises.chmod(hook, 0o755);
+      git("config", "core.hooksPath", hooks);
+      const result = await fixture.manager.createWorkspace({
+        projectPath: fixture.projectPath,
+        branchName: "sha256-source",
+        trunkBranch: "main",
+        trusted: true,
+        skipRemoteSync: true,
+        initLogger: fixture.initLogger,
+      });
+      if (!result.success || !result.workspacePath) throw new Error(JSON.stringify(result));
+      const tip = git("rev-parse", "sha256-source");
+      const gitDir = execFileSync("git", [
+        "-C",
+        result.workspacePath,
+        "rev-parse",
+        "--absolute-git-dir",
+      ])
+        .toString()
+        .trim();
+      expect((await fsPromises.readFile(log, "utf8")).trim().split("\n")).toEqual([
+        "0".repeat(tip.length),
+        tip,
+        "1",
+        result.workspacePath,
+        gitDir,
+      ]);
+      expect(tip.length).toBe(64);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("restores the reserved branch when a trusted hook changes HEAD and fails", async () => {
+    const fixture = await createWorktreeManagerFixture();
+    const branchName = "source-failed-hook";
+    const workspacePath = fixture.manager.getWorkspacePath(fixture.projectPath, branchName);
+    try {
+      execFileSync("git", ["branch", "hook-moved-head"], { cwd: fixture.projectPath });
+      const hook = path.join(fixture.projectPath, ".git", "hooks", "post-checkout");
+      await fsPromises.writeFile(
+        hook,
+        '#!/bin/sh\ngit -c core.hooksPath=/dev/null checkout hook-moved-head\nprintf "deliberate hook failure\\n" >&2\nexit 1\n'
+      );
+      await fsPromises.chmod(hook, 0o755);
+      const result = await fixture.manager.createWorkspace({
+        projectPath: fixture.projectPath,
+        branchName,
+        trunkBranch: "main",
+        skipRemoteSync: true,
+        trusted: true,
+        initLogger: fixture.initLogger,
+        deferMaterialization: true,
+      });
+      if (!result.success || !result.pendingMaterialization)
+        throw new Error("Expected reservation");
+      const failure = await fixture.manager
+        .materializeWorkspace(
+          {
+            projectPath: fixture.projectPath,
+            workspacePath,
+            branchName,
+            trunkBranch: "main",
+            trusted: true,
+            initLogger: fixture.initLogger,
+          },
+          result.pendingMaterialization
+        )
+        .then(
+          () => undefined,
+          (error: unknown) => error
+        );
+      expect(failure).toBeInstanceOf(Error);
+      expect((failure as Error).message).toContain("deliberate hook failure");
+      expect(
+        execFileSync("git", ["-C", workspacePath, "branch", "--show-current"]).toString().trim()
+      ).toBe(branchName);
+      expect(await fsPromises.readFile(path.join(workspacePath, "README.md"), "utf8")).toBe(
+        "hello\n"
+      );
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
   it("detaches instead of re-attaching when the branch is claimed during the hook switch", async () => {
     const branchName = "feature-claimed-in-gap";
     const fixture = await createWorktreeManagerFixture();
@@ -669,13 +1018,14 @@ describe("WorktreeManager.createWorkspace", () => {
         branchName,
         trunkBranch: "main",
         skipRemoteSync: true,
-        trusted: true,
+        trusted: false,
         initLogger: fixture.initLogger,
         deferMaterialization: true,
       });
       expect(result.success).toBe(true);
       if (!result.success || !result.workspacePath) throw new Error("Expected reservation");
 
+      // Reserve without hooks, then exercise legacy hook recovery directly.
       const failure = await fixture.manager
         .materializeWorkspace(
           {
@@ -686,7 +1036,8 @@ describe("WorktreeManager.createWorkspace", () => {
             trusted: true,
             initLogger: fixture.initLogger,
           },
-          result.pendingMaterialization!
+          result.pendingMaterialization!,
+          { legacyHookCheckout: true }
         )
         .then(
           () => undefined,

--- a/src/node/worktree/WorktreeManager.ts
+++ b/src/node/worktree/WorktreeManager.ts
@@ -65,6 +65,24 @@ export class WorktreeManager {
     return env || signal ? { ...(env ? { env } : {}), ...(signal ? { signal } : {}) } : undefined;
   }
 
+  private async supportsNativeHookRunner(signal?: AbortSignal): Promise<boolean> {
+    signal?.throwIfAborted();
+    try {
+      using proc = execFileAsync("git", ["--version"], { signal });
+      const { stdout } = await proc.result;
+      signal?.throwIfAborted();
+      const version = /^git version (\d+)\.(\d+)/.exec(stdout.trim());
+      return (
+        version !== null &&
+        (Number(version[1]) > 2 || (Number(version[1]) === 2 && Number(version[2]) >= 36))
+      );
+    } catch (error) {
+      // Unknown/older Git retains eager creation; cancellation must still stop creation.
+      if (signal?.aborted) throw error;
+      return false;
+    }
+  }
+
   private async pruneWorktreesBestEffort(
     projectPath: string,
     noHooksEnv: GitExecOptions
@@ -206,7 +224,12 @@ export class WorktreeManager {
       const pending: PendingMaterialization = {
         fastForwardFromOrigin: !skipRemoteSync && shouldUseOrigin && branchExists,
       };
-      if (params.deferMaterialization) {
+      // Older Git needs the legacy hook checkout, which briefly changes HEAD. Keep it
+      // before announcement so an immediate fork cannot observe its unborn placeholder.
+      const nativeHookRunner =
+        !gitHooksAllowed(params.trusted) ||
+        (await this.supportsNativeHookRunner(params.abortSignal));
+      if (params.deferMaterialization && nativeHookRunner) {
         await this.persistWorkspaceBranchMapping(projectPath, workspaceName, branchName);
         return { success: true, workspacePath, pendingMaterialization: pending };
       }
@@ -222,7 +245,8 @@ export class WorktreeManager {
           env: params.env,
           trusted: params.trusted,
         },
-        pending
+        pending,
+        { legacyHookCheckout: !nativeHookRunner }
       );
 
       await this.persistWorkspaceBranchMapping(projectPath, workspaceName, branchName);
@@ -283,7 +307,8 @@ export class WorktreeManager {
       env?: Record<string, string>;
       trusted?: boolean;
     },
-    pending: PendingMaterialization
+    pending: PendingMaterialization,
+    options?: { legacyHookCheckout?: boolean }
   ): Promise<void> {
     const { projectPath, workspacePath, branchName, trunkBranch, initLogger } = params;
     const noHooksEnv = await this.getGitExecOptions(
@@ -308,11 +333,10 @@ export class WorktreeManager {
       // Smudge filters and hooks inherit git's pipes; cancelling must not hang on them.
       killTreeOnTermination: true,
     };
-    let headMoved = false;
+    let restoreHeadOnFailure = false;
     try {
       // Populate the files while HEAD still holds the branch, so no other worktree can claim it
-      // for as long as the checkout streams. Hooks stay off here: the switch below reruns the
-      // checkout for them.
+      // for as long as the checkout streams. Hooks stay off here and run separately below.
       // Submodule repos do not exist yet in a linked worktree, so recursion would fail;
       // syncLocalGitSubmodules materializes them below, like `git worktree add` does.
       // No --force: a deferred checkout runs in an announced workspace, so anything written
@@ -338,23 +362,55 @@ export class WorktreeManager {
         }
       );
       stdout.push((await populateProc.result).stdout);
-      // The files are in place; switch onto the branch from an unborn ref so trusted
-      // post-checkout hooks receive the same arguments as a plain `git worktree add` (null old
-      // commit, new-worktree flag). Nothing is written, so the branch is unclaimed only for the
-      // instant between these two commands.
-      using unbornProc = execFileAsync(
-        "git",
-        ["-C", workspacePath, "symbolic-ref", "HEAD", `refs/heads/xum-unborn-${randomUUID()}`],
-        noHooksEnv
-      );
-      await unbornProc.result;
-      headMoved = true;
-      using switchProc = execFileAsync(
-        "git",
-        ["-C", workspacePath, "checkout", "--no-recurse-submodules", branchName],
-        checkoutOptions
-      );
-      stdout.push((await switchProc.result).stdout);
+      if (gitHooksAllowed(params.trusted)) {
+        if (options?.legacyHookCheckout !== true) {
+          // Announced worktrees can be forked while hooks run. Invoke Git's hook runner
+          // with the new-worktree arguments without ever releasing or changing HEAD.
+          using tipProc = execFileAsync(
+            "git",
+            ["-C", workspacePath, "rev-parse", "HEAD"],
+            noHooksEnv
+          );
+          const tip = (await tipProc.result).stdout.trim();
+          // A failing hook may move HEAD; retain the legacy restoration guarantee.
+          restoreHeadOnFailure = true;
+          using hookProc = execFileAsync(
+            "git",
+            [
+              "-C",
+              workspacePath,
+              "hook",
+              "run",
+              "--ignore-missing",
+              "post-checkout",
+              "--",
+              "0".repeat(tip.length),
+              tip,
+              "1",
+            ],
+            checkoutOptions
+          );
+          stdout.push((await hookProc.result).stdout);
+        } else {
+          // The files are in place; switch onto the branch from an unborn ref so trusted
+          // post-checkout hooks receive the same arguments as a plain `git worktree add` (null old
+          // commit, new-worktree flag). Nothing is written, so the branch is unclaimed only for the
+          // instant between these two commands.
+          using unbornProc = execFileAsync(
+            "git",
+            ["-C", workspacePath, "symbolic-ref", "HEAD", `refs/heads/xum-unborn-${randomUUID()}`],
+            noHooksEnv
+          );
+          await unbornProc.result;
+          restoreHeadOnFailure = true;
+          using switchProc = execFileAsync(
+            "git",
+            ["-C", workspacePath, "checkout", "--no-recurse-submodules", branchName],
+            checkoutOptions
+          );
+          stdout.push((await switchProc.result).stdout);
+        }
+      }
       progress.flush();
       for (const line of [...output, ...stdout.flatMap((text) => text.split(/[\r\n]/))]) {
         if (line) initLogger.logStdout(line);
@@ -368,7 +424,7 @@ export class WorktreeManager {
       // checkout needs the restore most.
       const restoreOptions = noHooksEnv?.env ? { env: noHooksEnv.env } : undefined;
       try {
-        if (headMoved) {
+        if (restoreHeadOnFailure) {
           // If another worktree claimed the branch during that instant, re-attaching would
           // leave two worktrees on it; detach at the tip instead and let the error report it.
           const claimedElsewhere = (await this.listWorktreeBlocks(projectPath, restoreOptions))


### PR DESCRIPTION
Forking a newly created workspace could fail with `fatal: invalid reference: xum-unborn-…`. Deferred checkout briefly put HEAD on a nonexistent branch after the workspace was visible. The failure reproduces on main as well as the Effect refactor stack.

Keep HEAD on its reserved branch while populating files, then use Git’s native hook runner with the original new-worktree arguments. Trusted workspaces on Git older than 2.36, or whose version cannot be determined, finish checkout before becoming visible. Untrusted workspaces skip hook replay. Cancellation and failed-hook branch restoration retain their existing behavior.

Validation: 43 WorktreeManager tests / 189 assertions, a provider-free service reproduction, full TypeScript checks, and `make static-check` pass. Tests cover immediate forks, branch reservation during a held hook, older/unknown Git, cancellation, failed hooks, configured hook paths, and SHA-256 hook arguments. The final test-only portability/cleanup adjustment passes its two focused tests plus full types, lint, and formatting; its FIFO stress case is POSIX-only, while the portable fork regression remains enabled on Windows.

The provider-free service reproduction also passes with this fix applied on top of the current eight-PR Effect phase; the fix applies cleanly and changes only the two WorktreeManager files.

The main compatibility tradeoff is that trusted workspaces using older Git wait for checkout before appearing. Hook arguments and environment remain equivalent to the previous checkout path.

---

_Generated with `xum` • Model: `unavailable` • Thinking: `unavailable` • Cost: `$unavailable`_

<!-- mux-attribution: model=unavailable thinking=unavailable costs=unavailable -->
