### PR TITLE
🤖 fix: report backup repository access denial instead of a login failure

### DIFF
--- a/src/browser/features/Settings/Sections/BackupSection.tsx
+++ b/src/browser/features/Settings/Sections/BackupSection.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/browser/utils/ui/keybinds";
 import { getErrorMessage } from "@/common/utils/errors";
 import type { SettingsBackupInput } from "@/common/orpc/schemas/backup";
+import { BACKUP_CREDENTIAL_LABELS } from "@/constants/backup";
 
 type BackupRoute = keyof APIClient["backup"];
 type BackupRouteOutput<Route extends BackupRoute> = Awaited<ReturnType<APIClient["backup"][Route]>>;
@@ -87,17 +88,6 @@ function draftsEqual(left: BackupDraft, right: BackupDraft): boolean {
 function getOperationErrorMessage(error: BackupOperationError): string {
   if (!error.files?.length) return error.message;
   return `${error.message}: ${error.files.join(", ")}`;
-}
-
-function getCredentialLabel(credential: BackupValidation["credential"]): string {
-  switch (credential) {
-    case "ssh":
-      return "SSH key or agent";
-    case "gh":
-      return "GitHub CLI";
-    case "ambient":
-      return "system git credentials";
-  }
 }
 
 /**
@@ -524,7 +514,7 @@ export function BackupSection() {
       setProjectImportSelections({});
       setProjectBundleSkipped(false);
       setStatusMessage(
-        `Backed up settings at ${result.data.commit} using ${getCredentialLabel(result.data.credential)}.`
+        `Backed up settings at ${result.data.commit} using ${BACKUP_CREDENTIAL_LABELS[result.data.credential]}.`
       );
     } catch (error) {
       setActionError(getErrorMessage(error));
@@ -811,7 +801,7 @@ export function BackupSection() {
         {validation ? (
           <div className="bg-background-secondary rounded-md px-3 py-2 text-xs">
             <div className="text-foreground">
-              Credential used: {getCredentialLabel(validation.credential)}
+              Credential used: {BACKUP_CREDENTIAL_LABELS[validation.credential]}
             </div>
             <div className="text-muted mt-1">
               {validation.empty

--- a/src/constants/backup.ts
+++ b/src/constants/backup.ts
@@ -1,0 +1,7 @@
+import type { BackupCredentialKind } from "@/common/orpc/schemas/backup";
+
+export const BACKUP_CREDENTIAL_LABELS: Record<BackupCredentialKind, string> = {
+  ssh: "SSH key or agent",
+  gh: "GitHub CLI",
+  ambient: "system git credentials",
+};

--- a/src/node/services/backup/credentials.test.ts
+++ b/src/node/services/backup/credentials.test.ts
@@ -353,6 +353,39 @@ exit 128
     expect(message).not.toContain("Enumerating objects");
   });
 
+  it("falls back to the fatal denial when no remote line explains it", async () => {
+    if (process.platform === "win32") return;
+    await writeExecutable(path.join(binDir, "gh"), "#!/bin/sh\nexit 1\n");
+    await writeExecutable(
+      path.join(binDir, "git"),
+      `#!/bin/sh
+case "$*" in
+  *core.sshCommand*) exit 1 ;;
+esac
+echo 'remote: Enumerating objects: 5, done.' >&2
+echo "fatal: unable to access 'https://github.com/owner/repo.git/': The requested URL returned error: 403" >&2
+exit 128
+`
+    );
+
+    let caught: unknown;
+    try {
+      await withPath(binDir, () =>
+        runGitWithCredentialLadder(["push", "origin", "HEAD:refs/heads/main"], {
+          repoUrl: "https://github.com/owner/repo.git",
+          env: { GIT_LOG: logPath },
+        })
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(BackupAuthFailedError);
+    const message = (caught as Error).message;
+    expect(message).toContain("The requested URL returned error: 403");
+    expect(message).not.toContain("Enumerating objects");
+  });
+
   it("prefers the rung the remote recognised over one that had no credential", async () => {
     if (process.platform === "win32") return;
     await writeExecutable(path.join(binDir, "gh"), "#!/bin/sh\nexit 0\n");

--- a/src/node/services/backup/credentials.test.ts
+++ b/src/node/services/backup/credentials.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { BACKUP_CREDENTIAL_LABELS } from "@/constants/backup";
 import {
   BackupAuthFailedError,
   BackupRemoteUnreachableError,
@@ -234,6 +235,8 @@ exit 128
     // The service maps any error it cannot classify to IO_ERROR, which would tell the
     // user their disk failed when their credential is what expired.
     expect((caught as BackupAuthFailedError).code).toBe("AUTH_FAILED");
+    // No rung was recognised by the remote, so signing in is the advice that can help.
+    expect((caught as Error).message).toContain("gh auth login");
   });
 
   it("treats a push denied by write permissions as an authentication failure", async () => {
@@ -272,6 +275,121 @@ exit 128
     // still deserves a turn in case it is the one with write access.
     const attempts = (await fs.readFile(logPath, "utf-8")).split("---\n").filter(Boolean);
     expect(attempts).toHaveLength(2);
+  });
+
+  it("reports a write-access denial as a repository permission problem", async () => {
+    if (process.platform === "win32") return;
+    await writeExecutable(path.join(binDir, "gh"), "#!/bin/sh\nexit 0\n");
+    await writeExecutable(
+      path.join(binDir, "git"),
+      `#!/bin/sh
+case "$*" in
+  *core.sshCommand*) exit 1 ;;
+esac
+printf '%s\\n' '---' >> "$GIT_LOG"
+printf '%s\\n' "$@" >> "$GIT_LOG"
+echo 'remote: Write access to repository not granted.' >&2
+echo "fatal: unable to access 'https://github.com/owner/repo.git/': The requested URL returned error: 403" >&2
+exit 128
+`
+    );
+
+    let caught: unknown;
+    try {
+      await withPath(binDir, () =>
+        runGitWithCredentialLadder(["push", "origin", "HEAD:refs/heads/main"], {
+          repoUrl: "https://github.com/owner/repo.git",
+          env: { GIT_LOG: logPath },
+        })
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(BackupAuthFailedError);
+    const thrown = caught as BackupAuthFailedError;
+    expect(thrown.code).toBe("AUTH_FAILED");
+    // The remote recognised the credential and refused the repository, so the user is
+    // pointed at repository permissions rather than at signing in again.
+    expect(thrown.message).toContain("Write access to repository not granted");
+    expect(thrown.message).toContain(BACKUP_CREDENTIAL_LABELS.gh);
+    expect(thrown.message).not.toContain("gh auth login");
+    expect((thrown.cause as Error).message).toContain("Write access to repository not granted");
+    const attempts = (await fs.readFile(logPath, "utf-8")).split("---\n").filter(Boolean);
+    expect(attempts).toHaveLength(2);
+  });
+
+  it("prefers the rung the remote recognised over one that had no credential", async () => {
+    if (process.platform === "win32") return;
+    await writeExecutable(path.join(binDir, "gh"), "#!/bin/sh\nexit 0\n");
+    await writeExecutable(
+      path.join(binDir, "git"),
+      `#!/bin/sh
+case "$*" in
+  *core.sshCommand*) exit 1 ;;
+  *credential.helper*)
+    echo 'remote: Write access to repository not granted.' >&2
+    echo "fatal: unable to access 'https://github.com/owner/repo.git/': The requested URL returned error: 403" >&2
+    exit 128 ;;
+esac
+echo "fatal: could not read Username for 'https://github.com': terminal prompts disabled" >&2
+exit 128
+`
+    );
+
+    let caught: unknown;
+    try {
+      await withPath(binDir, () =>
+        runGitWithCredentialLadder(["push", "origin", "HEAD:refs/heads/main"], {
+          repoUrl: "https://github.com/owner/repo.git",
+          env: { GIT_LOG: logPath },
+        })
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(BackupAuthFailedError);
+    // The ambient rung failed last, but only because it had nothing to offer; the gh rung's
+    // denial is the diagnosis that explains what to fix.
+    const message = (caught as Error).message;
+    expect(message).toContain(BACKUP_CREDENTIAL_LABELS.gh);
+    expect(message).toContain("Write access to repository not granted");
+    expect(message).not.toContain("terminal prompts disabled");
+    expect(message).not.toContain("gh auth login");
+  });
+
+  it("reports an ssh access denial with the ssh credential", async () => {
+    if (process.platform === "win32") return;
+    await writeExecutable(
+      path.join(binDir, "git"),
+      `#!/bin/sh
+case "$*" in
+  *core.sshCommand*) exit 1 ;;
+esac
+echo 'ERROR: Permission to owner/repo.git denied to someone.' >&2
+echo 'fatal: Could not read from remote repository.' >&2
+exit 128
+`
+    );
+
+    let caught: unknown;
+    try {
+      await withPath(binDir, () =>
+        runGitWithCredentialLadder(["ls-remote", "git@github.com:owner/repo.git"], {
+          repoUrl: "git@github.com:owner/repo.git",
+          env: { GIT_LOG: logPath },
+        })
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(BackupAuthFailedError);
+    const message = (caught as Error).message;
+    expect(message).toContain(BACKUP_CREDENTIAL_LABELS.ssh);
+    expect(message).toContain("Permission to owner/repo.git denied to someone");
+    expect(message).not.toContain("gh auth login");
   });
 
   it("leaves a non-authentication ambient failure unclassified", async () => {

--- a/src/node/services/backup/credentials.test.ts
+++ b/src/node/services/backup/credentials.test.ts
@@ -319,6 +319,40 @@ exit 128
     expect(attempts).toHaveLength(2);
   });
 
+  it("quotes the denial line, not server progress that preceded it", async () => {
+    if (process.platform === "win32") return;
+    await writeExecutable(path.join(binDir, "gh"), "#!/bin/sh\nexit 1\n");
+    await writeExecutable(
+      path.join(binDir, "git"),
+      `#!/bin/sh
+case "$*" in
+  *core.sshCommand*) exit 1 ;;
+esac
+echo 'remote: Enumerating objects: 5, done.' >&2
+echo 'remote: Permission to owner/repo.git denied to someone.' >&2
+echo "fatal: unable to access 'https://github.com/owner/repo.git/': The requested URL returned error: 403" >&2
+exit 128
+`
+    );
+
+    let caught: unknown;
+    try {
+      await withPath(binDir, () =>
+        runGitWithCredentialLadder(["push", "origin", "HEAD:refs/heads/main"], {
+          repoUrl: "https://github.com/owner/repo.git",
+          env: { GIT_LOG: logPath },
+        })
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(BackupAuthFailedError);
+    const message = (caught as Error).message;
+    expect(message).toContain("Permission to owner/repo.git denied to someone");
+    expect(message).not.toContain("Enumerating objects");
+  });
+
   it("prefers the rung the remote recognised over one that had no credential", async () => {
     if (process.platform === "win32") return;
     await writeExecutable(path.join(binDir, "gh"), "#!/bin/sh\nexit 0\n");

--- a/src/node/services/backup/credentials.ts
+++ b/src/node/services/backup/credentials.ts
@@ -243,7 +243,7 @@ const LOGIN_FAILED_MESSAGE =
   "Could not authenticate to the backup repository. Check your SSH key or `gh auth login`.";
 
 function accessDeniedMessage(credential: BackupCredential, error: unknown): string {
-  return `Access to the backup repository was denied (credential: ${BACKUP_CREDENTIAL_LABELS[credential]}): ${remoteReason(error)} The credential was accepted, so signing in again will not help. Check that the URL names the right repository and that the account behind this credential, or the integration that issues its token, has write access to it.`;
+  return `Access to the backup repository was denied (credential: ${BACKUP_CREDENTIAL_LABELS[credential]}): ${remoteReason(error)} Check that the URL names the right repository and that the account behind this credential, or the integration that issues its token, has write access to it.`;
 }
 
 export interface GitCredentialOptions extends Omit<ExecFileAsyncOptions, "killTreeOnTermination"> {
@@ -436,12 +436,15 @@ function remoteReason(error: unknown): string {
     error instanceof Error ? (error as Error & { stderr?: unknown }).stderr : undefined;
   const text = typeof stderr === "string" ? stderr : errorText(error);
   // Server progress arrives as `remote:` lines too, so the denial is the line that matched the
-  // classifier, not whichever line the server sent first.
+  // classifier, wherever it sits, not whichever line the server sent first.
   const remoteLines = Array.from(text.matchAll(REMOTE_REASON_LINES), (match) => match[1]);
+  const fatalLine = FATAL_LINE.exec(text)?.[1];
   const line =
-    remoteLines.find((candidate) => ACCESS_DENIED_PATTERN.test(candidate)) ??
+    [...remoteLines, ...(fatalLine === undefined ? [] : [fatalLine])].find((candidate) =>
+      ACCESS_DENIED_PATTERN.test(candidate)
+    ) ??
     remoteLines[0] ??
-    FATAL_LINE.exec(text)?.[1] ??
+    fatalLine ??
     text.split("\n").find((candidate) => candidate.trim() !== "") ??
     "";
   const reason = line.trim().slice(0, REMOTE_REASON_MAX_LENGTH);

--- a/src/node/services/backup/credentials.ts
+++ b/src/node/services/backup/credentials.ts
@@ -401,7 +401,7 @@ const AUTH_FAILURE_PATTERN =
 const ACCESS_DENIED_PATTERN =
   /write access to repository not granted|permission to [^\n]*denied|repository not found|marked as read.?only|returned error: 403/i;
 
-const REMOTE_REASON_LINE = /^(?:remote|ERROR):[ \t]*(.+)$/m;
+const REMOTE_REASON_LINES = /^(?:remote|ERROR):[ \t]*(.+)$/gm;
 const FATAL_LINE = /^fatal:[ \t]*(.+)$/m;
 const REMOTE_REASON_MAX_LENGTH = 200;
 
@@ -435,8 +435,12 @@ function remoteReason(error: unknown): string {
   const stderr =
     error instanceof Error ? (error as Error & { stderr?: unknown }).stderr : undefined;
   const text = typeof stderr === "string" ? stderr : errorText(error);
+  // Server progress arrives as `remote:` lines too, so the denial is the line that matched the
+  // classifier, not whichever line the server sent first.
+  const remoteLines = Array.from(text.matchAll(REMOTE_REASON_LINES), (match) => match[1]);
   const line =
-    REMOTE_REASON_LINE.exec(text)?.[1] ??
+    remoteLines.find((candidate) => ACCESS_DENIED_PATTERN.test(candidate)) ??
+    remoteLines[0] ??
     FATAL_LINE.exec(text)?.[1] ??
     text.split("\n").find((candidate) => candidate.trim() !== "") ??
     "";

--- a/src/node/services/backup/credentials.ts
+++ b/src/node/services/backup/credentials.ts
@@ -1,6 +1,7 @@
 import type { BackupCredentialKind } from "@/common/orpc/schemas/backup";
 import { shellQuote } from "@/common/utils/shell";
 import { execFileAsync, type ExecFileAsyncOptions } from "@/node/utils/disposableExec";
+import { BACKUP_CREDENTIAL_LABELS } from "@/constants/backup";
 import { SSH_PROTOCOL_SCHEMES } from "@/constants/git";
 
 const NON_INTERACTIVE_ENV = {
@@ -232,13 +233,17 @@ export class BackupRemoteUnreachableError extends Error {
 export class BackupAuthFailedError extends Error {
   readonly code = "AUTH_FAILED";
 
-  constructor(cause: unknown) {
-    super(
-      "Could not authenticate to the backup repository. Check your SSH key or `gh auth login`.",
-      { cause }
-    );
+  constructor(message: string, cause: unknown) {
+    super(message, { cause });
     this.name = "BackupAuthFailedError";
   }
+}
+
+const LOGIN_FAILED_MESSAGE =
+  "Could not authenticate to the backup repository. Check your SSH key or `gh auth login`.";
+
+function accessDeniedMessage(credential: BackupCredential, error: unknown): string {
+  return `Access to the backup repository was denied (credential: ${BACKUP_CREDENTIAL_LABELS[credential]}): ${remoteReason(error)} The credential was accepted, so signing in again will not help. Check that the URL names the right repository and that the account behind this credential, or the integration that issues its token, has write access to it.`;
 }
 
 export interface GitCredentialOptions extends Omit<ExecFileAsyncOptions, "killTreeOnTermination"> {
@@ -385,7 +390,20 @@ async function controlledCredentials(
  * the ladder retry with the ambient helper, which may hold a writable credential.
  */
 const AUTH_FAILURE_PATTERN =
-  /authentication failed|could not read (?:username|password)|permission denied|permission to [^\n]*denied|publickey|access denied|repository not found|terminal prompts disabled|invalid username or (?:password|token)|returned error: 40[13]|authentication is required/i;
+  /authentication failed|could not read (?:username|password)|permission denied|permission to [^\n]*denied|publickey|access denied|repository not found|marked as read.?only|terminal prompts disabled|invalid username or (?:password|token)|returned error: 40[13]|authentication is required/i;
+
+/**
+ * GitHub answers a recognised token that lacks the repository with 403 and a `remote:` reason,
+ * and hides an invisible private repository behind "Repository not found"; over ssh the same
+ * refusal reads "Permission to X denied to Y". A login prompt cannot fix any of these, so the
+ * denying rung's diagnosis wins over a later rung that merely had no credential to offer.
+ */
+const ACCESS_DENIED_PATTERN =
+  /write access to repository not granted|permission to [^\n]*denied|repository not found|marked as read.?only|returned error: 403/i;
+
+const REMOTE_REASON_LINE = /^(?:remote|ERROR):[ \t]*(.+)$/m;
+const FATAL_LINE = /^fatal:[ \t]*(.+)$/m;
+const REMOTE_REASON_MAX_LENGTH = 200;
 
 /**
  * Local object-store failures also say "Permission denied", so they are excluded first.
@@ -399,14 +417,35 @@ const LOCAL_FILESYSTEM_FAILURE_PATTERN =
 const REMOTE_UNREACHABLE_PATTERN =
   /could not resolve (?:host|hostname|proxy)|name or service not known|temporary failure in name resolution|connection (?:refused|timed out|reset)|network is (?:unreachable|down)|no route to host|failed to connect to|couldn't connect to server|operation timed out|returned error: 5\d\d|service unavailable|bad gateway|ENOTFOUND|EAI_AGAIN|ECONNREFUSED|ETIMEDOUT|EHOSTUNREACH|ENETUNREACH/i;
 
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 function isAuthenticationFailure(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
+  const message = errorText(error);
   if (LOCAL_FILESYSTEM_FAILURE_PATTERN.test(message)) return false;
   return AUTH_FAILURE_PATTERN.test(message);
 }
 
+function isAccessDenied(error: unknown): boolean {
+  return isAuthenticationFailure(error) && ACCESS_DENIED_PATTERN.test(errorText(error));
+}
+
+function remoteReason(error: unknown): string {
+  const stderr =
+    error instanceof Error ? (error as Error & { stderr?: unknown }).stderr : undefined;
+  const text = typeof stderr === "string" ? stderr : errorText(error);
+  const line =
+    REMOTE_REASON_LINE.exec(text)?.[1] ??
+    FATAL_LINE.exec(text)?.[1] ??
+    text.split("\n").find((candidate) => candidate.trim() !== "") ??
+    "";
+  const reason = line.trim().slice(0, REMOTE_REASON_MAX_LENGTH);
+  return /[.!?]$/.test(reason) ? reason : `${reason}.`;
+}
+
 function isRemoteUnreachable(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
+  const message = errorText(error);
   if (LOCAL_FILESYSTEM_FAILURE_PATTERN.test(message)) return false;
   // A blackholed remote may emit no diagnostic before timeout kills Git, so key on `signal`.
   if (isSignalTermination(error)) return true;
@@ -417,6 +456,11 @@ function isSignalTermination(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   const signal = (error as Error & { signal?: unknown }).signal;
   return typeof signal === "string" && signal !== "";
+}
+
+interface AuthenticationFailure {
+  credential: BackupCredential;
+  error: unknown;
 }
 
 export async function runGitWithCredentialLadder(
@@ -430,6 +474,7 @@ export async function runGitWithCredentialLadder(
     onStderrData: options.onStderrData,
   };
 
+  const failures: AuthenticationFailure[] = [];
   for (const controlled of await controlledCredentials(args, options)) {
     try {
       const result = await run("git", [...controlled.argsPrefix, ...args], {
@@ -449,6 +494,7 @@ export async function runGitWithCredentialLadder(
         if (isRemoteUnreachable(error)) throw new BackupRemoteUnreachableError(error);
         throw error;
       }
+      failures.push({ credential: controlled.credential, error });
     }
   }
 
@@ -469,7 +515,16 @@ export async function runGitWithCredentialLadder(
   } catch (error) {
     // Every rung has now failed. A raw git error carries a numeric exit code, which the
     // service cannot distinguish from a local filesystem failure.
-    if (isAuthenticationFailure(error)) throw new BackupAuthFailedError(error);
+    if (isAuthenticationFailure(error)) {
+      failures.push({ credential: "ambient", error });
+      const denied = failures.find((failure) => isAccessDenied(failure.error));
+      throw denied === undefined
+        ? new BackupAuthFailedError(LOGIN_FAILED_MESSAGE, error)
+        : new BackupAuthFailedError(
+            accessDeniedMessage(denied.credential, denied.error),
+            denied.error
+          );
+    }
     if (isRemoteUnreachable(error)) throw new BackupRemoteUnreachableError(error);
     throw error;
   }


### PR DESCRIPTION
## Summary

When the backup repository refuses a credential the host already accepted, the Settings > Backup section now says so, naming the refused credential and quoting the remote's own reason, instead of telling the user to run `gh auth login`.

## Background

With a wrapper-managed `gh` (for example on a Coder workspace), `gh auth status` succeeds, but pushing to a backup repository the token cannot write returns `remote: Write access to repository not granted.` followed by `The requested URL returned error: 403`. `runGitWithCredentialLadder` matched that as an authentication failure and threw the fixed message "Could not authenticate to the backup repository. Check your SSH key or `gh auth login`", sending a logged-in user to log in again. The thrown `cause` was also only the ambient rung's failure, so the gh rung's informative denial disappeared whenever the ambient rung failed differently (for example "could not read Username ... terminal prompts disabled").

## Implementation

- `credentials.ts`: `ACCESS_DENIED_PATTERN` (403, "Write access to repository not granted", "Permission to X denied", "Repository not found", read-only deploy key) selects, among all recorded rung failures in ladder order, the first the remote recognised and refused. The diagnostic line that matched the classifier (a `remote:` or `ERROR:` line, else the `fatal:` line) and the credential label go into the message. Pure login failures keep the existing message. The error code stays `AUTH_FAILED`, so there is no IPC or schema change and the `instanceof` checks in `gitRepo.ts` are unchanged.
- `src/constants/backup.ts`: shared `BACKUP_CREDENTIAL_LABELS`, used by the backend message and by `BackupSection.tsx` (replaces the local `getCredentialLabel`).
- Tests: three new behavioral cases in `credentials.test.ts` (a 403 denial names the gh rung and quotes the reason; the denying rung wins over a credential-less ambient rung; an ssh `ERROR: Permission to ... denied` names the ssh rung) plus a login-guidance assertion on the existing exhausted-ladder case.

## Validation

- Remote dogfood UAT (Coder Agents) on this exact head: 403 denial on a read-only public repository via "Back up now", 404 "Repository not found" via Validate, the login message with no credential available at all (credential-stripped server), the network error for an unreachable host, a successful backup to a writable repository, rendering at 1280 px and 375 px, and the ssh rung denial once known_hosts was populated. All passed.
- Red-green: disabling the access-denied selection fails exactly the three new tests.

## Risks

Low. Classification only changes which message is thrown after every rung has already failed; ladder order and retry behaviour are unchanged. The one widening is that a read-only deploy key ("marked as read only") now counts as an auth failure, so the ambient rung gets a turn instead of the raw git error surfacing.

## Follow-up (pre-existing, out of scope)

UAT also found that an ssh host-key verification failure (`Host key verification failed`, here from `coder gitssh` without a known_hosts entry) still surfaces raw multi-line stderr in the error area. That path matched no classifier before this PR either and is untouched here; it deserves its own classifier and message.

<details>
<summary>Delivery record (reviews, UAT, CI)</summary>

**Reviews** (process limit: 6 completed code, security, and advisory reviews per PR; 7 completed, see note)

| # | Kind | Head | Reviewer | Findings | Disposition |
|---|------|------|----------|----------|-------------|
| 1 | Code (automatic) | `42c9038c6` | Codex ([request](https://github.com/coder/xum/pull/4226#issuecomment-5650021372), [verdict](https://github.com/coder/xum/pull/4226#issuecomment-5650045664)) | none ("Didn't find any major issues", reviewed commit 42c9038c68) | clean, no threads |
| 2 | Security (automatic) | `42c9038c6` | Codex ([result](https://github.com/coder/xum/pull/4226#issuecomment-5650049685)) | none | clean |
| 3 | Advisory (fresh clean-context final reviewer) | `42c9038c6` | Xum read-only review sub-agent | P2: `remoteReason()` quoted the first `remote:` line, which could be server progress rather than the denial. P3: a bare HTTP 403 treated as proof that re-authenticating cannot help. Recommendation: specific blocker on the P2. | P2 fixed in `1adb0ed5d` (quote the remote line that matched the classifier; new test; red-green verified). P3 was first rejected with reasoning (401 vs 403), then fixed in `a56ddd6a6` after Codex raised the same point: the "signing in again will not help" sentence is gone. |
| 4 | Code (automatic) | `1adb0ed5d` | Codex ([request](https://github.com/coder/xum/pull/4226#issuecomment-5650101216), [review](https://github.com/coder/xum/pull/4226#pullrequestreview-5189031480)) | P2 [thread](https://github.com/coder/xum/pull/4226#discussion_r3998351145): a progress `remote:` line could be quoted over a matching `fatal:` 403 line. P2 [thread](https://github.com/coder/xum/pull/4226#discussion_r3998351147): bare 403 / not-found treated as proof the credential was accepted. | Both fixed in `a56ddd6a6` (search remote and fatal lines for the classifier match; sentence removed); replied on both threads and resolved them. |
| 5 | Security (automatic) | `1adb0ed5d` | Codex ([result](https://github.com/coder/xum/pull/4226#issuecomment-5650123556)) | none | clean |
| 6 | Code (automatic, "New commits" trigger, not requested) | `a56ddd6a6` | Codex (summary row completed 02:16:19Z; 👍 reaction 02:17:16Z) | none | clean, no threads |
| 7 | Security (automatic, "New commits" trigger, not requested) | `a56ddd6a6` | Codex (summary row completed 02:17:11Z) | none | clean |

Process note: the six-review limit was exceeded by one. This repository's Codex integration starts a code and a security review automatically on every push ("New commits" trigger); rows 6 and 7 were not requested and cannot be suppressed without changing repository settings, which was out of bounds. No further review was requested after row 5.

**Remote dogfood UAT** (Coder Agents, vibe-coding template; evidence kept in the driving workspace under `.mux-uat/`, not committed)

- Round 1 on `42c9038c6` (remote chat `c742c3f5`): the remote agent's own verdict was FAIL, twice. A separate critical UAT runner re-examined the evidence, rejected duplicate and cropped screenshots, forced re-proofs, and endorsed PASS for every claim in scope: 403 denial via "Back up now", 404 "Repository not found" via Validate, login message with no credential available, network error for an unreachable host, successful backup to a writable repository, rendering at 1280 px and 375 px, ssh-rung denial after populating known_hosts. The FAIL came from one pre-existing defect outside this change (below).
- Smoke on `1adb0ed5d`: PASS, superseded by the next push.
- Smoke-final on `a56ddd6a6` (same chat, remote `git rev-parse HEAD` and the app version badge both confirm the SHA): PASS. 403 via "Back up now" and 404 via Validate both render the final wording; DOM checks confirm the removed sentence and `gh auth login` are absent. The remote checkout reported `-dirty` because its bun 1.2.15 rewrote `bun.lock` (repo pins bun 1.3.5): the diff is a `configVersion` header plus re-hoisting of the type-only packages `@types/node` and `undici-types`; no runtime package changed and nothing under `src/` differed, so the tested build is dependency-equivalent to the committed lockfile.

**Deferred, pre-existing:** an ssh host-key verification failure (`Host key verification failed`, here from `coder gitssh` without a known_hosts entry) surfaces raw multi-line stderr in the Backup error area. It matched no classifier before this PR and is untouched by it. Owner: next backup follow-up PR. Trigger: add a host-key classifier and message in `credentials.ts` next to the network and login classifiers.

**CI:** on `42c9038c6`, attempt 1 failed on "Codex Comments" (ran before Codex answered) and "Test / Unit" (Bun 1.3.5 segfault, zero failing tests). On `a56ddd6a6`, attempt 1 failed only on "Codex Comments" for the same timing reason; the failed jobs were rerun once Codex had completed.

</details>

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh`_

<!-- xum-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh -->

