### PR TITLE
🤖 fix: summarize invalid tool input errors and state the advisor question cap

### DIFF
--- a/src/common/constants/advisor.ts
+++ b/src/common/constants/advisor.ts
@@ -3,6 +3,9 @@ import { normalizeAgentId } from "@/common/utils/agentIds";
 /** Default per-turn usage cap for the experimental advisor tool. */
 export const ADVISOR_DEFAULT_MAX_USES_PER_TURN = 3;
 
+/** Upper bound on the advisor tool's `question` input (schema and description share it). */
+export const ADVISOR_QUESTION_MAX_CHARS = 2000;
+
 const ADVISOR_ENABLED_BY_DEFAULT_AGENT_IDS = new Set(["exec", "plan"]);
 
 export function isAdvisorEnabledByDefaultForAgent(agentId: string): boolean {
@@ -45,7 +48,7 @@ export const ADVISOR_USAGE_GUIDANCE =
 export const ADVISOR_TOOL_DESCRIPTION =
   "Ask a stronger model for strategic advice based on the live conversation transcript. " +
   ADVISOR_USAGE_GUIDANCE +
-  " Pass a brief `question` summarizing the decision or ambiguity.";
+  ` Pass a brief \`question\` (at most ${ADVISOR_QUESTION_MAX_CHARS} characters) summarizing the decision or ambiguity.`;
 
 /**
  * System prompt for the nested advisor model call.

--- a/src/common/utils/tools/formatToolInputIssues.test.ts
+++ b/src/common/utils/tools/formatToolInputIssues.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { formatToolInputIssues, isToolInputIssueArray } from "./formatToolInputIssues";
+
+function issuesFor(schema: z.ZodType, value: unknown) {
+  const result = schema.safeParse(value);
+  if (result.success) {
+    throw new Error("expected schema to reject value");
+  }
+  return result.error.issues;
+}
+
+describe("formatToolInputIssues", () => {
+  test("appends the received length for a string max violation without echoing the value", () => {
+    const input = { question: "x".repeat(2100) };
+    const schema = z.object({ question: z.string().max(2000) });
+
+    const message = formatToolInputIssues(issuesFor(schema, input), input);
+
+    expect(message).toBe(
+      "question: Too big: expected string to have <=2000 characters (received 2100 characters)"
+    );
+    expect(message).not.toContain("xxx");
+  });
+
+  test("appends the received length for a string min violation", () => {
+    const input = { question: "ab" };
+    const schema = z.object({ question: z.string().min(5) });
+
+    expect(formatToolInputIssues(issuesFor(schema, input), input)).toEndWith(
+      "(received 2 characters)"
+    );
+  });
+
+  test("joins multiple issues and only annotates string-origin size issues", () => {
+    const input = { question: "x".repeat(2100), tags: ["a", "b"], nested: { count: 1 } };
+    const schema = z.object({
+      question: z.string().max(2000),
+      tags: z.array(z.string()).max(1),
+      nested: z.object({ count: z.number().min(2) }),
+    });
+
+    const message = formatToolInputIssues(issuesFor(schema, input), input);
+    const parts = message.split("; ");
+
+    expect(parts).toHaveLength(3);
+    expect(parts[0]).toContain("received 2100 characters");
+    expect(parts[1]).toStartWith("tags: ");
+    expect(parts[1]).not.toContain("received");
+    expect(parts[2]).toStartWith("nested.count: ");
+    expect(parts[2]).not.toContain("received");
+  });
+
+  test("labels a root-level issue as the whole input", () => {
+    const message = formatToolInputIssues(issuesFor(z.object({ a: z.string() }), "oops"), "oops");
+
+    expect(message).toStartWith("input: ");
+  });
+
+  test("skips the received suffix when the value at the path is not a string", () => {
+    const issues = [{ path: ["question"], message: "Too big", code: "too_big", origin: "string" }];
+
+    expect(formatToolInputIssues(issues, { question: 42 })).toBe("question: Too big");
+    expect(formatToolInputIssues(issues, null)).toBe("question: Too big");
+  });
+});
+
+describe("isToolInputIssueArray", () => {
+  test("accepts zod issues and rejects other shapes", () => {
+    expect(isToolInputIssueArray(issuesFor(z.string(), 1))).toBe(true);
+    expect(isToolInputIssueArray([{ path: "question", message: "x" }])).toBe(false);
+    expect(isToolInputIssueArray([{ path: [], message: 1 }])).toBe(false);
+    expect(isToolInputIssueArray("issues")).toBe(false);
+  });
+});

--- a/src/common/utils/tools/formatToolInputIssues.ts
+++ b/src/common/utils/tools/formatToolInputIssues.ts
@@ -1,0 +1,59 @@
+/**
+ * Zod v4 issue fields read when rendering tool input validation failures.
+ * Duck-typed so callers can pass issues recovered from an AI SDK error cause
+ * chain (InvalidToolInputError -> TypeValidationError -> ZodError) without
+ * importing zod.
+ */
+export interface ToolInputIssue {
+  path: readonly PropertyKey[];
+  message: string;
+  code?: string;
+  origin?: string;
+}
+
+export function isToolInputIssueArray(value: unknown): value is ToolInputIssue[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (issue: unknown) =>
+        typeof issue === "object" &&
+        issue !== null &&
+        Array.isArray((issue as { path?: unknown }).path) &&
+        typeof (issue as { message?: unknown }).message === "string"
+    )
+  );
+}
+
+/**
+ * Render zod issues as one concise line: "<path>: <message>[ (received N characters)]".
+ * Never echoes the input value itself; the AI SDK's own message does, which buries the
+ * actionable issue under kilobytes of the model's rejected input.
+ */
+export function formatToolInputIssues(issues: readonly ToolInputIssue[], input: unknown): string {
+  return issues.map((issue) => formatToolInputIssue(issue, input)).join("; ");
+}
+
+function formatToolInputIssue(issue: ToolInputIssue, input: unknown): string {
+  const label = issue.path.length > 0 ? issue.path.map(String).join(".") : "input";
+  let text = `${label}: ${issue.message}`;
+  // Zod v4 size messages state the limit but not the actual length, which is
+  // the number the model needs to shorten its retry.
+  if ((issue.code === "too_big" || issue.code === "too_small") && issue.origin === "string") {
+    const value = resolvePath(input, issue.path);
+    if (typeof value === "string") {
+      text += ` (received ${value.length} characters)`;
+    }
+  }
+  return text;
+}
+
+function resolvePath(input: unknown, path: readonly PropertyKey[]): unknown {
+  let current: unknown = input;
+  for (const key of path) {
+    if (current === null || typeof current !== "object") {
+      return undefined;
+    }
+    current = (current as Record<PropertyKey, unknown>)[key];
+  }
+  return current;
+}

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -60,7 +60,7 @@ import {
   BASH_MAX_TOTAL_BYTES,
   WEB_FETCH_MAX_OUTPUT_BYTES,
 } from "@/common/constants/toolLimits";
-import { ADVISOR_TOOL_DESCRIPTION } from "@/common/constants/advisor";
+import { ADVISOR_QUESTION_MAX_CHARS, ADVISOR_TOOL_DESCRIPTION } from "@/common/constants/advisor";
 import {
   MEMORY_INTUITION_MAX_CUE_CHARS,
   MEMORY_INTUITION_MAX_EXCERPT_CHARS,
@@ -246,7 +246,7 @@ export const HeartbeatToolArgsSchema = z
 export const AdvisorToolInputSchema = z
   .object({
     // Advisor prompts often need tradeoff context; keep bounded while allowing a compact brief.
-    question: z.string().min(1).max(2000).nullish(),
+    question: z.string().min(1).max(ADVISOR_QUESTION_MAX_CHARS).nullish(),
   })
   .strict();
 

--- a/src/node/services/ptc/toolBridge.test.ts
+++ b/src/node/services/ptc/toolBridge.test.ts
@@ -225,6 +225,40 @@ describe("ToolBridge", () => {
       expect(mockExecute).toHaveBeenCalledTimes(1);
     });
 
+    it("reports the received length for a string size violation", async () => {
+      const tools: Record<string, Tool> = {
+        file_read: createMockTool(
+          "file_read",
+          z.object({ path: z.string().max(10) }),
+          mock(() => ({ result: "ok" }))
+        ),
+      };
+      const bridge = new ToolBridge(tools);
+      let registeredMux: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+      bridge.register(
+        createMockRuntime({
+          registerObject: mock(
+            (name: string, obj: Record<string, (...args: unknown[]) => Promise<unknown>>) => {
+              if (name === "mux") registeredMux = obj;
+              return undefined;
+            }
+          ),
+        })
+      );
+
+      const fileRead = registeredMux.file_read as (...args: unknown[]) => Promise<unknown>;
+      const path = "y".repeat(25);
+      try {
+        await fileRead({ path });
+        expect.unreachable("Should have thrown");
+      } catch (e) {
+        const message = String(e);
+        expect(message).toContain("Invalid arguments for file_read: path:");
+        expect(message).toContain("(received 25 characters)");
+        expect(message).not.toContain(path);
+      }
+    });
+
     it("passes args through for JSON-Schema (MCP-style) tools", async () => {
       // MCP tools carry the AI SDK's jsonSchema() wrapper instead of a Zod
       // schema. Regression: validateArgs called schema.safeParse on it and

--- a/src/node/services/ptc/toolBridge.ts
+++ b/src/node/services/ptc/toolBridge.ts
@@ -21,6 +21,7 @@ import {
   isBridgeToolGranted,
   type CapabilityGrants,
 } from "@/common/types/capabilityGrants";
+import { formatToolInputIssues } from "@/common/utils/tools/formatToolInputIssues";
 import { isToolContentResult } from "@/common/utils/tools/toolContentResult";
 import { TOOL_DEFINITIONS } from "@/common/utils/tools/toolDefinitions";
 import { isSupportedAttachmentMediaType } from "@/common/utils/attachments/supportedAttachmentMediaTypes";
@@ -592,10 +593,9 @@ export class ToolBridge {
     if (typeof schema === "object" && "_def" in schema) {
       const result = (schema as z.ZodType).safeParse(args);
       if (!result.success) {
-        const issues = result.error.issues
-          .map((i) => `${i.path.join(".")}: ${i.message}`)
-          .join("; ");
-        throw new Error(`Invalid arguments for ${toolName}: ${issues}`);
+        throw new Error(
+          `Invalid arguments for ${toolName}: ${formatToolInputIssues(result.error.issues, args)}`
+        );
       }
       return result.data;
     }

--- a/src/node/services/streamManager.invalidToolInput.test.ts
+++ b/src/node/services/streamManager.invalidToolInput.test.ts
@@ -1,0 +1,127 @@
+import { tmpdir } from "node:os";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { describe, expect, test } from "bun:test";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import { tool } from "ai";
+import type { LanguageModelV3Prompt, LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import { createMuxMessage } from "@/common/types/message";
+import { AdvisorToolInputSchema } from "@/common/utils/tools/toolDefinitions";
+import { LocalRuntime } from "@/node/runtime/LocalRuntime";
+import { StreamManager } from "./streamManager";
+import { createTestHistoryService } from "./testHistoryService";
+
+describe("StreamManager - invalid tool input", () => {
+  test("the model's same-turn retry and the persisted history both get the concise summary", async () => {
+    const h = await createTestHistoryService();
+    const workspaceId = "invalid-tool-input";
+    const messageId = "invalid-tool-input-assistant";
+    const toolCallId = "advisor-invalid-call";
+    const oversized = "x".repeat(2100);
+    let providerCalls = 0;
+    let retryPrompt: LanguageModelV3Prompt | undefined;
+    const model = new MockLanguageModelV3({
+      doStream: (request) => {
+        providerCalls++;
+        if (providerCalls === 2) retryPrompt = request.prompt;
+        const usage = {
+          inputTokens: { total: 100, noCache: 100, cacheRead: 0, cacheWrite: 0 },
+          outputTokens: { total: 10, text: 10, reasoning: 0 },
+        };
+        const chunks: LanguageModelV3StreamPart[] =
+          providerCalls === 1
+            ? [
+                { type: "stream-start", warnings: [] },
+                {
+                  type: "tool-call",
+                  toolCallId,
+                  toolName: "advisor",
+                  input: JSON.stringify({ question: oversized }),
+                },
+                {
+                  type: "finish",
+                  finishReason: { unified: "tool-calls", raw: "tool_calls" },
+                  usage,
+                },
+              ]
+            : [
+                { type: "stream-start", warnings: [] },
+                { type: "text-start", id: "answer" },
+                { type: "text-delta", id: "answer", delta: "Done" },
+                { type: "text-end", id: "answer" },
+                { type: "finish", finishReason: { unified: "stop", raw: "stop" }, usage },
+              ];
+        return Promise.resolve({ stream: simulateReadableStream({ chunks }) });
+      },
+    });
+    const manager = new StreamManager(h.historyService);
+    const runtimeDir = await fs.mkdtemp(path.join(tmpdir(), "invalid-tool-input-stream-"));
+    try {
+      expect(
+        (
+          await h.historyService.appendManyToHistory(workspaceId, [
+            createMuxMessage("user", "user", "Ask the advisor"),
+            createMuxMessage(messageId, "assistant", ""),
+          ])
+        ).success
+      ).toBe(true);
+      const started = await manager.startStream({
+        workspaceId,
+        messageId,
+        historySequence: 1,
+        model,
+        modelString: "openai:gpt-4o",
+        messages: [{ role: "user", content: "Ask the advisor" }],
+        system: "Use tools",
+        runtime: new LocalRuntime(h.tempDir),
+        providedRuntimeTempDir: runtimeDir,
+        tools: {
+          advisor: tool({
+            description: "test advisor",
+            inputSchema: AdvisorToolInputSchema,
+            execute: (): Promise<{ advice: string }> =>
+              Promise.reject(new Error("invalid input must not execute")),
+          }),
+        },
+      });
+      expect(started.success).toBe(true);
+      if (!started.success) throw new Error("Expected stream construction");
+      const completion = await started.data.completion;
+      expect(completion.status).toBe("completed");
+      expect(providerCalls).toBe(2);
+
+      // Same turn: streamText feeds the rejected call's tool-result straight into the
+      // next step, so the retry prompt is where the SDK's input-echoing text would land.
+      const retryToolResult = retryPrompt
+        ?.flatMap((message) => (message.role === "tool" ? message.content : []))
+        .find((part) => part.type === "tool-result" && part.toolCallId === toolCallId);
+      if (retryToolResult?.type !== "tool-result") throw new Error("Expected a tool-result");
+      expect(retryToolResult.output.type).toBe("error-text");
+      if (retryToolResult.output.type !== "error-text") throw new Error("Expected error-text");
+      const summary = retryToolResult.output.value;
+      expect(summary).toContain("advisor");
+      expect(summary).toContain("question");
+      expect(summary).toContain("2000");
+      expect(summary).toContain("received 2100 characters");
+      expect(summary).not.toContain("xxxx");
+      expect(summary.length).toBeLessThan(300);
+
+      // Later turns: the persisted tool part carries the same summary.
+      expect((await h.historyService.commitPartial(workspaceId)).success).toBe(true);
+      const history = await h.historyService.getHistoryFromLatestBoundary(workspaceId);
+      if (!history.success) throw new Error(history.error);
+      const toolPart = history.data
+        .find((row) => row.id === messageId)
+        ?.parts.find((part) => part.type === "dynamic-tool");
+      expect(toolPart).toMatchObject({
+        toolCallId,
+        state: "output-available",
+        output: { success: false, error: summary },
+      });
+    } finally {
+      await manager.stopStream(workspaceId);
+      await fs.rm(runtimeDir, { recursive: true, force: true });
+      await h.cleanup();
+    }
+  });
+});

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -23,7 +23,6 @@ import { createMuxMessage, type MuxMessage } from "@/common/types/message";
 import type { WorkflowRunRecord } from "@/common/types/workflow";
 import { Ok, Err } from "@/common/types/result";
 import type { ToolPolicy } from "@/common/utils/tools/toolPolicy";
-import { AdvisorToolInputSchema } from "@/common/utils/tools/toolDefinitions";
 import type { ToolSearchStreamState } from "@/common/utils/tools/toolCatalog";
 import {
   StreamManager,
@@ -41,9 +40,7 @@ import { stripEncryptedContent } from "@/node/utils/messages/stripEncryptedConte
 import * as aiSdk from "ai";
 import {
   APICallError,
-  InvalidToolInputError,
   RetryError,
-  TypeValidationError,
   tool,
   type LanguageModel,
   type ModelMessage,
@@ -4119,88 +4116,6 @@ describe("StreamManager - exact step indices", () => {
       ).toEqual(preserveParts ? [0] : []);
     }
   );
-});
-
-describe("StreamManager - invalid tool input", () => {
-  test("relays a concise zod summary instead of the SDK's input-echoing error", async () => {
-    const streamManager = new StreamManager(historyService);
-    const workspaceId = "invalid-tool-input-workspace";
-    const messageId = "invalid-tool-input-message";
-    await appendPartialAssistantForTests(workspaceId, messageId, 1);
-    Reflect.set(streamManager, "tokenTracker", {
-      setModel: () => Promise.resolve(undefined),
-      countTokens: () => Promise.resolve(0),
-    });
-
-    // Mirror the SDK's pre-execution rejection: an invalid dynamic tool-call
-    // carrying the Error, then a tool-error carrying only its message string.
-    const input = { question: "x".repeat(2100) };
-    const validation = AdvisorToolInputSchema.safeParse(input);
-    if (validation.success) throw new Error("Expected the advisor schema to reject the input");
-    const error = new InvalidToolInputError({
-      toolName: "advisor",
-      toolInput: JSON.stringify(input),
-      cause: TypeValidationError.wrap({ value: input, cause: validation.error }),
-    });
-    const toolCallId = "advisor-invalid-call";
-    const streamInfo = createStreamInfoForTests({
-      messageId,
-      streamResult: createStreamResultForTests(
-        (async function* () {
-          await Promise.resolve();
-          yield { type: "start-step" };
-          yield {
-            type: "tool-call",
-            toolCallId,
-            toolName: "advisor",
-            input,
-            dynamic: true,
-            invalid: true,
-            error,
-          };
-          yield {
-            type: "tool-error",
-            toolCallId,
-            toolName: "advisor",
-            input,
-            error: error.message,
-            dynamic: true,
-          };
-          yield {
-            type: "finish-step",
-            usage: { inputTokens: 10, outputTokens: 1, totalTokens: 11 },
-          };
-          yield { type: "finish", finishReason: "stop" };
-        })()
-      ),
-    });
-
-    await getProcessStreamWithCleanupForTests(streamManager).call(
-      streamManager,
-      workspaceId,
-      streamInfo,
-      1
-    );
-
-    const history = await historyService.getHistoryFromLatestBoundary(workspaceId);
-    expect(history.success).toBe(true);
-    if (!history.success) throw new Error(history.error);
-    const toolPart = history.data
-      .find((row) => row.id === messageId)
-      ?.parts.find((part) => part.type === "dynamic-tool");
-    if (toolPart?.type !== "dynamic-tool" || toolPart.state !== "output-available") {
-      throw new Error("Expected a completed dynamic-tool part");
-    }
-    const output = toolPart.output as { success: boolean; error: string };
-
-    expect(output.success).toBe(false);
-    expect(output.error).toContain("advisor");
-    expect(output.error).toContain("question");
-    expect(output.error).toContain("2000");
-    expect(output.error).toContain("2100");
-    expect(output.error.length).toBeLessThan(500);
-    expect(output.error).not.toContain("xxxx");
-  });
 });
 
 describe("StreamManager - empty stream completions", () => {

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -23,6 +23,7 @@ import { createMuxMessage, type MuxMessage } from "@/common/types/message";
 import type { WorkflowRunRecord } from "@/common/types/workflow";
 import { Ok, Err } from "@/common/types/result";
 import type { ToolPolicy } from "@/common/utils/tools/toolPolicy";
+import { AdvisorToolInputSchema } from "@/common/utils/tools/toolDefinitions";
 import type { ToolSearchStreamState } from "@/common/utils/tools/toolCatalog";
 import {
   StreamManager,
@@ -40,7 +41,9 @@ import { stripEncryptedContent } from "@/node/utils/messages/stripEncryptedConte
 import * as aiSdk from "ai";
 import {
   APICallError,
+  InvalidToolInputError,
   RetryError,
+  TypeValidationError,
   tool,
   type LanguageModel,
   type ModelMessage,
@@ -4116,6 +4119,88 @@ describe("StreamManager - exact step indices", () => {
       ).toEqual(preserveParts ? [0] : []);
     }
   );
+});
+
+describe("StreamManager - invalid tool input", () => {
+  test("relays a concise zod summary instead of the SDK's input-echoing error", async () => {
+    const streamManager = new StreamManager(historyService);
+    const workspaceId = "invalid-tool-input-workspace";
+    const messageId = "invalid-tool-input-message";
+    await appendPartialAssistantForTests(workspaceId, messageId, 1);
+    Reflect.set(streamManager, "tokenTracker", {
+      setModel: () => Promise.resolve(undefined),
+      countTokens: () => Promise.resolve(0),
+    });
+
+    // Mirror the SDK's pre-execution rejection: an invalid dynamic tool-call
+    // carrying the Error, then a tool-error carrying only its message string.
+    const input = { question: "x".repeat(2100) };
+    const validation = AdvisorToolInputSchema.safeParse(input);
+    if (validation.success) throw new Error("Expected the advisor schema to reject the input");
+    const error = new InvalidToolInputError({
+      toolName: "advisor",
+      toolInput: JSON.stringify(input),
+      cause: TypeValidationError.wrap({ value: input, cause: validation.error }),
+    });
+    const toolCallId = "advisor-invalid-call";
+    const streamInfo = createStreamInfoForTests({
+      messageId,
+      streamResult: createStreamResultForTests(
+        (async function* () {
+          await Promise.resolve();
+          yield { type: "start-step" };
+          yield {
+            type: "tool-call",
+            toolCallId,
+            toolName: "advisor",
+            input,
+            dynamic: true,
+            invalid: true,
+            error,
+          };
+          yield {
+            type: "tool-error",
+            toolCallId,
+            toolName: "advisor",
+            input,
+            error: error.message,
+            dynamic: true,
+          };
+          yield {
+            type: "finish-step",
+            usage: { inputTokens: 10, outputTokens: 1, totalTokens: 11 },
+          };
+          yield { type: "finish", finishReason: "stop" };
+        })()
+      ),
+    });
+
+    await getProcessStreamWithCleanupForTests(streamManager).call(
+      streamManager,
+      workspaceId,
+      streamInfo,
+      1
+    );
+
+    const history = await historyService.getHistoryFromLatestBoundary(workspaceId);
+    expect(history.success).toBe(true);
+    if (!history.success) throw new Error(history.error);
+    const toolPart = history.data
+      .find((row) => row.id === messageId)
+      ?.parts.find((part) => part.type === "dynamic-tool");
+    if (toolPart?.type !== "dynamic-tool" || toolPart.state !== "output-available") {
+      throw new Error("Expected a completed dynamic-tool part");
+    }
+    const output = toolPart.output as { success: boolean; error: string };
+
+    expect(output.success).toBe(false);
+    expect(output.error).toContain("advisor");
+    expect(output.error).toContain("question");
+    expect(output.error).toContain("2000");
+    expect(output.error).toContain("2100");
+    expect(output.error.length).toBeLessThan(500);
+    expect(output.error).not.toContain("xxxx");
+  });
 });
 
 describe("StreamManager - empty stream completions", () => {

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -26,7 +26,6 @@ import {
   type ToolSet,
   LoadAPIKeyError,
   APICallError,
-  InvalidToolInputError,
   RetryError,
 } from "ai";
 import type { LanguageModelV2Usage } from "@ai-sdk/provider";
@@ -87,10 +86,7 @@ import {
 import { linkAbortSignal } from "@/node/utils/abort";
 import { AsyncMutex } from "@/node/utils/concurrency/asyncMutex";
 import { stripInternalToolResultFields } from "@/common/utils/tools/internalToolResultFields";
-import {
-  formatToolInputIssues,
-  isToolInputIssueArray,
-} from "@/common/utils/tools/formatToolInputIssues";
+import { summarizeInvalidToolInputErrors } from "@/node/utils/messages/summarizeInvalidToolInputErrors";
 import { buildRequiredToolPatterns, type ToolPolicy } from "@/common/utils/tools/toolPolicy";
 import {
   computeActiveToolNames,
@@ -195,31 +191,9 @@ interface ToolCallState {
   toolName: string;
   input: unknown;
   output?: unknown;
-  /** Concise message for a call the SDK rejected before execution; replaces the raw tool-error string. */
-  invalidInputError?: string;
 }
 
 type ToolCallMap = Map<string, ToolCallState>;
-
-/**
- * The SDK's InvalidToolInputError message echoes the entire submitted input
- * and buries the zod issue at the end, so the model retries blind. Render only
- * the issues (with received string lengths) when the cause chain
- * (InvalidToolInputError -> TypeValidationError -> ZodError) exposes them.
- */
-function describeInvalidToolInput(toolName: string, input: unknown, error: unknown): string {
-  if (InvalidToolInputError.isInstance(error)) {
-    let cause: unknown = error.cause;
-    for (let depth = 0; depth < 3 && typeof cause === "object" && cause !== null; depth += 1) {
-      const issues: unknown = (cause as { issues?: unknown }).issues;
-      if (isToolInputIssueArray(issues)) {
-        return `Invalid input for tool ${toolName}: ${formatToolInputIssues(issues, input)}`;
-      }
-      cause = (cause as { cause?: unknown }).cause;
-    }
-  }
-  return clampErrorMessage(getErrorMessage(error));
-}
 
 type WorkspaceId = string & { __brand: "WorkspaceId" };
 type StreamToken = string & { __brand: "StreamToken" };
@@ -2828,6 +2802,7 @@ export class StreamManager {
       },
       onChunk: request.onChunk,
       tools: request.tools,
+      experimental_transform: summarizeInvalidToolInputErrors(),
       stopWhen: this.createStopWhenCondition(request),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
       providerOptions: request.providerOptions as any, // Pass provider-specific options (thinking/reasoning config)
@@ -4107,15 +4082,10 @@ export class StreamManager {
 
               case "tool-call": {
                 // Tool call started - store in map for later lookup
-                const invalidInputError =
-                  part.dynamic === true && part.invalid === true && part.error != null
-                    ? describeInvalidToolInput(part.toolName, part.input, part.error)
-                    : undefined;
                 toolCalls.set(part.toolCallId, {
                   toolCallId: part.toolCallId,
                   toolName: part.toolName,
                   input: part.input,
-                  ...(invalidInputError != null ? { invalidInputError } : {}),
                 });
 
                 // Note: Tool availability is handled by the SDK, which emits tool-error events
@@ -4218,12 +4188,11 @@ export class StreamManager {
                 const errorOutput = {
                   success: false,
                   error:
-                    toolCalls.get(toolErrorPart.toolCallId)?.invalidInputError ??
-                    (typeof toolErrorPart.error === "string"
+                    typeof toolErrorPart.error === "string"
                       ? toolErrorPart.error
                       : toolErrorPart.error instanceof Error
                         ? toolErrorPart.error.message
-                        : getErrorMessage(toolErrorPart.error)),
+                        : getErrorMessage(toolErrorPart.error),
                 };
 
                 // Use shared completion logic (await to ensure partial is flushed before event)

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -26,6 +26,7 @@ import {
   type ToolSet,
   LoadAPIKeyError,
   APICallError,
+  InvalidToolInputError,
   RetryError,
 } from "ai";
 import type { LanguageModelV2Usage } from "@ai-sdk/provider";
@@ -86,6 +87,10 @@ import {
 import { linkAbortSignal } from "@/node/utils/abort";
 import { AsyncMutex } from "@/node/utils/concurrency/asyncMutex";
 import { stripInternalToolResultFields } from "@/common/utils/tools/internalToolResultFields";
+import {
+  formatToolInputIssues,
+  isToolInputIssueArray,
+} from "@/common/utils/tools/formatToolInputIssues";
 import { buildRequiredToolPatterns, type ToolPolicy } from "@/common/utils/tools/toolPolicy";
 import {
   computeActiveToolNames,
@@ -190,9 +195,31 @@ interface ToolCallState {
   toolName: string;
   input: unknown;
   output?: unknown;
+  /** Concise message for a call the SDK rejected before execution; replaces the raw tool-error string. */
+  invalidInputError?: string;
 }
 
 type ToolCallMap = Map<string, ToolCallState>;
+
+/**
+ * The SDK's InvalidToolInputError message echoes the entire submitted input
+ * and buries the zod issue at the end, so the model retries blind. Render only
+ * the issues (with received string lengths) when the cause chain
+ * (InvalidToolInputError -> TypeValidationError -> ZodError) exposes them.
+ */
+function describeInvalidToolInput(toolName: string, input: unknown, error: unknown): string {
+  if (InvalidToolInputError.isInstance(error)) {
+    let cause: unknown = error.cause;
+    for (let depth = 0; depth < 3 && typeof cause === "object" && cause !== null; depth += 1) {
+      const issues: unknown = (cause as { issues?: unknown }).issues;
+      if (isToolInputIssueArray(issues)) {
+        return `Invalid input for tool ${toolName}: ${formatToolInputIssues(issues, input)}`;
+      }
+      cause = (cause as { cause?: unknown }).cause;
+    }
+  }
+  return clampErrorMessage(getErrorMessage(error));
+}
 
 type WorkspaceId = string & { __brand: "WorkspaceId" };
 type StreamToken = string & { __brand: "StreamToken" };
@@ -4080,10 +4107,15 @@ export class StreamManager {
 
               case "tool-call": {
                 // Tool call started - store in map for later lookup
+                const invalidInputError =
+                  part.dynamic === true && part.invalid === true && part.error != null
+                    ? describeInvalidToolInput(part.toolName, part.input, part.error)
+                    : undefined;
                 toolCalls.set(part.toolCallId, {
                   toolCallId: part.toolCallId,
                   toolName: part.toolName,
                   input: part.input,
+                  ...(invalidInputError != null ? { invalidInputError } : {}),
                 });
 
                 // Note: Tool availability is handled by the SDK, which emits tool-error events
@@ -4186,11 +4218,12 @@ export class StreamManager {
                 const errorOutput = {
                   success: false,
                   error:
-                    typeof toolErrorPart.error === "string"
+                    toolCalls.get(toolErrorPart.toolCallId)?.invalidInputError ??
+                    (typeof toolErrorPart.error === "string"
                       ? toolErrorPart.error
                       : toolErrorPart.error instanceof Error
                         ? toolErrorPart.error.message
-                        : getErrorMessage(toolErrorPart.error),
+                        : getErrorMessage(toolErrorPart.error)),
                 };
 
                 // Use shared completion logic (await to ensure partial is flushed before event)

--- a/src/node/services/tools/advisor.test.ts
+++ b/src/node/services/tools/advisor.test.ts
@@ -683,6 +683,26 @@ describe("advisor tool", () => {
     expect(reportModelUsage).not.toHaveBeenCalled();
   });
 
+  it("returns an error instead of empty advice when the stream produced no text", async () => {
+    using tempDir = new TestTempDir("advisor-tool-empty-advice");
+    const reportModelUsage = mock((_event: ToolModelUsageEvent) => undefined);
+    const { config } = createToolConfig(tempDir.path, { reportModelUsage });
+    mockStreamTextSuccess({
+      text: "",
+      finishReason: "stop",
+      usage: { inputTokens: 12, outputTokens: 0, totalTokens: 12 },
+    });
+
+    const tool = createAdvisorTool(config);
+    const rawResult: unknown = await Promise.resolve(tool.execute!({}, mockToolCallOptions));
+
+    const result = rawResult as { type?: unknown; isError?: unknown; message?: unknown };
+    expect(result.type).toBe("error");
+    expect(result.isError).toBe(true);
+    expect(result.message).toEqual(expect.stringContaining("stop"));
+    expect(reportModelUsage).toHaveBeenCalledTimes(1);
+  });
+
   it("sanitizes binary-like advisor provider failures", async () => {
     using tempDir = new TestTempDir("advisor-tool-sanitized-error");
     const { config } = createToolConfig(tempDir.path);

--- a/src/node/services/tools/advisor.ts
+++ b/src/node/services/tools/advisor.ts
@@ -366,6 +366,16 @@ export function createAdvisorTool(config: ToolConfiguration): Tool {
           }
         }
 
+        // An empty stream (for example a gateway hiccup) used to surface as a
+        // success-shaped result, so the caller saw "advice" that said nothing.
+        if (advice.trim().length === 0) {
+          return {
+            type: "error" as const,
+            isError: true,
+            message: `Advisor returned no advice (finish reason: ${finishReason}). Retry once or continue without it.`,
+          };
+        }
+
         return {
           type: "advice" as const,
           advice,

--- a/src/node/utils/messages/summarizeInvalidToolInputErrors.test.ts
+++ b/src/node/utils/messages/summarizeInvalidToolInputErrors.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { InvalidToolInputError, TypeValidationError, type TextStreamPart, type ToolSet } from "ai";
+import { z } from "zod";
+import { summarizeInvalidToolInputErrors } from "./summarizeInvalidToolInputErrors";
+
+async function runTransform(
+  parts: Array<TextStreamPart<ToolSet>>
+): Promise<Array<TextStreamPart<ToolSet>>> {
+  const transform = summarizeInvalidToolInputErrors<ToolSet>()({
+    tools: {},
+    stopStream: () => undefined,
+  });
+  const output: Array<TextStreamPart<ToolSet>> = [];
+  await new ReadableStream<TextStreamPart<ToolSet>>({
+    start(controller) {
+      for (const part of parts) controller.enqueue(part);
+      controller.close();
+    },
+  })
+    .pipeThrough(transform)
+    .pipeTo(
+      new WritableStream({
+        write(part) {
+          output.push(part);
+        },
+      })
+    );
+  return output;
+}
+
+function rejectedCall(toolCallId: string, input: unknown, cause: unknown) {
+  const error = new InvalidToolInputError({
+    toolName: "note",
+    toolInput: JSON.stringify(input),
+    cause,
+  });
+  return {
+    call: {
+      type: "tool-call" as const,
+      toolCallId,
+      toolName: "note",
+      input,
+      dynamic: true as const,
+      invalid: true,
+      error,
+    },
+    toolError: {
+      type: "tool-error" as const,
+      toolCallId,
+      toolName: "note",
+      input,
+      error: error.message,
+      dynamic: true as const,
+    },
+  };
+}
+
+describe("summarizeInvalidToolInputErrors", () => {
+  test("rewrites only the rejected call's tool-error and leaves other errors alone", async () => {
+    const schema = z.object({ text: z.string().max(5) });
+    const input = { text: "toolong" };
+    const validation = schema.safeParse(input);
+    if (validation.success) throw new Error("Expected the schema to reject the input");
+    const rejected = rejectedCall(
+      "rejected",
+      input,
+      TypeValidationError.wrap({ value: input, cause: validation.error })
+    );
+    const executionFailure = {
+      type: "tool-error" as const,
+      toolCallId: "executed",
+      toolName: "note",
+      input: { text: "ok" },
+      error: new Error("disk full"),
+    };
+
+    const output = await runTransform([rejected.call, rejected.toolError, executionFailure]);
+
+    expect(output).toHaveLength(3);
+    expect(output[0]).toBe(rejected.call);
+    expect(output[1]).toMatchObject({
+      type: "tool-error",
+      toolCallId: "rejected",
+      error:
+        "Invalid input for tool note: text: Too big: expected string to have <=5 characters (received 7 characters)",
+    });
+    expect(output[2]).toBe(executionFailure);
+  });
+
+  test("falls back to the error message when the cause chain has no issues", async () => {
+    const rejected = rejectedCall("unparsable", "{not json", new Error("JSON parsing failed"));
+
+    const output = await runTransform([rejected.call, rejected.toolError]);
+
+    expect(output[1]).toMatchObject({ type: "tool-error", error: rejected.toolError.error });
+  });
+});

--- a/src/node/utils/messages/summarizeInvalidToolInputErrors.ts
+++ b/src/node/utils/messages/summarizeInvalidToolInputErrors.ts
@@ -1,0 +1,70 @@
+import {
+  InvalidToolInputError,
+  type StreamTextTransform,
+  type TextStreamPart,
+  type ToolSet,
+} from "ai";
+import { clampErrorMessage, getErrorMessage } from "@/common/utils/errors";
+import {
+  formatToolInputIssues,
+  isToolInputIssueArray,
+} from "@/common/utils/tools/formatToolInputIssues";
+
+/**
+ * The SDK's InvalidToolInputError message echoes the entire submitted input
+ * and buries the zod issue at the end, so the model retries blind. Render only
+ * the issues (with received string lengths) when the cause chain
+ * (InvalidToolInputError -> TypeValidationError -> ZodError) exposes them.
+ */
+export function describeInvalidToolInput(toolName: string, input: unknown, error: unknown): string {
+  if (InvalidToolInputError.isInstance(error)) {
+    let cause: unknown = error.cause;
+    for (let depth = 0; depth < 3 && typeof cause === "object" && cause !== null; depth += 1) {
+      const issues: unknown = (cause as { issues?: unknown }).issues;
+      if (isToolInputIssueArray(issues)) {
+        return `Invalid input for tool ${toolName}: ${formatToolInputIssues(issues, input)}`;
+      }
+      cause = (cause as { cause?: unknown }).cause;
+    }
+  }
+  return clampErrorMessage(getErrorMessage(error));
+}
+
+/**
+ * streamText transform that rewrites the tool-error of a call the SDK rejected
+ * before execution (invalid input) to describeInvalidToolInput's summary.
+ *
+ * This has to be a stream transform rather than fullStream consumer logic:
+ * streamText builds the next step's tool-result message from the transformed
+ * stream, so only a transform changes what the model sees on its same-turn
+ * retry. The consumer then persists the same summary for later turns.
+ */
+export function summarizeInvalidToolInputErrors<
+  TOOLS extends ToolSet,
+>(): StreamTextTransform<TOOLS> {
+  return () => {
+    const summaries = new Map<string, string>();
+    return new TransformStream<TextStreamPart<TOOLS>, TextStreamPart<TOOLS>>({
+      transform(part, controller) {
+        if (
+          part.type === "tool-call" &&
+          part.dynamic === true &&
+          part.invalid === true &&
+          part.error != null
+        ) {
+          summaries.set(
+            part.toolCallId,
+            describeInvalidToolInput(part.toolName, part.input, part.error)
+          );
+        } else if (part.type === "tool-error") {
+          const summary = summaries.get(part.toolCallId);
+          if (summary != null) {
+            controller.enqueue({ ...part, error: summary });
+            return;
+          }
+        }
+        controller.enqueue(part);
+      },
+    });
+  };
+}


### PR DESCRIPTION
## Summary

Tool input validation failures now reach the model as one concise, actionable sentence instead of the AI SDK's raw `AI_InvalidToolInputError` string, the `advisor` tool description states its 2000-character `question` cap, and an advisor stream that produces no text is reported as an error instead of a success-shaped empty result.

## Background

In an RLM-mode session the model called `advisor` with a 3421-character `question`. The zod schema rejected it before execution and StreamManager relayed the SDK's error verbatim as the tool result: a ~4 KB string that echoes the entire submitted input and only at the very end says `Too big: expected string to have <=2000 characters`, without the actual length. The model retried at 2071 characters (same blob), then its two in-limit calls returned `{ type: "advice", advice: "" }` because the advisor model stream produced nothing, which the tool reported as success. Four calls, zero advice, and the tool description never mentioned the cap.

The RLM kernel path (`toolBridge.ts`) already rendered zod failures readably; only the top-level AI SDK path relayed the raw string.

## Implementation

- `formatToolInputIssues` (new, `src/common/utils/tools`): renders zod v4 issues as `<path>: <message>`, appending `(received N characters)` for string size violations by resolving the path inside the parsed input. It never includes the input value. Shared by the kernel bridge and StreamManager so both paths produce the same shape.
- `summarizeInvalidToolInputErrors` (new, `src/node/utils/messages`): a `streamText` `experimental_transform`. An invalid dynamic `tool-call` part carries the structured error; its cause chain (`InvalidToolInputError` -> `TypeValidationError` -> `ZodError`) is walked to build `Invalid input for tool advisor: question: Too big: expected string to have <=2000 characters (received 3421 characters)`, and the matching `tool-error` part's `error` is rewritten to it. Non-zod causes fall back to the clamped original message. It has to be a transform rather than fullStream-consumer logic: AI SDK 7 builds the next step's tool-result message from the transformed stream (and `prepareStep` does not rewrite it), so a consumer-side rewrite only reached the tool card and later turns while the model's same-turn retry still got the input-echoing text. StreamManager wires the transform in `createStreamResult`; its `tool-error` handling is unchanged and now simply persists the rewritten string.
- `ADVISOR_QUESTION_MAX_CHARS` is shared by `AdvisorToolInputSchema` and `ADVISOR_TOOL_DESCRIPTION`.
- `advisor.ts`: blank advice returns `{ type: "error", message: "Advisor returned no advice (finish reason: ...)" }` after usage is still reported.

## Validation

`streamManager.invalidToolInput.test.ts` drives a real `startStream` with a mock model that emits an over-cap `advisor` call and captures the second provider request: its tool-result is the one-line summary (with `received 2100 characters`, no echoed input), and the persisted tool part carries the same text. Without the transform the same test receives the ~2 KB `AI_InvalidToolInputError` blob.

Remote dogfood UAT on `b5a71760` (Coder Agents, fresh workspace, real models): over-long (2500, 6057 chars), boundary (2000 passes, 2001 fails with `received 2001`), special-character and multibyte payloads all produce the one-line error with no echoed input; a retry within the limit and a short regression call return real advice; the tool description shows the cap; an organic empty advisor response rendered as a failed card with the finish reason. Round 2 (RLM Mode enabled) repeated the over-cap, 2000/2001 boundary, hostile-character, kernel (`xum.timeline_event` 400 chars -> `received 400 characters`) and short-regression cases, and found the same-turn gap fixed by the third commit. Round 3 on the final head is recorded in the ledger below.

## Risks

Low. The StreamManager change only alters the `error` string of tool results the SDK already rejected before execution; successful tool calls and non-validation tool errors are untouched. The advisor change converts a previously silent empty success into a visible error result.

## Found during UAT, out of scope

Instructing the agent to call `advisor({ question: "" })` produced a provider-side stream error from the dev AI gateway (`processing error: accumulate event: error converting content block to JSON ... invalid character '}'`) before any tool-call part reached StreamManager. The stream then auto-retried indefinitely (Stop did not end it) and the app hung on "Loading Xum..." for every browser session until the backend was restarted. Nothing in this diff is on that path (the error arrives as a provider `error` part, not as a tool call), and round 2 reproduced it byte-identically on the merge-base `023701d63`, so it is pre-existing and tracked separately: see #4228.

Round 2 also noted that kernel `code_execution` results echo an oversized argument inside `toolCalls[].args` even though the error string is concise. That is the designed, size-capped args trace (`KERNEL_COMPACT_ARGS_CAP_BYTES` in `src/constants/kernelOutput.ts`), untouched here.

Deferred from review: capping the number of rendered zod issues in `formatToolInputIssues` (Codex P1, round 2). Not a regression of this PR; the change is ready and tested on branch `mike/bound-tool-input-summary` (`d65a6739`, stacked on this head) and can be opened as a stacked PR on request once this PR lands.

<details>
<summary>Review ledger (delivery record)</summary>

| #   | Review                                             | Kind     | Commit     | Findings                                                    | Disposition                                                                                                                                                                                                                                             |
| --- | -------------------------------------------------- | -------- | ---------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 1   | Codex code review (manual `@codex review`, 01:58Z) | code     | `b5a71760` | 1 P1: move `ADVISOR_QUESTION_MAX_CHARS` to `src/constants/` | Reasoned rejection, replied on the thread and resolved: the constant sits with the other advisor bounds and the description that consumes it in `src/common/constants/advisor.ts`; tool limits already live under `src/common/constants/toolLimits.ts`. |
| 2   | Codex security review (automatic)                  | security | `b5a71760` | none                                                        | Clean.                                                                                                                                                                                                                                                  |
| 3   | Codex code review (automatic on push, 03:10Z)      | code     | `44aafafb` | 1 P1: bound `formatToolInputIssues` for many zod issues     | Valid hardening, not a regression (the pre-PR SDK text was strictly larger for the same call); deferred with reasoning on the thread and resolved. Follow-up commit ready on `mike/bound-tool-input-summary` (`d65a6739`, stacked on this head) to open as a stacked PR after this one lands. |
| 4   | Codex security review (automatic on push)          | security | `44aafafb` | none                                                        | Clean.                                                                                                                                                                                                                                                  |
| 5   | Final Advisor (fresh clean-context review, 03:25Z) | advisory | `44aafafb` | none blocking                                               | VERDICT: READY. Confirmed the transform sits where the same-turn retry reads (AI SDK 7.0.19 event processor), tests are behavioural, both Codex dispositions defensible; rated the deferred issue-count bound Low and recommended folding it in if another review round is affordable, otherwise shipping it as a stacked PR promptly. |

UAT: round 1 on `b5a71760` (remote Coder Agents chat, real models) passed every in-scope scenario; its one Critical finding is the pre-existing gateway/retry hang tracked in #4228. Round 2 on `b5a71760` (RLM Mode path, kernel path, baseline of the empty-question case on the merge-base): remote verdict FAIL, adjudicated as in-scope PASS; the empty-question hang and the reload hang reproduced identically on the merge-base; one new Medium finding (the model's same-turn retry still received the verbose SDK text) is fixed by `44aafafb`. Round 3 on `44aafafb` (final head, API Debug Logs enabled): PASS. The `devtools.jsonl` excerpt shows the second provider request of the turn carries the rejected call's tool-result as the 119-character one-liner (no echoed question, no `Type validation failed`), the same-turn retry returned real advice, 2000 accepted / 2001 rejected, and an unrelated `file_read` was unaffected. Review count: 5 of a 6-review budget.

**Status: held unmerged; BLOCKED on the explicit Codex approval gate.** Mike authorized the merge in the delivery chat on 2026-09-13 ("if CI is green and codex is good"); the PR was submitted to the `main` merge queue at 06:55Z and withdrawn through the normal dequeue path at 07:07Z, because the "Codex is good" condition, as the repo's readiness rule defines it (AGENTS.md "PR readiness", `scripts/wait_pr_codex.sh`: a thumbs-up reaction or a "Didn't find any major issues" comment), is not met. Codex's round on `44aafafb` (code review https://github.com/coder/xum/pull/4227#pullrequestreview-5189304785, security clean per the summary comment https://github.com/coder/xum/pull/4227#issuecomment-5650089546) closed with its one finding answered and resolved, and the PR has no approval reaction, approval comment, or APPROVED review. This delivery runs under a hard six-review ceiling (5 used); a re-request would trigger an automatic code + security pair beyond it, so no further review will be requested and merge consent alone does not clear the gate within this delivery. CI on `44aafafb` is green (`Required` success). The deferred `formatToolInputIssues` bound (`d65a6739` on `mike/bound-tool-input-summary`) follows as a stacked PR on request.

> Xum, acting for Mike, enqueued and then withdrew this PR from the merge queue; it remains unmerged under the gate above.

</details>

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh`_

<!-- xum-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh -->





